### PR TITLE
Update documentation reflecting Numeric ID to instead reflect UUID.

### DIFF
--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -52,7 +52,7 @@ HTTP_ACTIONS = {
 class BulkUpdateModelMixin:
     """
     Support bulk modification of objects using the list endpoint for a model. Accepts a PATCH action with a list of one
-    or more JSON objects, each specifying the numeric ID of an object to be updated as well as the attributes to be set.
+    or more JSON objects, each specifying the UUID of an object to be updated as well as the attributes to be set.
     For example:
 
     PATCH /api/dcim/sites/
@@ -101,12 +101,12 @@ class BulkUpdateModelMixin:
 class BulkDestroyModelMixin:
     """
     Support bulk deletion of objects using the list endpoint for a model. Accepts a DELETE action with a list of one
-    or more JSON objects, each specifying the numeric ID of an object to be deleted. For example:
+    or more JSON objects, each specifying the UUID of an object to be deleted. For example:
 
     DELETE /api/dcim/sites/
     [
-        {"id": 123},
-        {"id": 456}
+        {"id": "3f01f169-49b9-42d5-a526-df9118635d62"},
+        {"id": "c27d6c5b-7ea8-41e7-b9dd-c065efd5d9cd"}
     ]
     """
 

--- a/nautobot/docs/additional-features/caching.md
+++ b/nautobot/docs/additional-features/caching.md
@@ -6,10 +6,10 @@ If a change is made to any of the objects returned by the query within that time
 
 ## Invalidating Cached Data
 
-Although caching is performed automatically and rarely requires administrative intervention, Nautobot provides the `invalidate` management command to force invalidation of cached results. This command can reference a specific object my its type and numeric ID:
+Although caching is performed automatically and rarely requires administrative intervention, Nautobot provides the `invalidate` management command to force invalidation of cached results. This command can reference a specific object my its type and UUID:
 
 ```no-highlight
-$ nautobot-server invalidate dcim.Device.34
+$ nautobot-server invalidate dcim.Device.84ae706d-c189-4d13-a898-9737648e34b3
 ```
 
 Alternatively, it can also delete all cached results for an object type:

--- a/nautobot/docs/rest-api/overview.md
+++ b/nautobot/docs/rest-api/overview.md
@@ -14,13 +14,13 @@ Additionally, the `OPTIONS` verb can be used to inspect a particular REST API en
 One of the primary benefits of a REST API is its human-friendliness. Because it utilizes HTTP and JSON, it's very easy to interact with Nautobot data on the command line using common tools. For example, we can request an IP address from Nautobot and output the JSON using `curl` and `jq`. The following command makes an HTTP `GET` request for information about a particular IP address, identified by its primary key, and uses `jq` to present the raw JSON data returned in a more human-friendly format. (Piping the output through `jq` isn't strictly required but makes it much easier to read.)
 
 ```no-highlight
-curl -s http://nautobot/api/ipam/ip-addresses/2954/ | jq '.'
+curl -s http://nautobot/api/ipam/ip-addresses/c557df87-9a63-4555-bfd1-21cea2f6aac3/ | jq '.'
 ```
 
 ```json
 {
   "id": 2954,
-  "url": "http://nautobot/api/ipam/ip-addresses/2954/",
+  "url": "http://nautobot/api/ipam/ip-addresses/c557df87-9a63-4555-bfd1-21cea2f6aac3/",
   "family": {
     "value": 4,
     "label": "IPv4"
@@ -34,13 +34,13 @@ curl -s http://nautobot/api/ipam/ip-addresses/2954/ | jq '.'
   },
   "role": null,
   "assigned_object_type": "dcim.interface",
-  "assigned_object_id": 114771,
+  "assigned_object_id": "9fd066d2-135c-4005-b032-e0551cc61cec",
   "assigned_object": {
-    "id": 114771,
-    "url": "http://nautobot/api/dcim/interfaces/114771/",
+    "id": "9fd066d2-135c-4005-b032-e0551cc61cec",
+    "url": "http://nautobot/api/dcim/interfaces/9fd066d2-135c-4005-b032-e0551cc61cec/",
     "device": {
-      "id": 2230,
-      "url": "http://nautobot/api/dcim/devices/2230/",
+      "id": "6a522ebb-5739-4c5c-922f-ab4a2dc12eb0",
+      "url": "http://nautobot/api/dcim/devices/6a522ebb-5739-4c5c-922f-ab4a2dc12eb0/",
       "name": "router1",
       "display_name": "router1"
     },
@@ -80,15 +80,15 @@ Likewise, the site, rack, and device objects are located under the "DCIM" applic
 
 The full hierarchy of available endpoints can be viewed by navigating to the API root in a web browser.
 
-Each model generally has two views associated with it: a list view and a detail view. The list view is used to retrieve a list of multiple objects and to create new objects. The detail view is used to retrieve, update, or delete an single existing object. All objects are referenced by their numeric primary key (`id`).
+Each model generally has two views associated with it: a list view and a detail view. The list view is used to retrieve a list of multiple objects and to create new objects. The detail view is used to retrieve, update, or delete an single existing object. All objects are referenced by their UUID primary key (`id`).
 
 * `/api/dcim/devices/` - List existing devices or create a new device
-* `/api/dcim/devices/123/` - Retrieve, update, or delete the device with ID 123
+* `/api/dcim/devices/6a522ebb-5739-4c5c-922f-ab4a2dc12eb0/` - Retrieve, update, or delete the device with ID 6a522ebb-5739-4c5c-922f-ab4a2dc12eb0
 
-Lists of objects can be filtered using a set of query parameters. For example, to find all interfaces belonging to the device with ID 123:
+Lists of objects can be filtered using a set of query parameters. For example, to find all interfaces belonging to the device with ID 6a522ebb-5739-4c5c-922f-ab4a2dc12eb0:
 
 ```
-GET /api/dcim/interfaces/?device_id=123
+GET /api/dcim/interfaces/?device_id=6a522ebb-5739-4c5c-922f-ab4a2dc12eb0
 ```
 
 See the [filtering documentation](filtering.md) for more details.
@@ -101,14 +101,14 @@ The REST API employs two types of serializers to represent model data: base seri
 {
     "id": 1048,
     "site": {
-        "id": 7,
-        "url": "http://nautobot/api/dcim/sites/7/",
+        "id": "09c9e21c-e038-44fd-be9a-43aef97bff8f",
+        "url": "http://nautobot/api/dcim/sites/09c9e21c-e038-44fd-be9a-43aef97bff8f/",
         "name": "Corporate HQ",
         "slug": "corporate-hq"
     },
     "group": {
-        "id": 4,
-        "url": "http://nautobot/api/ipam/vlan-groups/4/",
+        "id": "eccc0964-9fab-43bc-bb77-66b1be08f64b",
+        "url": "http://nautobot/api/ipam/vlan-groups/eccc0964-9fab-43bc-bb77-66b1be08f64b/",
         "name": "Production",
         "slug": "production"
     },
@@ -116,12 +116,12 @@ The REST API employs two types of serializers to represent model data: base seri
     "name": "Users-Floor1",
     "tenant": null,
     "status": {
-        "value": 1,
+        "value": "active",
         "label": "Active"
     },
     "role": {
-        "id": 9,
-        "url": "http://nautobot/api/ipam/roles/9/",
+        "id": "a1fd5e46-a85e-48c3-a2f4-3c2ec2bb2464",
+        "url": "http://nautobot/api/ipam/roles/a1fd5e46-a85e-48c3-a2f4-3c2ec2bb2464/",
         "name": "User Access",
         "slug": "user-access"
     },
@@ -133,14 +133,14 @@ The REST API employs two types of serializers to represent model data: base seri
 
 ### Related Objects
 
-Related objects (e.g. `ForeignKey` fields) are represented using nested serializers. A nested serializer provides a minimal representation of an object, including only its direct URL and enough information to display the object to a user. When performing write API actions (`POST`, `PUT`, and `PATCH`), related objects may be specified by either numeric ID (primary key), or by a set of attributes sufficiently unique to return the desired object.
+Related objects (e.g. `ForeignKey` fields) are represented using nested serializers. A nested serializer provides a minimal representation of an object, including only its direct URL and enough information to display the object to a user. When performing write API actions (`POST`, `PUT`, and `PATCH`), related objects may be specified by either UUID (primary key), or by a set of attributes sufficiently unique to return the desired object.
 
 For example, when creating a new device, its rack can be specified by Nautobot ID (PK):
 
 ```json
 {
     "name": "MyNewDevice",
-    "rack": 123,
+    "rack": "7f3ca431-8103-45cc-a9ce-b94c1f784a1d",
     ...
 }
 ```
@@ -167,7 +167,7 @@ Note that if the provided parameters do not return exactly one object, a validat
 Some objects within Nautobot have attributes which can reference an object of multiple types, known as _generic relations_. For example, an IP address can be assigned to either a device interface _or_ a virtual machine interface. When making this assignment via the REST API, we must specify two attributes:
 
 * `assigned_object_type` - The content type of the assigned object, defined as `<app>.<model>`
-* `assigned_object_id` - The assigned object's unique numeric ID
+* `assigned_object_id` - The assigned object's unique UUID
 
 Together, these values identify a unique object in Nautobot. The assigned object (if any) is represented by the `assigned_object` attribute on the IP address model.
 
@@ -180,22 +180,22 @@ http://nautobot/api/ipam/ip-addresses/ \
 --data '{
     "address": "192.0.2.1/24",
     "assigned_object_type": "dcim.interface",
-    "assigned_object_id": 69023
+    "assigned_object_id": "e824bc29-623f-407e-8aa8-828f4c0b98ee"
 }'
 ```
 
 ```json
 {
-    "id": 56296,
+    "id": "e2f29f8f-002a-4c4a-9d19-24cc7549e715",
     "url": "http://nautobot/api/ipam/ip-addresses/56296/",
     "assigned_object_type": "dcim.interface",
-    "assigned_object_id": 69000,
+    "assigned_object_id": "e824bc29-623f-407e-8aa8-828f4c0b98ee",
     "assigned_object": {
-        "id": 69000,
-        "url": "http://nautobot/api/dcim/interfaces/69023/",
+        "id": "e824bc29-623f-407e-8aa8-828f4c0b98ee",
+        "url": "http://nautobot/api/dcim/interfaces/e824bc29-623f-407e-8aa8-828f4c0b98ee/",
         "device": {
-            "id": 2174,
-            "url": "http://nautobot/api/dcim/devices/2174/",
+            "id": "76816a69-db2c-40e6-812d-115c61156e21",
+            "url": "http://nautobot/api/dcim/devices/76816a69-db2c-40e6-812d-115c61156e21/",
             "name": "device105",
             "display_name": "device105"
         },
@@ -214,19 +214,19 @@ If we wanted to assign this IP address to a virtual machine interface instead, w
 Most API endpoints support an optional "brief" format, which returns only a minimal representation of each object in the response. This is useful when you need only a list of available objects without any related data, such as when populating a drop-down list in a form. As an example, the default (complete) format of an IP address looks like this:
 
 ```
-GET /api/ipam/prefixes/13980/
+GET /api/ipam/prefixes/7d2d24ac-4737-4fc1-a850-b30366618f3d/
 
 {
-    "id": 13980,
-    "url": "http://nautobot/api/ipam/prefixes/13980/",
+    "id": "7d2d24ac-4737-4fc1-a850-b30366618f3d",
+    "url": "http://nautobot/api/ipam/prefixes/7d2d24ac-4737-4fc1-a850-b30366618f3d/",
     "family": {
         "value": 4,
         "label": "IPv4"
     },
     "prefix": "192.0.2.0/24",
     "site": {
-        "id": 3,
-        "url": "http://nautobot/api/dcim/sites/17/",
+        "id": "b9edf2ee-cad9-48be-9921-006294bff730",
+        "url": "http://nautobot/api/dcim/sites/b9edf2ee-cad9-48be-9921-006294bff730/",
         "name": "Site 23A",
         "slug": "site-23a"
     },
@@ -238,8 +238,8 @@ GET /api/ipam/prefixes/13980/
         "label": "Container"
     },
     "role": {
-        "id": 17,
-        "url": "http://nautobot/api/ipam/roles/17/",
+        "id": "ae1470bc-a858-4ce7-b9ce-dd1cd46333fe",
+        "url": "http://nautobot/api/ipam/roles/ae1470bc-a858-4ce7-b9ce-dd1cd46333fe/",
         "name": "Staging",
         "slug": "staging"
     },
@@ -255,11 +255,11 @@ GET /api/ipam/prefixes/13980/
 The brief format is much more terse:
 
 ```
-GET /api/ipam/prefixes/13980/?brief=1
+GET /api/ipam/prefixes/7d2d24ac-4737-4fc1-a850-b30366618f3d/?brief=1
 
 {
-    "id": 13980,
-    "url": "http://nautobot/api/ipam/prefixes/13980/",
+    "id": "7d2d24ac-4737-4fc1-a850-b30366618f3d",
+    "url": "http://nautobot/api/ipam/prefixes/7d2d24ac-4737-4fc1-a850-b30366618f3d/",
     "family": 4,
     "prefix": "10.40.3.0/24"
 }
@@ -294,12 +294,12 @@ Vary: Accept
     "previous": null,
     "results": [
         {
-            "id": 231,
+            "id": "fa069c4b-4f6e-4349-88ac-8b6baf9d70c5",
             "name": "Device1",
             ...
         },
         {
-            "id": 232,
+            "id": "a37df58c-8bf3-4b97-bad5-301ef3880bea",
             "name": "Device2",
             ...
         },
@@ -347,17 +347,17 @@ curl -s -X GET http://nautobot/api/ipam/ip-addresses/ | jq '.'
   "previous": null,
   "results": [
     {
-      "id": 5618,
+      "id": "bd307eca-de34-4bda-9195-d69ca52206d6",
       "address": "192.0.2.1/24",
       ...
     },
     {
-      "id": 5619,
+      "id": "6c52e918-4f0c-4c50-ae49-6bef22c97fd5",
       "address": "192.0.2.2/24",
       ...
     },
     {
-      "id": 5620,
+      "id": "b8cde1ee-1b86-4ea4-a884-041c472d8999",
       "address": "192.0.2.3/24",
       ...
     },
@@ -368,18 +368,18 @@ curl -s -X GET http://nautobot/api/ipam/ip-addresses/ | jq '.'
 
 ### Retrieving a Single Object
 
-To query Nautobot for a single object, make a `GET` request to the model's _detail_ endpoint specifying its unique numeric ID.
+To query Nautobot for a single object, make a `GET` request to the model's _detail_ endpoint specifying its unique UUID.
 
 !!! note
     Note that the trailing slash is required. Omitting this will return a 302 redirect.
 
 ```no-highlight
-curl -s -X GET http://nautobot/api/ipam/ip-addresses/5618/ | jq '.'
+curl -s -X GET http://nautobot/api/ipam/ip-addresses/bd307eca-de34-4bda-9195-d69ca52206d6/ | jq '.'
 ```
 
 ```json
 {
-  "id": 5618,
+  "id": "bd307eca-de34-4bda-9195-d69ca52206d6",
   "address": "192.0.2.1/24",
   ...
 }
@@ -394,21 +394,21 @@ curl -s -X POST \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
 http://nautobot/api/ipam/prefixes/ \
---data '{"prefix": "192.0.2.0/24", "site": 6}' | jq '.'
+--data '{"prefix": "192.0.2.0/24", "site": 8df9e629-4338-438b-8ea9-06114f7be08e}' | jq '.'
 ```
 
 ```json
 {
-  "id": 18691,
-  "url": "http://nautobot/api/ipam/prefixes/18691/",
+  "id": "48df6965-0fcb-4155-b5f8-00fe8b9b01af",
+  "url": "http://nautobot/api/ipam/prefixes/48df6965-0fcb-4155-b5f8-00fe8b9b01af/",
   "family": {
     "value": 4,
     "label": "IPv4"
   },
   "prefix": "192.0.2.0/24",
   "site": {
-    "id": 6,
-    "url": "http://nautobot/api/dcim/sites/6/",
+    "id": "8df9e629-4338-438b-8ea9-06114f7be08e",
+    "url": "http://nautobot/api/dcim/sites/8df9e629-4338-438b-8ea9-06114f7be08e/",
     "name": "US-East 4",
     "slug": "us-east-4"
   },
@@ -448,20 +448,20 @@ http://nautobot/api/dcim/sites/ \
 ```json
 [
     {
-        "id": 21,
-        "url": "http://nautobot/api/dcim/sites/21/",
+        "id": "0238a4e3-66f2-455a-831f-5f177215de0f",
+        "url": "http://nautobot/api/dcim/sites/0238a4e3-66f2-455a-831f-5f177215de0f/",
         "name": "Site 1",
         ...
     },
     {
-        "id": 22,
-        "url": "http://nautobot/api/dcim/sites/22/",
+        "id": "33ac3a3b-0ee7-49b7-bf2a-244096051dc0",
+        "url": "http://nautobot/api/dcim/sites/33ac3a3b-0ee7-49b7-bf2a-244096051dc0/",
         "name": "Site 2",
         ...
     },
     {
-        "id": 23,
-        "url": "http://nautobot/api/dcim/sites/23/",
+        "id": "10b3134d-960b-4794-ad18-0e73edd357c4",
+        "url": "http://nautobot/api/dcim/sites/10b3134d-960b-4794-ad18-0e73edd357c4/",
         "name": "Site 3",
         ...
     }
@@ -470,28 +470,28 @@ http://nautobot/api/dcim/sites/ \
 
 ### Updating an Object
 
-To modify an object which has already been created, make a `PATCH` request to the model's _detail_ endpoint specifying its unique numeric ID. Include any data which you wish to update on the object. As with object creation, the `Authorization` and `Content-Type` headers must also be specified.
+To modify an object which has already been created, make a `PATCH` request to the model's _detail_ endpoint specifying its unique UUID. Include any data which you wish to update on the object. As with object creation, the `Authorization` and `Content-Type` headers must also be specified.
 
 ```no-highlight
 curl -s -X PATCH \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
-http://nautobot/api/ipam/prefixes/18691/ \
+http://nautobot/api/ipam/prefixes/b484b0ac-12e3-484a-84c0-aa17955eaedc/ \
 --data '{"status": "reserved"}' | jq '.'
 ```
 
 ```json
 {
-  "id": 18691,
-  "url": "http://nautobot/api/ipam/prefixes/18691/",
+  "id": "48df6965-0fcb-4155-b5f8-00fe8b9b01af",
+  "url": "http://nautobot/api/ipam/prefixes/48df6965-0fcb-4155-b5f8-00fe8b9b01af/",
   "family": {
     "value": 4,
     "label": "IPv4"
   },
   "prefix": "192.0.2.0/24",
   "site": {
-    "id": 6,
-    "url": "http://nautobot/api/dcim/sites/6/",
+    "id": "8df9e629-4338-438b-8ea9-06114f7be08e",
+    "url": "http://nautobot/api/dcim/sites/8df9e629-4338-438b-8ea9-06114f7be08e/",
     "name": "US-East 4",
     "slug": "us-east-4"
   },
@@ -517,14 +517,14 @@ http://nautobot/api/ipam/prefixes/18691/ \
 
 ### Updating Multiple Objects
 
-Multiple objects can be updated simultaneously by issuing a `PUT` or `PATCH` request to a model's list endpoint with a list of dictionaries specifying the numeric ID of each object to be deleted and the attributes to be updated. For example, to update sites with IDs 10 and 11 to a status of "active", issue the following request:
+Multiple objects can be updated simultaneously by issuing a `PUT` or `PATCH` request to a model's list endpoint with a list of dictionaries specifying the UUID of each object to be deleted and the attributes to be updated. For example, to update sites with UUIDs 18de055e-3ea9-4cc3-ba78-b7eef6f0d589 and 1a414273-3d68-4586-ba22-6ae0a5702b8f to a status of "active", issue the following request:
 
 ```no-highlight
 curl -s -X PATCH \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
 http://nautobot/api/dcim/sites/ \
---data '[{"id": 10, "status": "active"}, {"id": 11, "status": "active"}]'
+--data '[{"id": "18de055e-3ea9-4cc3-ba78-b7eef6f0d589", "status": "active"}, {"id": "1a414273-3d68-4586-ba22-6ae0a5702b8f", "status": "active"}]'
 ```
 
 Note that there is no requirement for the attributes to be identical among objects. For instance, it's possible to update the status of one site along with the name of another in the same request.
@@ -534,12 +534,12 @@ Note that there is no requirement for the attributes to be identical among objec
 
 ### Deleting an Object
 
-To delete an object from Nautobot, make a `DELETE` request to the model's _detail_ endpoint specifying its unique numeric ID. The `Authorization` header must be included to specify an authorization token, however this type of request does not support passing any data in the body.
+To delete an object from Nautobot, make a `DELETE` request to the model's _detail_ endpoint specifying its unique UUID. The `Authorization` header must be included to specify an authorization token, however this type of request does not support passing any data in the body.
 
 ```no-highlight
 curl -s -X DELETE \
 -H "Authorization: Token $TOKEN" \
-http://nautobot/api/ipam/prefixes/18691/
+http://nautobot/api/ipam/prefixes/48df6965-0fcb-4155-b5f8-00fe8b9b01af/
 ```
 
 Note that `DELETE` requests do not return any data: If successful, the API will return a 204 (No Content) response.
@@ -549,14 +549,14 @@ Note that `DELETE` requests do not return any data: If successful, the API will 
 
 ### Deleting Multiple Objects
 
-Nautobot supports the simultaneous deletion of multiple objects of the same type by issuing a `DELETE` request to the model's list endpoint with a list of dictionaries specifying the numeric ID of each object to be deleted. For example, to delete sites with IDs 10, 11, and 12, issue the following request:
+Nautobot supports the simultaneous deletion of multiple objects of the same type by issuing a `DELETE` request to the model's list endpoint with a list of dictionaries specifying the UUID of each object to be deleted. For example, to delete sites with UUIDs 18de055e-3ea9-4cc3-ba78-b7eef6f0d589, 1a414273-3d68-4586-ba22-6ae0a5702b8f, and c2516019-caf6-41f0-98a6-4276c1a73fa3, issue the following request:
 
 ```no-highlight
 curl -s -X DELETE \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
 http://nautobot/api/dcim/sites/ \
---data '[{"id": 10}, {"id": 11}, {"id": 12}]'
+--data '[{"id": "18de055e-3ea9-4cc3-ba78-b7eef6f0d589"}, {"id": "1a414273-3d68-4586-ba22-6ae0a5702b8f"}, {"id": "c2516019-caf6-41f0-98a6-4276c1a73fa3"}]'
 ```
 
 !!! note

--- a/nautobot/docs/rest-api/overview.md
+++ b/nautobot/docs/rest-api/overview.md
@@ -167,7 +167,7 @@ Note that if the provided parameters do not return exactly one object, a validat
 Some objects within Nautobot have attributes which can reference an object of multiple types, known as _generic relations_. For example, an IP address can be assigned to either a device interface _or_ a virtual machine interface. When making this assignment via the REST API, we must specify two attributes:
 
 * `assigned_object_type` - The content type of the assigned object, defined as `<app>.<model>`
-* `assigned_object_id` - The assigned object's unique UUID
+* `assigned_object_id` - The assigned object's UUID
 
 Together, these values identify a unique object in Nautobot. The assigned object (if any) is represented by the `assigned_object` attribute on the IP address model.
 
@@ -368,7 +368,7 @@ curl -s -X GET http://nautobot/api/ipam/ip-addresses/ | jq '.'
 
 ### Retrieving a Single Object
 
-To query Nautobot for a single object, make a `GET` request to the model's _detail_ endpoint specifying its unique UUID.
+To query Nautobot for a single object, make a `GET` request to the model's _detail_ endpoint specifying its UUID.
 
 !!! note
     Note that the trailing slash is required. Omitting this will return a 302 redirect.
@@ -470,7 +470,7 @@ http://nautobot/api/dcim/sites/ \
 
 ### Updating an Object
 
-To modify an object which has already been created, make a `PATCH` request to the model's _detail_ endpoint specifying its unique UUID. Include any data which you wish to update on the object. As with object creation, the `Authorization` and `Content-Type` headers must also be specified.
+To modify an object which has already been created, make a `PATCH` request to the model's _detail_ endpoint specifying its UUID. Include any data which you wish to update on the object. As with object creation, the `Authorization` and `Content-Type` headers must also be specified.
 
 ```no-highlight
 curl -s -X PATCH \
@@ -534,7 +534,7 @@ Note that there is no requirement for the attributes to be identical among objec
 
 ### Deleting an Object
 
-To delete an object from Nautobot, make a `DELETE` request to the model's _detail_ endpoint specifying its unique UUID. The `Authorization` header must be included to specify an authorization token, however this type of request does not support passing any data in the body.
+To delete an object from Nautobot, make a `DELETE` request to the model's _detail_ endpoint specifying its UUID. The `Authorization` header must be included to specify an authorization token, however this type of request does not support passing any data in the body.
 
 ```no-highlight
 curl -s -X DELETE \

--- a/nautobot/utilities/testing/api.py
+++ b/nautobot/utilities/testing/api.py
@@ -358,7 +358,7 @@ class APIViewTestCases:
 
         def test_delete_object(self):
             """
-            DELETE a single object identified by its UUID.
+            DELETE a single object identified by its primary key.
             """
             instance = self._get_queryset().first()
             url = self._get_detail_url(instance)

--- a/nautobot/utilities/testing/api.py
+++ b/nautobot/utilities/testing/api.py
@@ -358,7 +358,7 @@ class APIViewTestCases:
 
         def test_delete_object(self):
             """
-            DELETE a single object identified by its numeric ID.
+            DELETE a single object identified by its UUID.
             """
             instance = self._get_queryset().first()
             url = self._get_detail_url(instance)

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -85,7 +85,7 @@ class TestCase(_TestCase):
 
             if api:
 
-                # Replace ContentType numeric IDs with <app_label>.<model>
+                # Replace ContentType UUIDs with <app_label>.<model>
                 if type(getattr(instance, key)) is ContentType:
                     ct = ContentType.objects.get(pk=value)
                     model_dict[key] = f"{ct.app_label}.{ct.model}"

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -85,7 +85,7 @@ class TestCase(_TestCase):
 
             if api:
 
-                # Replace ContentType UUIDs with <app_label>.<model>
+                # Replace ContentType primary keys with <app_label>.<model>
                 if type(getattr(instance, key)) is ContentType:
                     ct = ContentType.objects.get(pk=value)
                     model_dict[key] = f"{ct.app_label}.{ct.model}"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #205 
<!--
    Please include a summary of the proposed changes below.
-->
This PR updates all documentation in REST Overview to use UUID's instead of Numeric IDs. This also includes a few docstring corrections and updates a reference to the Numeric ID in the caching.md.

This skips over the numeric ID when refrencing VLAN ID (1-4096).
