### PR TITLE
Add a system check for when BASE_PATH and LOGIN_URL mismatch

### DIFF
--- a/nautobot/core/tests/test_checks.py
+++ b/nautobot/core/tests/test_checks.py
@@ -42,3 +42,18 @@ class CheckCoreSettingsTest(TestCase):
     def test_check_storage_config_and_backend(self):
         """Warn if STORAGE_CONFIG and STORAGE_BACKEND aren't mutually set."""
         self.assertEqual(checks.check_storage_config_and_backend(None), [checks.W005])
+
+    @override_settings(
+        BASE_PATH="nautobot/",
+    )
+    def test_check_base_path_and_login_url_failure(self):
+        """Error if BASE_PATH and LOGIN_URL aren't mutually set."""
+        self.assertEqual(checks.check_base_path_and_login_url(None), [checks.E006])
+
+    @override_settings(
+        BASE_PATH="nautobot/",
+        LOGIN_URL="/nautobot/login/",
+    )
+    def test_check_base_path_and_login_url_success(self):
+        """Pass if BASE_PATH and LOGIN_URL are mutually set."""
+        self.assertEqual(checks.check_base_path_and_login_url(None), [])

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -68,13 +68,16 @@ This defines custom content to be displayed on the login page above the login fo
 
 ## BASE_PATH
 
-Default: `None`
+Default: `""` (Empty string)
 
-The base URL path to use when accessing Nautobot. Do not include the scheme or domain name. For example, if installed at https://example.com/nautobot/, set:
+The base URL path to use as a prefix when accessing Nautobot. Do not include the scheme or domain name. For example, if Nautobot is installed at *https://example.com/nautobot/*, set:
 
 ```python
 BASE_PATH = 'nautobot/'
 ```
+
+!!! warning
+    When setting [`BASE_PATH`](#base_path) you must also update [`LOGIN_URL`](#login_url) to begin with the value of `BASE_PATH`. For example if `BASE_PATH` is set to `"nautobot/"`, then `LOGIN_URL` must be set to `"/nautobot/login/"`.
 
 ---
 
@@ -345,6 +348,17 @@ LOGGING = {
 * `nautobot.plugins.*` - Plugin loading and activity
 * `nautobot.views.*` - Views which handle business logic for the web UI
 * `rq.worker` - Background task handling
+
+---
+
+## LOGIN_URL
+
+Default: `"/login/"`
+
+The URL where requests are redirected for login to authenticate users requiring access to protected views. Any views inheriting from [`LoginRequiredMixin`](https://docs.djangoproject.com/en/stable/topics/auth/default/#django.contrib.auth.mixins.LoginRequiredMixin) or [`AccessMixin`](https://docs.djangoproject.com/en/stable/topics/auth/default/#django.contrib.auth.mixins.AccessMixin) will require login.
+
+!!! warning
+    When setting [`BASE_PATH`](#base_path) you must also update [`LOGIN_URL`](#login_url) to begin with the value of `BASE_PATH`. For example if `BASE_PATH` is set to `"nautobot/"`, then `LOGIN_URL` must be set to `"/nautobot/login/"`.
 
 ---
 


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #147 
<!--
    Please include a summary of the proposed changes below.
-->
If `LOGIN_URL` does not contain `BASE_PATH`, a system error is raised and a hint is displayed to attempt to help set the correct value for `LOGIN_URL`.

Also updated the documentation for `BASE_PATH` to include a warning admonition and added docs for `LOGIN_URL` including the same admonition.

Example:
```
$ nautobot-server check
SystemCheckError: System check identified some issues:

ERRORS:
?: (nautobot.core.E006) BASE_PATH has been updated but LOGIN_URL has not. LOGIN_URL must include BASE_PATH.
	HINT: Your BASE_PATH is set to 'nautobot/'; Set LOGIN_URL = '/nautobot/login/'

System check identified 1 issue (0 silenced).
```