### PR TITLE
Allow plugins to use built-in buttons

### DIFF
--- a/nautobot/utilities/templatetags/buttons.py
+++ b/nautobot/utilities/templatetags/buttons.py
@@ -1,5 +1,6 @@
 from django import template
 from django.urls import reverse
+from django.conf import settings
 
 from nautobot.extras.models import ExportTemplate
 from nautobot.utilities.utils import prepare_cloned_fields
@@ -15,6 +16,8 @@ def _get_viewname(instance, action):
     # Validate action
     assert action in ("add", "edit", "delete")
     viewname = "{}:{}_{}".format(instance._meta.app_label, instance._meta.model_name, action)
+    if instance._meta.app_label in settings.PLUGINS:
+        viewname = f"plugins:{viewname}"
 
     return viewname
 

--- a/nautobot/utilities/templatetags/helpers.py
+++ b/nautobot/utilities/templatetags/helpers.py
@@ -90,6 +90,8 @@ def validated_viewname(model, action):
     Return the view name for the given model and action if valid, or None if invalid.
     """
     viewname = f"{model._meta.app_label}:{model._meta.model_name}_{action}"
+    if model._meta.app_label in settings.PLUGINS:
+        viewname = f"plugins:{viewname}"
     try:
         # Validate and return the view name. We don't return the actual URL yet because many of the templates
         # are written to pass a name to {% url %}.


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #212 
<!--
    Please include a summary of the proposed changes below.
-->
Check to see if `instance/model._meta.app_label` is within `settings.PLUGINS` to append `plugins:` to the constructed viewnames per @glennmatthews suggestion!

I didn't go down a rabbit hole to see where else this pattern can be used and whether or not it can be some utility function, but these changes allow plugin authors to use the built-in views and templates without having to manage HTML templates if desired.