### PR TITLE
Moves PowerFeed Utilization Bar to Standard Template

### DIFF
--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1997,8 +1997,7 @@ class PowerFeedTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         powerfeed = self.powerfeeds[0]
 
-        cable = Cable(termination_a=powerport, termination_b=powerfeed, status=Status.objects.get(slug="connected"))
-        cable.save()
+        cable = Cable.objects.create(termination_a=powerport, termination_b=powerfeed, status=Status.objects.get(slug="connected"))
 
         url = reverse("dcim:powerfeed", kwargs=dict(pk=powerfeed.pk))
         self.assertHttpStatus(self.client.get(url), 200)

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1997,7 +1997,8 @@ class PowerFeedTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         powerfeed = self.powerfeeds[0]
 
-        Cable(termination_a=powerport, termination_b=powerfeed, status=Status.objects.get(slug="connected"))
+        cable = Cable(termination_a=powerport, termination_b=powerfeed, status=Status.objects.get(slug="connected"))
+        cable.save()
 
         url = reverse("dcim:powerfeed", kwargs=dict(pk=powerfeed.pk))
         self.assertHttpStatus(self.client.get(url), 200)

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1997,7 +1997,7 @@ class PowerFeedTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         powerfeed = self.powerfeeds[0]
 
-        cable = Cable.objects.create(
+        Cable.objects.create(
             termination_a=powerport, termination_b=powerfeed, status=Status.objects.get(slug="connected")
         )
 

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1980,7 +1980,6 @@ class PowerFeedTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "comments": "New comments",
         }
 
-
     def test_power_feed_detail(self):
         self.add_permissions("dcim.view_powerfeed")
         # Setup base device info
@@ -1993,11 +1992,11 @@ class PowerFeedTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             name="Device1",
             site=self.site,
         )
-        
+
         powerport = PowerPort.objects.create(device=device, name="Power Port 1")
 
         powerfeed = self.powerfeeds[0]
-        
+
         Cable(termination_a=powerport, termination_b=powerfeed, status=Status.objects.get(slug="connected"))
 
         url = reverse("dcim:powerfeed", kwargs=dict(pk=powerfeed.pk))

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1997,7 +1997,9 @@ class PowerFeedTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         powerfeed = self.powerfeeds[0]
 
-        cable = Cable.objects.create(termination_a=powerport, termination_b=powerfeed, status=Status.objects.get(slug="connected"))
+        cable = Cable.objects.create(
+            termination_a=powerport, termination_b=powerfeed, status=Status.objects.get(slug="connected")
+        )
 
         url = reverse("dcim:powerfeed", kwargs=dict(pk=powerfeed.pk))
         self.assertHttpStatus(self.client.get(url), 200)

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1916,23 +1916,33 @@ class PowerFeedTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         site = Site.objects.create(name="Site 1", slug="site-1")
 
+        # Assign site generated to the class object for use later.
+        cls.site = site
+
         powerpanels = (
             PowerPanel.objects.create(site=site, name="Power Panel 1"),
             PowerPanel.objects.create(site=site, name="Power Panel 2"),
         )
+
+        # Assign power panels generated to the class object for use later.
+        cls.powerpanels = powerpanels
 
         racks = (
             Rack.objects.create(site=site, name="Rack 1"),
             Rack.objects.create(site=site, name="Rack 2"),
         )
 
-        PowerFeed.objects.create(name="Power Feed 1", power_panel=powerpanels[0], rack=racks[0])
-        PowerFeed.objects.create(name="Power Feed 2", power_panel=powerpanels[0], rack=racks[0])
-        PowerFeed.objects.create(name="Power Feed 3", power_panel=powerpanels[0], rack=racks[0])
+        powerfeed_1 = PowerFeed.objects.create(name="Power Feed 1", power_panel=powerpanels[0], rack=racks[0])
+        powerfeed_2 = PowerFeed.objects.create(name="Power Feed 2", power_panel=powerpanels[0], rack=racks[0])
+        powerfeed_3 = PowerFeed.objects.create(name="Power Feed 3", power_panel=powerpanels[0], rack=racks[0])
+
+        # Assign power feeds for the tests later
+        cls.powerfeeds = (powerfeed_1, powerfeed_2)
 
         tags = cls.create_tags("Alpha", "Bravo", "Charlie")
 
         statuses = Status.objects.get_for_model(PowerFeed)
+        cls.statuses = statuses
         status_planned = statuses.get(slug="planned")
 
         cls.form_data = {
@@ -1969,3 +1979,26 @@ class PowerFeedTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "max_utilization": 50,
             "comments": "New comments",
         }
+
+
+    def test_power_feed_detail(self):
+        self.add_permissions("dcim.view_powerfeed")
+        # Setup base device info
+        manufacturer = Manufacturer.objects.create(name="Manufacturer", slug="manufacturer-1")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="Device Type 1", slug="device-type-1")
+        device_role = DeviceRole.objects.create(name="Device Role", slug="device-role-1")
+        device = Device.objects.create(
+            device_type=device_type,
+            device_role=device_role,
+            name="Device1",
+            site=self.site,
+        )
+        
+        powerport = PowerPort.objects.create(device=device, name="Power Port 1")
+
+        powerfeed = self.powerfeeds[0]
+        
+        Cable(termination_a=powerport, termination_b=powerfeed, status=Status.objects.get(slug="connected"))
+
+        url = reverse("dcim:powerfeed", kwargs=dict(pk=powerfeed.pk))
+        self.assertHttpStatus(self.client.get(url), 200)

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1934,7 +1934,7 @@ class PowerFeedTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         powerfeed_1 = PowerFeed.objects.create(name="Power Feed 1", power_panel=powerpanels[0], rack=racks[0])
         powerfeed_2 = PowerFeed.objects.create(name="Power Feed 2", power_panel=powerpanels[0], rack=racks[0])
-        powerfeed_3 = PowerFeed.objects.create(name="Power Feed 3", power_panel=powerpanels[0], rack=racks[0])
+        PowerFeed.objects.create(name="Power Feed 3", power_panel=powerpanels[0], rack=racks[0])
 
         # Assign power feeds for the tests later
         cls.powerfeeds = (powerfeed_1, powerfeed_2)

--- a/nautobot/utilities/templatetags/helpers.py
+++ b/nautobot/utilities/templatetags/helpers.py
@@ -272,7 +272,7 @@ def utilization_graph(utilization_data, warning_threshold=75, danger_threshold=9
     )
 
 
-@register.inclusion_tag("utilities/templatetags/utilization_graph_raw_data.html")
+@register.inclusion_tag("utilities/templatetags/utilization_graph.html")
 def utilization_graph_raw_data(numerator, denominator, warning_threshold=75, danger_threshold=90):
     """Display a horizontal bar graph indicating a percentage of utilization.
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #308 
<!--
    Please include a summary of the proposed changes below.
-->

- Updates the template tag rendered for the utilization_graph_raw_data from one that does not exist to the existing one.