### PR TITLE
Fix display of parent prefixes from IPAddress detail view

### DIFF
--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -586,7 +586,7 @@ class IPAddressView(generic.ObjectView):
         # Parent prefixes table
         parent_prefixes = (
             Prefix.objects.restrict(request.user, "view")
-            .net_contains(instance.address)
+            .net_contains_or_equals(instance.address)
             .filter(vrf=instance.vrf)
             .prefetch_related("site", "status", "role")
         )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #288 
<!--
    Please include a summary of the proposed changes below.
-->

This adjusts the query performed inside of the `IPAddressViewSet` to construct the list of parent prefixes to perform a `net_contains_or_equals` query, since the test case has the same prefix length as the parent prefix, the "equals" part is necessary.

We do not have any easy way to perform tests against rendered documents or the rendering of tables, so I couldn't add a regression test for this. Yet another issue that exposes the severe need for UI integration testing.