### PR TITLE
Remove obsolete logic to auto-set CSRF_TRUSTED_ORIGINS based on ALLOWED_HOSTS

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -70,7 +70,7 @@ ENFORCE_GLOBAL_UNIQUE = False
 # by specifying the model individually in the EXEMPT_VIEW_PERMISSIONS configuration parameter.
 EXEMPT_EXCLUDE_MODELS = (
     ("auth", "group"),
-    ("auth", "user"),
+    ("users", "user"),
     ("users", "objectpermission"),
 )
 
@@ -282,6 +282,7 @@ SECRET_KEY = os.environ.get("SECRET_KEY")
 
 # Default overrides
 ALLOWED_HOSTS = []
+CSRF_TRUSTED_ORIGINS = []
 DATETIME_FORMAT = "N j, Y g:i a"
 INTERNAL_IPS = ("127.0.0.1", "::1")
 LOGGING = {}
@@ -398,8 +399,6 @@ MESSAGE_TAGS = {
 # Authentication URLs
 LOGIN_URL = "/{}login/".format(BASE_PATH)
 LOGIN_REDIRECT_URL = "/"
-
-CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS
 
 #
 # From django-cors-headers

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -134,9 +134,11 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     # r'^(https?://)?(\w+\.)?example\.com$',
 ]
 
-# The file path where jobs will be stored. A trailing slash is not needed. Note that the default value of
-# this setting is inside the invoking user's home directory.
-# JOBS_ROOT = os.path.expanduser('~/.nautobot/jobs')
+# FQDNs that are considered trusted origins for secure, cross-domain, requests such as HTTPS POST.
+# If running Nautobot under a single domain, you may not need to set this variable;
+# if running on multiple domains, you *may* need to set this variable to more or less the same as ALLOWED_HOSTS above.
+# https://docs.djangoproject.com/en/stable/ref/settings/#csrf-trusted-origins
+CSRF_TRUSTED_ORIGINS = []
 
 # Set to True to enable server debugging. WARNING: Debugging introduces a substantial performance penalty and may reveal
 # sensitive information about your installation. Only enable debugging while performing testing. Never enable debugging

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -159,7 +159,7 @@ Previously this setting was called `CORS_ORIGIN_WHITELIST`, which still works as
 
 Default: `[]`
 
-A list of strings representing regexes that match Origins that are authorized to make cross-site HTTP requests. Useful when [`CORS_ALLOWED_ORIGINS`](#cores_allowed_origins) is impractical, such as when you have a large number of subdomains.
+A list of strings representing regexes that match Origins that are authorized to make cross-site HTTP requests. Useful when [`CORS_ALLOWED_ORIGINS`](#cors_allowed_origins) is impractical, such as when you have a large number of subdomains.
 
 Example:
 
@@ -170,6 +170,16 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
 ```
 
 Previously this setting was called `CORS_ORIGIN_REGEX_WHITELIST`, which still works as an alias, with the new name taking precedence.
+
+---
+
+## CSRF_TRUSTED_ORIGINS
+
+Default: `[]`
+
+A list of hosts (fully-qualified domain names (FQDNs) or subdomains) that are considered trusted origins for cross-site secure requests such as HTTPS POST.
+
+For more information, please see the [official Django documentation on `CSRF_TRUSTED_ORIGINS`](https://docs.djangoproject.com/en/stable/ref/settings/#csrf-trusted-origins) and more generally the [official Django documentation on CSRF protection](https://docs.djangoproject.com/en/stable/ref/csrf/#how-it-works)
 
 ---
 

--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -4,16 +4,19 @@
 
 This is a list of valid fully-qualified domain names (FQDNs) and/or IP addresses that can be used to reach the Nautobot service. Usually this is the same as the hostname for the Nautobot server, but can also be different; for example, when using a reverse proxy serving the Nautobot website under a different FQDN than the hostname of the Nautobot server. To help guard against [HTTP Host header attacks](https://docs.djangoproject.com/en/stable/topics/security/#host-headers-virtual-hosting), Nautobot will not permit access to the server via any other hostnames (or IPs).
 
+Keep in mind that by default Nautobot sets [`USE_X_FORWARDED_HOST`](https://docs.djangoproject.com/en/stable/ref/settings/#use-x-forwarded-host) to `True`, which means that if you're using a reverse proxy, the FQDN used to reach that reverse proxy needs to be in this list.
+
 !!! note
     This parameter must always be defined as a list or tuple, even if only a single value is provided.
-
-The value of this option is also used to set [`CSRF_TRUSTED_ORIGINS`](https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS), which restricts POST requests to the same set of hosts. Keep in mind that by default Nautobot sets [`USE_X_FORWARDED_HOST`](https://docs.djangoproject.com/en/stable/ref/settings/#use-x-forwarded-host) to `True`, which means that if you're using a reverse proxy, the FQDN used to reach that reverse proxy needs to be in this list.
 
 Example:
 
 ```
 ALLOWED_HOSTS = ['nautobot.example.com', '192.0.2.123']
 ```
+
+!!! tip
+    If there is more than one hostname in this list, you *may* also need to set [`CSRF_TRUSTED_ORIGINS`](optional-settings.md#csrf_trusted_origins) as well.
 
 If you are not yet sure what the domain name and/or IP address of the Nautobot installation will be, and are comfortable accepting the risks in doing so, you can set this to a wildcard (asterisk) to allow all host values:
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #188
<!--
    Please include a summary of the proposed changes below.
-->

Remove the code in `settings.py` that sets `CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS`, as that doesn't account for any changes made to `ALLOWED_HOSTS` by a user's `nautobot_config.py`. Update the documentation accordingly.

Also fix one reference to the legacy User model that I noticed in passing.