### PR TITLE
Fix #93 - Implement a system check for `CACHEOPS_DEFAULT['timeout']`

### DIFF
--- a/nautobot/core/__init__.py
+++ b/nautobot/core/__init__.py
@@ -1,0 +1,1 @@
+from . import checks

--- a/nautobot/core/checks.py
+++ b/nautobot/core/checks.py
@@ -8,7 +8,7 @@ E001 = Error(
 )
 
 
-@register(Tags.database)
+@register(Tags.caches)
 def cache_timeout_check(app_configs, **kwargs):
     if settings.CACHEOPS_DEFAULTS.get("timeout") == 0:
         return [E001]

--- a/nautobot/core/checks.py
+++ b/nautobot/core/checks.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django.core.checks import Error, Tags, register
+
+
+E001 = Error(
+    "CACHEOPS_DEFAULTS['timeout'] value cannot be 0. To disable caching set CACHEOPS_ENABLED=False.",
+    id="nautobot.E001",
+)
+
+
+@register(Tags.database)
+def cache_timeout_check(app_configs, **kwargs):
+    if settings.CACHEOPS_DEFAULTS.get("timeout") == 0:
+        return [E001]
+    return []

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -459,6 +459,7 @@ CACHEOPS = {
     "virtualization.*": {"ops": "all"},
 }
 CACHEOPS_DEGRADE_ON_FAILURE = True
+CACHEOPS_ENABLED = True
 CACHEOPS_REDIS = "redis://localhost:6379/1"
 CACHEOPS_DEFAULTS = {"timeout": 900}
 

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -111,7 +111,7 @@ BASE_PATH = ""
 # Cache timeout in seconds. Cannot be 0. Defaults to 900 (15 minutes). To disable caching, set CACHEOPS_ENABLED to False
 CACHEOPS_DEFAULTS = {"timeout": 900}
 
-# Set to False to disable caching with cachops. (Default: True)
+# Set to False to disable caching with cacheops. (Default: True)
 CACHEOPS_ENABLED = True
 
 # Maximum number of days to retain logged changes. Set to 0 to retain changes indefinitely. (Default: 90)

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -108,8 +108,11 @@ BANNER_LOGIN = ""
 # BASE_PATH = 'nautobot/'
 BASE_PATH = ""
 
-# Cache timeout in seconds. Set to 0 to dissable caching. Defaults to 900 (15 minutes)
+# Cache timeout in seconds. Cannot be 0. Defaults to 900 (15 minutes). To disable caching, set CACHEOPS_ENABLED to False
 CACHEOPS_DEFAULTS = {"timeout": 900}
+
+# Set to False to disable caching with cachops. (Default: True)
+CACHEOPS_ENABLED = True
 
 # Maximum number of days to retain logged changes. Set to 0 to retain changes indefinitely. (Default: 90)
 CHANGELOG_RETENTION = 90

--- a/nautobot/core/tests/test_checks.py
+++ b/nautobot/core/tests/test_checks.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from django.test import override_settings
+
+from nautobot.core import checks
+
+
+class CheckCacheopsDefaultsTest(TestCase):
+    @override_settings(
+        CACHEOPS_DEFAULTS={"timeout": 0},
+    )
+    def test_timeout_invalid(self):
+        """Error if CACHEOPS_DEFAULTS['timeout'] is 0."""
+        self.assertEqual(checks.cache_timeout_check(None), [checks.E001])

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -82,7 +82,20 @@ The filesystem path to use to store Nautobot files (jobs, uploaded images, Git r
 
 Default: `{'timeout': 900}` (15 minutes, in seconds)
 
+!!! warning
+    It is an error to set the timeout value to `0`. If you wish to disable caching, please use [`CACHEOPS_ENABLED`](#cacheops_enabled).
+
 Various defaults for caching, the most important of which being the cache timeout. The `timeout` is the number of seconds that cache entries will be retained before expiring.
+
+---
+
+## CACHEOPS_ENABLED
+
+Default: `True`
+
+A boolean that turns on/off caching.
+
+If set to `False`, all caching is bypassed and Nautobot operates as if there is no cache.
 
 ---
 

--- a/nautobot/docs/installation/nautobot.md
+++ b/nautobot/docs/installation/nautobot.md
@@ -172,6 +172,19 @@ To use remote file storage, add `django-storages` to your `local_requirements.tx
 (nautobot) $ echo django-storages >> /opt/nautobot/local_requirements.txt
 ```
 
+## Check your Configuration
+
+Nautobot leverages Django's built-in [system check framework](https://docs.djangoproject.com/en/stable/topics/checks/#writing-your-own-checks) to validate the configuration to detect common problems and to provide hints for how to fix them. 
+
+Checks are ran automatically when running a development server using `nautobot-server runserver`, but not when running in production using WSGI.
+
+!!! hint
+    Get into the habit of running checks before deployments!
+
+```no-highlight
+(nautobot) $ nautobot-server check
+```
+
 ## Prepare the Database
 
 Before Nautobot can run, the database migrations must be performed to prepare the database for use. This will populate the database tables and relationships:

--- a/nautobot/docs/installation/nautobot.md
+++ b/nautobot/docs/installation/nautobot.md
@@ -172,19 +172,6 @@ To use remote file storage, add `django-storages` to your `local_requirements.tx
 (nautobot) $ echo django-storages >> /opt/nautobot/local_requirements.txt
 ```
 
-## Check your Configuration
-
-Nautobot leverages Django's built-in [system check framework](https://docs.djangoproject.com/en/stable/topics/checks/#writing-your-own-checks) to validate the configuration to detect common problems and to provide hints for how to fix them. 
-
-Checks are ran automatically when running a development server using `nautobot-server runserver`, but not when running in production using WSGI.
-
-!!! hint
-    Get into the habit of running checks before deployments!
-
-```no-highlight
-(nautobot) $ nautobot-server check
-```
-
 ## Prepare the Database
 
 Before Nautobot can run, the database migrations must be performed to prepare the database for use. This will populate the database tables and relationships:
@@ -224,6 +211,19 @@ This step is entirely optional. As indicated above, we mentioned that any extra 
 
 ```no-highlight
 (nautobot) $ pip3 install -r /opt/nautobot/local_requirements.txt
+```
+
+## Check your Configuration
+
+Nautobot leverages Django's built-in [system check framework](https://docs.djangoproject.com/en/stable/topics/checks/#writing-your-own-checks) to validate the configuration to detect common problems and to provide hints for how to fix them. 
+
+Checks are ran automatically when running a development server using `nautobot-server runserver`, but not when running in production using WSGI.
+
+!!! hint
+    Get into the habit of running checks before deployments!
+
+```no-highlight
+(nautobot) $ nautobot-server check
 ```
 
 ## Test the Application


### PR DESCRIPTION
### Fixes: #93
<!--
    Please include a summary of the proposed changes below.
-->

This implements `nautobot.core.checks` and registers the first check error of `nautobot.E001` to assert that the value of `CACHEOPS_DEFAULTS['timeout']` can never be `0`.

When attempting to start the server if this value is `0`, startup is blocked and the following error will be displayed:

```
django.core.management.base.SystemCheckError: SystemCheckError: System check identified some issues:

ERRORS:
?: (nautobot.E001) CACHEOPS_DEFAULTS['timeout'] value cannot be 0. To disable caching set CACHEOPS_ENABLED=False.

System check identified 1 issue (0 silenced).
```

- `CACHEOPS_ENABLED = True` added back explicitly to `nautobot.core.settings`
- `CACHEOPS_ENABLED = True` added to the template config at `nautobot.core.templates.nautobot_config.py.j2`
- `CACHEOPS_ENABLED` added to optional settings documentation
- A unit test for the check has been implemented

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
