### PR TITLE
Add QFSP+ (64GFC) FiberChannel interface type

### DIFF
--- a/nautobot/dcim/choices.py
+++ b/nautobot/dcim/choices.py
@@ -735,6 +735,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_8GFC_SFP_PLUS = "8gfc-sfpp"
     TYPE_16GFC_SFP_PLUS = "16gfc-sfpp"
     TYPE_32GFC_SFP28 = "32gfc-sfp28"
+    TYPE_64GFC_QSFP_PLUS = "64gfc-qsfpp"
     TYPE_128GFC_QSFP28 = "128gfc-sfp28"
 
     # InfiniBand
@@ -850,6 +851,7 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_8GFC_SFP_PLUS, "SFP+ (8GFC)"),
                 (TYPE_16GFC_SFP_PLUS, "SFP+ (16GFC)"),
                 (TYPE_32GFC_SFP28, "SFP28 (32GFC)"),
+                (TYPE_64GFC_QSFP_PLUS, "QSFP+ (64GFC)"),
                 (TYPE_128GFC_QSFP28, "QSFP28 (128GFC)"),
             ),
         ),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #N/A
<!--
    Please include a summary of the proposed changes below.
-->

Simple port of netbox-community/netbox#5670 to Nautobot to improve compatibility with NetBox.