### PR TITLE
Swap contrib.postgres.fields.JSONField for db.models.JSONField

### DIFF
--- a/nautobot/utilities/custom_inspectors.py
+++ b/nautobot/utilities/custom_inspectors.py
@@ -1,4 +1,4 @@
-from django.contrib.postgres.fields import JSONField
+from django.db.models import JSONField
 from drf_yasg import openapi
 from drf_yasg.inspectors import (
     FieldInspector,


### PR DESCRIPTION
Reeplace Postgres-specific JSONField code in Swagger autoschema generation.