### PR TITLE
Add "present_in_database" property to BaseModel, fix incorrect leftover null-PK checks

### DIFF
--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -19,13 +19,20 @@ class BaseModel(models.Model):
     means the canonical pattern in Django of checking `self.pk is None` to tell
     if an object has been created in the actual database does not work because
     the object will always have the value populated prior to being saved to the
-    database for the first time. An alternate pattern of checking `self._state.adding`
+    database for the first time. An alternate pattern of checking `not self.present_in_database`
     can be used for the same purpose in most cases.
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, unique=True, editable=False)
 
     objects = RestrictedQuerySet.as_manager()
+
+    @property
+    def present_in_database(self):
+        """
+        True if the record exists in the database, False if it does not.
+        """
+        return not self._state.adding
 
     class Meta:
         abstract = True

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -280,7 +280,7 @@ class ObjectEditView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
                 "obj_type": self.queryset.model._meta.verbose_name,
                 "form": form,
                 "return_url": self.get_return_url(request, obj),
-                "editing": not obj._state.adding,
+                "editing": obj.present_in_database,
             },
         )
 
@@ -295,7 +295,7 @@ class ObjectEditView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
 
             try:
                 with transaction.atomic():
-                    object_created = form.instance.pk is None
+                    object_created = not form.instance.present_in_database
                     obj = form.save()
 
                     # Check that the new object conforms with any assigned object-level permissions
@@ -343,7 +343,7 @@ class ObjectEditView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
                 "obj_type": self.queryset.model._meta.verbose_name,
                 "form": form,
                 "return_url": self.get_return_url(request, obj),
-                "editing": not obj._state.adding,
+                "editing": obj.present_in_database,
             },
         )
 

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -1726,7 +1726,7 @@ class DeviceForm(BootstrapMixin, TenancyForm, CustomFieldModelForm, Relationship
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if not self.instance._state.adding:
+        if self.instance.present_in_database:
 
             # Compile list of choices for primary IPv4 and IPv6 addresses
             for family in [4, 6]:
@@ -3795,7 +3795,7 @@ class VirtualChassisCreateForm(BootstrapMixin, CustomFieldModelForm, Relationshi
         instance = super().save(*args, **kwargs)
 
         # Assign VC members
-        if not instance._state.adding:
+        if instance.present_in_database:
             initial_position = self.cleaned_data.get("initial_position") or 1
             for i, member in enumerate(self.cleaned_data["members"], start=initial_position):
                 member.virtual_chassis = instance

--- a/nautobot/dcim/models/cables.py
+++ b/nautobot/dcim/models/cables.py
@@ -169,7 +169,7 @@ class Cable(PrimaryModel, StatusModel):
             raise ValidationError({"termination_b": "Invalid ID for type {}".format(self.termination_b_type)})
 
         # If editing an existing Cable instance, check that neither termination has been modified.
-        if not self._state.adding:
+        if self.present_in_database:
             err_msg = "Cable termination points may not be modified. Delete and recreate the cable instead."
             if (
                 self.termination_a_type_id != self._orig_termination_a_type_id

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -476,7 +476,7 @@ class BaseInterface(RelationshipModel):
             self.untagged_vlan = None
 
         # Only "tagged" interfaces may have tagged VLANs assigned. ("tagged all" implies all VLANs are assigned.)
-        if not self._state.adding and self.mode != InterfaceModeChoices.MODE_TAGGED:
+        if self.present_in_database and self.mode != InterfaceModeChoices.MODE_TAGGED:
             self.tagged_vlans.clear()
 
         return super().save(*args, **kwargs)
@@ -606,7 +606,7 @@ class Interface(CableTermination, PathEndpoint, ComponentModel, BaseInterface):
             raise ValidationError({"lag": "Virtual interfaces cannot have a parent LAG interface."})
 
         # A LAG interface cannot be its own parent
-        if not self._state.adding and self.lag_id == self.pk:
+        if self.present_in_database and self.lag_id == self.pk:
             raise ValidationError({"lag": "A LAG interface cannot be its own parent."})
 
         # Validate untagged VLAN

--- a/nautobot/dcim/models/racks.py
+++ b/nautobot/dcim/models/racks.py
@@ -298,7 +298,7 @@ class Rack(PrimaryModel, StatusModel):
         elif self.outer_width is None and self.outer_depth is None:
             self.outer_unit = ""
 
-        if not self._state.adding:
+        if self.present_in_database:
             # Validate that Rack is tall enough to house the installed Devices
             top_device = Device.objects.filter(rack=self).exclude(position__isnull=True).order_by("-position").first()
             if top_device:
@@ -381,7 +381,7 @@ class Rack(PrimaryModel, StatusModel):
             }
 
         # Add devices to rack units list
-        if not self._state.adding:
+        if self.present_in_database:
 
             # Retrieve all devices installed within the rack
             queryset = (

--- a/nautobot/dcim/templates/dcim/virtualchassis_edit.html
+++ b/nautobot/dcim/templates/dcim/virtualchassis_edit.html
@@ -71,7 +71,7 @@
                                             {% endif %}
                                         </td>
                                         <td>
-                                            {% if virtual_chassis.pk %}
+                                            {% if virtual_chassis.present_in_database %}
                                                 <a href="{% url 'dcim:virtualchassis_remove_member' pk=device.pk %}?return_url={% url 'dcim:virtualchassis_edit' pk=virtual_chassis.pk %}" class="btn btn-danger btn-xs{% if virtual_chassis.master == device %} disabled{% endif %}">
                                                     <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span>
                                                 </a>

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -519,7 +519,7 @@ class RackReservationEditView(generic.ObjectEditView):
     template_name = "dcim/rackreservation_edit.html"
 
     def alter_obj(self, obj, request, args, kwargs):
-        if obj._state.adding:
+        if not obj.present_in_database:
             if "rack" in request.GET:
                 obj.rack = get_object_or_404(Rack, pk=request.GET.get("rack"))
             obj.user = request.user

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -260,7 +260,7 @@ Again, defining user variables is totally optional; you may create a job with ju
     ```
 
 !!! warning
-    When writing Jobs that create and manipulate data it is recommended to make use of the `validated_save()` convenience method which exists on all core models. This method saves the instance data but first enforces model validation logic. Simply calling `save()` on the model instance **does not** enforce validation automatically and may lead to bad data. See the development [best practices](../../development/best-practices.md).
+    When writing Jobs that create and manipulate data it is recommended to make use of the `validated_save()` convenience method which exists on all core models. This method saves the instance data but first enforces model validation logic. Simply calling `save()` on the model instance **does not** enforce validation automatically and may lead to bad data. See the development [best practices](../development/best-practices.md).
 
 !!! warning
     The Django ORM provides methods to create/edit many objects at once, namely `bulk_create()` and `update()`. These are best avoided in most cases as they bypass a model's built-in validation and can easily lead to database corruption if not used carefully.

--- a/nautobot/docs/administration/nautobot-shell.md
+++ b/nautobot/docs/administration/nautobot-shell.md
@@ -175,7 +175,7 @@ To modify an existing object, we retrieve it, update the desired field(s), and c
 ```
 
 !!! warning
-   It is recommended to make use of the `validated_save()` convenience method which exists on all core models. While the Django `save()` method still exists, the `validated_save()` method saves the instance data but first enforces model validation logic. Simply calling `save()` on the model instance **does not** enforce validation automatically and may lead to bad data. See the development [best practices](../../development/best-practices.md).
+   It is recommended to make use of the `validated_save()` convenience method which exists on all core models. While the Django `save()` method still exists, the `validated_save()` method saves the instance data but first enforces model validation logic. Simply calling `save()` on the model instance **does not** enforce validation automatically and may lead to bad data. See the development [best practices](../development/best-practices.md).
 
 !!! warning
     The Django ORM provides methods to create/edit many objects at once, namely `bulk_create()` and `update()`. These are best avoided in most cases as they bypass a model's built-in validation and can easily lead to database corruption if not used carefully.

--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -78,7 +78,7 @@ configurations.
 
 Nautobot supports database query caching using [`django-cacheops`](https://github.com/Suor/django-cacheops).
 
-Caching is configured by defining the [`CACHEOPS_REDIS`](#cacheops_redis) setting which in its simplest form is just a URL. 
+Caching is configured by defining the [`CACHEOPS_REDIS`](#cacheops_redis) setting which in its simplest form is just a URL.
 
 For more details Nautobot's caching see the guide on [Caching](../../additional-features/caching).
 
@@ -134,7 +134,7 @@ environment.
 
 #### RQ_QUEUES
 
-Default: 
+Default:
 
 ```python
 RQ_QUEUES = {
@@ -224,7 +224,7 @@ This is a secret, random string used to assist in the creation new cryptographic
 
 Please note that this key is **not** used directly for hashing user passwords or for the encrypted storage of secret data in Nautobot.
 
-`SECRET_KEY` should be at least 50 characters in length and contain a random mix of letters, digits, and symbols. 
+`SECRET_KEY` should be at least 50 characters in length and contain a random mix of letters, digits, and symbols.
 
 A unique `SECRET_KEY` is generated for you automatically when you use `nautobot init` to create a new configuration. You may run `nautobot-server generate_secret_key` to generate a new key at any time.
 
@@ -236,4 +236,4 @@ $ nautobot-server generate_secret_key.py
 !!! warning
     In the case of a highly available installation with multiple web servers, `SECRET_KEY` must be identical among all servers in order to maintain a persistent user session state.
 
-For more details see [Nautobot Configuration](..).
+For more details see [Nautobot Configuration](../).

--- a/nautobot/docs/development/best-practices.md
+++ b/nautobot/docs/development/best-practices.md
@@ -2,6 +2,39 @@
 
 While there are many different development interfaces in Nautobot that each expose unique functionality, there are a common set of a best practices that have broad applicability to users and developers alike. This includes elements of writing Jobs, Plugins, and scripts for execution through the `nbshell`.
 
+## Model Existence in the Database
+
+A common Django pattern is to check whether an model instance's primary key (`pk`) field is set as a proxy for whether the instance has been written to the database or whether it exists only in memory.
+Because of the way Nautobot's UUID primary keys are implemented, **this check will not work as expected** because model instances are assigned a UUID *at creation time*, not at the time they are written to the database.
+Instead, for any model which inherits from `nautobot.core.models.BaseModel`, you should check an instance's `present_in_database` property which will be either `True` or `False`.
+
+Wrong:
+
+```python
+if instance.pk:
+    # Are we working with an existing instance in the database?
+    # Actually, the above check doesn't tell us one way or the other!
+    ...
+else:
+    # Will never be reached!
+    ...
+```
+
+Right:
+
+```python
+if instance.present_in_database:
+    # We're working with an existing instance in the database!
+    ...
+else:
+    # We're working with a newly created instance not yet written to the database!
+    ...
+```
+
+!!! note
+    There is one case where a model instance *will* have a null primary key, and that is the case where it has been removed from the database and is in the process of being deleted.
+    For most purposes, this is not the case you are intending to check!
+
 ## Model Validation
 
 Django offers several places and mechanism in which to exert data and model validation. All model specific validation should occur within the model's `clean()` method or field specific validators. This ensures the validation logic runs and is consistent through the various Nautobot interfaces (Web UI, REST API, ORM, etc).

--- a/nautobot/docs/development/best-practices.md
+++ b/nautobot/docs/development/best-practices.md
@@ -5,7 +5,7 @@ While there are many different development interfaces in Nautobot that each expo
 ## Model Existence in the Database
 
 A common Django pattern is to check whether an model instance's primary key (`pk`) field is set as a proxy for whether the instance has been written to the database or whether it exists only in memory.
-Because of the way Nautobot's UUID primary keys are implemented, **this check will not work as expected** because model instances are assigned a UUID *at creation time*, not at the time they are written to the database.
+Because of the way Nautobot's UUID primary keys are implemented, **this check will not work as expected** because model instances are assigned a UUID in memory *at instance creation time*, not at the time they are written to the database (when the model's `save()` method is called).
 Instead, for any model which inherits from `nautobot.core.models.BaseModel`, you should check an instance's `present_in_database` property which will be either `True` or `False`.
 
 Wrong:

--- a/nautobot/docs/development/style-guide.md
+++ b/nautobot/docs/development/style-guide.md
@@ -59,4 +59,4 @@ When adding a new dependency, a short description of the package and the URL of 
 
 * When referring to Nautobot in writing, use the proper form "Nautobot," with the letter N. The lowercase form "nautobot" should be used in code, filenames, etc.
 
-* There is an SVG form of the Nautobot logo at [docs/nautobot_logo.svg](../nautobot_logo.svg). It is preferred to use this logo for all purposes as it scales to arbitrary sizes without loss of resolution. If a raster image is required, the SVG logo should be converted to a PNG image of the prescribed size.
+* There is an SVG form of the Nautobot logo at [nautobot/docs/nautobot_logo.svg](../nautobot_logo.svg). It is preferred to use this logo for all purposes as it scales to arbitrary sizes without loss of resolution. If a raster image is required, the SVG logo should be converted to a PNG image of the prescribed size.

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -67,7 +67,7 @@ class CustomFieldModelForm(forms.ModelForm):
         # Append form fields; assign initial values if modifying and existing object
         for cf in CustomField.objects.filter(content_types=self.obj_type):
             field_name = "cf_{}".format(cf.name)
-            if not self.instance._state.adding:
+            if self.instance.present_in_database:
                 self.fields[field_name] = cf.to_form_field(set_initial=False)
                 self.fields[field_name].initial = self.instance.custom_field_data.get(cf.name)
             else:
@@ -230,7 +230,7 @@ class RelationshipModelForm(forms.ModelForm):
                 self.fields[field_name] = cr.to_form_field(side=side)
 
                 # if the object already exists, populate the field with existing values
-                if not self.instance._state.adding:
+                if self.instance.present_in_database:
                     if cr.has_many(peer_side):
                         initial = [getattr(cra, peer_side) for cra in queryset.all()]
                         self.fields[field_name].initial = initial

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -341,7 +341,7 @@ class Relationship(BaseModel, ChangeLoggedModel):
                     raise ValidationError(f"'{key}' is not a valid filter parameter for {model_name} object")
 
         # If the model already exist, ensure that it's not possible to modify the source or destination type
-        if not self._state.adding:
+        if self.present_in_database:
             nbr_existing_cras = RelationshipAssociation.objects.filter(relationship=self).count()
 
             if nbr_existing_cras and self.__class__.objects.get(pk=self.pk).type != self.type:

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -438,7 +438,7 @@ class ImageAttachmentEditView(generic.ObjectEditView):
     model_form = forms.ImageAttachmentForm
 
     def alter_obj(self, imageattachment, request, args, kwargs):
-        if not imageattachment.pk:
+        if not imageattachment.present_in_database:
             # Assign the parent object based on URL kwargs
             model = kwargs.get("model")
             imageattachment.parent = get_object_or_404(model, pk=kwargs["object_id"])

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -693,7 +693,7 @@ class IPAddressForm(
         self.fields["vrf"].empty_label = "Global"
 
         # Initialize primary_for_parent if IP address is already assigned
-        if (not self.instance._state.adding) and self.instance.assigned_object:
+        if self.instance.present_in_database and self.instance.assigned_object:
             parent = self.instance.assigned_object.parent
             if (
                 self.instance.address.version == 4

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -266,7 +266,7 @@ class Aggregate(PrimaryModel):
 
             # Ensure that the aggregate being added is not covered by an existing aggregate
             covering_aggregates = Aggregate.objects.filter(prefix__net_contains_or_equals=str(self.prefix))
-            if not self._state.adding:
+            if self.present_in_database:
                 covering_aggregates = covering_aggregates.exclude(pk=self.pk)
             if covering_aggregates:
                 raise ValidationError(
@@ -279,7 +279,7 @@ class Aggregate(PrimaryModel):
 
             # Ensure that the aggregate being added does not cover an existing aggregate
             covered_aggregates = Aggregate.objects.filter(prefix__net_contained=str(self.prefix))
-            if not self._state.adding:
+            if self.present_in_database:
                 covered_aggregates = covered_aggregates.exclude(pk=self.pk)
             if covered_aggregates:
                 raise ValidationError(
@@ -770,7 +770,7 @@ class IPAddress(PrimaryModel, StatusModel):
                     )
 
         # Check for primary IP assignment that doesn't match the assigned device/VM
-        if not self._state.adding:
+        if self.present_in_database:
             device = Device.objects.filter(Q(primary_ip4=self) | Q(primary_ip6=self)).first()
             if device:
                 if getattr(self.assigned_object, "device", None) != device:

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -32,7 +32,7 @@ AVAILABLE_LABEL = mark_safe('<span class="label label-success">Available</span>'
 
 UTILIZATION_GRAPH = """
 {% load helpers %}
-{% if record.pk %}{% utilization_graph record.get_utilization %}{% else %}&mdash;{% endif %}
+{% if record.present_in_database %}{% utilization_graph record.get_utilization %}{% else %}&mdash;{% endif %}
 """
 
 PREFIX_LINK = """
@@ -40,7 +40,7 @@ PREFIX_LINK = """
 {% for i in record.parents|as_range %}
     <i class="mdi mdi-circle-small"></i>
 {% endfor %}
-<a href="{% if record.pk %}{% url 'ipam:prefix' pk=record.pk %}{% else %}{% url 'ipam:prefix_add' %}?prefix={{ record }}{% if parent.vrf %}&vrf={{ parent.vrf.pk }}{% endif %}{% if parent.site %}&site={{ parent.site.pk }}{% endif %}{% if parent.tenant %}&tenant_group={{ parent.tenant.group.pk }}&tenant={{ parent.tenant.pk }}{% endif %}{% endif %}">{{ record.prefix }}</a>
+<a href="{% if record.present_in_database %}{% url 'ipam:prefix' pk=record.pk %}{% else %}{% url 'ipam:prefix_add' %}?prefix={{ record }}{% if parent.vrf %}&vrf={{ parent.vrf.pk }}{% endif %}{% if parent.site %}&site={{ parent.site.pk }}{% endif %}{% if parent.tenant %}&tenant_group={{ parent.tenant.group.pk }}&tenant={{ parent.tenant.pk }}{% endif %}{% endif %}">{{ record.prefix }}</a>
 """
 
 PREFIX_ROLE_LINK = """
@@ -52,7 +52,7 @@ PREFIX_ROLE_LINK = """
 """
 
 IPADDRESS_LINK = """
-{% if record.pk %}
+{% if record.present_in_database %}
     <a href="{{ record.get_absolute_url }}">{{ record.address }}</a>
 {% elif perms.ipam.add_ipaddress %}
     <a href="{% url 'ipam:ipaddress_add' %}?address={{ record.1 }}{% if prefix.vrf %}&vrf={{ prefix.vrf.pk }}{% endif %}{% if prefix.tenant %}&tenant={{ prefix.tenant.pk }}{% endif %}" class="btn btn-xs btn-success">{% if record.0 <= 65536 %}{{ record.0 }}{% else %}Many{% endif %} IP{{ record.0|pluralize }} available</a>
@@ -84,7 +84,7 @@ VRF_TARGETS = """
 """
 
 VLAN_LINK = """
-{% if record.pk %}
+{% if record.present_in_database %}
     <a href="{{ record.get_absolute_url }}">{{ record.vid }}</a>
 {% elif perms.ipam.add_vlan %}
     <a href="{% url 'ipam:vlan_add' %}?vid={{ record.vid }}&group={{ vlan_group.pk }}{% if vlan_group.site %}&site={{ vlan_group.site.pk }}{% endif %}" class="btn btn-xs btn-success">{{ record.available }} VLAN{{ record.available|pluralize }} available</a>
@@ -348,7 +348,7 @@ class PrefixTable(StatusTableMixin, BaseTable):
             "description",
         )
         row_attrs = {
-            "class": lambda record: "success" if not record.pk else "",
+            "class": lambda record: "success" if not record.present_in_database else "",
         }
 
 

--- a/nautobot/users/admin.py
+++ b/nautobot/users/admin.py
@@ -169,7 +169,7 @@ class ObjectPermissionForm(forms.ModelForm):
         self.fields["users"].queryset = self.fields["users"].queryset.order_by("username")
 
         # Check the appropriate checkboxes when editing an existing ObjectPermission
-        if not self.instance._state.adding:
+        if self.instance.present_in_database:
             for action in ["view", "add", "change", "delete"]:
                 if action in self.instance.actions:
                     self.fields[f"can_{action}"].initial = True

--- a/nautobot/utilities/views.py
+++ b/nautobot/utilities/views.py
@@ -110,10 +110,10 @@ class GetReturnURLMixin:
             return query_param
 
         # Next, check if the object being modified (if any) has an absolute URL.
-        # Note that the use of both `obj._state.adding` and `obj.pk` is correct here because this conditional
+        # Note that the use of both `obj.present_in_database` and `obj.pk` is correct here because this conditional
         # handles all three of the create, update, and delete operations. When Django deletes an instance
         # from the DB, it sets the instance's PK field to None, regardless of the use of a UUID.
-        if obj is not None and not obj._state.adding and obj.pk and hasattr(obj, "get_absolute_url"):
+        if obj is not None and obj.present_in_database and obj.pk and hasattr(obj, "get_absolute_url"):
             return obj.get_absolute_url()
 
         # Fall back to the default URL (if specified) for the view.

--- a/nautobot/virtualization/forms.py
+++ b/nautobot/virtualization/forms.py
@@ -310,7 +310,7 @@ class VirtualMachineForm(BootstrapMixin, TenancyForm, CustomFieldModelForm, Rela
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if not self.instance._state.adding:
+        if self.instance.present_in_database:
 
             # Compile list of choices for primary IPv4 and IPv6 addresses
             for family in [4, 6]:

--- a/nautobot/virtualization/models.py
+++ b/nautobot/virtualization/models.py
@@ -175,7 +175,7 @@ class Cluster(PrimaryModel):
         super().clean()
 
         # If the Cluster is assigned to a Site, verify that all host Devices belong to that Site.
-        if (not self._state.adding) and self.site:
+        if self.present_in_database and self.site:
             nonsite_devices = Device.objects.filter(cluster=self).exclude(site=self.site).count()
             if nonsite_devices:
                 raise ValidationError(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #53
<!--
    Please include a summary of the proposed changes below.
-->

- Create a `present_in_database` property on the `BaseModel` class - this is a simple wrapper for `not self._state.adding`, but it's more readable, and it's needed for anywhere in template code since templates don't allow us to reference sunder-prefixed variable names directly.
- Replace all existent `_state.adding` checks with `present_in_database` checks for readability - note that the logic needs to be reversed in each such case, as `present_in_database == not _state.adding`. **Please double-check to make sure I've handled this correctly in each case!**
- Fixed every place I could find where we had checks of the form `if [not] instance.pk:`, `if instance.pk is [not] None` to use the `present_in_database` property for correct behavior. Places where this demonstrably fixed incorrect behavior include:
  - adding an image attachment to a device (was throwing an error previously)
  - listing prefixes within an aggregate (unallocated prefixes were not being displayed correctly)
  - listing addresses within a prefix (unallocated addresses were not being displayed correctly)

![image](https://user-images.githubusercontent.com/5603551/109507196-77ce5680-7a6c-11eb-92bc-3197f46ebe79.png)

![image](https://user-images.githubusercontent.com/5603551/109507068-58cfc480-7a6c-11eb-8576-964cfa8d6652.png)

![image](https://user-images.githubusercontent.com/5603551/109507113-62592c80-7a6c-11eb-84c0-0da9fe47699f.png)
