### PR TITLE
Git repository API sync request

### DIFF
--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -154,7 +154,7 @@ class GitRepositoryViewSet(CustomFieldModelViewSet):
 
         repository = GitRepository.objects.get(id=pk)
         enqueue_pull_git_repository_and_refresh_data(repository, request)
-        return Response({"message": "Repository {repository} sync job started."})
+        return Response({"message": f"Repository {repository} sync job started."})
 
 
 #

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -1,5 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.http import Http404
+from django.shortcuts import get_object_or_404
 from django_rq.queues import get_connection
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import action
@@ -146,14 +147,14 @@ class GitRepositoryViewSet(CustomFieldModelViewSet):
 
     @swagger_auto_schema(method="post", request_body=serializers.GitRepositorySerializer)
     @action(detail=True, methods=["post"])
-    def run(self, request, pk):
+    def sync(self, request, pk):
         """
         Enqueue pull git repository and refresh data.
         """
         if not Worker.count(get_connection("default")):
             raise RQWorkerNotRunningException()
 
-        repository = GitRepository.objects.get(id=pk)
+        repository = get_object_or_404(GitRepository, id=pk)
         enqueue_pull_git_repository_and_refresh_data(repository, request)
         return Response({"message": f"Repository {repository} sync job started."})
 

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -139,6 +139,7 @@ class GitRepositoryViewSet(CustomFieldModelViewSet):
     """
     Manage the use of Git repositories as external data sources.
     """
+
     queryset = GitRepository.objects.all()
     serializer_class = serializers.GitRepositorySerializer
     filterset_class = filters.GitRepositoryFilterSet

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -151,12 +151,15 @@ class GitRepositoryViewSet(CustomFieldModelViewSet):
         """
         Enqueue pull git repository and refresh data.
         """
+        if not request.user.has_perm("extras.change_gitrepository"):
+            raise PermissionDenied("This user does not have permission to make changes to Git repositories.")
+
         if not Worker.count(get_connection("default")):
             raise RQWorkerNotRunningException()
 
         repository = get_object_or_404(GitRepository, id=pk)
         enqueue_pull_git_repository_and_refresh_data(repository, request)
-        return Response({"message": f"Repository {repository} sync job started."})
+        return Response({"message": f"Repository {repository} sync job added to queue."})
 
 
 #

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -139,7 +139,6 @@ class GitRepositoryViewSet(CustomFieldModelViewSet):
     """
     Manage the use of Git repositories as external data sources.
     """
-
     queryset = GitRepository.objects.all()
     serializer_class = serializers.GitRepositorySerializer
     filterset_class = filters.GitRepositoryFilterSet
@@ -155,7 +154,7 @@ class GitRepositoryViewSet(CustomFieldModelViewSet):
 
         repository = GitRepository.objects.get(id=pk)
         enqueue_pull_git_repository_and_refresh_data(repository, request)
-        return Response(f"Repository {repository} sync job started.")
+        return Response({"message": "Repository {repository} sync job started."})
 
 
 #

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -208,6 +208,7 @@ class GitRepositoryTest(APIViewTestCases.APIViewTestCase):
         for repo in cls.repos:
             repo.save(trigger_resync=False)
 
+    @skipIf(not rq_worker_running, "RQ worker not running")
     @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
     def test_run_git_sync_nonexistent_repo(self):
         self.add_permissions("extras.add_gitrepository")
@@ -215,15 +216,18 @@ class GitRepositoryTest(APIViewTestCases.APIViewTestCase):
         response = self.client.post(url, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_404_NOT_FOUND)
 
+    @skipIf(not rq_worker_running, "RQ worker not running")
     @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
     def test_run_git_sync_without_permissions(self):
         url = reverse("extras-api:gitrepository-sync", kwargs={"pk": self.repos[0].id})
         response = self.client.post(url, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN)
 
+    @skipIf(not rq_worker_running, "RQ worker not running")
     @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
     def test_run_git_sync_with_permissions(self):
         self.add_permissions("extras.add_gitrepository")
+        self.add_permissions("extras.change_gitrepository")
         url = reverse("extras-api:gitrepository-sync", kwargs={"pk": self.repos[0].id})
         response = self.client.post(url, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

<!--
    Please include a summary of the proposed changes below.
-->
Adds function to sync a git repository through a POST request. When the endpoint is hit, a job is created for the worker to sync the repository.
URL: http://127.0.0.1/api/extras/git-repositories/[GitRepository_UUID]/run/
