### PR TITLE
Refactor GraphQL filter arguments generation

### DIFF
--- a/nautobot/core/graphql/utils.py
+++ b/nautobot/core/graphql/utils.py
@@ -1,6 +1,8 @@
 import graphene
 
+
 from django_filters.filters import BooleanFilter, NumberFilter, MultipleChoiceFilter
+from nautobot.utilities.filters import MultiValueNumberFilter
 
 
 def str_to_var_name(verbose_name):
@@ -42,7 +44,10 @@ def get_filtering_args_from_filterset(filterset):
         elif issubclass(filter_field_class, NumberFilter):
             field_type = graphene.Int
 
-        if issubclass(filter_field_class, MultipleChoiceFilter):
+        if issubclass(filter_field_class, MultiValueNumberFilter):
+            field_type = graphene.List(graphene.Int)
+
+        elif issubclass(filter_field_class, MultipleChoiceFilter):
             field_type = graphene.List(field_type)
 
         if field_type:

--- a/nautobot/core/graphql/utils.py
+++ b/nautobot/core/graphql/utils.py
@@ -1,7 +1,6 @@
+from django_filters.filters import BooleanFilter, NumberFilter, MultipleChoiceFilter
 import graphene
 
-
-from django_filters.filters import BooleanFilter, NumberFilter, MultipleChoiceFilter
 from nautobot.utilities.filters import MultiValueNumberFilter
 
 

--- a/nautobot/core/graphql/utils.py
+++ b/nautobot/core/graphql/utils.py
@@ -13,49 +13,49 @@ def str_to_var_name(verbose_name):
     return verbose_name.lower().replace(" ", "_").replace("-", "_")
 
 
-def get_filtering_args_from_filterset(filterset):
+def get_filtering_args_from_filterset(filterset_class):
     """Generate a list of filter arguments from a filterset.
 
     The FilterSet class will be instantiated before extracting the list of arguments to
-    account for dynamic filters, inserted when the class is instanciated. (required for Custom Fields filters).
+    account for dynamic filters, inserted when the class is instantiated. (required for Custom Fields filters).
 
-    Filter field that are inheriting from BooleanFilter and NumberFilter will be converted
+    Filter fields that are inheriting from BooleanFilter and NumberFilter will be converted
     to their appropriate type, everything else will be of type String.
-    if the field field is a subclass of MultipleChoiceFilter, the argument will be converted as a list
+    if the filter field is a subclass of MultipleChoiceFilter, the argument will be converted as a list
 
     Args:
-        filterset(FilterSet): FilterSet class used to extract the argument
+        filterset_class(FilterSet): FilterSet class used to extract the argument
 
     Returns:
         dict(graphene.Argument): Filter Arguments organized in a dictionary
     """
 
     args = {}
-    instance = filterset()
+    instance = filterset_class()
 
     for filter_name, filter_field in instance.filters.items():
 
         field_type = graphene.String
         filter_field_class = type(filter_field)
 
-        if issubclass(filter_field_class, BooleanFilter):
-            field_type = graphene.Boolean
-
-        elif issubclass(filter_field_class, NumberFilter):
-            field_type = graphene.Int
-
         if issubclass(filter_field_class, MultiValueNumberFilter):
             field_type = graphene.List(graphene.Int)
+        else:
+            if issubclass(filter_field_class, BooleanFilter):
+                field_type = graphene.Boolean
+            elif issubclass(filter_field_class, NumberFilter):
+                field_type = graphene.Int
+            else:
+                field_type = graphene.String
 
-        elif issubclass(filter_field_class, MultipleChoiceFilter):
-            field_type = graphene.List(field_type)
+            if issubclass(filter_field_class, MultipleChoiceFilter):
+                field_type = graphene.List(field_type)
 
-        if field_type:
-            args[filter_name] = graphene.Argument(
-                field_type,
-                description=filter_field.label,
-                required=False,
-            )
+        args[filter_name] = graphene.Argument(
+            field_type,
+            description=filter_field.label,
+            required=False,
+        )
 
     # Hack to swap `type` fields to `_type` since they will conflict with
     # `graphene.types.fields.Field.type` in Graphene 2.x.

--- a/nautobot/core/graphql/utils.py
+++ b/nautobot/core/graphql/utils.py
@@ -1,6 +1,63 @@
+import graphene
+
+from django_filters.filters import BooleanFilter, NumberFilter, MultipleChoiceFilter
+
+
 def str_to_var_name(verbose_name):
     """Convert a string to a variable compatible name.
     Examples:
         IP Addresses > ip_addresses
     """
     return verbose_name.lower().replace(" ", "_").replace("-", "_")
+
+
+def get_filtering_args_from_filterset(filterset):
+    """Generate a list of filter arguments from a filterset.
+
+    The FilterSet class will be instantiated before extracting the list of arguments to
+    account for dynamic filters, inserted when the class is instanciated. (required for Custom Fields filters).
+
+    Filter field that are inheriting from BooleanFilter and NumberFilter will be converted
+    to their appropriate type, everything else will be of type String.
+    if the field field is a subclass of MultipleChoiceFilter, the argument will be converted as a list
+
+    Args:
+        filterset(FilterSet): FilterSet class used to extract the argument
+
+    Returns:
+        dict(graphene.Argument): Filter Arguments organized in a dictionary
+    """
+
+    args = {}
+    instance = filterset()
+
+    for filter_name, filter_field in instance.filters.items():
+
+        field_type = graphene.String
+        filter_field_class = type(filter_field)
+
+        if issubclass(filter_field_class, BooleanFilter):
+            field_type = graphene.Boolean
+
+        elif issubclass(filter_field_class, NumberFilter):
+            field_type = graphene.Int
+
+        if issubclass(filter_field_class, MultipleChoiceFilter):
+            field_type = graphene.List(field_type)
+
+        if field_type:
+            args[filter_name] = graphene.Argument(
+                field_type,
+                description=filter_field.label,
+                required=False,
+            )
+
+    # Hack to swap `type` fields to `_type` since they will conflict with
+    # `graphene.types.fields.Field.type` in Graphene 2.x.
+    # TODO(jathan): Once we upgrade to Graphene 3.x we can remove this, but we
+    # will still need to do an API migration to deprecate it. This argument was
+    # validated to be safe to keep even in Graphene 3.
+    if "type" in args:
+        args["_type"] = args.pop("type")
+
+    return args

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1,8 +1,6 @@
 import types
 import uuid
 
-# from parameterized import parameterized
-
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
@@ -18,7 +16,7 @@ from rest_framework.test import APIClient
 
 
 from nautobot.users.models import ObjectPermission, Token
-from nautobot.dcim.models import Device, Site, Region, Rack, Manufacturer, DeviceType, DeviceRole, Interface
+from nautobot.dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Rack, Region, Site
 from nautobot.dcim.graphql.types import DeviceType as DeviceTypeGraphQL
 from nautobot.dcim.filters import DeviceFilterSet, SiteFilterSet
 from nautobot.dcim.choices import InterfaceTypeChoices

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -38,7 +38,6 @@ from nautobot.core.graphql.generators import (
 )
 from nautobot.extras.choices import CustomFieldTypeChoices
 
-
 # Use the proper swappable User model
 User = get_user_model()
 
@@ -485,12 +484,6 @@ class GraphQLQuery(TestCase):
         super().setUp()
         self.user = User.objects.create(username="Super User", is_active=True, is_superuser=True)
 
-        # Create Custom Fields
-        self.cf1 = CustomField.objects.create(name="cf1", label="cf1")
-        self.cf1.content_types.add(ContentType.objects.get_for_model(Device))
-        self.cf1.content_types.add(ContentType.objects.get_for_model(Interface))
-        self.cf1.save()
-
         # Initialize fake request that will be required to execute GraphQL query
         self.request = RequestFactory().request(SERVER_NAME="WebRequestContext")
         self.request.id = uuid.uuid4()
@@ -526,8 +519,6 @@ class GraphQLQuery(TestCase):
             face="front",
             comments="First Device",
         )
-        self.device1.cf["cf1"] = "value1"
-        self.device1.save()
 
         self.interface11 = Interface.objects.create(
             name="Int1", type=InterfaceTypeChoices.TYPE_VIRTUAL, device=self.device1, mac_address="00:11:11:11:11:11"
@@ -547,8 +538,6 @@ class GraphQLQuery(TestCase):
             status=self.status2,
             face="rear",
         )
-        self.device2.cf["cf1"] = "value2"
-        self.device2.save()
 
         self.interface21 = Interface.objects.create(
             name="Int1", type=InterfaceTypeChoices.TYPE_VIRTUAL, device=self.device2
@@ -706,9 +695,6 @@ class GraphQLQuery(TestCase):
             ('mac_address: "99:11:11:11:11:11"', 0),
             ('q: "first"', 1),
             ('q: "notthere"', 0),
-            ('cf_cf1: "value1"', 1),
-            ('cf_cf1: "value2"', 1),
-            ('cf_cf1: "value3"', 0),
         )
 
         for filter, nbr_expected_results in filters:

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -14,14 +14,10 @@ from graphql import get_default_backend
 from rest_framework import status
 from rest_framework.test import APIClient
 
-
-from nautobot.users.models import ObjectPermission, Token
-from nautobot.dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Rack, Region, Site
-from nautobot.dcim.graphql.types import DeviceType as DeviceTypeGraphQL
-from nautobot.dcim.filters import DeviceFilterSet, SiteFilterSet
-from nautobot.dcim.choices import InterfaceTypeChoices
-from nautobot.ipam.models import IPAddress, VLAN
-from nautobot.extras.models import ChangeLoggedModel, CustomField, ConfigContext, Relationship, Status
+from nautobot.core.graphql.generators import (
+    generate_list_search_parameters,
+    generate_schema_type,
+)
 from nautobot.core.graphql.utils import str_to_var_name
 from nautobot.core.graphql.schema import (
     extend_schema_type,
@@ -30,11 +26,14 @@ from nautobot.core.graphql.schema import (
     extend_schema_type_config_context,
     extend_schema_type_relationships,
 )
-from nautobot.core.graphql.generators import (
-    generate_list_search_parameters,
-    generate_schema_type,
-)
+from nautobot.dcim.choices import InterfaceTypeChoices
+from nautobot.dcim.filters import DeviceFilterSet, SiteFilterSet
+from nautobot.dcim.graphql.types import DeviceType as DeviceTypeGraphQL
+from nautobot.dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Rack, Region, Site
 from nautobot.extras.choices import CustomFieldTypeChoices
+from nautobot.extras.models import ChangeLoggedModel, CustomField, ConfigContext, Relationship, Status
+from nautobot.ipam.models import IPAddress, VLAN
+from nautobot.users.models import ObjectPermission, Token
 
 # Use the proper swappable User model
 User = get_user_model()

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -17,8 +17,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 
-from nautobot.utilities.testing import APITestCase
-from nautobot.users.models import ObjectPermission, Token, User
+from nautobot.users.models import ObjectPermission, Token
 from nautobot.dcim.models import Device, Site, Region, Rack, Manufacturer, DeviceType, DeviceRole, Interface
 from nautobot.dcim.graphql.types import DeviceType as DeviceTypeGraphQL
 from nautobot.dcim.filters import DeviceFilterSet, SiteFilterSet
@@ -40,8 +39,8 @@ from nautobot.core.graphql.generators import (
 from nautobot.extras.choices import CustomFieldTypeChoices
 
 
-# # Use the proper swappable User model
-# User = get_user_model()
+# Use the proper swappable User model
+User = get_user_model()
 
 
 class GraphQLUtilsTestCase(TestCase):

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -598,7 +598,7 @@ class GraphQLQuery(TestCase):
 
         self.assertIsInstance(result.data["devices"], list)
         device_names = [item["name"] for item in result.data["devices"]]
-        self.assertEqual(device_names, ["Device 1", "Device 2", "Device 3"])
+        self.assertEqual(sorted(device_names), ["Device 1", "Device 2", "Device 3"])
 
         config_context = [item["config_context"] for item in result.data["devices"]]
         self.assertIsInstance(config_context[0], dict)
@@ -619,7 +619,7 @@ class GraphQLQuery(TestCase):
 
         self.assertEqual(len(result.data["devices"]), 2)
         device_names = [item["name"] for item in result.data["devices"]]
-        self.assertEqual(device_names, ["Device 1", "Device 3"])
+        self.assertEqual(sorted(device_names), ["Device 1", "Device 3"])
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_with_bad_filter(self):


### PR DESCRIPTION
### Fixes: #283

This PR replaces the function `get_filtering_args_from_filterset` from `graphene_django.filter.utils` with a simpler version that supports all nautobot's specific filters.
We can't use `get_filtering_args_from_filterset` from `graphene_django.filter.utils` because we are using a lot of nautobot specific filters defined in `nautobot.utilities.filters` or `nautobot.extras.filters`

As part of this PR, I'm also planning to add more unit tests for GraphQL, for now I have a good coverage for DeviceType filter arguments and I'm planning to add similar tests for IPAddressType and SiteType filter arguments

