### PR TITLE
Allow DynamicModel[Multiple]ChoiceField to work with plugin models

### DIFF
--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -6,6 +6,7 @@ from io import StringIO
 import django_filters
 from django import forms
 from django.apps import apps
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.forms.fields import JSONField as _JSONField, InvalidJSONInput
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist, ValidationError
@@ -449,7 +450,10 @@ class DynamicModelChoiceMixin:
         if not widget.attrs.get("data-url"):
             app_label = self.queryset.model._meta.app_label
             model_name = self.queryset.model._meta.model_name
-            data_url = reverse("{}-api:{}-list".format(app_label, model_name))
+            if app_label in settings.PLUGINS:
+                data_url = reverse(f"plugins-api:{app_label}-api:{model_name}-list")
+            else:
+                data_url = reverse(f"{app_label}-api:{model_name}-list")
             widget.attrs["data-url"] = data_url
 
         return bound_field


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Incremental progress toward #13 
<!--
    Please include a summary of the proposed changes below.
-->

As originally reported in https://github.com/netbox-community/netbox/issues/5234, forms using a `DynamicModelChoiceField` or `DynamicModelMultipleChoiceField` throw a `NoReverseMatch` exception when the model they reference is a plugin-defined model. I re-encountered this issue in Nautobot when attempting to use a Relationship between a Nautobot model and a plugin-defined model; although the Relationship can be successfully defined, attempting to create or edit an instance of the Nautobot model triggered this exception.

I can confirm that the included fix (as originally proposed in the linked issue) suffices to resolve this exception and allow the Nautobot model form to render properly, including the choice field describing the relationship to the plugin model.
