### PR TITLE
Development workflow improvements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,16 @@
+[flake8]
+ignore =
+    # E203 whitespace before ':' (per Black, this is actually correct in some cases)
+    E203,
+    # F401 module imported but unused (TODO: fix and re-enable this one)
+    F401,
+    # F403 'from module import *' used (TODO: fix and re-enable this one)
+    F403,
+    # F405 name may be undefined or defined from star imports (TODO: fix and re-enable this one)
+    F405,
+    # E501 line greater than 80 characters in length (we use a 120-character line length, enforced by Black)
+    E501,
+    # W503 line break before binary operator (per Black, this is actually correct in some cases)
+    W503,
+    # W504 line break after binary operator (per Black, this is actually correct in some cases)
+    W504

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -33,11 +33,13 @@ RUN poetry config installer.parallel false
 # Used if someone wants to override the entrypoint and provision a super user
 COPY development/docker-entrypoint.sh /tmp/nautobot/docker-entrypoint.sh
 
-COPY . /opt/nautobot
+COPY pyproject.toml poetry.lock /opt/nautobot/
 WORKDIR /opt/nautobot
+
+RUN poetry install --no-root
+
+COPY . /opt/nautobot
 
 RUN poetry install
-
-WORKDIR /opt/nautobot
 
 ENTRYPOINT ["/tmp/nautobot/docker-entrypoint.sh"]

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -3,6 +3,8 @@ from distutils.util import strtobool
 import os
 import sys
 
+from nautobot.core.settings import *
+
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split(" ")
 
 DATABASES = {
@@ -96,10 +98,15 @@ RQ_QUEUES = {
 # REDIS CACHEOPS
 CACHEOPS_REDIS = f"redis://:{os.getenv('REDIS_PASSWORD')}@{os.getenv('REDIS_HOST')}:{os.getenv('REDIS_PORT')}/2"
 
+HIDE_RESTRICTED_UI = os.environ.get("HIDE_RESTRICTED_UI", False)
 
 SECRET_KEY = os.environ.get("SECRET_KEY", "")
 
 # Django Debug Toolbar
 TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
 DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG and not TESTING}
-HIDE_RESTRICTED_UI = os.environ.get("HIDE_RESTRICTED_UI", False)
+
+if "debug_toolbar" not in INSTALLED_APPS:
+    INSTALLED_APPS.append("debug_toolbar")
+if "debug_toolbar.middleware.DebugToolbarMiddleware" not in MIDDLEWARE:
+    MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")

--- a/nautobot/core/graphql/__init__.py
+++ b/nautobot/core/graphql/__init__.py
@@ -12,7 +12,7 @@ def convert_field_to_string(field, registry=None):
     return generic.GenericScalar()
 
 
-@convert_django_field.register(BinaryField)
+@convert_django_field.register(BinaryField)  # noqa: F811
 def convert_field_to_string(field, registry=None):  # noqa: F811
     """Convert BinaryField to String."""
     return graphene.String()

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -311,7 +311,6 @@ INSTALLED_APPS = [
     "django.contrib.humanize",
     "cacheops",
     "corsheaders",
-    "debug_toolbar",
     "django_filters",
     "django_tables2",
     "django_prometheus",
@@ -335,7 +334,6 @@ INSTALLED_APPS = [
 
 # Middleware
 MIDDLEWARE = [
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/nautobot/core/urls.py
+++ b/nautobot/core/urls.py
@@ -82,11 +82,14 @@ _patterns = [
 
 
 if settings.DEBUG:
-    import debug_toolbar
+    try:
+        import debug_toolbar
 
-    _patterns += [
-        path("__debug__/", include(debug_toolbar.urls)),
-    ]
+        _patterns += [
+            path("__debug__/", include(debug_toolbar.urls)),
+        ]
+    except ImportError:
+        pass
 
 if settings.METRICS_ENABLED:
     _patterns += [

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -263,7 +263,8 @@ HTTP_PROXIES = {
 Default: `('127.0.0.1', '::1')`
 
 A list of IP addresses recognized as internal to the system, used to control the display of debugging output. For
-example, the debugging toolbar will be viewable only when a client is accessing Nautobot from one of the listed IP
+example, the [Django debugging toolbar](https://django-debug-toolbar.readthedocs.io/), if installed,
+will be viewable only when a client is accessing Nautobot from one of the listed IP
 addresses (and [`DEBUG`](#debug) is true).
 
 ---

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -191,8 +191,8 @@ The newly created configuration includes sane defaults. If you need to customize
 * `ALLOWED_HOSTS`: This can be set to `['*']` for development purposes and must be set if `DEBUG=False`
 * `DATABASES`: PostgreSQL database connection parameters, if different from the defaults
 * `REDIS`: Redis configuration, if different from the defaults
-* `DEBUG`: Set to `True` to enable verbose exception logging and the [Django debug toolbar](https://django-debug-toolbar.readthedocs.io/en/latest/)
-* `EXTRA_INSTALLLED_APPS`: Optionally provide a list of extra Django apps/plugins you may desire to use for development
+* `DEBUG`: Set to `True` to enable verbose exception logging and, if installed, the [Django debug toolbar](https://django-debug-toolbar.readthedocs.io/en/latest/)
+* `EXTRA_INSTALLED_APPS`: Optionally provide a list of extra Django apps/plugins you may desire to use for development
 
 #### Starting the Development Server
 

--- a/nautobot/docs/development/style-guide.md
+++ b/nautobot/docs/development/style-guide.md
@@ -1,31 +1,31 @@
 # Style Guide
 
-Nautobot generally follows the [Django style guide](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/coding-style/), which is itself based on [PEP 8](https://www.python.org/dev/peps/pep-0008/). [Pycodestyle](https://github.com/pycqa/pycodestyle) is used to validate code formatting, ignoring certain violations. See `scripts/cibuild.sh`.
+Nautobot generally follows the [Django style guide](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/coding-style/), which is itself based on [PEP 8](https://www.python.org/dev/peps/pep-0008/). [Flake8](https://flake8.pycqa.org/) is used to validate code style, ignoring certain violations, and [Black](https://black.readthedocs.io/) is used to enforce code formatting conventions. See `scripts/cibuild.sh` and `tasks.py`.
 
-## PEP 8 Exceptions
+## Flake8 Exceptions
 
-* Wildcard imports (for example, `from .constants import *`) are acceptable under any of the following conditions:
-    * The library being import contains only constant declarations (e.g. `constants.py`)
-    * The library being imported explicitly defines `__all__`
-
+* Whitespace before ':' is permitted (E203) as Black maintains that there are cases where this is the preferred style.
+* Imported-but-unused modules (F401) are currently not flagged, but we want to fix this in the future.
+* Wildcard imports (for example `from .constants import *`, F403) are currently not flagged, as this is a pattern inherited from NetBox's coding style, but we want to change this in the future, and recommend against introducing this pattern in any new code.
+* "Name may be undefined or defined from star imports" (F405) is currently not flagged due to the previous item; we plan to
+enable this check after changing the above import pattern.
 * Maximum line length is 120 characters (E501)
-    * This does not apply to HTML templates or to automatically generated code (e.g. database migrations).
-
-* Line breaks are permitted following binary operators (W504)
+* Line breaks are permitted both before (W503) and after (W504) binary operators.
 
 ## Enforcing Code Style
 
-The `pycodestyle` utility (previously `pep8`) is used by the CI process to enforce code style. It is strongly recommended to include as part of your commit process. A git commit hook is provided in the source at `scripts/git-hooks/pre-commit`. Linking to this script from `.git/hooks/` will invoke `pycodestyle` prior to every commit attempt and abort if the validation fails.
+The `flake8` and `black` utilities are used by the CI process to enforce code style. It is strongly recommended to include both as part of your commit process. A git commit hook is provided in the source at `scripts/git-hooks/pre-commit`. Linking to this script from `.git/hooks/` will invoke `flake8` and `black --check` prior to every commit attempt and abort if the validation fails.
 
 ```
 $ cd .git/hooks/
 $ ln -s ../../scripts/git-hooks/pre-commit
 ```
 
-To invoke `pycodestyle` manually, run:
+You can also invoke these utilities manually against the development Docker containers by running:
 
 ```
-pycodestyle --ignore=W504,E501 ./
+invoke flake8
+invoke black
 ```
 
 ## Introducing New Dependencies
@@ -39,7 +39,7 @@ If there's a strong case for introducing a new dependency, it must meet the foll
 * It must be actively maintained, with no longer than one year between releases.
 * It must be available via the [Python Package Index](https://pypi.org/) (PyPI).
 
-When adding a new dependency, a short description of the package and the URL of its code repository must be added to `base_requirements.txt`. Additionally, a line specifying the package name pinned to the current stable release must be added to `requirements.txt`. This ensures that Nautobot will install only the known-good release and simplify support efforts.
+New dependencies can be added to the project via the `poetry add` command. This will correctly add the dependency to `pyproject.toml` as well as the `poetry.lock` file. You should then update the `pyproject.toml` with a comment providing a short description of the package and/or how Nautobot is making use of it.
 
 ## General Guidance
 

--- a/nautobot/ipam/graphql/types.py
+++ b/nautobot/ipam/graphql/types.py
@@ -14,7 +14,7 @@ def convert_field_to_string(field, registry=None):
     return graphene.String()
 
 
-@convert_django_field.register(IPNetworkField)
+@convert_django_field.register(IPNetworkField)  # noqa: F811
 def convert_field_to_string(field, registry=None):  # noqa: F811
     """Convert IPNetworkField to String."""
     return graphene.String()

--- a/poetry.lock
+++ b/poetry.lock
@@ -229,7 +229,7 @@ django-appconf = "*"
 name = "django-debug-toolbar"
 version = "3.2"
 description = "A configurable set of panels that display various debug information about the current request/response."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -1099,7 +1099,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "912e1fb7b4903230c4edb2ccc09f1e0cc2ca00948e346be146ff9a8d34117592"
+content-hash = "1948cde239a87bd4c75d3dff3c9ba32af781db611586447ae1c5f8ad6768195d"
 
 [metadata.files]
 aniso8601 = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -381,6 +381,20 @@ uritemplate = ">=3.0.0"
 validation = ["swagger-spec-validator (>=2.1.0)"]
 
 [[package]]
+name = "flake8"
+version = "3.8.4"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.6.0a1,<2.7.0"
+pyflakes = ">=2.2.0,<2.3.0"
+
+[[package]]
 name = "funcy"
 version = "1.15"
 description = "A fancy and practical functional tools"
@@ -668,6 +682,14 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
 [[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "mkdocs"
 version = "1.1.2"
 description = "Project documentation with Markdown."
@@ -808,6 +830,14 @@ description = "Cryptographic library for Python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.2.0"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyparsing"
@@ -1069,7 +1099,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "8e1b3caa91b8d3cc097ac172b0765cd8d6521f7253e6d02e8831a4057a407089"
+content-hash = "912e1fb7b4903230c4edb2ccc09f1e0cc2ca00948e346be146ff9a8d34117592"
 
 [metadata.files]
 aniso8601 = [
@@ -1203,11 +1233,16 @@ coverage = [
 ]
 cryptography = [
     {file = "cryptography-3.4.6-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:57ad77d32917bc55299b16d3b996ffa42a1c73c6cfa829b14043c561288d2799"},
+    {file = "cryptography-3.4.6-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:4169a27b818de4a1860720108b55a2801f32b6ae79e7f99c00d79f2a2822eeb7"},
     {file = "cryptography-3.4.6-cp36-abi3-manylinux2010_x86_64.whl", hash = "sha256:93cfe5b7ff006de13e1e89830810ecbd014791b042cbe5eec253be11ac2b28f3"},
     {file = "cryptography-3.4.6-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:5ecf2bcb34d17415e89b546dbb44e73080f747e504273e4d4987630493cded1b"},
     {file = "cryptography-3.4.6-cp36-abi3-manylinux2014_x86_64.whl", hash = "sha256:fec7fb46b10da10d9e1d078d1ff8ed9e05ae14f431fdbd11145edd0550b9a964"},
     {file = "cryptography-3.4.6-cp36-abi3-win32.whl", hash = "sha256:df186fcbf86dc1ce56305becb8434e4b6b7504bc724b71ad7a3239e0c9d14ef2"},
     {file = "cryptography-3.4.6-cp36-abi3-win_amd64.whl", hash = "sha256:66b57a9ca4b3221d51b237094b0303843b914b7d5afd4349970bb26518e350b0"},
+    {file = "cryptography-3.4.6-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:066bc53f052dfeda2f2d7c195cf16fb3e5ff13e1b6b7415b468514b40b381a5b"},
+    {file = "cryptography-3.4.6-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:600cf9bfe75e96d965509a4c0b2b183f74a4fa6f5331dcb40fb7b77b7c2484df"},
+    {file = "cryptography-3.4.6-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:0923ba600d00718d63a3976f23cab19aef10c1765038945628cd9be047ad0336"},
+    {file = "cryptography-3.4.6-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:9e98b452132963678e3ac6c73f7010fe53adf72209a32854d55690acac3f6724"},
     {file = "cryptography-3.4.6.tar.gz", hash = "sha256:2d32223e5b0ee02943f32b19245b61a62db83a882f0e76cc564e1cec60d48f87"},
 ]
 dataclasses = [
@@ -1280,6 +1315,10 @@ djangorestframework = [
 drf-yasg = [
     {file = "drf-yasg-1.20.0.tar.gz", hash = "sha256:d50f197c7f02545d0b736df88c6d5cf874f8fea2507ad85ad7de6ae5bf2d9e5a"},
     {file = "drf_yasg-1.20.0-py2.py3-none-any.whl", hash = "sha256:8b72e5b1875931a8d11af407be3a9a5ba8776541492947a0df5bafda6b7f8267"},
+]
+flake8 = [
+    {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
+    {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
 funcy = [
     {file = "funcy-1.15-py2.py3-none-any.whl", hash = "sha256:c247c3d085e03a89974e0c9e8331e9a79db3768a263556ba896d6c92d665bba2"},
@@ -1386,40 +1425,25 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mkdocs = [
     {file = "mkdocs-1.1.2-py3-none-any.whl", hash = "sha256:096f52ff52c02c7e90332d2e53da862fde5c062086e1b5356a6e392d5d60f5e9"},
@@ -1562,6 +1586,10 @@ pycryptodome = [
     {file = "pycryptodome-3.10.1-pp36-pypy36_pp73-win32.whl", hash = "sha256:6bbf7fee7b7948b29d7e71fcacf48bac0c57fb41332007061a933f2d996f9713"},
     {file = "pycryptodome-3.10.1.tar.gz", hash = "sha256:3e2e3a06580c5f190df843cdb90ea28d61099cf4924334d5297a995de68e4673"},
 ]
+pyflakes = [
+    {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
+    {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
+]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
@@ -1663,29 +1691,20 @@ rq = [
     {file = "ruamel.yaml.clib-0.2.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:73b3d43e04cc4b228fa6fa5d796409ece6fcb53a6c270eb2048109cbcbc3b9c2"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:53b9dd1abd70e257a6e32f934ebc482dac5edb8c93e23deb663eac724c30b026"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:839dd72545ef7ba78fd2aa1a5dd07b33696adf3e68fae7f31327161c1093001b"},
-    {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1236df55e0f73cd138c0eca074ee086136c3f16a97c2ac719032c050f7e0622f"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-win32.whl", hash = "sha256:b1e981fe1aff1fd11627f531524826a4dcc1f26c726235a52fcb62ded27d150f"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-win_amd64.whl", hash = "sha256:4e52c96ca66de04be42ea2278012a2342d89f5e82b4512fb6fb7134e377e2e62"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a873e4d4954f865dcb60bdc4914af7eaae48fb56b60ed6daa1d6251c72f5337c"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ab845f1f51f7eb750a78937be9f79baea4a42c7960f5a94dde34e69f3cce1988"},
-    {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2fd336a5c6415c82e2deb40d08c222087febe0aebe520f4d21910629018ab0f3"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-win32.whl", hash = "sha256:e9f7d1d8c26a6a12c23421061f9022bb62704e38211fe375c645485f38df34a2"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:2602e91bd5c1b874d6f93d3086f9830f3e907c543c7672cf293a97c3fabdcd91"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:44c7b0498c39f27795224438f1a6be6c5352f82cb887bc33d962c3a3acc00df6"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8e8fd0a22c9d92af3a34f91e8a2594eeb35cba90ab643c5e0e643567dc8be43e"},
-    {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:75f0ee6839532e52a3a53f80ce64925ed4aed697dd3fa890c4c918f3304bd4f4"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-win32.whl", hash = "sha256:464e66a04e740d754170be5e740657a3b3b6d2bcc567f0c3437879a6e6087ff6"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:52ae5739e4b5d6317b52f5b040b1b6639e8af68a5b8fd606a8b08658fbd0cab5"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4df5019e7783d14b79217ad9c56edf1ba7485d614ad5a385d1b3c768635c81c0"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5254af7d8bdf4d5484c089f929cb7f5bafa59b4f01d4f48adda4be41e6d29f99"},
-    {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8be05be57dc5c7b4a0b24edcaa2f7275866d9c907725226cdde46da09367d923"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-win32.whl", hash = "sha256:74161d827407f4db9072011adcfb825b5258a5ccb3d2cd518dd6c9edea9e30f1"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:058a1cc3df2a8aecc12f983a48bda99315cebf55a3b3a5463e37bb599b05727b"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c6ac7e45367b1317e56f1461719c853fd6825226f45b835df7436bb04031fd8a"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b4b0d31f2052b3f9f9b5327024dc629a253a83d8649d4734ca7f35b60ec3e9e5"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1f8c0a4577c0e6c99d208de5c4d3fd8aceed9574bb154d7a2b21c16bb924154c"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-win32.whl", hash = "sha256:46d6d20815064e8bb023ea8628cfb7402c0f0e83de2c2227a88097e239a7dffd"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:6c0a5dc52fc74eb87c67374a4e554d4761fd42a4d01390b7e868b30d21f4b8bb"},
     {file = "ruamel.yaml.clib-0.2.2.tar.gz", hash = "sha256:2d24bd98af676f4990c4d715bcdc2a60b19c56a3fb3a763164d2d8ca0e806ba7"},
 ]
 rx = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,6 @@ django-cacheops = "~5.1"
 django-cors-headers = "~3.7.0"
 # Support for encrypted database fields
 django-cryptography = "~1.0"
-# Tool for debugging Django
-django-debug-toolbar = "~3.2"
 # Advanced query filters
 django-filter = "~2.4.0"
 # Modified Preorder Tree Traversal - tree structure for Region, RackGroup, etc.
@@ -91,6 +89,8 @@ svgwrite = "~1.4.1"
 black = "^20.8b1"
 # Test code coverage measurement
 coverage = "~5.4"
+# Tool for debugging Django
+django-debug-toolbar = "^3.2"
 # Code style checking and limited static analysis
 flake8 = "^3.8.4"
 # Alternative to Make, CLI based on `tasks.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,41 +31,74 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
+# Fundamental web framework for Nautobot
 Django = "~3.1.7"
+# Caching with Redis
 django-cacheops = "~5.1"
+# Permit cross-domain API requests
 django-cors-headers = "~3.7.0"
+# Support for encrypted database fields
 django-cryptography = "~1.0"
+# Tool for debugging Django
 django-debug-toolbar = "~3.2"
+# Advanced query filters
 django-filter = "~2.4.0"
+# Modified Preorder Tree Traversal - tree structure for Region, RackGroup, etc.
 django-mptt = "~0.11.0"
+# PostgreSQL advisory lock handling
 django-pglocks = "~1.0.4"
+# Prometheus metrics for Django
 django-prometheus = "~2.1.0"
+# RQ (Redis Queueing) for background handlin of webhooks, jobs, etc.
 django-rq = "^2.4.0"
+# Advanced HTML tables
 django-tables2 = "~2.3.4"
+# Tags
 django-taggit = "~1.3.0"
+# Represent time zones in Django
 django-timezone-field = "~4.1.1"
+# REST API framework
 djangorestframework = "~3.12.2"
+# Swagger schema generation for the REST API
 drf-yasg = {extras = ["validation"], version = "~1.20.0"}
+# Git integrations for Python
 GitPython = "~3.1.13"
+# GraphQL support
 graphene-django = "~2.15.0"
+# WSGI HTTP server
 gunicorn = "~20.0.4"
+# Package version detection in older versions of Python
 importlib-metadata = {version = "~3.4.0", python = "<3.8"}
+# Template rendering engine
 Jinja2 = "~2.11.3"
+# Rendering of markdown files to HTML
 Markdown = "~3.3.3"
+# IP prefix and address handling
 netaddr = "~0.8.0"
+# Image processing library
 Pillow = "~8.1.0"
+# PostgreSQL database adapter
 psycopg2-binary = "~2.8.6"
+# Cryptographic library
 pycryptodome = "~3.10.1"
+# YAML parsing and rendering
 PyYAML = "~5.4.1"
+# Rendering of SVG images (for rack elevations, etc.)
 svgwrite = "~1.4.1"
 
 [tool.poetry.dev-dependencies]
-pycodestyle = "~2.6.0"
-coverage = "~5.4"
-invoke = "~1.5.0"
+# Code style enforcement
 black = "^20.8b1"
-mkdocs = "~1.1.2"
+# Test code coverage measurement
+coverage = "~5.4"
+# Code style checking and limited static analysis
+flake8 = "^3.8.4"
+# Alternative to Make, CLI based on `tasks.py`
+invoke = "~1.5.0"
+# Allow Markdown files to include other files
 markdown-include = "~0.6.0"
+# Rendering docs to HTML
+mkdocs = "~1.1.2"
 
 [tool.poetry.scripts]
 nautobot-server = "nautobot.core.cli:main"

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -24,11 +24,14 @@ fi
 # Check all built-in python source files for PEP 8 compliance, but explicitly
 # ignore:
 #  - E203: whitespace before ':' (because Black sometimes does this)
+#  - F401: module imported but unused (TODO: fix and re-enable this one)
+#  - F403: 'from module import *' used (TODO: fix and re-enable this one)
+#  - F405: name may be undefined or defined from star imports (TODO: fix and re-enable this one)
 #  - E501: line greater than 80 characters in length
 #  - W503: line break before binary operator
 #  - W504: line break after binary operator
-pycodestyle \
-    --ignore=E203,E501,W503,W504 \
+flake8 \
+    --ignore=E203,F401,F403,F405,E501,W503,W504 \
     contrib/ development/ nautobot/ tasks.py
 RC=$?
 if [[ $RC != 0 ]]; then

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -21,18 +21,8 @@ if [[ ! -z $SYNTAX ]]; then
 	EXIT=1
 fi
 
-# Check all built-in python source files for PEP 8 compliance, but explicitly
-# ignore:
-#  - E203: whitespace before ':' (because Black sometimes does this)
-#  - F401: module imported but unused (TODO: fix and re-enable this one)
-#  - F403: 'from module import *' used (TODO: fix and re-enable this one)
-#  - F405: name may be undefined or defined from star imports (TODO: fix and re-enable this one)
-#  - E501: line greater than 80 characters in length
-#  - W503: line break before binary operator
-#  - W504: line break after binary operator
-flake8 \
-    --ignore=E203,F401,F403,F405,E501,W503,W504 \
-    contrib/ development/ nautobot/ tasks.py
+# Check all built-in python source files for PEP 8 compliance
+flake8 contrib/ development/ nautobot/ tasks.py
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more PEP 8 errors detected; failing build."

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,11 +1,15 @@
 #!/bin/sh
 # Create a link to this file at .git/hooks/pre-commit to
-# force PEP8 validation prior to committing
+# force PEP8 and Black style validation prior to committing
 #
 # Ignored violations:
-#
-#   W504: Line break after binary operator
-#   E501: Line too long
+#  - E203: whitespace before ':' (because Black sometimes does this)
+#  - F401: module imported but unused (TODO: fix and re-enable this one)
+#  - F403: 'from module import *' used (TODO: fix and re-enable this one)
+#  - F405: name may be undefined or defined from star imports (TODO: fix and re-enable this one)
+#  - E501: line greater than 80 characters in length
+#  - W503: line break before binary operator
+#  - W504: line break after binary operator
 
 exec 1>&2
 
@@ -23,11 +27,17 @@ if [ -d ./venv/ ]; then
 fi
 
 echo "Validating PEP8 compliance..."
-pycodestyle \
-    --ignore=W504,E501 \
+flake8 \
+    --ignore=E203,F401,F403,F405,E501,W503,W504 \
     contrib/ development/ nautobot/ tasks.py
 if [ $? != 0 ]; then
 	EXIT=1
+fi
+
+# Check that all files conform to Black.
+black --check contrib/ development/ nautobot/ tasks.py
+if [[ $? != 0 ]]; then
+    EXIT=1
 fi
 
 echo "Checking for missing migrations..."

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,15 +1,6 @@
 #!/bin/sh
 # Create a link to this file at .git/hooks/pre-commit to
 # force PEP8 and Black style validation prior to committing
-#
-# Ignored violations:
-#  - E203: whitespace before ':' (because Black sometimes does this)
-#  - F401: module imported but unused (TODO: fix and re-enable this one)
-#  - F403: 'from module import *' used (TODO: fix and re-enable this one)
-#  - F405: name may be undefined or defined from star imports (TODO: fix and re-enable this one)
-#  - E501: line greater than 80 characters in length
-#  - W503: line break before binary operator
-#  - W504: line break after binary operator
 
 exec 1>&2
 
@@ -27,9 +18,7 @@ if [ -d ./venv/ ]; then
 fi
 
 echo "Validating PEP8 compliance..."
-flake8 \
-    --ignore=E203,F401,F403,F405,E501,W503,W504 \
-    contrib/ development/ nautobot/ tasks.py
+flake8 contrib/ development/ nautobot/ tasks.py
 if [ $? != 0 ]; then
 	EXIT=1
 fi

--- a/tasks.py
+++ b/tasks.py
@@ -237,10 +237,7 @@ def flake8(context, python_ver=PYTHON_VER):
         python_ver (str): Will use the Python version docker image to build from
     """
     context.run(
-        f"{COMPOSE_COMMAND} run nautobot"
-        # TODO: we eventually want to re-enable F401,F403,F405 at least
-        " flake8 --ignore=E203,F401,F403,F405,E501,W503,W504 --exclude '*migrations*'"
-        " contrib/ development/ nautobot/ tasks.py",
+        f"{COMPOSE_COMMAND} run nautobot flake8 contrib/ development/ nautobot/ tasks.py",
         env={"PYTHON_VER": python_ver},
         pty=True,
     )


### PR DESCRIPTION
Various improvements to the development workflow:

- Replace `pycodestyle` with `flake8` in `tasks.py`, `cibuild.sh`, and `pre-commit` scripts.
- Add `black` to `tasks.py` and `pre-commit` (it was already in `cibuild.sh`)
- Add `invoke tests` command to run `black`, `flake8`, and unit tests together.
- In the development docker build, split the `poetry install` into two steps - one to install project dependencies (which will rarely changed, and hence can usually be cached) and one to install nautobot itself (which will be much more likely to change between rebuilds)

Additionally, I moved `django-debug-toolbar` to be a development dependency rather than a core project dependency.