### PR TITLE
Improve usability of MultipleContentTypeField

### DIFF
--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -751,7 +751,7 @@ class StatusForm(BootstrapMixin, CustomFieldModelForm, RelationshipModelForm):
     """Generic create/update form for `Status` objects."""
 
     slug = SlugField()
-    content_types = MultipleContentTypeField(feature="statuses", label="Content type(s)")
+    content_types = MultipleContentTypeField(feature="statuses", label="Content Type(s)")
 
     class Meta:
         model = Status

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -202,9 +202,13 @@ class RelationshipFilterForm(BootstrapMixin, forms.Form):
 
     type = forms.MultipleChoiceField(choices=RelationshipTypeChoices, required=False, widget=StaticSelect2Multiple())
 
-    source_type = MultipleContentTypeField(feature="relationships", required=False, label="Source Type")
+    source_type = MultipleContentTypeField(
+        feature="relationships", choices_as_strings=True, required=False, label="Source Type"
+    )
 
-    destination_type = MultipleContentTypeField(feature="relationships", required=False, label="Destination Type")
+    destination_type = MultipleContentTypeField(
+        feature="relationships", choices_as_strings=True, required=False, label="Destination Type"
+    )
 
 
 class RelationshipModelForm(forms.ModelForm):
@@ -309,9 +313,13 @@ class RelationshipAssociationFilterForm(BootstrapMixin, forms.Form):
         required=False,
     )
 
-    source_type = MultipleContentTypeField(feature="relationships", required=False, label="Source Type")
+    source_type = MultipleContentTypeField(
+        feature="relationships", choices_as_strings=True, required=False, label="Source Type"
+    )
 
-    destination_type = MultipleContentTypeField(feature="relationships", required=False, label="Destination Type")
+    destination_type = MultipleContentTypeField(
+        feature="relationships", choices_as_strings=True, required=False, label="Destination Type"
+    )
 
 
 #
@@ -725,7 +733,9 @@ class WebhookForm(BootstrapMixin, forms.ModelForm):
 class WebhookFilterForm(BootstrapMixin, forms.Form):
     model = Webhook
     q = forms.CharField(required=False, label="Search")
-    content_types = MultipleContentTypeField(feature="webhooks", required=False, label="Content Type(s)")
+    content_types = MultipleContentTypeField(
+        feature="webhooks", choices_as_strings=True, required=False, label="Content Type(s)"
+    )
     type_create = forms.NullBooleanField(required=False, widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES))
     type_update = forms.NullBooleanField(required=False, widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES))
     type_delete = forms.NullBooleanField(required=False, widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES))
@@ -755,6 +765,7 @@ class StatusCSVForm(CustomFieldModelCSVForm):
     slug = SlugField()
     content_types = CSVMultipleContentTypeField(
         feature="statuses",
+        choices_as_strings=True,
         help_text=mark_safe(
             "The object types to which this status applies. Multiple values "
             "must be comma-separated and wrapped in double quotes. (e.g. "
@@ -776,7 +787,9 @@ class StatusFilterForm(BootstrapMixin, CustomFieldFilterForm):
 
     model = Status
     q = forms.CharField(required=False, label="Search")
-    content_types = MultipleContentTypeField(feature="statuses", required=False, label="Content type(s)")
+    content_types = MultipleContentTypeField(
+        feature="statuses", choices_as_strings=True, required=False, label="Content type(s)"
+    )
     color = forms.CharField(max_length=6, required=False, widget=ColorSelect())
 
 

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -202,19 +202,9 @@ class RelationshipFilterForm(BootstrapMixin, forms.Form):
 
     type = forms.MultipleChoiceField(choices=RelationshipTypeChoices, required=False, widget=StaticSelect2Multiple())
 
-    source_type = MultipleContentTypeField(
-        queryset=ContentType.objects.filter(FeatureQuery("relationships").get_query()).order_by("app_label", "model"),
-        required=False,
-        label="Source Type",
-        widget=StaticSelect2Multiple(),
-    )
+    source_type = MultipleContentTypeField(feature="relationships", required=False, label="Source Type")
 
-    destination_type = MultipleContentTypeField(
-        queryset=ContentType.objects.filter(FeatureQuery("relationships").get_query()).order_by("app_label", "model"),
-        required=False,
-        label="Destination Type",
-        widget=StaticSelect2Multiple(),
-    )
+    destination_type = MultipleContentTypeField(feature="relationships", required=False, label="Destination Type")
 
 
 class RelationshipModelForm(forms.ModelForm):
@@ -319,19 +309,9 @@ class RelationshipAssociationFilterForm(BootstrapMixin, forms.Form):
         required=False,
     )
 
-    source_type = MultipleContentTypeField(
-        queryset=ContentType.objects.filter(FeatureQuery("relationships").get_query()).order_by("app_label", "model"),
-        required=False,
-        label="Source Type",
-        widget=StaticSelect2Multiple(),
-    )
+    source_type = MultipleContentTypeField(feature="relationships", required=False, label="Source Type")
 
-    destination_type = MultipleContentTypeField(
-        queryset=ContentType.objects.filter(FeatureQuery("relationships").get_query()).order_by("app_label", "model"),
-        required=False,
-        label="Destination Type",
-        widget=StaticSelect2Multiple(),
-    )
+    destination_type = MultipleContentTypeField(feature="relationships", required=False, label="Destination Type")
 
 
 #
@@ -720,11 +700,7 @@ class CustomLinkFilterForm(BootstrapMixin, forms.Form):
 
 
 class WebhookForm(BootstrapMixin, forms.ModelForm):
-    content_types = forms.ModelMultipleChoiceField(
-        queryset=ContentType.objects.filter(FeatureQuery("webhooks").get_query()).order_by("app_label", "model"),
-        required=False,
-        label="Content Types",
-    )
+    content_types = MultipleContentTypeField(feature="webhooks", required=False, label="Content Type(s)")
 
     class Meta:
         model = Webhook
@@ -749,11 +725,7 @@ class WebhookForm(BootstrapMixin, forms.ModelForm):
 class WebhookFilterForm(BootstrapMixin, forms.Form):
     model = Webhook
     q = forms.CharField(required=False, label="Search")
-    content_types = forms.ModelMultipleChoiceField(
-        queryset=ContentType.objects.filter(FeatureQuery("webhooks").get_query()).order_by("app_label", "model"),
-        required=False,
-        label="Content Types",
-    )
+    content_types = MultipleContentTypeField(feature="webhooks", required=False, label="Content Type(s)")
     type_create = forms.NullBooleanField(required=False, widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES))
     type_update = forms.NullBooleanField(required=False, widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES))
     type_delete = forms.NullBooleanField(required=False, widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES))
@@ -769,10 +741,7 @@ class StatusForm(BootstrapMixin, CustomFieldModelForm, RelationshipModelForm):
     """Generic create/update form for `Status` objects."""
 
     slug = SlugField()
-    content_types = forms.ModelMultipleChoiceField(
-        queryset=ContentType.objects.filter(FeatureQuery("statuses").get_query()).order_by("app_label", "model"),
-        label="Content type(s)",
-    )
+    content_types = MultipleContentTypeField(feature="statuses", label="Content type(s)")
 
     class Meta:
         model = Status
@@ -785,7 +754,7 @@ class StatusCSVForm(CustomFieldModelCSVForm):
 
     slug = SlugField()
     content_types = CSVMultipleContentTypeField(
-        queryset=ContentType.objects.filter(FeatureQuery("statuses").get_query()).order_by("app_label", "model"),
+        feature="statuses",
         help_text=mark_safe(
             "The object types to which this status applies. Multiple values "
             "must be comma-separated and wrapped in double quotes. (e.g. "
@@ -807,12 +776,7 @@ class StatusFilterForm(BootstrapMixin, CustomFieldFilterForm):
 
     model = Status
     q = forms.CharField(required=False, label="Search")
-    content_types = MultipleContentTypeField(
-        queryset=ContentType.objects.filter(FeatureQuery("statuses").get_query()).order_by("app_label", "model"),
-        required=False,
-        label="Content type(s)",
-        widget=StaticSelect2Multiple(),
-    )
+    content_types = MultipleContentTypeField(feature="statuses", required=False, label="Content type(s)")
     color = forms.CharField(max_length=6, required=False, widget=ColorSelect())
 
 
@@ -821,11 +785,7 @@ class StatusBulkEditForm(BootstrapMixin, CustomFieldBulkEditForm):
 
     pk = forms.ModelMultipleChoiceField(queryset=Status.objects.all(), widget=forms.MultipleHiddenInput)
     color = forms.CharField(max_length=6, required=False, widget=ColorSelect())
-    content_types = forms.ModelMultipleChoiceField(
-        queryset=ContentType.objects.filter(FeatureQuery("statuses").get_query()).order_by("app_label", "model"),
-        label="Content type(s)",
-        required=False,
-    )
+    content_types = MultipleContentTypeField(feature="statuses", required=False, label="Content type(s)")
 
     class Meta:
         nullable_fields = []

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -788,7 +788,7 @@ class StatusFilterForm(BootstrapMixin, CustomFieldFilterForm):
     model = Status
     q = forms.CharField(required=False, label="Search")
     content_types = MultipleContentTypeField(
-        feature="statuses", choices_as_strings=True, required=False, label="Content type(s)"
+        feature="statuses", choices_as_strings=True, required=False, label="Content Type(s)"
     )
     color = forms.CharField(max_length=6, required=False, widget=ColorSelect())
 

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -798,7 +798,7 @@ class StatusBulkEditForm(BootstrapMixin, CustomFieldBulkEditForm):
 
     pk = forms.ModelMultipleChoiceField(queryset=Status.objects.all(), widget=forms.MultipleHiddenInput)
     color = forms.CharField(max_length=6, required=False, widget=ColorSelect())
-    content_types = MultipleContentTypeField(feature="statuses", required=False, label="Content type(s)")
+    content_types = MultipleContentTypeField(feature="statuses", required=False, label="Content Type(s)")
 
     class Meta:
         nullable_fields = []

--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -168,32 +168,39 @@ class CSVContentTypeField(CSVModelChoiceField):
 
 class MultipleContentTypeField(forms.ModelMultipleChoiceField):
     """
-    Reference a list of `ContentType` objects in the form `{app_label}.{model}'.
+    Field for choosing any number of `ContentType` objects.
+
+    Optionally can restrict the available ContentTypes to those supporting a particular feature only.
+    Optionally can pass the selection through as a list of "`{app_label}.{model}`" strings intead of PK values.
     """
 
     STATIC_CHOICES = True
 
-    def __init__(self, *args, feature=None, **kwargs):
+    def __init__(self, *args, feature=None, choices_as_strings=False, **kwargs):
         """
         Construct a MultipleContentTypeField.
 
         Args:
-            feature (str): Feature name to use in constructing a FeatureQuery for the queryset.
+            feature (str): Feature name to use in constructing a FeatureQuery to restrict the available ContentTypes.
+            choices_as_strings (bool): If True, render selection as a list of `"{app_label}.{model}"` strings.
         """
         if "queryset" not in kwargs:
-            kwargs["queryset"] = ContentType.objects.filter(FeatureQuery(feature).get_query()).order_by(
-                "app_label", "model"
-            )
+            if feature is not None:
+                kwargs["queryset"] = ContentType.objects.filter(FeatureQuery(feature).get_query()).order_by(
+                    "app_label", "model"
+                )
+            else:
+                kwargs["queryset"] = ContentType.objects.order_by("app_label", "model")
         if "widget" not in kwargs:
             kwargs["widget"] = widgets.StaticSelect2Multiple()
 
         super().__init__(*args, **kwargs)
 
-        # Generate choices from queryset each time form is initialized.
-        self.choices = self._generate_choices_from_queryset
+        if choices_as_strings:
+            self.choices = self._string_choices_from_queryset
 
-    def _generate_choices_from_queryset(self):
-        """Overload choices to return "<app>.<model>" for CSV import help text."""
+    def _string_choices_from_queryset(self):
+        """Overload choices to return "<app>.<model>" instead of PKs."""
         return [(f"{m.app_label}.{m.model}", m.app_labeled_name) for m in self.queryset.all()]
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #98 
<!--
    Please include a summary of the proposed changes below.
-->

Just some basic code cleanup. Makes it a lot simpler to use a `MultipleContentTypeField` or `CSVMultipleContentTypeField`.