### PR TITLE
Do not coerce provided UUIDs to version-4 format

### DIFF
--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -84,7 +84,7 @@ class WritableNestedSerializer(serializers.ModelSerializer):
             # PK of related object
             try:
                 # Ensure the pk is a valid UUID
-                pk = uuid.UUID(str(data), version=4)
+                pk = uuid.UUID(str(data))
             except (TypeError, ValueError):
                 raise ValidationError(
                     "Related objects must be referenced by ID or by dictionary of attributes. Received an "

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -13,7 +13,7 @@ def decompile_path_node(repr):
     ct_id, object_id = repr.split(":")
     # The value is stored as a string, but the lookup later uses UUID objects as keys so we convert it now.
     # Note that the content type ID is still an integer because we have no control over that model.
-    return int(ct_id), uuid.UUID(object_id, version=4)
+    return int(ct_id), uuid.UUID(object_id)
 
 
 def object_to_path_node(obj):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #260 
<!--
    Please include a summary of the proposed changes below.
-->

There are two points in the code where it coerces a provided string value into a UUID and explicitly forces the UUID to be coerced to the "version 4" UUID format that we use as a default format for all auto-assigned PKs.

However, there's nothing in the database that actually *requires* UUIDs to be "version 4" specifically; a data source may potentially opt to explicitly set an object's PK when creating it, and the database will accept any valid UUID of any version. Specifically, `nautobot-netbox-importer` specifies "version 5" UUIDs for all records that it populates into Nautobot, which unearthed this behavior as issue #260.

Furthermore, `uuid.UUID(value, version=4)` does NOT, as one might expect, reject values that are not version-4 UUIDs, instead it *converts* such values into version-4 UUIDs:

```python
>>> import uuid
>>> value = '38e314fe-1213-538a-a31a-127c948d0f35'
>>> new_value = uuid.UUID(value, version=4)
>>> new_value
UUID('38e314fe-1213-438a-a31a-127c948d0f35')
>>> str(new_value)
'38e314fe-1213-438a-a31a-127c948d0f35'
>>> str(new_value) == value
False
```

(Note the change from `538a` to `438a`)

So in short, explicitly specifying `version=4` when validating UUID values is incorrect in this context and should not be done. :-)

I've manually verified that cable-paths for devices/interfaces imported by `nautobot-netbox-importer` now are traced correctly and successfully with this change.