### PR TITLE
Fix #95 - Defensively load plugins and conditional settings

### DIFF
--- a/nautobot/core/cli.py
+++ b/nautobot/core/cli.py
@@ -223,11 +223,4 @@ def _configure_settings(config):
 
     # Process the plugins and manipulate the specified config settings that are
     # passed in.
-    load_plugins(
-        settings.PLUGINS,
-        settings.INSTALLED_APPS,
-        settings.PLUGINS_CONFIG,
-        settings.VERSION,
-        settings.MIDDLEWARE,
-        settings.CACHEOPS,
-    )
+    load_plugins(settings)

--- a/nautobot/extras/tests/test_plugins.py
+++ b/nautobot/extras/tests/test_plugins.py
@@ -310,25 +310,13 @@ class LoadPluginTest(TestCase):
         """Test `load_plugin`."""
 
         plugin_name = "bad.plugin"  # Start with a bogus plugin name
-        installed_apps = settings.INSTALLED_APPS
-        plugins_config = settings.PLUGINS_CONFIG
-        version = settings.VERSION
-        middleware = settings.MIDDLEWARE
-        cacheops = settings.CACHEOPS
 
         # FIXME(jathan): We're expecting a PluginNotFound to be raised, but
         # unittest doesn't appear to let that happen and we only see the
         # original ModuleNotFoundError, so this will have to do for now.
         with self.assertRaises(ModuleNotFoundError):
-            load_plugin(
-                plugin_name,
-                installed_apps,
-                plugins_config,
-                version,
-                middleware,
-                cacheops,
-            )
+            load_plugin(plugin_name, settings)
 
         # Move to the dummy plugin. No errors should be raised (which is good).
         plugin_name = "nautobot.extras.tests.dummy_plugin"
-        load_plugin(plugin_name, installed_apps, plugins_config, version, middleware, cacheops)
+        load_plugin(plugin_name, settings)


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #95
<!--
    Please include a summary of the proposed changes below.
-->
This updates `nautobot.extras.plugins.utils.load_plugins` to only update
or extend `INSTALLED_APPS` and `MIDDLEWARE` if the plugins in question
haven't already been applied.

In my testing this appears to have alleviated the bug in plugins not
being correctly loaded within the WSGI application for both Gunicorn and
uWSGI.

- Also updated the signature for `load_plugins` to just take an incoming settings object to increase usability.