### PR TITLE
Fix VSCode dev container integration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,14 +8,12 @@
 		"eamodio.gitlens",
 		"oderwat.indent-rainbow",
 		"ms-python.python",
-		"ms-vsliveshare.vsliveshare",
-		"littlefoxteam.vscode-python-test-adapter"
+		"ms-vsliveshare.vsliveshare"
 	],
 	"settings": {
 		"python.pythonPath": "/usr/local/bin/python",
 		"python.analysis.extraPaths": ["/opt/nautobot"],
 		"python.linting.pylintEnabled": true,
-		"python.linting.enabled": true,
-		"pythonTestExplorer.testFramework": "pytest"
+		"python.linting.enabled": true
 	}
 }

--- a/development/docker-compose.debug.yml
+++ b/development/docker-compose.debug.yml
@@ -1,6 +1,5 @@
 ---
-version: '3'
+version: "3"
 services:
   nautobot:
-    command: >
-      /bin/sh -c "while sleep 1000; do :; done"
+    command: "sleep infinity"

--- a/nautobot.code-workspace
+++ b/nautobot.code-workspace
@@ -6,8 +6,7 @@
 	],
 	"settings": {
 		"python.linting.pylintEnabled": true,
-		"python.linting.enabled": true,
-		"pythonTestExplorer.testFramework": "pytest"
+		"python.linting.enabled": true
 	},
 	"launch": {
 		"version": "0.2.0",
@@ -22,7 +21,12 @@
 					"runserver",
 					"0.0.0.0:8000"
 				],
-				"django": true
+				"django": true,
+				"serverReadyAction": {
+					"action": "openExternally",
+					"pattern": "Starting development server at (https?://\\S+|[0-9]+)",
+					"uriFormat": "%s"
+				}
 			}
 		]
 	}

--- a/nautobot.code-workspace
+++ b/nautobot.code-workspace
@@ -15,7 +15,7 @@
 				"name": "Python: Nautobot",
 				"type": "python",
 				"request": "launch",
-				"program": "nautobot-server",
+				"program": "/usr/local/bin/nautobot-server",
 				"console": "integratedTerminal",
 				"args": [
 					"runserver",

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -95,6 +95,14 @@ These will create the user with the specified username, email, password, and API
 
 After these two files are created, you can use the normal **invoke** commands to manage the development containers.
 
+### Docker Development - Microsoft Visual Studio Code
+
+The `devcontainer.json` and `nautobot.code-workspace` files are provided to ease development when using VS Code and the Remote-Containers extension. After opening the project directory in VS Code in a
+supported environment, you will be prompted by VS Code to "Reopen in Container" and "Open Workspace". Select "Reopen in Container" to build and start the dev containers. Once your window is
+connected to the container, you can open the workspace which enables support for Run/Debug.
+
+To start Nautobot, select "Run Without Debugging" or "Start Debugging" from the Run menu. Once Nautobot has started, you will be prompted to open a browser to connect to Nautobot.
+
 ### Python Virtual Environment Workflow
 
 There are a few things you'll need:
@@ -123,7 +131,7 @@ A [virtual environment](https://docs.python.org/3/tutorial/venv.html) is like a 
 
 For Nautobot development, we have selected Poetry, which will transparently create a virtualenv for you, automatically install all dependencies required for Nautobot to operate, and will also install the `nautobot-server` CLI command that you will utilize to interact with Nautobot from here on out.
 
-Bootstrap your virtual environment using `poetry install`. 
+Bootstrap your virtual environment using `poetry install`.
 
 ```bash
 $ poetry install


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #51 
<!--
    Please include a summary of the proposed changes below.
-->
This PR updates the VSCode development container integration to work properly on both Windows 10/WSL2 and Mac including Run/Debug.

The following changes were implemented:

1. Fix the debug Dockerfile command to properly sleep and allow Nautobot to be started/stopped without the container being stopped.
2. Adjust paths for use within the container.
3. Add feature to prompt opening a browser when Nautobot is started via Run/Debug.
