### PR TITLE
Fix for GraphQL fsargs breaking custom filter methods

### DIFF
--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -170,7 +170,7 @@ def generate_list_resolver(schema_type, resolver_name):
             # the value cannot be inside a list. https://docs.djangoproject.com/en/3.1/ref/request-response/#querydict-objects
             for key, value in kwargs.items():
                 # Check if filter field has a method attached
-                if schema_type._meta.filterset_class.base_filters[key]._method:
+                if schema_type._meta.filterset_class.base_filters[key]._method is not None:
                     fsargs[key] = value
                 else:
                     # Put value inside of list if there is no method

--- a/nautobot/ipam/graphql/types.py
+++ b/nautobot/ipam/graphql/types.py
@@ -1,3 +1,5 @@
+import graphene
+
 from graphene_django import DjangoObjectType
 
 from nautobot.ipam.models import IPAddress
@@ -7,6 +9,8 @@ from nautobot.extras.graphql.types import TagType  # noqa: F401
 
 class IPAddressType(DjangoObjectType):
     """Graphql Type Object for IPAddress model."""
+
+    address = graphene.String()
 
     class Meta:
         model = IPAddress


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #167 
<!--
    Please include a summary of the proposed changes below.
-->

Fix virtual field filtering: Added code to IPAM IPAddressType to allow filtering on virtual fields. 

Fix for #167: Modified GraphQL list generator to allow for custom method fields. ​
Before the fix `list_resolver` created filter parameters by taking kwargs and making a custom dict called fsargs. 
Example of kwargs:
``` python
{
    'status': 'active',
    'parent': '10.0.65.0/24'
}
```

After `list_resolver` has processed kwargs (fsargs):
``` python
{
    'status': ['active'],
    'parent': ['10.0.65.0/24']
}
```

For a search field like status, this is good. Django filters get passed inside of list objects and it is handle correctly.
But with a field like parent, which has a method attached, the fsargs value is passed into the custom method as a string. This means the function receives a value parameter of `"['10.0.65.0/24']"`, so there are no matches when from the GraphQL request.

The fix is to catch when a field has a method attached, if there is then the value should not be put into a list.

``` python
            for key, value in kwargs.items():
                # Check if filter field has a method attached
                if schema_type._meta.filterset_class.base_filters[key]._method:
                    fsargs[key] = value
                else:
                    # Put value inside of list if there is no method
                    fsargs[key] = [value]
```
