### PR TITLE
Make PR template less dogmatic; add '#' before issue number for clarity

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,13 @@
 <!--
     Thank you for your interest in contributing to Nautobot! Please note
-    that our contribution policy requires that a feature request or bug
+    that our contribution policy recommends that a feature request or bug
     report be opened for approval prior to filing a pull request. This
     helps avoid wasting time and effort on something that we might not
     be able to accept.
 
     Please indicate the relevant feature request or bug report below.
-    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
-    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
 -->
-### Fixes: <ISSUE NUMBER GOES HERE>
+### Fixes: #<ISSUE NUMBER GOES HERE>
 <!--
     Please include a summary of the proposed changes below.
 -->


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: N/A
<!--
    Please include a summary of the proposed changes below.
-->

- Add a `#` before the `<ISSUE NUMBER GOES HERE>` so that issue number references will be appropriately hyperlinked.
- Update some wording to reflect our updated contributing guidelines.