### PR TITLE
Fix #172 - General code cleanup HTML tags

### DIFF
--- a/nautobot/core/templates/inc/nav_menu.html
+++ b/nautobot/core/templates/inc/nav_menu.html
@@ -552,7 +552,7 @@
                         </li>
                     {% endif %}
                     {% if perms.virtualization.view_vminterface or not settings.HIDE_RESTRICTED_UI %}
-                        <li{% if not perms.virtualization.view_vminterface%} class="disabled"{% endif %}>
+                        <li{% if not perms.virtualization.view_vminterface %} class="disabled"{% endif %}>
                             {% if perms.virtualization.add_vminterface %}
                                 <div class="buttons pull-right">
                                     <a href="{% url 'virtualization:vminterface_import' %}" class="btn btn-xs btn-info" title="Import"><i class="mdi mdi-database-import-outline"></i></a>

--- a/nautobot/dcim/templates/dcim/cable_trace.html
+++ b/nautobot/dcim/templates/dcim/cable_trace.html
@@ -18,7 +18,7 @@
                             {% include 'dcim/trace/termination.html' with termination=near_end %}
                         {% elif near_end.power_panel %}
                             {% include 'dcim/trace/powerpanel.html' with powerpanel=near_end.power_panel %}
-                            {% include 'dcim/trace/termination.html' with termination=far_end%}
+                            {% include 'dcim/trace/termination.html' with termination=far_end %}
                         {% elif near_end.circuit %}
                             {% include 'dcim/trace/circuit.html' with circuit=near_end.circuit %}
                             {% include 'dcim/trace/termination.html' with termination=near_end %}

--- a/nautobot/dcim/templates/dcim/interface.html
+++ b/nautobot/dcim/templates/dcim/interface.html
@@ -41,7 +41,7 @@
                     <tr>
                         <td>LAG</td>
                         <td>
-                            {% if object.lag%}
+                            {% if object.lag %}
                                 <a href="{{ object.lag.get_absolute_url }}">{{ object.lag }}</a>
                             {% else %}
                                 <span class="text-muted">None</span>
@@ -119,7 +119,7 @@
                                     <tr>
                                         <td>LAG</td>
                                         <td>
-                                            {% if iface.lag%}
+                                            {% if iface.lag %}
                                                 <a href="{{ iface.lag.get_absolute_url }}">{{ iface.lag }}</a>
                                             {% else %}
                                                 <span class="text-muted">None</span>

--- a/nautobot/ipam/templates/ipam/ipaddress.html
+++ b/nautobot/ipam/templates/ipam/ipaddress.html
@@ -35,7 +35,7 @@
             {% clone_button object %}
         {% endif %}
         {% if perms.ipam.change_ipaddress %}
-            {%edit_button object %}
+            {% edit_button object %}
         {% endif %}
         {% if perms.ipam.delete_ipaddress %}
             {% delete_button object %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #172
<!--
    Please include a summary of the proposed changes below.
-->
This is simply general code cleanup. In 4 different HTML files, there are some {% tag %} tags with incorrect spacing. While functional, they do not conform to the existing standards for all other tags.

For example, {% tag %} can be found written as either {%tag %} or {% tag%} in some places.