### PR TITLE
Docker development environment improvements

### DIFF
--- a/development/docker-entrypoint.sh
+++ b/development/docker-entrypoint.sh
@@ -65,8 +65,6 @@ else:
 END
 
   echo "💡 Superuser Username: ${SUPERUSER_NAME}, E-Mail: ${SUPERUSER_EMAIL}"
-else
-  echo "↩️ Skip creating the superuser"
 fi
 
 

--- a/nautobot/core/runner/settings.py
+++ b/nautobot/core/runner/settings.py
@@ -54,9 +54,7 @@ def create_module(name, install=True):
     return mod
 
 
-def load_settings(
-    mod_or_filename, silent=False, allow_extras=True, settings=django_settings
-):
+def load_settings(mod_or_filename, silent=False, allow_extras=True, settings=django_settings):
     if isinstance(mod_or_filename, basestring):
         conf = create_module("temp_config", install=False)
         conf.__file__ = mod_or_filename

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -55,9 +55,7 @@ if BASE_PATH:
     BASE_PATH = BASE_PATH.strip("/") + "/"  # Enforce trailing slash only
 
 # Base directory wherein all created files (jobs, git repositories, file uploads, static files) will be stored)
-NAUTOBOT_ROOT = os.environ.get(
-    "NAUTOBOT_ROOT", os.path.expanduser("~/.nautobot")
-)
+NAUTOBOT_ROOT = os.environ.get("NAUTOBOT_ROOT", os.path.expanduser("~/.nautobot"))
 
 CHANGELOG_RETENTION = 90
 DOCS_ROOT = os.path.join(os.path.dirname(BASE_DIR), "docs")
@@ -77,13 +75,9 @@ EXEMPT_EXCLUDE_MODELS = (
 )
 
 EXEMPT_VIEW_PERMISSIONS = []
-GIT_ROOT = os.environ.get(
-    "NAUTOBOT_GIT_ROOT", os.path.join(NAUTOBOT_ROOT, "git").rstrip("/")
-)
+GIT_ROOT = os.environ.get("NAUTOBOT_GIT_ROOT", os.path.join(NAUTOBOT_ROOT, "git").rstrip("/"))
 HTTP_PROXIES = None
-JOBS_ROOT = os.environ.get(
-    "NAUTOBOT_JOBS_ROOT", os.path.join(NAUTOBOT_ROOT, "jobs").rstrip("/")
-)
+JOBS_ROOT = os.environ.get("NAUTOBOT_JOBS_ROOT", os.path.join(NAUTOBOT_ROOT, "jobs").rstrip("/"))
 MAINTENANCE_MODE = False
 MAX_PAGE_SIZE = 1000
 
@@ -176,9 +170,7 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "DEFAULT_METADATA_CLASS": "nautobot.core.api.metadata.BulkOperationMetadata",
     "DEFAULT_PAGINATION_CLASS": "nautobot.core.api.pagination.OptionalLimitOffsetPagination",
-    "DEFAULT_PERMISSION_CLASSES": (
-        "nautobot.core.api.authentication.TokenPermissions",
-    ),
+    "DEFAULT_PERMISSION_CLASSES": ("nautobot.core.api.authentication.TokenPermissions",),
     "DEFAULT_RENDERER_CLASSES": (
         "rest_framework.renderers.JSONRenderer",
         "nautobot.core.api.renderers.FormlessBrowsableAPIRenderer",

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -144,22 +144,23 @@ Now that you have an `invoke` command, list the tasks defined in `tasks.py`:
 $ invoke --list
 Available tasks:
 
-  black             Check Python code style with Black
-  build             Build all docker images.
-  cli               Launch a bash shell inside the running Nautobot container.
-  coverage-report   Run coverage report
-  coverage-run      Run tests
-  createsuperuser   Create a new superuser in django (default: admin), will prompt for password.
-  debug             Start Nautobot and its dependencies in debug mode.
-  destroy           Destroy all containers and volumes.
-  flake8            Check PEP8 compliance and other style issues
-  makemigrations    Run Make Migration in Django.
-  migrate           Perform migrate operation in Django.
-  nbshell           Launch a nbshell session.
-  start             Start Nautobot and its dependencies in detached mode.
-  stop              Stop Nautobot and its dependencies.
-  tests             Run all tests
-  vscode            Launch Visual Studio Code with the appropriate Environment variables to run in a container.
+  black               Check Python code style with Black.
+  build               Build all docker images.
+  cli                 Launch a bash shell inside the running Nautobot container.
+  createsuperuser     Create a new Nautobot superuser account (default: "admin"), will prompt for password.
+  debug               Start Nautobot and its dependencies in debug mode.
+  destroy             Destroy all containers and volumes.
+  flake8              Check for PEP8 compliance and other style issues.
+  makemigrations      Perform makemigrations operation in Django.
+  migrate             Perform migrate operation in Django.
+  nbshell             Launch an interactive nbshell session.
+  restart             Gracefully restart all containers.
+  start               Start Nautobot and its dependencies in detached mode.
+  stop                Stop Nautobot and its dependencies.
+  tests               Run all tests and linters.
+  unittest            Run Nautobot unit tests.
+  unittest-coverage   Report on code test coverage as measured by 'invoke unittest'.
+  vscode              Launch Visual Studio Code with the appropriate Environment variables to run in a container.
 ```
 
 #### Using Docker with Invoke
@@ -174,6 +175,9 @@ Additional useful commands for the development environment:
 
 - `invoke start` - Starts all Docker containers to run in the background with debug disabled
 - `invoke stop` - Stops all containers created by `invoke start`
+
+!!! info
+    By default the Nautobot docker images for development are built with Python 3.7. If you wish to build them with a different Python version, stop any running containers, then set the environment variable `PYTHON_VER` to the desired version (for example, `export PYTHON_VER=3.8`) and rerun the `invoke build` command. As long as `PYTHON_VER` remains set, all other `invoke` tasks will use the containers built for this version instead of the default.
 
 #### Working with Docker Compose
 
@@ -338,7 +342,7 @@ It may not always be convenient to enter into the virtual shell just to run prog
 $ poetry run mkdocs serve
 ```
 
-Check out the [Poetry usage guide](https://python-poetry.org/docs/basic-usage/) for more tips.	
+Check out the [Poetry usage guide](https://python-poetry.org/docs/basic-usage/) for more tips.
 
 !!! note
 	Unless otherwise noted, all following commands should be executed inside the virtualenv.
@@ -416,23 +420,32 @@ $ nautobot-server nbshell
 
 ## Running Tests
 
-Throughout the course of development, it's a good idea to occasionally run Nautobot's test suite to catch any potential errors. Tests are run using the `test` management command:
+Throughout the course of development, it's a good idea to occasionally run Nautobot's test suite to catch any potential errors. Tests are run using the `invoke unittest` command (if using the Docker development environment) or the `nautobot-server test` command:
 
-```no-highlight
-$ nautobot-server test
-```
+| Docker Compose Workflow | Virtual Environment Workflow |
+|-------------------------|------------------------------|
+| `invoke unittest`       | `nautobot-server test`       |
 
 In cases where you haven't made any changes to the database (which is most of the time), you can append the `--keepdb` argument to this command to reuse the test database between runs. This cuts down on the time it takes to run the test suite since the database doesn't have to be rebuilt each time.
+
+| Docker Compose Workflow    | Virtual Environment Workflow    |
+|----------------------------|---------------------------------|
+| `invoke unittest --keepdb` | `nautobot-server test --keepdb` |
 
 !!! note
 	Using the `--keepdb` argument will cause errors if you've modified any model fields since the previous test run.
 
-```no-highlight
-$ nautobot-server test --keepdb
-```
-
 !!! warning
 	In some cases when tests fail and exit uncleanly it may leave the test database in an inconsistent state. If you encounter errors about missing objects, remove `--keepdb` and run the tests again.
+
+## Verifying Code Style
+
+To enforce best practices around consistent [coding style](style-guide.md), Nautobot uses [Flake8](https://flake8.pycqa.org/) and [Black](https://black.readthedocs.io/). You should run both of these commands and ensure that they pass fully with regard to your code changes before opening a pull request upstream.
+
+| Docker Compose Workflow | Virtual Environment Workflow |
+|-------------------------|------------------------------|
+| `invoke flake8`         | `flake8`                     |
+| `invoke black`          | `black`                      |
 
 ## Submitting Pull Requests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,5 @@ exclude = '''
     | build
     | dist
   )/
-  | settings.py     # This is where you define files that should not be stylized by black
-                     # the root of the project
 )
 '''

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,6 @@
 """Tasks for use with Invoke.
 
-(c) 2020 Network To Code
+(c) 2020-2021 Network To Code
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -26,263 +26,169 @@ COMPOSE_COMMAND = f'docker-compose --project-directory "{COMPOSE_DIR}" -f "{COMP
 if os.path.isfile(COMPOSE_OVERRIDE_FILE):
     COMPOSE_COMMAND += f' -f "{COMPOSE_OVERRIDE_FILE}"'
 
-NAUTOBOT_ROOT = "/opt/nautobot/"
+
+def docker_compose(context, command, **kwargs):
+    """Helper function for running a specific docker-compose command with all appropriate parameters and environment.
+
+    Args:
+        context (obj): Used to run specific commands
+        command (str): Command string to append to the "docker-compose ..." command, such as "build", "up", etc.
+        **kwargs: Passed through to the context.run() call.
+    """
+    print(f'Running docker-compose command "{command}"')
+    return context.run(f"{COMPOSE_COMMAND} {command}", env={"PYTHON_VER": PYTHON_VER}, **kwargs)
 
 
 # ------------------------------------------------------------------------------
 # BUILD
 # ------------------------------------------------------------------------------
 @task
-def build(context, python_ver=PYTHON_VER):
+def build(context, nocache=False, forcerm=False):
     """Build all docker images.
 
     Args:
         context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
+        nocache (bool): Do not use cache when building the image
+        forcerm (bool): Always remove intermediate containers
     """
     print("Building Nautobot .. ")
-
-    context.run(
-        f"{COMPOSE_COMMAND} build --build-arg PYTHON_VER={python_ver}",
-        env={"PYTHON_VER": python_ver},
-    )
+    command = f"build --build-arg PYTHON_VER={PYTHON_VER}"
+    if nocache:
+        command += " --no-cache"
+    if forcerm:
+        command += " --force-rm"
+    docker_compose(context, command)
 
 
 # ------------------------------------------------------------------------------
 # START / STOP / DEBUG
 # ------------------------------------------------------------------------------
 @task
-def debug(context, python_ver=PYTHON_VER):
-    """Start Nautobot and its dependencies in debug mode.
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
-    """
-    print("Starting Nautobot in debug mode.. ")
-
-    context.run(
-        f"{COMPOSE_COMMAND} up",
-        env={"PYTHON_VER": python_ver},
-    )
+def debug(context):
+    """Start Nautobot and its dependencies in debug mode."""
+    print("Starting Nautobot in debug mode...")
+    docker_compose(context, "up")
 
 
 @task
-def start(context, python_ver=PYTHON_VER):
-    """Start Nautobot and its dependencies in detached mode.
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
-    """
-    print("Starting Nautobot in detached mode .. ")
-
-    context.run(
-        f"{COMPOSE_COMMAND} up -d",
-        env={"PYTHON_VER": python_ver},
-    )
+def start(context):
+    """Start Nautobot and its dependencies in detached mode."""
+    print("Starting Nautobot in detached mode...")
+    docker_compose(context, "up --detach")
 
 
 @task
-def stop(context, python_ver=PYTHON_VER):
-    """Stop Nautobot and its dependencies.
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
-    """
-    print("Stopping Nautobot .. ")
-
-    context.run(
-        f"{COMPOSE_COMMAND} stop",
-        env={"PYTHON_VER": python_ver},
-    )
+def restart(context):
+    """Gracefully restart all containers."""
+    print("Restarting Nautobot...")
+    docker_compose(context, "restart")
 
 
 @task
-def destroy(context, python_ver=PYTHON_VER):
-    """Destroy all containers and volumes.
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
-    """
-    print("Destroying Nautobot .. ")
-
-    # Removes volumes associated with the COMPOSE_PROJECT_NAME
-    context.run(
-        f"{COMPOSE_COMMAND} down --volumes",
-        env={"PYTHON_VER": python_ver},
-    )
+def stop(context):
+    """Stop Nautobot and its dependencies."""
+    print("Stopping Nautobot...")
+    docker_compose(context, "down")
 
 
 @task
-def vscode(context, python_ver=PYTHON_VER):
-    """Launch Visual Studio Code with the appropriate Environment variables to run in a container.
+def destroy(context):
+    """Destroy all containers and volumes."""
+    print("Destroying Nautobot...")
+    docker_compose(context, "down --volumes")
 
-    Args:
-        context (obj): Used to run specific commands
-    """
-    context.run("code nautobot.code-workspace", env={"PYTHON_VER": python_ver})
+
+@task
+def vscode(context):
+    """Launch Visual Studio Code with the appropriate Environment variables to run in a container."""
+    context.run("code nautobot.code-workspace", env={"PYTHON_VER": PYTHON_VER})
 
 
 # ------------------------------------------------------------------------------
 # ACTIONS
 # ------------------------------------------------------------------------------
 @task
-def nbshell(context, python_ver=PYTHON_VER):
-    """Launch a nbshell session.
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
-    """
-    context.run(
-        f"{COMPOSE_COMMAND} exec nautobot nautobot-server nbshell",
-        env={"PYTHON_VER": python_ver},
-        pty=True,
-    )
+def nbshell(context):
+    """Launch an interactive nbshell session."""
+    docker_compose(context, "run nautobot nautobot-server nbshell", pty=True)
 
 
 @task
-def cli(context, python_ver=PYTHON_VER):
-    """Launch a bash shell inside the running Nautobot container.
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
-    """
-    context.run(
-        f"{COMPOSE_COMMAND} exec nautobot bash",
-        env={"PYTHON_VER": python_ver},
-        pty=True,
-    )
+def cli(context):
+    """Launch a bash shell inside the running Nautobot container."""
+    docker_compose(context, "exec nautobot bash", pty=True)
 
 
 @task
-def createsuperuser(context, user="admin", python_ver=PYTHON_VER):
-    """Create a new superuser in django (default: admin), will prompt for password.
+def createsuperuser(context, user="admin"):
+    """Create a new Nautobot superuser account (default: "admin"), will prompt for password.
 
     Args:
         context (obj): Used to run specific commands
         user (str): name of the superuser to create
-        python_ver (str): Will use the Python version docker image to build from
     """
-    context.run(
-        f"{COMPOSE_COMMAND} run nautobot nautobot-server createsuperuser --username {user}",
-        env={"PYTHON_VER": python_ver},
-        pty=True,
-    )
+    docker_compose(context, "run nautobot nautobot-server createsuperuser --username {user}", pty=True)
 
 
 @task
-def makemigrations(context, name="", python_ver=PYTHON_VER):
-    """Run Make Migration in Django.
+def makemigrations(context, name=""):
+    """Perform makemigrations operation in Django.
 
     Args:
         context (obj): Used to run specific commands
-        name (str): Name of the migration to be created
-        python_ver (str): Will use the Python version docker image to build from
+        name (str): Name of the migration to be created (if not specified, will autogenerate a name)
     """
+    command = "run nautobot nautobot-server makemigrations"
     if name:
-        context.run(
-            f"{COMPOSE_COMMAND} run nautobot nautobot-server makemigrations --name {name}",
-            env={"PYTHON_VER": python_ver},
-        )
-    else:
-        context.run(
-            f"{COMPOSE_COMMAND} run nautobot nautobot-server makemigrations",
-            env={"PYTHON_VER": python_ver},
-        )
+        command += f" --name {name}"
+    docker_compose(context, command)
 
 
 @task
-def migrate(context, python_ver=PYTHON_VER):
-    """Perform migrate operation in Django.
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
-    """
-    context.run(
-        f"{COMPOSE_COMMAND} run nautobot nautobot-server migrate",
-        env={"PYTHON_VER": python_ver},
-    )
+def migrate(context):
+    """Perform migrate operation in Django."""
+    docker_compose(context, "run nautobot nautobot-server migrate")
 
 
 # ------------------------------------------------------------------------------
 # TESTS
 # ------------------------------------------------------------------------------
 @task
-def black(context, python_ver=PYTHON_VER):
-    """Check Python code style with Black
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
-    """
-    context.run(
-        f"{COMPOSE_COMMAND} run nautobot black --check --diff contrib/ development/ nautobot/ tasks.py",
-        env={"PYTHON_VER": python_ver},
-        pty=True,
-    )
+def black(context):
+    """Check Python code style with Black."""
+    docker_compose(context, "run nautobot black --check --diff contrib/ development/ nautobot/ tasks.py", pty=True)
 
 
 @task
-def flake8(context, python_ver=PYTHON_VER):
-    """Check PEP8 compliance and other style issues
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
-    """
-    context.run(
-        f"{COMPOSE_COMMAND} run nautobot flake8 contrib/ development/ nautobot/ tasks.py",
-        env={"PYTHON_VER": python_ver},
-        pty=True,
-    )
+def flake8(context):
+    """Check for PEP8 compliance and other style issues."""
+    docker_compose(context, "run nautobot flake8 contrib/ development/ nautobot/ tasks.py", pty=True)
 
 
 @task
-def coverage_run(context, dir="./", python_ver=PYTHON_VER):
-    """Run tests
+def unittest(context, label="nautobot", keepdb=False):
+    """Run Nautobot unit tests.
 
     Args:
         context (obj): Used to run specific commands
-        dir (str): Used to indicate tested directory
-        python_ver (str): Will use the Python version docker image to build from
+        label (str): Indicate a directory or module to test instead of running all Nautobot tests
+        keepdb (bool): Save and re-use test database between test runs for faster re-testing.
     """
-    context.run(
-        f"{COMPOSE_COMMAND} run nautobot" f" coverage run scripts/test_runner.py test {dir}",
-        env={"PYTHON_VER": python_ver},
-        pty=True,
-    )
+    command = f"run nautobot coverage run scripts/test_runner.py test {label}"
+    if keepdb:
+        command += " --keepdb"
+    docker_compose(context, command, pty=True)
 
 
 @task
-def coverage_report(context, python_ver=PYTHON_VER):
-    """Run coverage report
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Will use the Python version docker image to build from
-    """
-    context.run(
-        f"{COMPOSE_COMMAND} run nautobot" f" coverage report --skip-covered --omit *migrations*",
-        env={"PYTHON_VER": python_ver},
-        pty=True,
-    )
+def unittest_coverage(context):
+    """Report on code test coverage as measured by 'invoke unittest'."""
+    docker_compose(context, "run nautobot coverage report --skip-covered --omit *migrations*", pty=True)
 
 
 @task
-def tests(context, python_ver=PYTHON_VER):
-    """Run all tests
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): WIll use the Python version docker image to build from
-    """
-    black(context, python_ver=python_ver)
-    flake8(context, python_ver=python_ver)
-    coverage_run(context, python_ver=python_ver)
-    coverage_report(context, python_ver=python_ver)
+def tests(context):
+    """Run all tests and linters."""
+    black(context)
+    flake8(context)
+    unittest(context)

--- a/tasks.py
+++ b/tasks.py
@@ -156,13 +156,17 @@ def migrate(context):
 @task
 def black(context):
     """Check Python code style with Black."""
-    docker_compose(context, "run nautobot black --check --diff contrib/ development/ nautobot/ tasks.py", pty=True)
+    docker_compose(
+        context,
+        "run --entrypoint 'black --check --diff contrib/ development/ nautobot/ tasks.py' nautobot",
+        pty=True,
+    )
 
 
 @task
 def flake8(context):
     """Check for PEP8 compliance and other style issues."""
-    docker_compose(context, "run nautobot flake8 contrib/ development/ nautobot/ tasks.py", pty=True)
+    docker_compose(context, "run --entrypoint 'flake8 contrib/ development/ nautobot/ tasks.py' nautobot", pty=True)
 
 
 @task
@@ -174,16 +178,17 @@ def unittest(context, label="nautobot", keepdb=False):
         label (str): Indicate a directory or module to test instead of running all Nautobot tests
         keepdb (bool): Save and re-use test database between test runs for faster re-testing.
     """
-    command = f"run nautobot coverage run scripts/test_runner.py test {label}"
+    command = f"run --entrypoint 'coverage run scripts/test_runner.py test {label}"
     if keepdb:
         command += " --keepdb"
+    command += "' nautobot"
     docker_compose(context, command, pty=True)
 
 
 @task
 def unittest_coverage(context):
     """Report on code test coverage as measured by 'invoke unittest'."""
-    docker_compose(context, "run nautobot coverage report --skip-covered --omit *migrations*", pty=True)
+    docker_compose(context, "run --entrypoint 'coverage report --skip-covered --omit *migrations*' nautobot", pty=True)
 
 
 @task


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #163 (in a roundabout way)
<!--
    Please include a summary of the proposed changes below.
-->

- Remove the "↩️ Skip creating the superuser" message from `docker-entrypoint.sh` (which is extraneous at best, and downright confusing when running `invoke createsuperuser`)
- Adjust logging configuration in the development environment so that it isn't verbose when running unit tests (which otherwise results in a lot of noise)
- Remove `--python-ver` argument from all invoke tasks and document in the developer guide that `export PYTHON_VER=3.x` is the way to set a non-default Python version for the Docker Compose workflow.
- Add `docker_compose()` helper function in `tasks.py` and use it to cut down boilerplate.
- Add `--nocache` and `--forcerm` options to the `build` task.
- Add `invoke restart` task.
- Rename `coverage-run` and `coverage-report` tasks to `unittest` and `unittest-coverage` respectively.
- Add `--keepdb` option to the `unittest` task
- Bypass `docker-entrypoint.sh` when running unit tests and linters (saving container startup time).