### PR TITLE
Fix createsuperuser task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -121,7 +121,7 @@ def cli(context):
 @task(help={"user": "name of the superuser to create"})
 def createsuperuser(context, user="admin"):
     """Create a new Nautobot superuser account (default: "admin"), will prompt for password."""
-    docker_compose(context, "run nautobot nautobot-server createsuperuser --username {user}", pty=True)
+    docker_compose(context, f"run nautobot nautobot-server createsuperuser --username {user}", pty=True)
 
 
 @task(help={"name": "name of the migration to be created; if unspecified, will autogenerate a name"})


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #N/A
<!--
    Please include a summary of the proposed changes below.
-->

`invoke createsuperuser` task implementation was missing an `f`-string marker, so it was attempting `createsuperuser --username {user}` instead of `createsuperuser --username admin` by default.