### PR TITLE
Restore `docs/requirements.txt`

### DIFF
--- a/nautobot/docs/requirements.txt
+++ b/nautobot/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs==1.1		
+git+https://github.com/cmacmackin/markdown-include.git


### PR DESCRIPTION
This is used by RTD to build `MkDocs`. I forgot that there are a few more steps to streamline before we can move this.

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: <ISSUE NUMBER GOES HERE>
<!--
    Please include a summary of the proposed changes below.
-->
