### PR TITLE
Fix missing commas in task queue config example

### DIFF
--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -158,7 +158,7 @@ RQ_QUEUES = {
         "PASSWORD": "",
         "SSL": False,
         "DEFAULT_TIMEOUT": 300
-    }
+    },
     "check_releases": {
         "HOST": "localhost",
         "PORT": 6379,
@@ -166,7 +166,7 @@ RQ_QUEUES = {
         "PASSWORD": "",
         "SSL": False,
         "DEFAULT_TIMEOUT": 300
-    }
+    },
     "custom_fields": {
         "HOST": "localhost",
         "PORT": 6379,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: Minor issue with task queue config documentation
<!--
    Please include a summary of the proposed changes below.
-->
I've noticed that the example docs didn't have a valid dict in them; two commas are missing.