### PR TITLE
Fix all the GraphQL search/filtering issues

### DIFF
--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -112,9 +112,15 @@ def generate_list_search_parameters(schema_type):
     """Generate list of query parameters for the list resolver based on a filterset."""
 
     search_params = {}
-    if schema_type._meta.filterset_class:
+    if schema_type._meta.filterset_class is not None:
+        # We need an instance for custom fields generation to happen for the
+        # filterset_class or the `cf_*` fields won't be detected.
+        filterset = schema_type._meta.filterset_class()
+        # Patch base_filters because `get_filtering_args_from_filterset` looks there
+        filterset.base_filters = filterset.filters
+
         search_params = get_filtering_args_from_filterset(
-            schema_type._meta.filterset_class,
+            filterset,
             schema_type,
         )
 

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -117,7 +117,6 @@ def generate_list_search_parameters(schema_type):
     """Generate list of query parameters for the list resolver based on a filterset."""
 
     search_params = {}
-    exclude_filters = ["type"]
     if schema_type._meta.filterset_class:
         search_params = get_filtering_args_from_filterset(
             schema_type._meta.filterset_class,
@@ -176,9 +175,7 @@ def generate_list_resolver(schema_type, resolver_name):
     def list_resolver(self, info, **kwargs):
         filterset_class = schema_type._meta.filterset_class
         if filterset_class is not None:
-            resolved_obj = filterset_class(
-                kwargs, model.objects.restrict(info.context.user, "view").all()
-            )
+            resolved_obj = filterset_class(kwargs, model.objects.restrict(info.context.user, "view").all())
 
             # Check result filter for errors.
             if resolved_obj.errors:

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -170,7 +170,7 @@ def generate_list_resolver(schema_type, resolver_name):
             # the value cannot be inside a list. https://docs.djangoproject.com/en/3.1/ref/request-response/#querydict-objects
             for key, value in kwargs.items():
                 # Check if filter field has a method attached
-                if schema_type._meta.filterset_class.base_filters[key]._method:
+                if schema_type._meta.filterset_class.base_filters[key]._method is not None:
                     fsargs[key] = value
                 else:
                     # Put value inside of list if there is no method

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -124,11 +124,13 @@ def generate_list_search_parameters(schema_type):
             schema_type,
         )
 
-    # Hack to swap `type` fields to `type_` since they will conflict with
-    # `graphene.types.fields.Field.type`.
-    # FIXME(jathan): Once we upgrade to Graphene 3.x, remove this.
+    # Hack to swap `type` fields to `_type` since they will conflict with
+    # `graphene.types.fields.Field.type` in Graphene 2.x.
+    # TODO(jathan): Once we upgrade to Graphene 3.x we can remove this, but we
+    # will still need to do an API migration to deprecate it. This argument was
+    # validated to be safe to keep even in Graphene 3.
     if "type" in search_params:
-        search_params["type_"] = search_params.pop("type")
+        search_params["_type"] = search_params.pop("type")
 
     return search_params
 

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -16,11 +16,6 @@ from nautobot.utilities.utils import get_filterset_for_model
 logger = logging.getLogger("nautobot.graphql.generators")
 RESOLVER_PREFIX = "resolve_"
 
-# List field types
-LIST_FIELDS = [
-    django_filters.fields.ModelMultipleChoiceField,
-]
-
 
 def generate_restricted_queryset():
     """Generate a function to return a restricted queryset compatible with the internal permissions system."""

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -29,7 +29,7 @@ from nautobot.extras.registry import registry
 from nautobot.extras.models import CustomField, Relationship
 from nautobot.extras.choices import CustomFieldTypeChoices, RelationshipSideChoices
 from nautobot.extras.graphql.types import TagType
-from nautobot.ipam.graphql.types import IPAddressType
+from nautobot.ipam.graphql.types import AggregateType, IPAddressType, PrefixType
 
 logger = logging.getLogger("nautobot.graphql.schema")
 
@@ -40,7 +40,9 @@ registry["graphql_types"]["dcim.interface"] = InterfaceType
 registry["graphql_types"]["dcim.rack"] = RackType
 registry["graphql_types"]["dcim.cable"] = CableType
 registry["graphql_types"]["dcim.consoleserverport"] = ConsoleServerPortType
+registry["graphql_types"]["ipam.aggregate"] = AggregateType
 registry["graphql_types"]["ipam.ipaddress"] = IPAddressType
+registry["graphql_types"]["ipam.prefix"] = PrefixType
 registry["graphql_types"]["circuits.circuittermination"] = CircuitTerminationType
 registry["graphql_types"]["extras.tag"] = TagType
 

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -352,7 +352,7 @@ class GraphQLAPIPermissionTest(TestCase):
         """
 
         self.get_racks_var_query = """
-        query ($site: String!) {
+        query ($site: [ID]!) {
             racks(site: $site) {
                 name
             }

--- a/nautobot/docs/release-notes/version-1.0.md
+++ b/nautobot/docs/release-notes/version-1.0.md
@@ -4,7 +4,7 @@ This document describes all new features and changes in Nautobot 1.0, a divergen
 
 Users migrating from NetBox to Nautobot should also refer to the ["Migrating from NetBox"](../installation/migrating-from-netbox.md) documentation as well.
 
-## v1.0.0b3 (FUTURE)
+## v1.0.0b3 (2021-04-05)
 
 !!! warning
     v1.0.0b3 introduces several database changes that are **not** backwards-compatible with v1.0.0b2 and earlier. There is no direct upgrade path from v1.0.0b2 to v1.0.0b3 - you **must** create a new database when installing v1.0.0b3!
@@ -16,36 +16,71 @@ Users migrating from NetBox to Nautobot should also refer to the ["Migrating fro
 - [#109](https://github.com/nautobot/nautobot/pull/109) - Docker development environment build now automatically installs from any present `local_requirements.txt` file
 - [#121](https://github.com/nautobot/nautobot/pull/121) - Added "Data Model Changes" section to the "Migrating from NetBox" documentation
 - [#141](https://github.com/nautobot/nautobot/pull/141) - Custom Link UI now includes example usage hints
+- [#227](https://github.com/nautobot/nautobot/pull/227) - Add QFSP+ (64GFC) FiberChannel interface type
+- [#236](https://github.com/nautobot/nautobot/pull/236) - Add `post_upgrade` to developer docs and add `invoke post-upgrade`
 
 ### Changed
+
+Major backwards-incompatible database changes were included in this beta release that are intended are to pave the way for us to support MySQL as a database backend in a future update. Of those changes, these are the most notable:
+
+- All IPAM objects with network field types (`ipam.Aggregate`, `ipam.IPAddress`, and `ipam.Prefix`) are no longer hard-coded to use PostgreSQL-only `inet` or `cidr` field types and are now using a custom implementation leveraging SQL-standard `varbinary` field types
+- The `users.User` model has been completely replaced with a custom implementation that no longer requires the use of a secondary database table for storing user configuration.
+- Custom Fields have been overhauled for asserting data integrity and improving user experience
+    - Custom Fields can no longer be renamed or have their type changed after they have been created.
+    - Choices for Custom Fields are now stored as discrete database objects. Choices that are in active use cannot be deleted.
+
+Other changes:
 
 - [#78](https://github.com/nautobot/nautobot/pull/78) - Replaced PostgreSQL-specific IP network/address fields with more generic field types
 - [#83](https://github.com/nautobot/nautobot/issues/83) - Custom user model added; UserConfig model merged into User model
 - [#84](https://github.com/nautobot/nautobot/issues/84) - Revised developer documentation for clarity and current workflows
+- [#98](https://github.com/nautobot/nautobot/issues/98) - Simplify MultipleContentTypeField boilerplate
 - [#119](https://github.com/nautobot/nautobot/pull/119) - Various documentation improvements
+- [#120](https://github.com/nautobot/nautobot/issues/120) - Revise development release checklist document for new processes
+- [#128](https://github.com/nautobot/nautobot/pull/128) - Overview of usage for the `nautobot-netbox-importer` plugin could be mistaken for full instructions
 - [#122](https://github.com/nautobot/nautobot/pull/122) - Improved installation flow for creating nautobot user and virtualenv
 - [#131](https://github.com/nautobot/nautobot/pull/131) - Replaced PostgreSQL-specific ArrayField with a more generic JSONArrayField
+- [#137](https://github.com/nautobot/nautobot/issues/137) - Explicitly disallow Custom Field Name Changes
 - [#142](https://github.com/nautobot/nautobot/pull/142) - Converted various config validation checks into proper Django checks
+- [#149](https://github.com/nautobot/nautobot/issues/149) - Unify optional settings documentation for `REMOTE_AUTH*/SOCIAL_AUTH*`
+- [#159](https://github.com/nautobot/nautobot/issues/159) - Update documentation for external authentication SSO Backend to get a proper install
 - [#180](https://github.com/nautobot/nautobot/pull/180) - Revised available Invoke tasks for simplicity and maintainability
+- [#208](https://github.com/nautobot/nautobot/pull/208) - Custom fields model refactor
+- [#216](https://github.com/nautobot/nautobot/pull/216) - Update install docs to address inconsistent experience w/ `$PATH`
+- [#235](https://github.com/nautobot/nautobot/pull/235) - Update restart docs to include worker
 
 ### Removed
 
 - [#124](https://github.com/nautobot/nautobot/pull/124) - Removed incorrect statement from feature request template
 - [#161](https://github.com/nautobot/nautobot/pull/161) - Removed leftover references in documentation to `RQ_DEFAULT_TIMEOUT`
+- [#188](https://github.com/nautobot/nautobot/pull/189) - Remove `CSRF_TRUSTED_ORIGINS` from core settings
+- [#189](https://github.com/nautobot/nautobot/pull/189) - Remove all references to `settings.BASE_PATH`
 
 ### Fixed
 
+- [#26](https://github.com/nautobot/nautobot/issues/26) - `nautobot-server runserver` does not work using `poetry run`
+- [#58](https://github.com/nautobot/nautobot/issues/58) - GraphQL Device Query - Role filter issue
 - [#76](https://github.com/nautobot/nautobot/issues/76) - Cable paths could not be traced through circuits
 - [#95](https://github.com/nautobot/nautobot/issues/95) - Plugin load errors under Gunicorn
-- [#128](https://github.com/nautobot/nautobot/pull/128) - Overview of usage for the `nautobot-netbox-importer` plugin could be mistaken for full instructions
+- [#127](https://github.com/nautobot/nautobot/issues/127) - SSL error: decryption failed or bad record mac & SSL SYSCALL error: EOF detected
 - [#132](https://github.com/nautobot/nautobot/issues/132) - Generated `nautobot_config.py` did not include a trailing newline
 - [#134](https://github.com/nautobot/nautobot/issues/134) - Missing venv activation step in install guide
+- [#135](https://github.com/nautobot/nautobot/issues/135) - Custom field Selection value name change causes data inconsistency
+- [#147](https://github.com/nautobot/nautobot/issues/147) - Login failed when BASE_PATH is set
 - [#153](https://github.com/nautobot/nautobot/issues/153) - Editing an existing user token shows "create" buttons instead of "update"
 - [#154](https://github.com/nautobot/nautobot/issues/154) - Some tests were failing when run in the development Docker container
 - [#155](https://github.com/nautobot/nautobot/issues/155) - NAPALM driver string not displayed in Platform detail view
+- [#166](https://github.com/nautobot/nautobot/issues/166) - Contrib directory is missing (including the apache.conf)
 - [#168](https://github.com/nautobot/nautobot/issues/168) - Incorrect `AUTHENTICATION_BACKENDS` example in remote authentication documentation
+- [#170](https://github.com/nautobot/nautobot/issues/170) - GraphQL filtering failure returned all objects instead of none
 - [#172](https://github.com/nautobot/nautobot/issues/172) - Incorrect whitespace in some HTML template tags
 - [#181](https://github.com/nautobot/nautobot/pull/181) - Incorrect UI reference in Webhook documentation
+- [#185](https://github.com/nautobot/nautobot/issues/185) - Possible infinite loop in cable tracing algorithm
+- [#186](https://github.com/nautobot/nautobot/issues/186) - Example Jobs are not updated for Nautobot
+- [#201](https://github.com/nautobot/nautobot/issues/201) - Custom Fields cannot filter by name for content_types
+- [#205](https://github.com/nautobot/nautobot/issues/205) - API Documentation shows numeric id instead of UUID
+- [#213](https://github.com/nautobot/nautobot/issues/213) - Programming Error Exception Value: relation "social_auth_usersocialauth" does not exist
+- [#224](https://github.com/nautobot/nautobot/issues/224) - Edit view for IPAM network objects does not emit the current network address value
 
 ## v1.0.0b2 (2021-03-08)
 

--- a/nautobot/ipam/fields.py
+++ b/nautobot/ipam/fields.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.datastructures import DictWrapper
-from netaddr import AddrFormatError, IPNetwork, IPAddress
+import netaddr
 
 from .formfields import IPNetworkFormField
 
@@ -33,13 +33,47 @@ class VarbinaryIPField(models.BinaryField):
         value = self.value_from_object(obj)
         if not value:
             return value
+
+        return str(self._parse_ip_address(value))
+
+    def _parse_ip_address(self, value):
         try:
             value = int.from_bytes(value, "big")
-            return str(IPAddress(value))
-        except AddrFormatError:
+        except TypeError:
+            pass  # It's a string
+
+        try:
+            return netaddr.IPAddress(value)
+        except netaddr.AddrFormatError:
             raise ValidationError("Invalid IP address format: {}".format(value))
         except (TypeError, ValueError) as e:
             raise ValidationError(e)
+
+    def from_db_value(self, value, expression, connection):
+        return self.to_python(value)
+
+    def to_python(self, value):
+        if isinstance(value, netaddr.IPAddress):
+            return value
+
+        if value is None:
+            return value
+
+        return str(self._parse_ip_address(value))
+
+    def get_db_prep_value(self, value, connection, prepared=False):
+        if value is None:
+            return value
+
+        # Parse the address and then pack it to binary
+        value = self._parse_ip_address(value).packed
+
+        # Use defaults for Postgres
+        engine = connection.settings_dict["ENGINE"]
+        if "postgres" in engine:
+            return super().get_db_prep_value(value, connection, prepared)
+
+        return value
 
     def form_class(self):
         return IPNetworkFormField

--- a/nautobot/ipam/graphql/types.py
+++ b/nautobot/ipam/graphql/types.py
@@ -1,8 +1,13 @@
 import graphene
 from graphene_django import DjangoObjectType
+from graphene_django.converter import convert_django_field, convert_field_to_string
 
-from nautobot.ipam import models, filters
+from nautobot.ipam import models, filters, fields
 from nautobot.extras.graphql.types import TagType  # noqa: F401
+
+
+# Register VarbinaryIPField to be converted to a string type
+convert_django_field.register(fields.VarbinaryIPField)(convert_field_to_string)
 
 
 class AggregateType(DjangoObjectType):

--- a/nautobot/ipam/graphql/types.py
+++ b/nautobot/ipam/graphql/types.py
@@ -1,10 +1,18 @@
 import graphene
-
 from graphene_django import DjangoObjectType
 
-from nautobot.ipam.models import IPAddress
-from nautobot.ipam.filters import IPAddressFilterSet
+from nautobot.ipam import models, filters
 from nautobot.extras.graphql.types import TagType  # noqa: F401
+
+
+class AggregateType(DjangoObjectType):
+    """Graphql Type Object for Aggregate model."""
+
+    prefix = graphene.String()
+
+    class Meta:
+        model = models.Aggregate
+        filterset_class = filters.AggregateFilterSet
 
 
 class IPAddressType(DjangoObjectType):
@@ -13,5 +21,15 @@ class IPAddressType(DjangoObjectType):
     address = graphene.String()
 
     class Meta:
-        model = IPAddress
-        filterset_class = IPAddressFilterSet
+        model = models.IPAddress
+        filterset_class = filters.IPAddressFilterSet
+
+
+class PrefixType(DjangoObjectType):
+    """Graphql Type Object for Prefix model."""
+
+    prefix = graphene.String()
+
+    class Meta:
+        model = models.Prefix
+        filterset_class = filters.PrefixFilterSet

--- a/nautobot/ipam/graphql/types.py
+++ b/nautobot/ipam/graphql/types.py
@@ -1,3 +1,5 @@
+import graphene
+
 from graphene_django import DjangoObjectType
 
 from nautobot.ipam.models import IPAddress
@@ -7,6 +9,8 @@ from nautobot.extras.graphql.types import TagType  # noqa: F401
 
 class IPAddressType(DjangoObjectType):
     """Graphql Type Object for IPAddress model."""
+
+    address = graphene.String()
 
     class Meta:
         model = IPAddress

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -268,8 +268,8 @@ class Aggregate(PrimaryModel):
             # if |address.prefixlen| is 32 (ip4) or 128 (ip6)
             # then |address.broadcast| is None
             broadcast = pre.broadcast if pre.broadcast else pre.network
-            self.network = bytes(pre.network)
-            self.broadcast = bytes(broadcast)
+            self.network = str(pre.network)
+            self.broadcast = str(broadcast)
             self.prefix_length = pre.prefixlen
 
     def get_absolute_url(self):
@@ -325,8 +325,7 @@ class Aggregate(PrimaryModel):
     @property
     def cidr_str(self):
         if self.network and self.prefix_length:
-            ip = netaddr.IPAddress(int.from_bytes(self.network, "big"))
-            return "%s/%s" % (ip, self.prefix_length)
+            return "%s/%s" % (self.network, self.prefix_length)
 
     @property
     def prefix(self):
@@ -520,8 +519,8 @@ class Prefix(PrimaryModel, StatusModel):
             # if |prefix.prefixlen| is 32 (ip4) or 128 (ip6)
             # then |prefix.broadcast| is None
             broadcast = pre.broadcast if pre.broadcast else pre.network
-            self.network = bytes(pre.network)
-            self.broadcast = bytes(broadcast)
+            self.network = str(pre.network)
+            self.broadcast = str(broadcast)
             self.prefix_length = pre.prefixlen
 
     def get_absolute_url(self):
@@ -592,8 +591,7 @@ class Prefix(PrimaryModel, StatusModel):
     @property
     def cidr_str(self):
         if self.network and self.prefix_length:
-            ip = netaddr.IPAddress(int.from_bytes(self.network, "big"))
-            return "%s/%s" % (ip, self.prefix_length)
+            return "%s/%s" % (self.network, self.prefix_length)
 
     @property
     def prefix(self):
@@ -831,8 +829,8 @@ class IPAddress(PrimaryModel, StatusModel):
             # if |address.prefixlen| is 32 (ip4) or 128 (ip6)
             # then |address.broadcast| is None
             broadcast = address.broadcast if address.broadcast else address.network
-            self.host = bytes(address.ip)
-            self.broadcast = bytes(broadcast)
+            self.host = str(address.ip)
+            self.broadcast = str(broadcast)
             self.prefix_length = address.prefixlen
 
     def get_absolute_url(self):
@@ -937,8 +935,7 @@ class IPAddress(PrimaryModel, StatusModel):
     @property
     def address(self):
         if self.host and self.prefix_length:
-            host = netaddr.IPAddress(int.from_bytes(self.host, "big"))
-            cidr = "%s/%s" % (host, self.prefix_length)
+            cidr = "%s/%s" % (self.host, self.prefix_length)
             return netaddr.IPNetwork(cidr)
 
     @address.setter

--- a/nautobot/ipam/querysets.py
+++ b/nautobot/ipam/querysets.py
@@ -30,8 +30,8 @@ class NetworkQuerySet(QuerySet):
         broadcast = self._get_broadcast(prefix)
         return self.filter(
             prefix_length=prefix.prefixlen,
-            network=bytes(prefix.network),
-            broadcast=bytes(broadcast),
+            network=prefix.network,
+            broadcast=broadcast
         )
 
     def net_contained(self, prefix):
@@ -39,8 +39,8 @@ class NetworkQuerySet(QuerySet):
         broadcast = self._get_broadcast(prefix)
         return self.filter(
             prefix_length__gt=prefix.prefixlen,
-            network__gte=bytes(prefix.network),
-            broadcast__lte=bytes(broadcast),
+            network__gte=prefix.network,
+            broadcast__lte=broadcast,
         )
 
     def net_contained_or_equal(self, prefix):
@@ -48,8 +48,8 @@ class NetworkQuerySet(QuerySet):
         broadcast = self._get_broadcast(prefix)
         return self.filter(
             prefix_length__gte=prefix.prefixlen,
-            network__gte=bytes(prefix.network),
-            broadcast__lte=bytes(broadcast),
+            network__gte=prefix.network,
+            broadcast__lte=broadcast,
         )
 
     def net_contains(self, prefix):
@@ -57,8 +57,8 @@ class NetworkQuerySet(QuerySet):
         broadcast = self._get_broadcast(prefix)
         return self.filter(
             prefix_length__lt=prefix.prefixlen,
-            network__lte=bytes(prefix.network),
-            broadcast__gte=bytes(broadcast),
+            network__lte=prefix.network,
+            broadcast__gte=broadcast,
         )
 
     def net_contains_or_equal(self, prefix):
@@ -66,8 +66,8 @@ class NetworkQuerySet(QuerySet):
         broadcast = self._get_broadcast(prefix)
         return self.filter(
             prefix_length__lte=prefix.prefixlen,
-            network__lte=bytes(prefix.network),
-            broadcast__gte=bytes(broadcast),
+            network__lte=prefix.network,
+            broadcast__gte=broadcast,
         )
 
     def get(self, *args, prefix=None, **kwargs):
@@ -80,8 +80,8 @@ class NetworkQuerySet(QuerySet):
                 raise self.model.DoesNotExist()
             broadcast = self._get_broadcast(_prefix)
             kwargs["prefix_length"] = _prefix.prefixlen
-            kwargs["network"] = bytes(_prefix.ip)  # Query based on the input, not the true network address
-            kwargs["broadcast"] = bytes(broadcast)
+            kwargs["network"] = _prefix.ip  # Query based on the input, not the true network address
+            kwargs["broadcast"] = broadcast
         return super().get(*args, **kwargs)
 
     def filter(self, *args, prefix=None, **kwargs):
@@ -92,8 +92,8 @@ class NetworkQuerySet(QuerySet):
             _prefix = netaddr.IPNetwork(prefix)
             broadcast = self._get_broadcast(_prefix)
             kwargs["prefix_length"] = _prefix.prefixlen
-            kwargs["network"] = bytes(_prefix.ip)  # Query based on the input, not the true network address
-            kwargs["broadcast"] = bytes(broadcast)
+            kwargs["network"] = _prefix.ip  # Query based on the input, not the true network address
+            kwargs["broadcast"] = broadcast
         return super().filter(*args, **kwargs)
 
 
@@ -202,8 +202,8 @@ class IPAddressQuerySet(RestrictedQuerySet):
         network = netaddr.IPNetwork(network)
         broadcast = self._get_broadcast(network)
         return self.filter(
-            host__lte=bytes(broadcast),
-            host__gte=bytes(network.network),
+            host__lte=broadcast,
+            host__gte=network.network,
         )
 
     def net_in(self, networks):
@@ -222,8 +222,8 @@ class IPAddressQuerySet(RestrictedQuerySet):
             address = netaddr.IPNetwork(address)
             broadcast = self._get_broadcast(address)
             kwargs["prefix_length"] = address.prefixlen
-            kwargs["host"] = bytes(address.ip)
-            kwargs["broadcast"] = bytes(broadcast)
+            kwargs["host"] = address.ip
+            kwargs["broadcast"] = broadcast
         return super().get(*args, **kwargs)
 
     def filter(self, *args, address=None, **kwargs):
@@ -234,6 +234,6 @@ class IPAddressQuerySet(RestrictedQuerySet):
             address = netaddr.IPNetwork(address)
             broadcast = self._get_broadcast(address)
             kwargs["prefix_length"] = address.prefixlen
-            kwargs["host"] = bytes(address.ip)
-            kwargs["broadcast"] = bytes(broadcast)
+            kwargs["host"] = address.ip
+            kwargs["broadcast"] = broadcast
         return super().filter(*args, **kwargs)

--- a/nautobot/ipam/querysets.py
+++ b/nautobot/ipam/querysets.py
@@ -28,11 +28,7 @@ class NetworkQuerySet(QuerySet):
     def net_equals(self, prefix):
         prefix = netaddr.IPNetwork(prefix)
         broadcast = self._get_broadcast(prefix)
-        return self.filter(
-            prefix_length=prefix.prefixlen,
-            network=prefix.network,
-            broadcast=broadcast
-        )
+        return self.filter(prefix_length=prefix.prefixlen, network=prefix.network, broadcast=broadcast)
 
     def net_contained(self, prefix):
         prefix = netaddr.IPNetwork(prefix)

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -113,27 +113,6 @@ class TestVarbinaryIPField(TestCase):
         self.assertEqual(prepped, manual)
 
 
-class TestOtherShit(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.statuses = Status.objects.get_for_model(Prefix)
-        self.network = "10.20.30.0/24"
-        self.address = "10.20.30.1/32"
-
-    def test_create(self):
-        """Test network object creation."""
-        Prefix.objects.create
-
-    def test_update(self):
-        """Test network object update."""
-
-    def test_get(self):
-        """Test retrieve of single network object."""
-
-    def test_filter(self):
-        """Test filtering list of network objects."""
-
-
 class TestAggregate(TestCase):
     def test_get_utilization(self):
         rir = RIR.objects.create(name="RIR 1", slug="rir-1")

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -1,10 +1,137 @@
+import copy
+
 import netaddr
 from django.core.exceptions import ValidationError
+from django.db import connection
 from django.test import TestCase, override_settings
 
 from nautobot.extras.models import Status
 from nautobot.ipam.choices import IPAddressRoleChoices
 from nautobot.ipam.models import Aggregate, IPAddress, Prefix, RIR, VLAN, VLANGroup, VRF
+
+
+class DummyConnection:
+    """
+    Behaves like a connection but with a copy of the `settings_dict`.
+    """
+
+    def __init__(self, connection):
+        self._connection = connection
+        self.settings_dict = copy.deepcopy(connection.settings_dict)
+        self.ops = connection.ops
+        self.data_types = connection.data_types
+        self.Database = connection.Database
+
+    def set_engine(self, engine):
+        self.settings_dict["ENGINE"] = f"django.db.backends.{engine}"
+
+
+class TestVarbinaryIPField(TestCase):
+    """Tests for `nautobot.ipam.fields.VarbinaryIPField`."""
+
+    def setUp(self):
+        super().setUp()
+
+        # Reusable dummy connection object
+        self.connection = DummyConnection(connection)
+
+        # Field is a VarbinaryIPField we'll use to test.
+        self.prefix = Prefix.objects.create(prefix="10.0.0.0/24")
+        self.field = self.prefix._meta.get_field("network")
+        self.network = "10.0.0.0"
+        self.network_packed = bytes(self.prefix.prefix.ip)
+
+    def test_db_type(self):
+        """Test `VarbinaryIPField.db_type`."""
+        # Mapping of engine -> db_type
+        db_types = {
+            "postgres": "bytea",
+            "mysql": "varbinary(16)",
+        }
+
+        for engine, expected in db_types.items():
+            self.connection.set_engine(engine)
+            self.assertEqual(self.field.db_type(self.connection), expected)
+
+    def test_value_to_string(self):
+        """"Test `VarbinaryIPField.value_to_string`."""
+        # value_to_string calls _parse_address so no need for negative tests here.
+        self.assertEqual(self.field.value_to_string(self.prefix), self.network)
+
+    def test_parse_address_success(self):
+        """"Test `VarbinaryIPField._parse_address` PASS."""
+
+        # str => netaddr.IPAddress
+        obj = self.field._parse_address(self.prefix.network)
+        self.assertEqual(obj, netaddr.IPAddress(self.network))
+
+        # bytes => netaddr.IPAddress
+        self.assertEqual(self.field._parse_address(bytes(obj)), obj)
+
+        # int => netaddr.IPAddress
+        self.assertEqual(self.field._parse_address(int(obj)), obj)
+
+        # IPAddress => netaddr.IPAddress
+        self.assertEqual(self.field._parse_address(obj), obj)
+
+    def test_parse_address_failure(self):
+        """"Test `VarbinaryIPField._parse_address` FAIL."""
+
+        bad_inputs = (
+            None,
+            -42,
+            "10.10.10.10/32",  # Prefixes not allowed here
+            "310.10.10.10",  # Bad IP
+        )
+        for bad in bad_inputs:
+            self.assertRaises(ValidationError, self.field._parse_address, bad)
+
+    def test_to_python(self):
+        """"Test `VarbinaryIPField.to_python`."""
+
+        # to_python calls _parse_address so no need for negative tests here.
+
+        # str => str
+        self.assertEqual(self.field.to_python(self.prefix.network), self.network)
+
+        # netaddr.IPAddress => str
+        self.assertEqual(self.field.to_python(self.prefix.prefix.ip), self.network)
+
+    def test_get_db_prep_value(self):
+        """"Test `VarbinaryIPField.get_db_prep_value`."""
+
+        # PostgreSQL quotes `bytes` in `::bytea`
+        self.connection.set_engine("postgresql")
+        prepped = self.field.get_db_prep_value(self.network, self.connection)
+        manual = connection.Database.Binary(self.network_packed)
+        self.assertEqual(prepped.getquoted(), manual.getquoted())
+
+        # MySQL uses raw `bytes`
+        self.connection.set_engine("mysql")
+        prepped = self.field.get_db_prep_value(self.network, self.connection)
+        manual = bytes(self.network_packed)
+        self.assertEqual(prepped, manual)
+
+
+class TestOtherShit(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.statuses = Status.objects.get_for_model(Prefix)
+        self.network = "10.20.30.0/24"
+        self.address = "10.20.30.1/32"
+
+    def test_create(self):
+        """Test network object creation."""
+        Prefix.objects.create
+
+    def test_update(self):
+        """Test network object update."""
+
+    def test_get(self):
+        """Test retrieve of single network object."""
+
+    def test_filter(self):
+        """Test filtering list of network objects."""
 
 
 class TestAggregate(TestCase):

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -596,7 +596,7 @@ class IPAddressView(generic.ObjectView):
         # Duplicate IPs table
         duplicate_ips = (
             IPAddress.objects.restrict(request.user, "view")
-            .filter(vrf=instance.vrf, host=bytes(instance.host))
+            .filter(vrf=instance.vrf, host=instance.host)
             .exclude(pk=instance.pk)
             .prefetch_related("nat_inside")
         )
@@ -610,7 +610,7 @@ class IPAddressView(generic.ObjectView):
         related_ips = (
             IPAddress.objects.restrict(request.user, "view")
             .net_host_contained(instance.address)
-            .exclude(host=bytes(instance.host))
+            .exclude(host=instance.host)
             .filter(vrf=instance.vrf)
         )
         related_ips_table = tables.IPAddressTable(related_ips, orderable=False)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes

This fixes several issues related to virtual or computed fields such as `IPAddress.parent` filter field, or `IPAddress.address` model field. Additionally fixes the correct type detection such as correctly detecting `Device.has_primary_ip` (filter field) as a boolean field.

- Fixes #167 
- Closes #225 (Replaces it based on the work by @carbonarok)
- Fixes #232
- Fixes #233
- Fixes #247 
<!--
    Please include a summary of the proposed changes below.
-->

### Changes

#### GraphQL
- Add discrete GraphQL types in `nautobot.ipam.graphql.types` to account for the "virtual" (computed) model fields on these objects, specifically: `Aggregate.prefix`, `IPAddress.address`, `Prefix.prefix` (each of which have their corresponding `Type` object)
- Asserted that these types are registered in `nautobot.core.graphql.schema`
- Refactored `nautobot.core.graphql.generators.generate_list_search_parameters()` to call `graphene_django.filter.utils.get_filtering_args_from_filterset()` to generate the search filter params instead of doing it ourselves.
  - It patches the filterset to overload filter fields from `filterset.filters` to `filterset.base_filters` so GraphQL schema generation for list resolver query parameters detection/generation will correctly detect the custom fields and type them in the GQL schema.
- Refactored `nautobot.core.graphql.generators.generate_list_resolver()` to just pass through kwargs  since the search params are being correctly generated by `get_filtering_args_from_filterset()`.
- Register `VarbinaryIPField` as a string type in GraphQL
  - Also update tests for new schema generation (`String!` is now `[ID]!` in this test case)

#### IPAM models

Update network field types to behave as strings for humans but as varbinary for databases. This is necessary to have the fields emit correctly from Nautobot ORM without having to type cast them again for GraphQL. Less overall code to manage.

- Updated `nautobot.ipam.fields.IPNetworkFormField` to have `from_db_value`, `to_python`, and `get_db_prep_value` methods to facilitate bi-directional translation of `IPNetwork` <=> `varbinary` (packed binary int). All translation is now automatically handled by the field itself.
- Updated IPAM network models to cast objects to `str` vs. `bytes` on repr/deconstruct
- Updated IPAM network querysets to just pass objects through and not cast to `bytes`
- Updated `IPAddress` UI view to not cast `host` field to bytes and just pass it through to queryset

### Screenshots

Filtering on devices with `has_primary_ip` working as a boolean:
![Cursor_and_GraphiQL_-_Nautobot](https://user-images.githubusercontent.com/138052/113645283-6e23aa00-963b-11eb-809c-f4eb0138e4fc.png)
n

Filtering by interfaces `type` (mapped to `type_` due to internal GQL conflict fixed in Graphene 3.x):
![GraphiQL_-_Nautobot](https://user-images.githubusercontent.com/138052/113761049-dae68500-96cb-11eb-8aba-183f15e63fbb.png)

Single filter on devices by `site`:
![GraphiQL_-_Nautobot](https://user-images.githubusercontent.com/138052/113761093-e934a100-96cb-11eb-96e4-973bc9515b95.png)

Multiple filter on devices by `site`:
![GraphiQL_-_Nautobot](https://user-images.githubusercontent.com/138052/113761067-e0dc6600-96cb-11eb-83f5-2a68985f2b50.png)

Filtering by custom fields and also included a custom field in a query schema:
![GraphiQL_-_Nautobot](https://user-images.githubusercontent.com/138052/113774013-95ca4f00-96db-11eb-980a-ee3fa6ffddac.png)

