### PR TITLE
Add BASE_PATH to development/nautobot_config.py

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -95,6 +95,10 @@ RQ_QUEUES = {
     },
 }
 
+# Base URL path if accessing Nautobot within a directory. For example, if installed at https://example.com/nautobot/, set:
+# BASE_PATH = 'nautobot/'
+BASE_PATH = os.environ.get("BASE_PATH", "")
+
 # REDIS CACHEOPS
 CACHEOPS_REDIS = f"redis://:{os.getenv('REDIS_PASSWORD')}@{os.getenv('REDIS_HOST')}:{os.getenv('REDIS_PORT')}/2"
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
Since I'm using traefik reverse-proxy to access the development environment
the BASE_PATH variable is needed to define a traefik router.
