### PR TITLE
Fix logic for UI buttons in interface edit

### DIFF
--- a/nautobot/dcim/templates/dcim/interface_edit.html
+++ b/nautobot/dcim/templates/dcim/interface_edit.html
@@ -38,7 +38,7 @@
 {% endblock %}
 
 {% block buttons %}
-    {% if not editing %}
+    {% if editing %}
         <button type="submit" name="_update" class="btn btn-primary">Update</button>
         <button type="submit" formaction="?return_url={% url 'dcim:interface_edit' pk=obj.pk %}" class="btn btn-primary">Update and Continue Editing</button>
     {% else %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #45
<!--
    Please include a summary of the proposed changes below.
-->
UI was displaying "Create" buttons when editing an existing interface due to wrong logic in template.