### PR TITLE
Release v1.0.0b1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Nautobot](nautobot/docs/nautobot_logo.svg "Nautobot logo")
+![Nautobot](https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/nautobot_logo.svg "Nautobot logo")
 
 Nautobot is a Network Source of Truth and Network Automation Platform.  
 
@@ -13,22 +13,22 @@ or join us in the **#nautobot** Slack channel on [Network to Code](https://netwo
 
 ### Build Status
 
-|             | status |
+| Branch      | Status |
 |-------------|------------|
 | **main** | [![Build Status](https://travis-ci.com/nautobot/nautobot.svg?branch=main)](https://travis-ci.com/nautobot/nautobot) |
 | **develop** | [![Build Status](https://travis-ci.com/nautobot/nautobot.svg?branch=develop)](https://travis-ci.com/nautobot/nautobot) |
 
 ### Screenshots
 
-![Screenshot of main page](nautobot/docs/media/screenshot1.png "Main page")
+![Screenshot of main page](https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/media/screenshot1.png "Main page")
 
 ---
 
-![Screenshot of rack elevation](nautobot/docs/media/screenshot2.png "Rack elevation")
+![Screenshot of rack elevation](https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/media/screenshot2.png "Rack elevation")
 
 ---
 
-![Screenshot of prefix hierarchy](nautobot/docs/media/screenshot3.png "Prefix hierarchy")
+![Screenshot of prefix hierarchy](https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/media/screenshot3.png "Prefix hierarchy")
 
 ## Installation
 

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,11 @@ eval $COMMAND || {
 # Activate the virtual environment
 source "${VIRTUALENV}/bin/activate"
 
+# Upgrade pip3
+COMMAND="pip3 install --upgrade pip"
+echo "Upgrading Python package installer ($COMMAND)..."
+eval $COMMAND || exit 1
+
 # Install necessary system packages
 COMMAND="pip3 install wheel"
 echo "Installing Python system packages ($COMMAND)..."

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -25,21 +25,4 @@ PLUGINS = [
     "nautobot.extras.tests.dummy_plugin",
 ]
 
-REDIS = {
-    "tasks": {
-        "HOST": "localhost",
-        "PORT": 6379,
-        "PASSWORD": "",
-        "DATABASE": 0,
-        "SSL": False,
-    },
-    "caching": {
-        "HOST": "localhost",
-        "PORT": 6379,
-        "PASSWORD": "",
-        "DATABASE": 1,
-        "SSL": False,
-    },
-}
-
 SECRET_KEY = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"

--- a/nautobot/docs/installation/3-nautobot.md
+++ b/nautobot/docs/installation/3-nautobot.md
@@ -18,7 +18,7 @@ $ sudo apt install -y git python3 python3-pip python3-venv python3-dev
 ### CentOS
 
 ```no-highlight
-$ sudo yum install -y gcc git python36 python36-devel python3-pip libxml2-devel libxslt-devel libffi-devel openssl-devel redhat-rpm-config
+$ sudo yum install -y git python36 python36-devel python3-pip
 ```
 
 Before continuing with either platform, update [`pip`](https://pip.pypa.io/), Python's package installer, to its latest release:
@@ -95,24 +95,15 @@ files.
 
 #### Ubuntu
 
-```
+```no-highlight
 $ sudo adduser --system --group nautobot
-$ sudo chown --recursive nautobot /opt/nautobot/nautobot/media/
 ```
 
 #### CentOS
 
-```
+```no-highlight
 $ sudo groupadd --system nautobot
 $ sudo adduser --system -g nautobot nautobot
-```
-
-For CentOS, you'll also need to create the static file directories:
-
-```
-$ cd /opt/nautobot/
-$ sudo mkdir -p git jobs media/image-attachments media/devicetype-images
-$ sudo chown --recursive nautobot git jobs media
 ```
 
 ## Install Nautobot

--- a/nautobot/docs/installation/index.md
+++ b/nautobot/docs/installation/index.md
@@ -1,8 +1,7 @@
 # Installation
 
 !!! warning
-    As of Nautobot v1.0.0b1 these instructions are still in a pre-release state. Only Ubuntu instructions are supported
-    at this time.
+    As of Nautobot v1.0.0b1 these instructions are still in a pre-release state. We are working to revise them for the recent changes. 
 
 The installation instructions provided here have been tested to work on Ubuntu 20.04 and CentOS 8.2. The particular
 commands needed to install dependencies on other distributions may vary significantly. Unfortunately, this is outside

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.1"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
- Update CentOS install instructions; bump version from previous release. (#27)
- Bump version to v1.0.0b1 and patch test config a little.
- Revise README.md to use absolute image URLs so that once published to PyPI, the images render correctly.
- Update `install.sh` to also upgrade `pip`
