### PR TITLE
Fix 500 crash when posting ports as strings to IPAM services

### DIFF
--- a/nautobot/ipam/api/serializers.py
+++ b/nautobot/ipam/api/serializers.py
@@ -20,7 +20,7 @@ from nautobot.extras.api.serializers import (
     TaggedObjectSerializer,
 )
 from nautobot.ipam.choices import *
-from nautobot.ipam.constants import IPADDRESS_ASSIGNMENT_MODELS
+from nautobot.ipam import constants
 from nautobot.ipam.models import (
     Aggregate,
     IPAddress,
@@ -364,7 +364,7 @@ class IPAddressSerializer(TaggedObjectSerializer, StatusModelSerializerMixin, Cu
     tenant = NestedTenantSerializer(required=False, allow_null=True)
     role = ChoiceField(choices=IPAddressRoleChoices, allow_blank=True, required=False)
     assigned_object_type = ContentTypeField(
-        queryset=ContentType.objects.filter(IPADDRESS_ASSIGNMENT_MODELS),
+        queryset=ContentType.objects.filter(constants.IPADDRESS_ASSIGNMENT_MODELS),
         required=False,
         allow_null=True,
     )
@@ -444,6 +444,12 @@ class ServiceSerializer(TaggedObjectSerializer, CustomFieldModelSerializer):
         serializer=NestedIPAddressSerializer,
         required=False,
         many=True,
+    )
+    ports = serializers.ListField(
+        child=serializers.IntegerField(
+            min_value=constants.SERVICE_PORT_MIN,
+            max_value=constants.SERVICE_PORT_MAX,
+        )
     )
 
     class Meta:

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -561,6 +561,7 @@ class ServiceTest(APIViewTestCases.APIViewTestCase):
                 device_role=devicerole,
             ),
         )
+        cls.devices = devices
 
         Service.objects.create(
             device=devices[0],
@@ -601,3 +602,29 @@ class ServiceTest(APIViewTestCases.APIViewTestCase):
                 "ports": [6],
             },
         ]
+
+    def test_ports_regression(self):
+        """
+        Test that ports can be provided as str or int.
+
+        Ref: https://github.com/nautobot/nautobot/issues/265
+        """
+        device = self.devices[0]
+
+        # Ports as string should be good.
+        data = {
+            "name": "http",
+            "protocol": "tcp",
+            "device": str(device.id),
+            "ports": ["80"],
+        }
+
+        self.add_permissions("ipam.add_service")
+        url = reverse("ipam-api:service-list")
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+
+        # And do it again, but with ports as int
+        data["ports"] = [80]
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -609,22 +609,25 @@ class ServiceTest(APIViewTestCases.APIViewTestCase):
 
         Ref: https://github.com/nautobot/nautobot/issues/265
         """
+        self.add_permissions("ipam.add_service")
+        url = reverse("ipam-api:service-list")
         device = self.devices[0]
 
-        # Ports as string should be good.
         data = {
             "name": "http",
             "protocol": "tcp",
             "device": str(device.id),
             "ports": ["80"],
         }
+        expected = [80]  # We'll test w/ this
 
-        self.add_permissions("ipam.add_service")
-        url = reverse("ipam-api:service-list")
+        # Ports as string should be good.
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["ports"], expected)
 
-        # And do it again, but with ports as int
-        data["ports"] = [80]
+        # And do it again, but with ports as int.
+        data["ports"] = expected
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["ports"], expected)


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #265 
<!--
    Please include a summary of the proposed changes below.
-->
This worked pre-b3, due to native integration of PG `ArrayField` w/ DRF. Switching to `JSONArrayField` caused the `ports` to be treated as a `JSONField` in which a list of strings is valid.

- Patched `nautobot.ipam.api.serializers.ServiceSerializer` to overload `ports` field definition as a `ListField(child=IntegerField)`.
- Added a regression test for this fix.