### PR TITLE
Fix #81 - Device Rack Position now changeable

### DIFF
--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -343,7 +343,7 @@ class RackElevationDetailFilterSerializer(serializers.Serializer):
     unit_width = serializers.IntegerField(default=settings.RACK_ELEVATION_DEFAULT_UNIT_WIDTH)
     unit_height = serializers.IntegerField(default=settings.RACK_ELEVATION_DEFAULT_UNIT_HEIGHT)
     legend_width = serializers.IntegerField(default=RACK_ELEVATION_LEGEND_WIDTH_DEFAULT)
-    exclude = serializers.IntegerField(required=False, default=None)
+    exclude = serializers.UUIDField(required=False, default=None)
     expand_devices = serializers.BooleanField(required=False, default=True)
     include_images = serializers.BooleanField(required=False, default=True)
 

--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -204,8 +204,7 @@ class RackViewSet(StatusViewSetMixin, CustomFieldModelViewSet):
         """
         rack = get_object_or_404(self.queryset, pk=pk)
         serializer = serializers.RackElevationDetailFilterSerializer(data=request.GET)
-        if not serializer.is_valid():
-            return Response(serializer.errors, 400)
+        serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
         if data["render"] == "svg":

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -358,6 +358,19 @@ class RackTest(APIViewTestCases.APIViewTestCase):
         response = self.client.get(f"{url}?q=U10", **self.header)
         self.assertEqual(response.data["count"], 1)
 
+    def test_filter_rack_elevation(self):
+        """
+        Test filtering the list of rack elevations.
+
+        See: https://github.com/nautobot/nautobot/issues/81
+        """
+        rack = Rack.objects.first()
+        self.add_permissions("dcim.view_rack")
+        url = reverse("dcim-api:rack-elevation", kwargs={"pk": rack.pk})
+        params = {"brief": "true", "face": "front", "exclude": "a85a31aa-094f-4de9-8ba6-16cb088a1b74"}
+        response = self.client.get(url, params, **self.header)
+        self.assertHttpStatus(response, 200)
+
     def test_get_rack_elevation_svg(self):
         """
         GET a single rack elevation in SVG format.

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -2,7 +2,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.http import Http404
 from django_rq.queues import get_connection
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
@@ -241,10 +240,9 @@ class JobViewSet(ViewSet):
 
         job_class = self._get_job_class(class_path)
         job = job_class()
-        input_serializer = serializers.JobInputSerializer(data=request.data)
 
-        if not input_serializer.is_valid():
-            return Response(input_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        input_serializer = serializers.JobInputSerializer(data=request.data)
+        input_serializer.is_valid(raise_exception=True)
 
         data = input_serializer.data["data"]
         commit = input_serializer.data["commit"]

--- a/nautobot/ipam/api/views.py
+++ b/nautobot/ipam/api/views.py
@@ -148,8 +148,7 @@ class PrefixViewSet(StatusViewSetMixin, CustomFieldModelViewSet):
                     "prefix": prefix,
                 },
             )
-            if not serializer.is_valid():
-                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            serializer.is_valid(raise_exception=True)
 
             requested_prefixes = serializer.validated_data
             # Allocate prefixes to the requested objects based on availability within the parent
@@ -179,11 +178,9 @@ class PrefixViewSet(StatusViewSetMixin, CustomFieldModelViewSet):
                 serializer = serializers.PrefixSerializer(data=requested_prefixes[0], context=context)
 
             # Create the new Prefix(es)
-            if serializer.is_valid():
-                serializer.save()
-                return Response(serializer.data, status=status.HTTP_201_CREATED)
-
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
 
         else:
 
@@ -254,11 +251,9 @@ class PrefixViewSet(StatusViewSetMixin, CustomFieldModelViewSet):
                 serializer = serializers.IPAddressSerializer(data=requested_ips[0], context=context)
 
             # Create the new IP address(es)
-            if serializer.is_valid():
-                serializer.save()
-                return Response(serializer.data, status=status.HTTP_201_CREATED)
-
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
 
         # Determine the maximum number of IPs to return
         else:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #81 
<!--
    Please include a summary of the proposed changes below.
-->
This particular case is unique because it's a "query serializer" used to parse the query params for the `RackViewSet.elevation` method which was previously untested in this way.

- Swapped `nautobot.dcim.api.serializers.RackElevationDetailFilterSerializer.exclude` from `IntegerField` to `UUIDField`
- Added a new test `nautobot.dcim.tests.test_api.RackTest.test_filter_rack_elevation`
- Also revised validation of this serializer to raise an exception if invalid instead of returning a `Response` with
status code 400. Functionally equivalent, but operationally it's more correct to let the serializer raise an exception.
  - Made the same fixes in `nautobot.ipam.api.views` and `nautobot.extras.api.views`
