### PR TITLE
Migrate more conditional settings from `nautobot.core.cli` to `nautobot.core.checks`

### DIFF
--- a/nautobot/core/checks.py
+++ b/nautobot/core/checks.py
@@ -6,27 +6,27 @@ from django.core.validators import URLValidator
 
 E001 = Error(
     "CACHEOPS_DEFAULTS['timeout'] value cannot be 0. To disable caching set CACHEOPS_ENABLED=False.",
-    id="core.E001",
+    id="nautobot.core.E001",
 )
 
 E002 = Error(
     "'nautobot.core.authentication.ObjectPermissionBackend' must be included in AUTHENTICATION_BACKENDS",
-    id="core.E002",
+    id="nautobot.core.E002",
 )
 
 E003 = Error(
     "RELEASE_CHECK_TIMEOUT must be at least 3600 seconds (1 hour)",
-    id="core.E003",
+    id="nautobot.core.E003",
 )
 
 E004 = Error(
     "RELEASE_CHECK_URL must be a valid API URL. Example: https://api.github.com/repos/nautobot/nautobot",
-    id="core.E004",
+    id="nautobot.core.E004",
 )
 
 W005 = Warning(
     "STORAGE_CONFIG has been set but STORAGE_BACKEND is not defined. STORAGE_CONFIG will be ignored.",
-    id="core.W005",
+    id="nautobot.core.W005",
 )
 
 

--- a/nautobot/core/checks.py
+++ b/nautobot/core/checks.py
@@ -10,7 +10,7 @@ E001 = Error(
 )
 
 E002 = Error(
-    "'nautobot.core.authentication.ObjectPermissionBackend' must be defined in AUTHENTICATION_BACKENDS",
+    "'nautobot.core.authentication.ObjectPermissionBackend' must be included in AUTHENTICATION_BACKENDS",
     id="core.E002",
 )
 

--- a/nautobot/core/checks.py
+++ b/nautobot/core/checks.py
@@ -1,15 +1,69 @@
 from django.conf import settings
-from django.core.checks import Error, Tags, register
+from django.core.checks import register, Error, Tags, Warning
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
 
 
 E001 = Error(
     "CACHEOPS_DEFAULTS['timeout'] value cannot be 0. To disable caching set CACHEOPS_ENABLED=False.",
-    id="nautobot.E001",
+    id="core.E001",
+)
+
+E002 = Error(
+    "'nautobot.core.authentication.ObjectPermissionBackend' must be defined in AUTHENTICATION_BACKENDS",
+    id="core.E002",
+)
+
+E003 = Error(
+    "RELEASE_CHECK_TIMEOUT must be at least 3600 seconds (1 hour)",
+    id="core.E003",
+)
+
+E004 = Error(
+    "RELEASE_CHECK_URL must be a valid API URL. Example: https://api.github.com/repos/nautobot/nautobot",
+    id="core.E004",
+)
+
+W005 = Warning(
+    "STORAGE_CONFIG has been set but STORAGE_BACKEND is not defined. STORAGE_CONFIG will be ignored.",
+    id="core.W005",
 )
 
 
 @register(Tags.caches)
-def cache_timeout_check(app_configs, **kwargs):
+def check_cache_timeout(app_configs, **kwargs):
     if settings.CACHEOPS_DEFAULTS.get("timeout") == 0:
         return [E001]
+    return []
+
+
+@register(Tags.security)
+def check_object_permissions_backend(app_configs, **kwargs):
+    if "nautobot.core.authentication.ObjectPermissionBackend" not in settings.AUTHENTICATION_BACKENDS:
+        return [E002]
+    return []
+
+
+@register(Tags.compatibility)
+def check_release_check_timeout(app_configs, **kwargs):
+    if settings.RELEASE_CHECK_TIMEOUT < 3600:
+        return [E003]
+    return []
+
+
+@register(Tags.compatibility)
+def check_release_check_url(app_configs, **kwargs):
+    validator = URLValidator()
+    if settings.RELEASE_CHECK_URL:
+        try:
+            validator(settings.RELEASE_CHECK_URL)
+        except ValidationError:
+            return [E004]
+    return []
+
+
+@register(Tags.compatibility)
+def check_storage_config_and_backend(app_configs, **kwargs):
+    if settings.STORAGE_CONFIG and (settings.STORAGE_BACKEND is None):
+        return [W005]
     return []

--- a/nautobot/core/cli.py
+++ b/nautobot/core/cli.py
@@ -6,9 +6,8 @@ from pathlib import Path
 import os
 import warnings
 
-from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.exceptions import ImproperlyConfigured
 from django.core.management.utils import get_random_secret_key
-from django.core.validators import URLValidator
 from jinja2 import BaseLoader, Environment
 
 from nautobot.extras.plugins.utils import load_plugins, get_sso_backend_name
@@ -143,36 +142,6 @@ def _configure_settings(config):
         settings.PER_PAGE_DEFAULTS = sorted(settings.PER_PAGE_DEFAULTS)
 
     #
-    # Authentication
-    #
-
-    # FIXME(jathan): This is just here as an interim validation check, to be
-    # replaced in a future update when all other validations hard-coded here in
-    # settings are moved to use the Django system check framework.
-    if "nautobot.core.authentication.ObjectPermissionBackend" not in settings.AUTHENTICATION_BACKENDS:
-        raise ImproperlyConfigured(
-            "nautobot.core.authentication.ObjectPermissionBackend must be defined in " "'AUTHENTICATION_BACKENDS'"
-        )
-
-    #
-    # Releases
-    #
-
-    # Validate update repo URL and timeout
-    if settings.RELEASE_CHECK_URL:
-        try:
-            URLValidator(settings.RELEASE_CHECK_URL)
-        except ValidationError:
-            raise ImproperlyConfigured(
-                "RELEASE_CHECK_URL must be a valid API URL. Example: " "https://api.github.com/repos/nautobot/nautobot"
-            )
-
-    # FIXME(jathan): Why is this enforced here? This would be better enforced in the core.
-    # Enforce a minimum cache timeout for update checks
-    if settings.RELEASE_CHECK_TIMEOUT < 3600:
-        raise ImproperlyConfigured("RELEASE_CHECK_TIMEOUT has to be at least 3600 seconds (1 hour)")
-
-    #
     # Media storage
     #
 
@@ -199,12 +168,6 @@ def _configure_settings(config):
                 return globals().get(name, default)
 
             storages.utils.setting = _setting
-
-    if settings.STORAGE_CONFIG and settings.STORAGE_BACKEND is None:
-        warnings.warn(
-            "STORAGE_CONFIG has been set in settings but STORAGE_BACKEND is not defined. STORAGE_CONFIG will be "
-            "ignored."
-        )
 
     #
     # SSO

--- a/nautobot/core/tests/test_checks.py
+++ b/nautobot/core/tests/test_checks.py
@@ -4,10 +4,41 @@ from django.test import override_settings
 from nautobot.core import checks
 
 
-class CheckCacheopsDefaultsTest(TestCase):
+class CheckCoreSettingsTest(TestCase):
     @override_settings(
         CACHEOPS_DEFAULTS={"timeout": 0},
     )
-    def test_timeout_invalid(self):
+    def test_check_cache_timeout(self):
         """Error if CACHEOPS_DEFAULTS['timeout'] is 0."""
-        self.assertEqual(checks.cache_timeout_check(None), [checks.E001])
+        self.assertEqual(checks.check_cache_timeout(None), [checks.E001])
+
+    @override_settings(
+        AUTHENTICATION_BACKENDS=["django.contrib.auth.backends.ModelBackend"],
+    )
+    def test_check_object_permissions_backend(self):
+        """
+        Error if 'nautobot.core.authentication.ObjectPermissionBackend' not in AUTHENTICATION_BACKENDS.
+        """
+        self.assertEqual(checks.check_object_permissions_backend(None), [checks.E002])
+
+    @override_settings(
+        RELEASE_CHECK_TIMEOUT=0,
+    )
+    def test_check_release_check_timeout(self):
+        """Error if RELEASE_CHECK_TIMEOUT < 3600."""
+        self.assertEqual(checks.check_release_check_timeout(None), [checks.E003])
+
+    @override_settings(
+        RELEASE_CHECK_URL="bogus url://tom.horse",
+    )
+    def test_check_release_check_url(self):
+        """Error if RELEASE_CHECK_URL is not a valid URL."""
+        self.assertEqual(checks.check_release_check_url(None), [checks.E004])
+
+    @override_settings(
+        STORAGE_BACKEND=None,
+        STORAGE_CONFIG={"test_key": "test_value"},
+    )
+    def test_check_storage_config_and_backend(self):
+        """Warn if STORAGE_CONFIG and STORAGE_BACKEND aren't mutually set."""
+        self.assertEqual(checks.check_storage_config_and_backend(None), [checks.W005])


### PR DESCRIPTION
This reduces our reliance on having conditional statements in the processing of settings to leveraging the built-in Django system checks framework.

- Move test for `ObjectPermissionBackend` in `AUTHENTICATION_BACKENDS` to a check
- Move tests for `RELEASE_CHECK_URL` and `RELEASE_CHECK_TIMEOUT` to checks
- Move tests for `STORAGE_BACKEND` and `STORAGE_CONFIG` to checks
- Renamed check namespace for core checks from `nautobot` to `nautobot.core` to allow for more specific namespaces in the future for each app (e.g. `nautobot.dcim`, et al.)


AUTHENTICATION_BACKENDS
```
$ nautobot-server check
SystemCheckError: System check identified some issues:

ERRORS:
?: (nautobot.core.E002) 'nautobot.core.authentication.ObjectPermissionBackend' must be defined in AUTHENTICATION_BACKENDS

System check identified 1 issue (0 silenced).
```

RELEASE_CHECK_TIMEOUT
```
$ nautobot-server check
SystemCheckError: System check identified some issues:

ERRORS:
?: (nautobot.core.E003) RELEASE_CHECK_TIMEOUT must be at least 3600 seconds (1 hour)

System check identified 1 issue (0 silenced).
```

RELEASE_CHECK_URL
```
$ nautobot-server check
SystemCheckError: System check identified some issues:

ERRORS:
?: (nautobot.core.E004) RELEASE_CHECK_URL must be a valid API URL. Example: https://api.github.com/repos/nautobot/nautobot

System check identified 1 issue (0 silenced).
```

STORAGE_CONFIG and STORAGE_BACKEND
```
$ nautobot-server check
System check identified some issues:

WARNINGS:
?: (nautobot.core.W005) STORAGE_CONFIG has been set but STORAGE_BACKEND is not defined. STORAGE_CONFIG will be ignored.

System check identified 1 issue (0 silenced).
```
