### PR TITLE
Fix #224 - IPAM network objects will now emit current address

### DIFF
--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -389,6 +389,7 @@ class PrefixForm(PrefixFieldMixin, BootstrapMixin, TenancyForm, CustomFieldModel
         ]
 
     def __init__(self, *args, **kwargs):
+
         super().__init__(*args, **kwargs)
 
         self.fields["vrf"].empty_label = "Global"
@@ -691,6 +692,8 @@ class IPAddressForm(
                 elif type(nat_inside_parent) is VMInterface:
                     initial["nat_cluster"] = nat_inside_parent.virtual_machine.cluster.pk
                     initial["nat_virtual_machine"] = nat_inside_parent.virtual_machine.pk
+            # Address is a computed field, so it must be added to initial.
+            initial["address"] = instance.address
         kwargs["initial"] = initial
 
         super().__init__(*args, **kwargs)

--- a/nautobot/utilities/forms/forms.py
+++ b/nautobot/utilities/forms/forms.py
@@ -130,6 +130,20 @@ class PrefixFieldMixin(forms.ModelForm):
 
     prefix = IPNetworkFormField()
 
+    def __init__(self, *args, **kwargs):
+
+        instance = kwargs.get("instance")
+        initial = kwargs.get("initial", {}).copy()
+
+        # If we're editing an object with a `prefix` field, we need to patch initial to include
+        # `prefix` because it is a computed field.
+        if instance is not None:
+            initial["prefix"] = instance.prefix
+
+        kwargs["initial"] = initial
+
+        super().__init__(*args, **kwargs)
+
     def save(self, *args, **kwargs):
         instance = super().save(commit=False)
         # call the model's prefix.setter method


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #224 
<!--
    Please include a summary of the proposed changes below.
-->
This is required due to having changed `Prefix.prefix`, `Aggregate.prefix`, and `IPAddress.address` from concrete database fields to computed model fields. Once we have an instance, these fields can be accessed but because they aren't single database fields they do not get auto-populated like they did before.

I addressed this in `PrefixFieldMixin` for `Prefix` and `Aggregate` models, because the same fix would need to be applied to both of them. I applied this in `IPAddressForm.__init__` for the `IPAddress` model, because this is the only place it is used, and `IPAddressForm` has a lot more going on there I didn't want to muck with. 