### PR TITLE
Fix IPAddressForm/IPAddress clean()

### DIFF
--- a/nautobot/ipam/formfields.py
+++ b/nautobot/ipam/formfields.py
@@ -44,6 +44,10 @@ class IPNetworkFormField(forms.Field):
         "invalid": "Enter a valid IPv4 or IPv6 address (with CIDR mask).",
     }
 
+    def __init__(self, allow_zero_prefix=True, *args, **kwargs):
+        self.allow_zero_prefix = allow_zero_prefix
+        super().__init__(*args, **kwargs)
+
     def to_python(self, value):
         if not value:
             return None
@@ -56,6 +60,13 @@ class IPNetworkFormField(forms.Field):
             raise ValidationError("CIDR mask (e.g. /24) is required.")
 
         try:
-            return IPNetwork(value)
+            address = IPNetwork(value)
         except AddrFormatError:
             raise ValidationError("Please specify a valid IPv4 or IPv6 address.")
+
+        # If we're expecting an IPAddress, we set self.allow_zero_prefix to false
+        # to validate that IP address does not have a 0 CIDR mask
+        if not self.allow_zero_prefix and address.prefixlen == 0:
+            raise ValidationError("Cannot create IP address with /0 mask.")
+
+        return address

--- a/nautobot/ipam/formfields.py
+++ b/nautobot/ipam/formfields.py
@@ -45,6 +45,11 @@ class IPNetworkFormField(forms.Field):
     }
 
     def __init__(self, allow_zero_prefix=True, *args, **kwargs):
+        """Initialize any arguments that will be used for field validation.
+
+        Args:
+            allow_zero_prefix (bool, optional): Use for IPAddress validation to invalidate /0 CIDR masks. Defaults to True.
+        """
         self.allow_zero_prefix = allow_zero_prefix
         super().__init__(*args, **kwargs)
 

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -92,7 +92,10 @@ class VRFForm(BootstrapMixin, TenancyForm, CustomFieldModelForm, RelationshipMod
 
 class VRFCSVForm(CustomFieldModelCSVForm):
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(), required=False, to_field_name="name", help_text="Assigned tenant",
+        queryset=Tenant.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="Assigned tenant",
     )
 
     class Meta:
@@ -149,7 +152,10 @@ class RouteTargetForm(BootstrapMixin, TenancyForm, CustomFieldModelForm, Relatio
 
 class RouteTargetCSVForm(CustomFieldModelCSVForm):
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(), required=False, to_field_name="name", help_text="Assigned tenant",
+        queryset=Tenant.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="Assigned tenant",
     )
 
     class Meta:
@@ -221,7 +227,9 @@ class RIRCSVForm(CustomFieldModelCSVForm):
 class RIRFilterForm(BootstrapMixin, CustomFieldFilterForm):
     model = RIR
     is_private = forms.NullBooleanField(
-        required=False, label="Private", widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
+        required=False,
+        label="Private",
+        widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
 
 
@@ -257,7 +265,10 @@ class AggregateForm(BootstrapMixin, TenancyForm, PrefixFieldMixin, CustomFieldMo
 class AggregateCSVForm(PrefixFieldMixin, CustomFieldModelCSVForm):
     rir = CSVModelChoiceField(queryset=RIR.objects.all(), to_field_name="name", help_text="Assigned RIR")
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(), required=False, to_field_name="name", help_text="Assigned tenant",
+        queryset=Tenant.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="Assigned tenant",
     )
 
     class Meta:
@@ -328,11 +339,17 @@ class RoleCSVForm(CustomFieldModelCSVForm):
 
 class PrefixForm(PrefixFieldMixin, BootstrapMixin, TenancyForm, CustomFieldModelForm, RelationshipModelForm):
     vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
+        queryset=VRF.objects.all(),
+        required=False,
+        label="VRF",
+        display_field="display_name",
     )
     region = DynamicModelChoiceField(queryset=Region.objects.all(), required=False, initial_params={"sites": "$site"})
     site = DynamicModelChoiceField(
-        queryset=Site.objects.all(), required=False, null_option="None", query_params={"region_id": "$region"},
+        queryset=Site.objects.all(),
+        required=False,
+        null_option="None",
+        query_params={"region_id": "$region"},
     )
     vlan_group = DynamicModelChoiceField(
         queryset=VLANGroup.objects.all(),
@@ -347,7 +364,10 @@ class PrefixForm(PrefixFieldMixin, BootstrapMixin, TenancyForm, CustomFieldModel
         required=False,
         label="VLAN",
         display_field="display_name",
-        query_params={"site_id": "$site", "group_id": "$vlan_group",},
+        query_params={
+            "site_id": "$site",
+            "group_id": "$vlan_group",
+        },
     )
     role = DynamicModelChoiceField(queryset=Role.objects.all(), required=False)
     tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
@@ -377,22 +397,40 @@ class PrefixForm(PrefixFieldMixin, BootstrapMixin, TenancyForm, CustomFieldModel
 
 class PrefixCSVForm(PrefixFieldMixin, StatusModelCSVFormMixin, CustomFieldModelCSVForm):
     vrf = CSVModelChoiceField(
-        queryset=VRF.objects.all(), to_field_name="name", required=False, help_text="Assigned VRF",
+        queryset=VRF.objects.all(),
+        to_field_name="name",
+        required=False,
+        help_text="Assigned VRF",
     )
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(), required=False, to_field_name="name", help_text="Assigned tenant",
+        queryset=Tenant.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="Assigned tenant",
     )
     site = CSVModelChoiceField(
-        queryset=Site.objects.all(), required=False, to_field_name="name", help_text="Assigned site",
+        queryset=Site.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="Assigned site",
     )
     vlan_group = CSVModelChoiceField(
-        queryset=VLANGroup.objects.all(), required=False, to_field_name="name", help_text="VLAN's group (if any)",
+        queryset=VLANGroup.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="VLAN's group (if any)",
     )
     vlan = CSVModelChoiceField(
-        queryset=VLAN.objects.all(), required=False, to_field_name="vid", help_text="Assigned VLAN",
+        queryset=VLAN.objects.all(),
+        required=False,
+        to_field_name="vid",
+        help_text="Assigned VLAN",
     )
     role = CSVModelChoiceField(
-        queryset=Role.objects.all(), required=False, to_field_name="name", help_text="Functional role",
+        queryset=Role.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="Functional role",
     )
 
     class Meta:
@@ -417,7 +455,10 @@ class PrefixBulkEditForm(BootstrapMixin, AddRemoveTagsForm, StatusBulkEditFormMi
     region = DynamicModelChoiceField(queryset=Region.objects.all(), required=False, to_field_name="slug")
     site = DynamicModelChoiceField(queryset=Site.objects.all(), required=False, query_params={"region": "$region"})
     vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
+        queryset=VRF.objects.all(),
+        required=False,
+        label="VRF",
+        display_field="display_name",
     )
     prefix_length = forms.IntegerField(min_value=PREFIX_LENGTH_MIN, max_value=PREFIX_LENGTH_MAX, required=False)
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
@@ -456,7 +497,13 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin,
     mask_length__lte = forms.IntegerField(widget=forms.HiddenInput())
     q = forms.CharField(required=False, label="Search")
     within_include = forms.CharField(
-        required=False, widget=forms.TextInput(attrs={"placeholder": "Prefix",}), label="Search within",
+        required=False,
+        widget=forms.TextInput(
+            attrs={
+                "placeholder": "Prefix",
+            }
+        ),
+        label="Search within",
     )
     family = forms.ChoiceField(
         required=False,
@@ -465,10 +512,16 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin,
         widget=StaticSelect2(),
     )
     mask_length = forms.ChoiceField(
-        required=False, choices=PREFIX_MASK_LENGTH_CHOICES, label="Mask length", widget=StaticSelect2(),
+        required=False,
+        choices=PREFIX_MASK_LENGTH_CHOICES,
+        label="Mask length",
+        widget=StaticSelect2(),
     )
     vrf_id = DynamicModelMultipleChoiceField(
-        queryset=VRF.objects.all(), required=False, label="Assigned VRF", null_option="Global",
+        queryset=VRF.objects.all(),
+        required=False,
+        label="Assigned VRF",
+        null_option="Global",
     )
     present_in_vrf_id = DynamicModelChoiceField(queryset=VRF.objects.all(), required=False, label="Present in VRF")
     region = DynamicModelMultipleChoiceField(queryset=Region.objects.all(), to_field_name="slug", required=False)
@@ -480,10 +533,15 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin,
         query_params={"region": "$region"},
     )
     role = DynamicModelMultipleChoiceField(
-        queryset=Role.objects.all(), to_field_name="slug", required=False, null_option="None",
+        queryset=Role.objects.all(),
+        to_field_name="slug",
+        required=False,
+        null_option="None",
     )
     is_pool = forms.NullBooleanField(
-        required=False, label="Is a pool", widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
+        required=False,
+        label="Is a pool",
+        widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
     tag = TagFilterField(model)
 
@@ -494,7 +552,12 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin,
 
 
 class IPAddressForm(
-    BootstrapMixin, TenancyForm, ReturnURLForm, AddressFieldMixin, CustomFieldModelForm, RelationshipModelForm,
+    BootstrapMixin,
+    TenancyForm,
+    ReturnURLForm,
+    AddressFieldMixin,
+    CustomFieldModelForm,
+    RelationshipModelForm,
 ):
     address = IPNetworkFormField()
     device = DynamicModelChoiceField(
@@ -504,10 +567,14 @@ class IPAddressForm(
         initial_params={"interfaces": "$interface"},
     )
     interface = DynamicModelChoiceField(
-        queryset=Interface.objects.all(), required=False, query_params={"device_id": "$device"},
+        queryset=Interface.objects.all(),
+        required=False,
+        query_params={"device_id": "$device"},
     )
     virtual_machine = DynamicModelChoiceField(
-        queryset=VirtualMachine.objects.all(), required=False, initial_params={"interfaces": "$vminterface"},
+        queryset=VirtualMachine.objects.all(),
+        required=False,
+        initial_params={"interfaces": "$vminterface"},
     )
     vminterface = DynamicModelChoiceField(
         queryset=VMInterface.objects.all(),
@@ -516,13 +583,22 @@ class IPAddressForm(
         query_params={"virtual_machine_id": "$virtual_machine"},
     )
     vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
+        queryset=VRF.objects.all(),
+        required=False,
+        label="VRF",
+        display_field="display_name",
     )
     nat_region = DynamicModelChoiceField(
-        queryset=Region.objects.all(), required=False, label="Region", initial_params={"sites": "$nat_site"},
+        queryset=Region.objects.all(),
+        required=False,
+        label="Region",
+        initial_params={"sites": "$nat_site"},
     )
     nat_site = DynamicModelChoiceField(
-        queryset=Site.objects.all(), required=False, label="Site", query_params={"region_id": "$nat_region"},
+        queryset=Site.objects.all(),
+        required=False,
+        label="Site",
+        query_params={"region_id": "$nat_region"},
     )
     nat_rack = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
@@ -537,24 +613,36 @@ class IPAddressForm(
         required=False,
         label="Device",
         display_field="display_name",
-        query_params={"site_id": "$site", "rack_id": "$nat_rack",},
+        query_params={
+            "site_id": "$site",
+            "rack_id": "$nat_rack",
+        },
     )
     nat_cluster = DynamicModelChoiceField(queryset=Cluster.objects.all(), required=False, label="Cluster")
     nat_virtual_machine = DynamicModelChoiceField(
         queryset=VirtualMachine.objects.all(),
         required=False,
         label="Virtual Machine",
-        query_params={"cluster_id": "$nat_cluster",},
+        query_params={
+            "cluster_id": "$nat_cluster",
+        },
     )
     nat_vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
+        queryset=VRF.objects.all(),
+        required=False,
+        label="VRF",
+        display_field="display_name",
     )
     nat_inside = DynamicModelChoiceField(
         queryset=IPAddress.objects.all(),
         required=False,
         label="IP Address",
         display_field="address",
-        query_params={"device_id": "$nat_device", "virtual_machine_id": "$nat_virtual_machine", "vrf_id": "$nat_vrf",},
+        query_params={
+            "device_id": "$nat_device",
+            "virtual_machine_id": "$nat_virtual_machine",
+            "vrf_id": "$nat_vrf",
+        },
     )
     primary_for_parent = forms.BooleanField(required=False, label="Make this the primary IP for the device/VM")
     tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
@@ -639,7 +727,8 @@ class IPAddressForm(
         interface = self.cleaned_data.get("interface") or self.cleaned_data.get("vminterface")
         if self.cleaned_data.get("primary_for_parent") and not interface:
             self.add_error(
-                "primary_for_parent", "Only IP addresses assigned to an interface can be designated as primary IPs.",
+                "primary_for_parent",
+                "Only IP addresses assigned to an interface can be designated as primary IPs.",
             )
 
     def save(self, *args, **kwargs):
@@ -669,7 +758,10 @@ class IPAddressBulkCreateForm(BootstrapMixin, forms.Form):
 
 class IPAddressBulkAddForm(BootstrapMixin, TenancyForm, AddressFieldMixin, CustomFieldModelForm):
     vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
+        queryset=VRF.objects.all(),
+        required=False,
+        label="VRF",
+        display_field="display_name",
     )
     tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
 
@@ -697,10 +789,16 @@ class IPAddressBulkAddForm(BootstrapMixin, TenancyForm, AddressFieldMixin, Custo
 
 class IPAddressCSVForm(StatusModelCSVFormMixin, AddressFieldMixin, CustomFieldModelCSVForm):
     vrf = CSVModelChoiceField(
-        queryset=VRF.objects.all(), to_field_name="name", required=False, help_text="Assigned VRF",
+        queryset=VRF.objects.all(),
+        to_field_name="name",
+        required=False,
+        help_text="Assigned VRF",
     )
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(), to_field_name="name", required=False, help_text="Assigned tenant",
+        queryset=Tenant.objects.all(),
+        to_field_name="name",
+        required=False,
+        help_text="Assigned tenant",
     )
     role = CSVChoiceField(choices=IPAddressRoleChoices, required=False, help_text="Functional role")
     device = CSVModelChoiceField(
@@ -790,13 +888,22 @@ class IPAddressCSVForm(StatusModelCSVFormMixin, AddressFieldMixin, CustomFieldMo
 class IPAddressBulkEditForm(BootstrapMixin, AddRemoveTagsForm, StatusBulkEditFormMixin, CustomFieldBulkEditForm):
     pk = forms.ModelMultipleChoiceField(queryset=IPAddress.objects.all(), widget=forms.MultipleHiddenInput())
     vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
+        queryset=VRF.objects.all(),
+        required=False,
+        label="VRF",
+        display_field="display_name",
     )
     mask_length = forms.IntegerField(
-        min_value=IPADDRESS_MASK_LENGTH_MIN, max_value=IPADDRESS_MASK_LENGTH_MAX, required=False,
+        min_value=IPADDRESS_MASK_LENGTH_MIN,
+        max_value=IPADDRESS_MASK_LENGTH_MAX,
+        required=False,
     )
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
-    role = forms.ChoiceField(choices=add_blank_choice(IPAddressRoleChoices), required=False, widget=StaticSelect2(),)
+    role = forms.ChoiceField(
+        choices=add_blank_choice(IPAddressRoleChoices),
+        required=False,
+        widget=StaticSelect2(),
+    )
     dns_name = forms.CharField(max_length=255, required=False)
     description = forms.CharField(max_length=100, required=False)
 
@@ -812,7 +919,10 @@ class IPAddressBulkEditForm(BootstrapMixin, AddRemoveTagsForm, StatusBulkEditFor
 
 class IPAddressAssignForm(BootstrapMixin, forms.Form):
     vrf_id = DynamicModelChoiceField(queryset=VRF.objects.all(), required=False, label="VRF", empty_label="Global")
-    q = forms.CharField(required=False, label="Search",)
+    q = forms.CharField(
+        required=False,
+        label="Search",
+    )
 
 
 class IPAddressFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin, CustomFieldFilterForm):
@@ -832,7 +942,13 @@ class IPAddressFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMix
     ]
     q = forms.CharField(required=False, label="Search")
     parent = forms.CharField(
-        required=False, widget=forms.TextInput(attrs={"placeholder": "Prefix",}), label="Parent Prefix",
+        required=False,
+        widget=forms.TextInput(
+            attrs={
+                "placeholder": "Prefix",
+            }
+        ),
+        label="Parent Prefix",
     )
     family = forms.ChoiceField(
         required=False,
@@ -841,15 +957,23 @@ class IPAddressFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMix
         widget=StaticSelect2(),
     )
     mask_length = forms.ChoiceField(
-        required=False, choices=IPADDRESS_MASK_LENGTH_CHOICES, label="Mask length", widget=StaticSelect2(),
+        required=False,
+        choices=IPADDRESS_MASK_LENGTH_CHOICES,
+        label="Mask length",
+        widget=StaticSelect2(),
     )
     vrf_id = DynamicModelMultipleChoiceField(
-        queryset=VRF.objects.all(), required=False, label="Assigned VRF", null_option="Global",
+        queryset=VRF.objects.all(),
+        required=False,
+        label="Assigned VRF",
+        null_option="Global",
     )
     present_in_vrf_id = DynamicModelChoiceField(queryset=VRF.objects.all(), required=False, label="Present in VRF")
     role = forms.MultipleChoiceField(choices=IPAddressRoleChoices, required=False, widget=StaticSelect2Multiple())
     assigned_to_interface = forms.NullBooleanField(
-        required=False, label="Assigned to an interface", widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
+        required=False,
+        label="Assigned to an interface",
+        widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
     tag = TagFilterField(model)
 
@@ -861,7 +985,11 @@ class IPAddressFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMix
 
 class VLANGroupForm(BootstrapMixin, CustomFieldModelForm, RelationshipModelForm):
     region = DynamicModelChoiceField(queryset=Region.objects.all(), required=False, initial_params={"sites": "$site"})
-    site = DynamicModelChoiceField(queryset=Site.objects.all(), required=False, query_params={"region_id": "$region"},)
+    site = DynamicModelChoiceField(
+        queryset=Site.objects.all(),
+        required=False,
+        query_params={"region_id": "$region"},
+    )
     slug = SlugField()
 
     class Meta:
@@ -877,7 +1005,10 @@ class VLANGroupForm(BootstrapMixin, CustomFieldModelForm, RelationshipModelForm)
 
 class VLANGroupCSVForm(CustomFieldModelCSVForm):
     site = CSVModelChoiceField(
-        queryset=Site.objects.all(), required=False, to_field_name="name", help_text="Assigned site",
+        queryset=Site.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="Assigned site",
     )
     slug = SlugField()
 
@@ -906,10 +1037,15 @@ class VLANGroupFilterForm(BootstrapMixin, CustomFieldFilterForm):
 class VLANForm(BootstrapMixin, TenancyForm, CustomFieldModelForm, RelationshipModelForm):
     region = DynamicModelChoiceField(queryset=Region.objects.all(), required=False, initial_params={"sites": "$site"})
     site = DynamicModelChoiceField(
-        queryset=Site.objects.all(), required=False, null_option="None", query_params={"region_id": "$region"},
+        queryset=Site.objects.all(),
+        required=False,
+        null_option="None",
+        query_params={"region_id": "$region"},
     )
     group = DynamicModelChoiceField(
-        queryset=VLANGroup.objects.all(), required=False, query_params={"site_id": "$site"},
+        queryset=VLANGroup.objects.all(),
+        required=False,
+        query_params={"site_id": "$site"},
     )
     role = DynamicModelChoiceField(queryset=Role.objects.all(), required=False)
     tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
@@ -940,16 +1076,28 @@ class VLANForm(BootstrapMixin, TenancyForm, CustomFieldModelForm, RelationshipMo
 
 class VLANCSVForm(StatusModelCSVFormMixin, CustomFieldModelCSVForm):
     site = CSVModelChoiceField(
-        queryset=Site.objects.all(), required=False, to_field_name="name", help_text="Assigned site",
+        queryset=Site.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="Assigned site",
     )
     group = CSVModelChoiceField(
-        queryset=VLANGroup.objects.all(), required=False, to_field_name="name", help_text="Assigned VLAN group",
+        queryset=VLANGroup.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="Assigned VLAN group",
     )
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(), to_field_name="name", required=False, help_text="Assigned tenant",
+        queryset=Tenant.objects.all(),
+        to_field_name="name",
+        required=False,
+        help_text="Assigned tenant",
     )
     role = CSVModelChoiceField(
-        queryset=Role.objects.all(), required=False, to_field_name="name", help_text="Functional role",
+        queryset=Role.objects.all(),
+        required=False,
+        to_field_name="name",
+        help_text="Functional role",
     )
 
     class Meta:
@@ -975,7 +1123,9 @@ class VLANBulkEditForm(BootstrapMixin, AddRemoveTagsForm, StatusBulkEditFormMixi
     region = DynamicModelChoiceField(queryset=Region.objects.all(), required=False, to_field_name="slug")
     site = DynamicModelChoiceField(queryset=Site.objects.all(), required=False, query_params={"region": "$region"})
     group = DynamicModelChoiceField(
-        queryset=VLANGroup.objects.all(), required=False, query_params={"site_id": "$site"},
+        queryset=VLANGroup.objects.all(),
+        required=False,
+        query_params={"site_id": "$site"},
     )
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
     role = DynamicModelChoiceField(queryset=Role.objects.all(), required=False)
@@ -1020,7 +1170,10 @@ class VLANFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin, C
         query_params={"region": "$region"},
     )
     role = DynamicModelMultipleChoiceField(
-        queryset=Role.objects.all(), to_field_name="slug", required=False, null_option="None",
+        queryset=Role.objects.all(),
+        to_field_name="slug",
+        required=False,
+        null_option="None",
     )
     tag = TagFilterField(model)
 
@@ -1076,9 +1229,13 @@ class ServiceFilterForm(BootstrapMixin, CustomFieldFilterForm):
     model = Service
     q = forms.CharField(required=False, label="Search")
     protocol = forms.ChoiceField(
-        choices=add_blank_choice(ServiceProtocolChoices), required=False, widget=StaticSelect2Multiple(),
+        choices=add_blank_choice(ServiceProtocolChoices),
+        required=False,
+        widget=StaticSelect2Multiple(),
     )
-    port = forms.IntegerField(required=False,)
+    port = forms.IntegerField(
+        required=False,
+    )
     tag = TagFilterField(model)
 
 
@@ -1105,10 +1262,13 @@ class ServiceCSVForm(CustomFieldModelCSVForm):
 class ServiceBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditForm):
     pk = forms.ModelMultipleChoiceField(queryset=Service.objects.all(), widget=forms.MultipleHiddenInput())
     protocol = forms.ChoiceField(
-        choices=add_blank_choice(ServiceProtocolChoices), required=False, widget=StaticSelect2(),
+        choices=add_blank_choice(ServiceProtocolChoices),
+        required=False,
+        widget=StaticSelect2(),
     )
     ports = NumericArrayField(
-        base_field=forms.IntegerField(min_value=SERVICE_PORT_MIN, max_value=SERVICE_PORT_MAX), required=False,
+        base_field=forms.IntegerField(min_value=SERVICE_PORT_MIN, max_value=SERVICE_PORT_MAX),
+        required=False,
     )
     description = forms.CharField(max_length=100, required=False)
 

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -559,7 +559,7 @@ class IPAddressForm(
     CustomFieldModelForm,
     RelationshipModelForm,
 ):
-    address = IPNetworkFormField()
+    address = IPNetworkFormField(allow_zero_prefix=False)
     device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
         required=False,

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -92,10 +92,7 @@ class VRFForm(BootstrapMixin, TenancyForm, CustomFieldModelForm, RelationshipMod
 
 class VRFCSVForm(CustomFieldModelCSVForm):
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="Assigned tenant",
+        queryset=Tenant.objects.all(), required=False, to_field_name="name", help_text="Assigned tenant",
     )
 
     class Meta:
@@ -152,10 +149,7 @@ class RouteTargetForm(BootstrapMixin, TenancyForm, CustomFieldModelForm, Relatio
 
 class RouteTargetCSVForm(CustomFieldModelCSVForm):
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="Assigned tenant",
+        queryset=Tenant.objects.all(), required=False, to_field_name="name", help_text="Assigned tenant",
     )
 
     class Meta:
@@ -227,9 +221,7 @@ class RIRCSVForm(CustomFieldModelCSVForm):
 class RIRFilterForm(BootstrapMixin, CustomFieldFilterForm):
     model = RIR
     is_private = forms.NullBooleanField(
-        required=False,
-        label="Private",
-        widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
+        required=False, label="Private", widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
 
 
@@ -265,10 +257,7 @@ class AggregateForm(BootstrapMixin, TenancyForm, PrefixFieldMixin, CustomFieldMo
 class AggregateCSVForm(PrefixFieldMixin, CustomFieldModelCSVForm):
     rir = CSVModelChoiceField(queryset=RIR.objects.all(), to_field_name="name", help_text="Assigned RIR")
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="Assigned tenant",
+        queryset=Tenant.objects.all(), required=False, to_field_name="name", help_text="Assigned tenant",
     )
 
     class Meta:
@@ -339,17 +328,11 @@ class RoleCSVForm(CustomFieldModelCSVForm):
 
 class PrefixForm(PrefixFieldMixin, BootstrapMixin, TenancyForm, CustomFieldModelForm, RelationshipModelForm):
     vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(),
-        required=False,
-        label="VRF",
-        display_field="display_name",
+        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
     )
     region = DynamicModelChoiceField(queryset=Region.objects.all(), required=False, initial_params={"sites": "$site"})
     site = DynamicModelChoiceField(
-        queryset=Site.objects.all(),
-        required=False,
-        null_option="None",
-        query_params={"region_id": "$region"},
+        queryset=Site.objects.all(), required=False, null_option="None", query_params={"region_id": "$region"},
     )
     vlan_group = DynamicModelChoiceField(
         queryset=VLANGroup.objects.all(),
@@ -364,10 +347,7 @@ class PrefixForm(PrefixFieldMixin, BootstrapMixin, TenancyForm, CustomFieldModel
         required=False,
         label="VLAN",
         display_field="display_name",
-        query_params={
-            "site_id": "$site",
-            "group_id": "$vlan_group",
-        },
+        query_params={"site_id": "$site", "group_id": "$vlan_group",},
     )
     role = DynamicModelChoiceField(queryset=Role.objects.all(), required=False)
     tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
@@ -397,40 +377,22 @@ class PrefixForm(PrefixFieldMixin, BootstrapMixin, TenancyForm, CustomFieldModel
 
 class PrefixCSVForm(PrefixFieldMixin, StatusModelCSVFormMixin, CustomFieldModelCSVForm):
     vrf = CSVModelChoiceField(
-        queryset=VRF.objects.all(),
-        to_field_name="name",
-        required=False,
-        help_text="Assigned VRF",
+        queryset=VRF.objects.all(), to_field_name="name", required=False, help_text="Assigned VRF",
     )
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="Assigned tenant",
+        queryset=Tenant.objects.all(), required=False, to_field_name="name", help_text="Assigned tenant",
     )
     site = CSVModelChoiceField(
-        queryset=Site.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="Assigned site",
+        queryset=Site.objects.all(), required=False, to_field_name="name", help_text="Assigned site",
     )
     vlan_group = CSVModelChoiceField(
-        queryset=VLANGroup.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="VLAN's group (if any)",
+        queryset=VLANGroup.objects.all(), required=False, to_field_name="name", help_text="VLAN's group (if any)",
     )
     vlan = CSVModelChoiceField(
-        queryset=VLAN.objects.all(),
-        required=False,
-        to_field_name="vid",
-        help_text="Assigned VLAN",
+        queryset=VLAN.objects.all(), required=False, to_field_name="vid", help_text="Assigned VLAN",
     )
     role = CSVModelChoiceField(
-        queryset=Role.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="Functional role",
+        queryset=Role.objects.all(), required=False, to_field_name="name", help_text="Functional role",
     )
 
     class Meta:
@@ -455,10 +417,7 @@ class PrefixBulkEditForm(BootstrapMixin, AddRemoveTagsForm, StatusBulkEditFormMi
     region = DynamicModelChoiceField(queryset=Region.objects.all(), required=False, to_field_name="slug")
     site = DynamicModelChoiceField(queryset=Site.objects.all(), required=False, query_params={"region": "$region"})
     vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(),
-        required=False,
-        label="VRF",
-        display_field="display_name",
+        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
     )
     prefix_length = forms.IntegerField(min_value=PREFIX_LENGTH_MIN, max_value=PREFIX_LENGTH_MAX, required=False)
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
@@ -497,13 +456,7 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin,
     mask_length__lte = forms.IntegerField(widget=forms.HiddenInput())
     q = forms.CharField(required=False, label="Search")
     within_include = forms.CharField(
-        required=False,
-        widget=forms.TextInput(
-            attrs={
-                "placeholder": "Prefix",
-            }
-        ),
-        label="Search within",
+        required=False, widget=forms.TextInput(attrs={"placeholder": "Prefix",}), label="Search within",
     )
     family = forms.ChoiceField(
         required=False,
@@ -512,16 +465,10 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin,
         widget=StaticSelect2(),
     )
     mask_length = forms.ChoiceField(
-        required=False,
-        choices=PREFIX_MASK_LENGTH_CHOICES,
-        label="Mask length",
-        widget=StaticSelect2(),
+        required=False, choices=PREFIX_MASK_LENGTH_CHOICES, label="Mask length", widget=StaticSelect2(),
     )
     vrf_id = DynamicModelMultipleChoiceField(
-        queryset=VRF.objects.all(),
-        required=False,
-        label="Assigned VRF",
-        null_option="Global",
+        queryset=VRF.objects.all(), required=False, label="Assigned VRF", null_option="Global",
     )
     present_in_vrf_id = DynamicModelChoiceField(queryset=VRF.objects.all(), required=False, label="Present in VRF")
     region = DynamicModelMultipleChoiceField(queryset=Region.objects.all(), to_field_name="slug", required=False)
@@ -533,15 +480,10 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin,
         query_params={"region": "$region"},
     )
     role = DynamicModelMultipleChoiceField(
-        queryset=Role.objects.all(),
-        to_field_name="slug",
-        required=False,
-        null_option="None",
+        queryset=Role.objects.all(), to_field_name="slug", required=False, null_option="None",
     )
     is_pool = forms.NullBooleanField(
-        required=False,
-        label="Is a pool",
-        widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
+        required=False, label="Is a pool", widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
     tag = TagFilterField(model)
 
@@ -552,12 +494,7 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin,
 
 
 class IPAddressForm(
-    BootstrapMixin,
-    TenancyForm,
-    ReturnURLForm,
-    AddressFieldMixin,
-    CustomFieldModelForm,
-    RelationshipModelForm,
+    BootstrapMixin, TenancyForm, ReturnURLForm, AddressFieldMixin, CustomFieldModelForm, RelationshipModelForm,
 ):
     address = IPNetworkFormField()
     device = DynamicModelChoiceField(
@@ -567,14 +504,10 @@ class IPAddressForm(
         initial_params={"interfaces": "$interface"},
     )
     interface = DynamicModelChoiceField(
-        queryset=Interface.objects.all(),
-        required=False,
-        query_params={"device_id": "$device"},
+        queryset=Interface.objects.all(), required=False, query_params={"device_id": "$device"},
     )
     virtual_machine = DynamicModelChoiceField(
-        queryset=VirtualMachine.objects.all(),
-        required=False,
-        initial_params={"interfaces": "$vminterface"},
+        queryset=VirtualMachine.objects.all(), required=False, initial_params={"interfaces": "$vminterface"},
     )
     vminterface = DynamicModelChoiceField(
         queryset=VMInterface.objects.all(),
@@ -583,22 +516,13 @@ class IPAddressForm(
         query_params={"virtual_machine_id": "$virtual_machine"},
     )
     vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(),
-        required=False,
-        label="VRF",
-        display_field="display_name",
+        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
     )
     nat_region = DynamicModelChoiceField(
-        queryset=Region.objects.all(),
-        required=False,
-        label="Region",
-        initial_params={"sites": "$nat_site"},
+        queryset=Region.objects.all(), required=False, label="Region", initial_params={"sites": "$nat_site"},
     )
     nat_site = DynamicModelChoiceField(
-        queryset=Site.objects.all(),
-        required=False,
-        label="Site",
-        query_params={"region_id": "$nat_region"},
+        queryset=Site.objects.all(), required=False, label="Site", query_params={"region_id": "$nat_region"},
     )
     nat_rack = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
@@ -613,36 +537,24 @@ class IPAddressForm(
         required=False,
         label="Device",
         display_field="display_name",
-        query_params={
-            "site_id": "$site",
-            "rack_id": "$nat_rack",
-        },
+        query_params={"site_id": "$site", "rack_id": "$nat_rack",},
     )
     nat_cluster = DynamicModelChoiceField(queryset=Cluster.objects.all(), required=False, label="Cluster")
     nat_virtual_machine = DynamicModelChoiceField(
         queryset=VirtualMachine.objects.all(),
         required=False,
         label="Virtual Machine",
-        query_params={
-            "cluster_id": "$nat_cluster",
-        },
+        query_params={"cluster_id": "$nat_cluster",},
     )
     nat_vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(),
-        required=False,
-        label="VRF",
-        display_field="display_name",
+        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
     )
     nat_inside = DynamicModelChoiceField(
         queryset=IPAddress.objects.all(),
         required=False,
         label="IP Address",
         display_field="address",
-        query_params={
-            "device_id": "$nat_device",
-            "virtual_machine_id": "$nat_virtual_machine",
-            "vrf_id": "$nat_vrf",
-        },
+        query_params={"device_id": "$nat_device", "virtual_machine_id": "$nat_virtual_machine", "vrf_id": "$nat_vrf",},
     )
     primary_for_parent = forms.BooleanField(required=False, label="Make this the primary IP for the device/VM")
     tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
@@ -714,9 +626,9 @@ class IPAddressForm(
     def clean(self):
         super().clean()
 
-        # Need to set instance attribute to non-overlapping address computed field
+        # Need to set instance attribute to address field
         # to run proper address validation on Model.clean()
-        self.instance.form_address = self.cleaned_data.get("address")
+        self.instance.address = self.cleaned_data.get("address")
 
         # Cannot select both a device interface and a VM interface
         if self.cleaned_data.get("interface") and self.cleaned_data.get("vminterface"):
@@ -727,8 +639,7 @@ class IPAddressForm(
         interface = self.cleaned_data.get("interface") or self.cleaned_data.get("vminterface")
         if self.cleaned_data.get("primary_for_parent") and not interface:
             self.add_error(
-                "primary_for_parent",
-                "Only IP addresses assigned to an interface can be designated as primary IPs.",
+                "primary_for_parent", "Only IP addresses assigned to an interface can be designated as primary IPs.",
             )
 
     def save(self, *args, **kwargs):
@@ -758,10 +669,7 @@ class IPAddressBulkCreateForm(BootstrapMixin, forms.Form):
 
 class IPAddressBulkAddForm(BootstrapMixin, TenancyForm, AddressFieldMixin, CustomFieldModelForm):
     vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(),
-        required=False,
-        label="VRF",
-        display_field="display_name",
+        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
     )
     tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
 
@@ -789,16 +697,10 @@ class IPAddressBulkAddForm(BootstrapMixin, TenancyForm, AddressFieldMixin, Custo
 
 class IPAddressCSVForm(StatusModelCSVFormMixin, AddressFieldMixin, CustomFieldModelCSVForm):
     vrf = CSVModelChoiceField(
-        queryset=VRF.objects.all(),
-        to_field_name="name",
-        required=False,
-        help_text="Assigned VRF",
+        queryset=VRF.objects.all(), to_field_name="name", required=False, help_text="Assigned VRF",
     )
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(),
-        to_field_name="name",
-        required=False,
-        help_text="Assigned tenant",
+        queryset=Tenant.objects.all(), to_field_name="name", required=False, help_text="Assigned tenant",
     )
     role = CSVChoiceField(choices=IPAddressRoleChoices, required=False, help_text="Functional role")
     device = CSVModelChoiceField(
@@ -888,22 +790,13 @@ class IPAddressCSVForm(StatusModelCSVFormMixin, AddressFieldMixin, CustomFieldMo
 class IPAddressBulkEditForm(BootstrapMixin, AddRemoveTagsForm, StatusBulkEditFormMixin, CustomFieldBulkEditForm):
     pk = forms.ModelMultipleChoiceField(queryset=IPAddress.objects.all(), widget=forms.MultipleHiddenInput())
     vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(),
-        required=False,
-        label="VRF",
-        display_field="display_name",
+        queryset=VRF.objects.all(), required=False, label="VRF", display_field="display_name",
     )
     mask_length = forms.IntegerField(
-        min_value=IPADDRESS_MASK_LENGTH_MIN,
-        max_value=IPADDRESS_MASK_LENGTH_MAX,
-        required=False,
+        min_value=IPADDRESS_MASK_LENGTH_MIN, max_value=IPADDRESS_MASK_LENGTH_MAX, required=False,
     )
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
-    role = forms.ChoiceField(
-        choices=add_blank_choice(IPAddressRoleChoices),
-        required=False,
-        widget=StaticSelect2(),
-    )
+    role = forms.ChoiceField(choices=add_blank_choice(IPAddressRoleChoices), required=False, widget=StaticSelect2(),)
     dns_name = forms.CharField(max_length=255, required=False)
     description = forms.CharField(max_length=100, required=False)
 
@@ -919,10 +812,7 @@ class IPAddressBulkEditForm(BootstrapMixin, AddRemoveTagsForm, StatusBulkEditFor
 
 class IPAddressAssignForm(BootstrapMixin, forms.Form):
     vrf_id = DynamicModelChoiceField(queryset=VRF.objects.all(), required=False, label="VRF", empty_label="Global")
-    q = forms.CharField(
-        required=False,
-        label="Search",
-    )
+    q = forms.CharField(required=False, label="Search",)
 
 
 class IPAddressFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin, CustomFieldFilterForm):
@@ -942,13 +832,7 @@ class IPAddressFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMix
     ]
     q = forms.CharField(required=False, label="Search")
     parent = forms.CharField(
-        required=False,
-        widget=forms.TextInput(
-            attrs={
-                "placeholder": "Prefix",
-            }
-        ),
-        label="Parent Prefix",
+        required=False, widget=forms.TextInput(attrs={"placeholder": "Prefix",}), label="Parent Prefix",
     )
     family = forms.ChoiceField(
         required=False,
@@ -957,23 +841,15 @@ class IPAddressFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMix
         widget=StaticSelect2(),
     )
     mask_length = forms.ChoiceField(
-        required=False,
-        choices=IPADDRESS_MASK_LENGTH_CHOICES,
-        label="Mask length",
-        widget=StaticSelect2(),
+        required=False, choices=IPADDRESS_MASK_LENGTH_CHOICES, label="Mask length", widget=StaticSelect2(),
     )
     vrf_id = DynamicModelMultipleChoiceField(
-        queryset=VRF.objects.all(),
-        required=False,
-        label="Assigned VRF",
-        null_option="Global",
+        queryset=VRF.objects.all(), required=False, label="Assigned VRF", null_option="Global",
     )
     present_in_vrf_id = DynamicModelChoiceField(queryset=VRF.objects.all(), required=False, label="Present in VRF")
     role = forms.MultipleChoiceField(choices=IPAddressRoleChoices, required=False, widget=StaticSelect2Multiple())
     assigned_to_interface = forms.NullBooleanField(
-        required=False,
-        label="Assigned to an interface",
-        widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
+        required=False, label="Assigned to an interface", widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
     tag = TagFilterField(model)
 
@@ -985,11 +861,7 @@ class IPAddressFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMix
 
 class VLANGroupForm(BootstrapMixin, CustomFieldModelForm, RelationshipModelForm):
     region = DynamicModelChoiceField(queryset=Region.objects.all(), required=False, initial_params={"sites": "$site"})
-    site = DynamicModelChoiceField(
-        queryset=Site.objects.all(),
-        required=False,
-        query_params={"region_id": "$region"},
-    )
+    site = DynamicModelChoiceField(queryset=Site.objects.all(), required=False, query_params={"region_id": "$region"},)
     slug = SlugField()
 
     class Meta:
@@ -1005,10 +877,7 @@ class VLANGroupForm(BootstrapMixin, CustomFieldModelForm, RelationshipModelForm)
 
 class VLANGroupCSVForm(CustomFieldModelCSVForm):
     site = CSVModelChoiceField(
-        queryset=Site.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="Assigned site",
+        queryset=Site.objects.all(), required=False, to_field_name="name", help_text="Assigned site",
     )
     slug = SlugField()
 
@@ -1037,15 +906,10 @@ class VLANGroupFilterForm(BootstrapMixin, CustomFieldFilterForm):
 class VLANForm(BootstrapMixin, TenancyForm, CustomFieldModelForm, RelationshipModelForm):
     region = DynamicModelChoiceField(queryset=Region.objects.all(), required=False, initial_params={"sites": "$site"})
     site = DynamicModelChoiceField(
-        queryset=Site.objects.all(),
-        required=False,
-        null_option="None",
-        query_params={"region_id": "$region"},
+        queryset=Site.objects.all(), required=False, null_option="None", query_params={"region_id": "$region"},
     )
     group = DynamicModelChoiceField(
-        queryset=VLANGroup.objects.all(),
-        required=False,
-        query_params={"site_id": "$site"},
+        queryset=VLANGroup.objects.all(), required=False, query_params={"site_id": "$site"},
     )
     role = DynamicModelChoiceField(queryset=Role.objects.all(), required=False)
     tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
@@ -1076,28 +940,16 @@ class VLANForm(BootstrapMixin, TenancyForm, CustomFieldModelForm, RelationshipMo
 
 class VLANCSVForm(StatusModelCSVFormMixin, CustomFieldModelCSVForm):
     site = CSVModelChoiceField(
-        queryset=Site.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="Assigned site",
+        queryset=Site.objects.all(), required=False, to_field_name="name", help_text="Assigned site",
     )
     group = CSVModelChoiceField(
-        queryset=VLANGroup.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="Assigned VLAN group",
+        queryset=VLANGroup.objects.all(), required=False, to_field_name="name", help_text="Assigned VLAN group",
     )
     tenant = CSVModelChoiceField(
-        queryset=Tenant.objects.all(),
-        to_field_name="name",
-        required=False,
-        help_text="Assigned tenant",
+        queryset=Tenant.objects.all(), to_field_name="name", required=False, help_text="Assigned tenant",
     )
     role = CSVModelChoiceField(
-        queryset=Role.objects.all(),
-        required=False,
-        to_field_name="name",
-        help_text="Functional role",
+        queryset=Role.objects.all(), required=False, to_field_name="name", help_text="Functional role",
     )
 
     class Meta:
@@ -1123,9 +975,7 @@ class VLANBulkEditForm(BootstrapMixin, AddRemoveTagsForm, StatusBulkEditFormMixi
     region = DynamicModelChoiceField(queryset=Region.objects.all(), required=False, to_field_name="slug")
     site = DynamicModelChoiceField(queryset=Site.objects.all(), required=False, query_params={"region": "$region"})
     group = DynamicModelChoiceField(
-        queryset=VLANGroup.objects.all(),
-        required=False,
-        query_params={"site_id": "$site"},
+        queryset=VLANGroup.objects.all(), required=False, query_params={"site_id": "$site"},
     )
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
     role = DynamicModelChoiceField(queryset=Role.objects.all(), required=False)
@@ -1170,10 +1020,7 @@ class VLANFilterForm(BootstrapMixin, TenancyFilterForm, StatusFilterFormMixin, C
         query_params={"region": "$region"},
     )
     role = DynamicModelMultipleChoiceField(
-        queryset=Role.objects.all(),
-        to_field_name="slug",
-        required=False,
-        null_option="None",
+        queryset=Role.objects.all(), to_field_name="slug", required=False, null_option="None",
     )
     tag = TagFilterField(model)
 
@@ -1229,13 +1076,9 @@ class ServiceFilterForm(BootstrapMixin, CustomFieldFilterForm):
     model = Service
     q = forms.CharField(required=False, label="Search")
     protocol = forms.ChoiceField(
-        choices=add_blank_choice(ServiceProtocolChoices),
-        required=False,
-        widget=StaticSelect2Multiple(),
+        choices=add_blank_choice(ServiceProtocolChoices), required=False, widget=StaticSelect2Multiple(),
     )
-    port = forms.IntegerField(
-        required=False,
-    )
+    port = forms.IntegerField(required=False,)
     tag = TagFilterField(model)
 
 
@@ -1262,13 +1105,10 @@ class ServiceCSVForm(CustomFieldModelCSVForm):
 class ServiceBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditForm):
     pk = forms.ModelMultipleChoiceField(queryset=Service.objects.all(), widget=forms.MultipleHiddenInput())
     protocol = forms.ChoiceField(
-        choices=add_blank_choice(ServiceProtocolChoices),
-        required=False,
-        widget=StaticSelect2(),
+        choices=add_blank_choice(ServiceProtocolChoices), required=False, widget=StaticSelect2(),
     )
     ports = NumericArrayField(
-        base_field=forms.IntegerField(min_value=SERVICE_PORT_MIN, max_value=SERVICE_PORT_MAX),
-        required=False,
+        base_field=forms.IntegerField(min_value=SERVICE_PORT_MIN, max_value=SERVICE_PORT_MAX), required=False,
     )
     description = forms.CharField(max_length=100, required=False)
 

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -714,6 +714,10 @@ class IPAddressForm(
     def clean(self):
         super().clean()
 
+        # Need to set instance attribute to non-overlapping address computed field
+        # to run proper address validation on Model.clean()
+        self.instance.form_address = self.cleaned_data.get("address")
+
         # Cannot select both a device interface and a VM interface
         if self.cleaned_data.get("interface") and self.cleaned_data.get("vminterface"):
             raise forms.ValidationError("Cannot select both a device interface and a virtual machine interface")

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -38,13 +38,7 @@ __all__ = (
 
 
 @extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "graphql",
-    "relationships",
-    "webhooks",
+    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
 )
 class VRF(PrimaryModel):
     """
@@ -63,11 +57,7 @@ class VRF(PrimaryModel):
         help_text="Unique route distinguisher (as defined in RFC 4364)",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="vrfs",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="vrfs", blank=True, null=True,
     )
     enforce_unique = models.BooleanField(
         default=True,
@@ -113,13 +103,7 @@ class VRF(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "graphql",
-    "relationships",
-    "webhooks",
+    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
 )
 class RouteTarget(PrimaryModel):
     """
@@ -133,11 +117,7 @@ class RouteTarget(PrimaryModel):
     )
     description = models.CharField(max_length=200, blank=True)
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="route_targets",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="route_targets", blank=True, null=True,
     )
 
     csv_headers = ["name", "description", "tenant"]
@@ -160,10 +140,7 @@ class RouteTarget(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_validators",
-    "graphql",
-    "relationships",
+    "custom_fields", "custom_validators", "graphql", "relationships",
 )
 class RIR(OrganizationalModel):
     """
@@ -174,9 +151,7 @@ class RIR(OrganizationalModel):
     name = models.CharField(max_length=100, unique=True)
     slug = models.SlugField(max_length=100, unique=True)
     is_private = models.BooleanField(
-        default=False,
-        verbose_name="Private",
-        help_text="IP space managed by this RIR is considered private",
+        default=False, verbose_name="Private", help_text="IP space managed by this RIR is considered private",
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -203,13 +178,7 @@ class RIR(OrganizationalModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "graphql",
-    "relationships",
-    "webhooks",
+    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
 )
 class Aggregate(PrimaryModel):
     """
@@ -217,25 +186,12 @@ class Aggregate(PrimaryModel):
     the hierarchy and track the overall utilization of available address space. Each Aggregate is assigned to a RIR.
     """
 
-    network = VarbinaryIPField(
-        null=False,
-        db_index=True,
-        help_text="IPv4 or IPv6 network address",
-    )
+    network = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 network address",)
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
-    rir = models.ForeignKey(
-        to="ipam.RIR",
-        on_delete=models.PROTECT,
-        related_name="aggregates",
-        verbose_name="RIR",
-    )
+    rir = models.ForeignKey(to="ipam.RIR", on_delete=models.PROTECT, related_name="aggregates", verbose_name="RIR",)
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="aggregates",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="aggregates", blank=True, null=True,
     )
     date_added = models.DateField(blank=True, null=True)
     description = models.CharField(max_length=200, blank=True)
@@ -363,10 +319,7 @@ class Aggregate(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_validators",
-    "graphql",
-    "relationships",
+    "custom_fields", "custom_validators", "graphql", "relationships",
 )
 class Role(OrganizationalModel):
     """
@@ -377,10 +330,7 @@ class Role(OrganizationalModel):
     name = models.CharField(max_length=100, unique=True)
     slug = models.SlugField(max_length=100, unique=True)
     weight = models.PositiveSmallIntegerField(default=1000)
-    description = models.CharField(
-        max_length=200,
-        blank=True,
-    )
+    description = models.CharField(max_length=200, blank=True,)
 
     csv_headers = ["name", "slug", "weight", "description"]
 
@@ -419,42 +369,18 @@ class Prefix(PrimaryModel, StatusModel):
     assigned to a VLAN where appropriate.
     """
 
-    network = VarbinaryIPField(
-        null=False,
-        db_index=True,
-        help_text="IPv4 or IPv6 network address",
-    )
+    network = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 network address",)
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
-    site = models.ForeignKey(
-        to="dcim.Site",
-        on_delete=models.PROTECT,
-        related_name="prefixes",
-        blank=True,
-        null=True,
-    )
+    site = models.ForeignKey(to="dcim.Site", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True,)
     vrf = models.ForeignKey(
-        to="ipam.VRF",
-        on_delete=models.PROTECT,
-        related_name="prefixes",
-        blank=True,
-        null=True,
-        verbose_name="VRF",
+        to="ipam.VRF", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True, verbose_name="VRF",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="prefixes",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True,
     )
     vlan = models.ForeignKey(
-        to="ipam.VLAN",
-        on_delete=models.PROTECT,
-        related_name="prefixes",
-        blank=True,
-        null=True,
-        verbose_name="VLAN",
+        to="ipam.VLAN", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True, verbose_name="VLAN",
     )
     role = models.ForeignKey(
         to="ipam.Role",
@@ -465,9 +391,7 @@ class Prefix(PrimaryModel, StatusModel):
         help_text="The primary function of this prefix",
     )
     is_pool = models.BooleanField(
-        verbose_name="Is a pool",
-        default=False,
-        help_text="All IP addresses within this prefix are considered usable",
+        verbose_name="Is a pool", default=False, help_text="All IP addresses within this prefix are considered usable",
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -559,8 +483,7 @@ class Prefix(PrimaryModel, StatusModel):
                     raise ValidationError(
                         {
                             "prefix": "Duplicate prefix found in {}: {}".format(
-                                "VRF {}".format(self.vrf) if self.vrf else "global table",
-                                duplicate_prefixes.first(),
+                                "VRF {}".format(self.vrf) if self.vrf else "global table", duplicate_prefixes.first(),
                             )
                         }
                     )
@@ -660,12 +583,7 @@ class Prefix(PrimaryModel, StatusModel):
             return available_ips
 
         # Omit first and last IP address from the available set
-        available_ips -= netaddr.IPSet(
-            [
-                netaddr.IPAddress(self.prefix.first),
-                netaddr.IPAddress(self.prefix.last),
-            ]
-        )
+        available_ips -= netaddr.IPSet([netaddr.IPAddress(self.prefix.first), netaddr.IPAddress(self.prefix.last),])
 
         return available_ips
 
@@ -731,33 +649,17 @@ class IPAddress(PrimaryModel, StatusModel):
     which has a NAT outside IP, that Interface's Device can use either the inside or outside IP as its primary IP.
     """
 
-    host = VarbinaryIPField(
-        null=False,
-        db_index=True,
-        help_text="IPv4 or IPv6 host address",
-    )
+    host = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 host address",)
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
     vrf = models.ForeignKey(
-        to="ipam.VRF",
-        on_delete=models.PROTECT,
-        related_name="ip_addresses",
-        blank=True,
-        null=True,
-        verbose_name="VRF",
+        to="ipam.VRF", on_delete=models.PROTECT, related_name="ip_addresses", blank=True, null=True, verbose_name="VRF",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="ip_addresses",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="ip_addresses", blank=True, null=True,
     )
     role = models.CharField(
-        max_length=50,
-        choices=IPAddressRoleChoices,
-        blank=True,
-        help_text="The functional role of this IP",
+        max_length=50, choices=IPAddressRoleChoices, blank=True, help_text="The functional role of this IP",
     )
     assigned_object_type = models.ForeignKey(
         to=ContentType,
@@ -849,14 +751,10 @@ class IPAddress(PrimaryModel, StatusModel):
     def clean(self):
         super().clean()
 
-        # Set necessary instance attributes after parsing temp_address field
-        if hasattr(self, "form_address"):
-            self._deconstruct_address(self.form_address)
-
-        if self.address or hasattr(self, "form_address"):
+        if self.address:
 
             # /0 masks are not acceptable
-            if self.prefix_length == 0:
+            if self.prefixlen == 0:
                 raise ValidationError({"address": "Cannot create IP address with /0 mask."})
 
             # Enforce unique IP space (if applicable)
@@ -868,8 +766,7 @@ class IPAddress(PrimaryModel, StatusModel):
                     raise ValidationError(
                         {
                             "address": "Duplicate IP address found in {}: {}".format(
-                                "VRF {}".format(self.vrf) if self.vrf else "global table",
-                                duplicate_ips.first(),
+                                "VRF {}".format(self.vrf) if self.vrf else "global table", duplicate_ips.first(),
                             )
                         }
                     )
@@ -967,10 +864,7 @@ class IPAddress(PrimaryModel, StatusModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_validators",
-    "graphql",
-    "relationships",
+    "custom_fields", "custom_validators", "graphql", "relationships",
 )
 class VLANGroup(OrganizationalModel):
     """
@@ -980,11 +874,7 @@ class VLANGroup(OrganizationalModel):
     name = models.CharField(max_length=100)
     slug = models.SlugField(max_length=100)
     site = models.ForeignKey(
-        to="dcim.Site",
-        on_delete=models.PROTECT,
-        related_name="vlan_groups",
-        blank=True,
-        null=True,
+        to="dcim.Site", on_delete=models.PROTECT, related_name="vlan_groups", blank=True, null=True,
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -1047,38 +937,18 @@ class VLAN(PrimaryModel, StatusModel):
     or more Prefixes assigned to it.
     """
 
-    site = models.ForeignKey(
-        to="dcim.Site",
-        on_delete=models.PROTECT,
-        related_name="vlans",
-        blank=True,
-        null=True,
-    )
+    site = models.ForeignKey(to="dcim.Site", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,)
     group = models.ForeignKey(
-        to="ipam.VLANGroup",
-        on_delete=models.PROTECT,
-        related_name="vlans",
-        blank=True,
-        null=True,
+        to="ipam.VLANGroup", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,
     )
     vid = models.PositiveSmallIntegerField(
         verbose_name="ID", validators=[MinValueValidator(1), MaxValueValidator(4094)]
     )
     name = models.CharField(max_length=64)
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="vlans",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,
     )
-    role = models.ForeignKey(
-        to="ipam.Role",
-        on_delete=models.SET_NULL,
-        related_name="vlans",
-        blank=True,
-        null=True,
-    )
+    role = models.ForeignKey(to="ipam.Role", on_delete=models.SET_NULL, related_name="vlans", blank=True, null=True,)
     description = models.CharField(max_length=200, blank=True)
 
     csv_headers = [
@@ -1152,13 +1022,7 @@ class VLAN(PrimaryModel, StatusModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "graphql",
-    "relationships",
-    "webhooks",
+    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
 )
 class Service(PrimaryModel):
     """
@@ -1175,28 +1039,18 @@ class Service(PrimaryModel):
         blank=True,
     )
     virtual_machine = models.ForeignKey(
-        to="virtualization.VirtualMachine",
-        on_delete=models.CASCADE,
-        related_name="services",
-        null=True,
-        blank=True,
+        to="virtualization.VirtualMachine", on_delete=models.CASCADE, related_name="services", null=True, blank=True,
     )
     name = models.CharField(max_length=100)
     protocol = models.CharField(max_length=50, choices=ServiceProtocolChoices)
     ports = JSONArrayField(
         base_field=models.PositiveIntegerField(
-            validators=[
-                MinValueValidator(SERVICE_PORT_MIN),
-                MaxValueValidator(SERVICE_PORT_MAX),
-            ]
+            validators=[MinValueValidator(SERVICE_PORT_MIN), MaxValueValidator(SERVICE_PORT_MAX),]
         ),
         verbose_name="Port numbers",
     )
     ipaddresses = models.ManyToManyField(
-        to="ipam.IPAddress",
-        related_name="services",
-        blank=True,
-        verbose_name="IP addresses",
+        to="ipam.IPAddress", related_name="services", blank=True, verbose_name="IP addresses",
     )
     description = models.CharField(max_length=200, blank=True)
 

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -38,13 +38,7 @@ __all__ = (
 
 
 @extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "graphql",
-    "relationships",
-    "webhooks",
+    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
 )
 class VRF(PrimaryModel):
     """
@@ -63,11 +57,7 @@ class VRF(PrimaryModel):
         help_text="Unique route distinguisher (as defined in RFC 4364)",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="vrfs",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="vrfs", blank=True, null=True,
     )
     enforce_unique = models.BooleanField(
         default=True,
@@ -113,13 +103,7 @@ class VRF(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "graphql",
-    "relationships",
-    "webhooks",
+    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
 )
 class RouteTarget(PrimaryModel):
     """
@@ -133,11 +117,7 @@ class RouteTarget(PrimaryModel):
     )
     description = models.CharField(max_length=200, blank=True)
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="route_targets",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="route_targets", blank=True, null=True,
     )
 
     csv_headers = ["name", "description", "tenant"]
@@ -160,10 +140,7 @@ class RouteTarget(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_validators",
-    "graphql",
-    "relationships",
+    "custom_fields", "custom_validators", "graphql", "relationships",
 )
 class RIR(OrganizationalModel):
     """
@@ -174,9 +151,7 @@ class RIR(OrganizationalModel):
     name = models.CharField(max_length=100, unique=True)
     slug = models.SlugField(max_length=100, unique=True)
     is_private = models.BooleanField(
-        default=False,
-        verbose_name="Private",
-        help_text="IP space managed by this RIR is considered private",
+        default=False, verbose_name="Private", help_text="IP space managed by this RIR is considered private",
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -203,13 +178,7 @@ class RIR(OrganizationalModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "graphql",
-    "relationships",
-    "webhooks",
+    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
 )
 class Aggregate(PrimaryModel):
     """
@@ -217,25 +186,12 @@ class Aggregate(PrimaryModel):
     the hierarchy and track the overall utilization of available address space. Each Aggregate is assigned to a RIR.
     """
 
-    network = VarbinaryIPField(
-        null=False,
-        db_index=True,
-        help_text="IPv4 or IPv6 network address",
-    )
+    network = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 network address",)
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
-    rir = models.ForeignKey(
-        to="ipam.RIR",
-        on_delete=models.PROTECT,
-        related_name="aggregates",
-        verbose_name="RIR",
-    )
+    rir = models.ForeignKey(to="ipam.RIR", on_delete=models.PROTECT, related_name="aggregates", verbose_name="RIR",)
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="aggregates",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="aggregates", blank=True, null=True,
     )
     date_added = models.DateField(blank=True, null=True)
     description = models.CharField(max_length=200, blank=True)
@@ -363,10 +319,7 @@ class Aggregate(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_validators",
-    "graphql",
-    "relationships",
+    "custom_fields", "custom_validators", "graphql", "relationships",
 )
 class Role(OrganizationalModel):
     """
@@ -377,10 +330,7 @@ class Role(OrganizationalModel):
     name = models.CharField(max_length=100, unique=True)
     slug = models.SlugField(max_length=100, unique=True)
     weight = models.PositiveSmallIntegerField(default=1000)
-    description = models.CharField(
-        max_length=200,
-        blank=True,
-    )
+    description = models.CharField(max_length=200, blank=True,)
 
     csv_headers = ["name", "slug", "weight", "description"]
 
@@ -419,42 +369,18 @@ class Prefix(PrimaryModel, StatusModel):
     assigned to a VLAN where appropriate.
     """
 
-    network = VarbinaryIPField(
-        null=False,
-        db_index=True,
-        help_text="IPv4 or IPv6 network address",
-    )
+    network = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 network address",)
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
-    site = models.ForeignKey(
-        to="dcim.Site",
-        on_delete=models.PROTECT,
-        related_name="prefixes",
-        blank=True,
-        null=True,
-    )
+    site = models.ForeignKey(to="dcim.Site", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True,)
     vrf = models.ForeignKey(
-        to="ipam.VRF",
-        on_delete=models.PROTECT,
-        related_name="prefixes",
-        blank=True,
-        null=True,
-        verbose_name="VRF",
+        to="ipam.VRF", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True, verbose_name="VRF",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="prefixes",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True,
     )
     vlan = models.ForeignKey(
-        to="ipam.VLAN",
-        on_delete=models.PROTECT,
-        related_name="prefixes",
-        blank=True,
-        null=True,
-        verbose_name="VLAN",
+        to="ipam.VLAN", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True, verbose_name="VLAN",
     )
     role = models.ForeignKey(
         to="ipam.Role",
@@ -465,9 +391,7 @@ class Prefix(PrimaryModel, StatusModel):
         help_text="The primary function of this prefix",
     )
     is_pool = models.BooleanField(
-        verbose_name="Is a pool",
-        default=False,
-        help_text="All IP addresses within this prefix are considered usable",
+        verbose_name="Is a pool", default=False, help_text="All IP addresses within this prefix are considered usable",
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -559,8 +483,7 @@ class Prefix(PrimaryModel, StatusModel):
                     raise ValidationError(
                         {
                             "prefix": "Duplicate prefix found in {}: {}".format(
-                                "VRF {}".format(self.vrf) if self.vrf else "global table",
-                                duplicate_prefixes.first(),
+                                "VRF {}".format(self.vrf) if self.vrf else "global table", duplicate_prefixes.first(),
                             )
                         }
                     )
@@ -660,12 +583,7 @@ class Prefix(PrimaryModel, StatusModel):
             return available_ips
 
         # Omit first and last IP address from the available set
-        available_ips -= netaddr.IPSet(
-            [
-                netaddr.IPAddress(self.prefix.first),
-                netaddr.IPAddress(self.prefix.last),
-            ]
-        )
+        available_ips -= netaddr.IPSet([netaddr.IPAddress(self.prefix.first), netaddr.IPAddress(self.prefix.last),])
 
         return available_ips
 
@@ -731,33 +649,17 @@ class IPAddress(PrimaryModel, StatusModel):
     which has a NAT outside IP, that Interface's Device can use either the inside or outside IP as its primary IP.
     """
 
-    host = VarbinaryIPField(
-        null=False,
-        db_index=True,
-        help_text="IPv4 or IPv6 host address",
-    )
+    host = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 host address",)
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
     vrf = models.ForeignKey(
-        to="ipam.VRF",
-        on_delete=models.PROTECT,
-        related_name="ip_addresses",
-        blank=True,
-        null=True,
-        verbose_name="VRF",
+        to="ipam.VRF", on_delete=models.PROTECT, related_name="ip_addresses", blank=True, null=True, verbose_name="VRF",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="ip_addresses",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="ip_addresses", blank=True, null=True,
     )
     role = models.CharField(
-        max_length=50,
-        choices=IPAddressRoleChoices,
-        blank=True,
-        help_text="The functional role of this IP",
+        max_length=50, choices=IPAddressRoleChoices, blank=True, help_text="The functional role of this IP",
     )
     assigned_object_type = models.ForeignKey(
         to=ContentType,
@@ -853,7 +755,7 @@ class IPAddress(PrimaryModel, StatusModel):
         if hasattr(self, "form_address"):
             self._deconstruct_address(self.form_address)
 
-        if self.address or hasattr(self, "temp_address"):
+        if self.address or hasattr(self, "form_address"):
 
             # /0 masks are not acceptable
             if self.prefix_length == 0:
@@ -868,8 +770,7 @@ class IPAddress(PrimaryModel, StatusModel):
                     raise ValidationError(
                         {
                             "address": "Duplicate IP address found in {}: {}".format(
-                                "VRF {}".format(self.vrf) if self.vrf else "global table",
-                                duplicate_ips.first(),
+                                "VRF {}".format(self.vrf) if self.vrf else "global table", duplicate_ips.first(),
                             )
                         }
                     )
@@ -967,10 +868,7 @@ class IPAddress(PrimaryModel, StatusModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_validators",
-    "graphql",
-    "relationships",
+    "custom_fields", "custom_validators", "graphql", "relationships",
 )
 class VLANGroup(OrganizationalModel):
     """
@@ -980,11 +878,7 @@ class VLANGroup(OrganizationalModel):
     name = models.CharField(max_length=100)
     slug = models.SlugField(max_length=100)
     site = models.ForeignKey(
-        to="dcim.Site",
-        on_delete=models.PROTECT,
-        related_name="vlan_groups",
-        blank=True,
-        null=True,
+        to="dcim.Site", on_delete=models.PROTECT, related_name="vlan_groups", blank=True, null=True,
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -1047,38 +941,18 @@ class VLAN(PrimaryModel, StatusModel):
     or more Prefixes assigned to it.
     """
 
-    site = models.ForeignKey(
-        to="dcim.Site",
-        on_delete=models.PROTECT,
-        related_name="vlans",
-        blank=True,
-        null=True,
-    )
+    site = models.ForeignKey(to="dcim.Site", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,)
     group = models.ForeignKey(
-        to="ipam.VLANGroup",
-        on_delete=models.PROTECT,
-        related_name="vlans",
-        blank=True,
-        null=True,
+        to="ipam.VLANGroup", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,
     )
     vid = models.PositiveSmallIntegerField(
         verbose_name="ID", validators=[MinValueValidator(1), MaxValueValidator(4094)]
     )
     name = models.CharField(max_length=64)
     tenant = models.ForeignKey(
-        to="tenancy.Tenant",
-        on_delete=models.PROTECT,
-        related_name="vlans",
-        blank=True,
-        null=True,
+        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,
     )
-    role = models.ForeignKey(
-        to="ipam.Role",
-        on_delete=models.SET_NULL,
-        related_name="vlans",
-        blank=True,
-        null=True,
-    )
+    role = models.ForeignKey(to="ipam.Role", on_delete=models.SET_NULL, related_name="vlans", blank=True, null=True,)
     description = models.CharField(max_length=200, blank=True)
 
     csv_headers = [
@@ -1152,13 +1026,7 @@ class VLAN(PrimaryModel, StatusModel):
 
 
 @extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "graphql",
-    "relationships",
-    "webhooks",
+    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
 )
 class Service(PrimaryModel):
     """
@@ -1175,28 +1043,18 @@ class Service(PrimaryModel):
         blank=True,
     )
     virtual_machine = models.ForeignKey(
-        to="virtualization.VirtualMachine",
-        on_delete=models.CASCADE,
-        related_name="services",
-        null=True,
-        blank=True,
+        to="virtualization.VirtualMachine", on_delete=models.CASCADE, related_name="services", null=True, blank=True,
     )
     name = models.CharField(max_length=100)
     protocol = models.CharField(max_length=50, choices=ServiceProtocolChoices)
     ports = JSONArrayField(
         base_field=models.PositiveIntegerField(
-            validators=[
-                MinValueValidator(SERVICE_PORT_MIN),
-                MaxValueValidator(SERVICE_PORT_MAX),
-            ]
+            validators=[MinValueValidator(SERVICE_PORT_MIN), MaxValueValidator(SERVICE_PORT_MAX),]
         ),
         verbose_name="Port numbers",
     )
     ipaddresses = models.ManyToManyField(
-        to="ipam.IPAddress",
-        related_name="services",
-        blank=True,
-        verbose_name="IP addresses",
+        to="ipam.IPAddress", related_name="services", blank=True, verbose_name="IP addresses",
     )
     description = models.CharField(max_length=200, blank=True)
 

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -38,7 +38,13 @@ __all__ = (
 
 
 @extras_features(
-    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
+    "custom_fields",
+    "custom_links",
+    "custom_validators",
+    "export_templates",
+    "graphql",
+    "relationships",
+    "webhooks",
 )
 class VRF(PrimaryModel):
     """
@@ -57,7 +63,11 @@ class VRF(PrimaryModel):
         help_text="Unique route distinguisher (as defined in RFC 4364)",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="vrfs", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="vrfs",
+        blank=True,
+        null=True,
     )
     enforce_unique = models.BooleanField(
         default=True,
@@ -103,7 +113,13 @@ class VRF(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
+    "custom_fields",
+    "custom_links",
+    "custom_validators",
+    "export_templates",
+    "graphql",
+    "relationships",
+    "webhooks",
 )
 class RouteTarget(PrimaryModel):
     """
@@ -117,7 +133,11 @@ class RouteTarget(PrimaryModel):
     )
     description = models.CharField(max_length=200, blank=True)
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="route_targets", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="route_targets",
+        blank=True,
+        null=True,
     )
 
     csv_headers = ["name", "description", "tenant"]
@@ -140,7 +160,10 @@ class RouteTarget(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields", "custom_validators", "graphql", "relationships",
+    "custom_fields",
+    "custom_validators",
+    "graphql",
+    "relationships",
 )
 class RIR(OrganizationalModel):
     """
@@ -151,7 +174,9 @@ class RIR(OrganizationalModel):
     name = models.CharField(max_length=100, unique=True)
     slug = models.SlugField(max_length=100, unique=True)
     is_private = models.BooleanField(
-        default=False, verbose_name="Private", help_text="IP space managed by this RIR is considered private",
+        default=False,
+        verbose_name="Private",
+        help_text="IP space managed by this RIR is considered private",
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -178,7 +203,13 @@ class RIR(OrganizationalModel):
 
 
 @extras_features(
-    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
+    "custom_fields",
+    "custom_links",
+    "custom_validators",
+    "export_templates",
+    "graphql",
+    "relationships",
+    "webhooks",
 )
 class Aggregate(PrimaryModel):
     """
@@ -186,12 +217,25 @@ class Aggregate(PrimaryModel):
     the hierarchy and track the overall utilization of available address space. Each Aggregate is assigned to a RIR.
     """
 
-    network = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 network address",)
+    network = VarbinaryIPField(
+        null=False,
+        db_index=True,
+        help_text="IPv4 or IPv6 network address",
+    )
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
-    rir = models.ForeignKey(to="ipam.RIR", on_delete=models.PROTECT, related_name="aggregates", verbose_name="RIR",)
+    rir = models.ForeignKey(
+        to="ipam.RIR",
+        on_delete=models.PROTECT,
+        related_name="aggregates",
+        verbose_name="RIR",
+    )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="aggregates", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="aggregates",
+        blank=True,
+        null=True,
     )
     date_added = models.DateField(blank=True, null=True)
     description = models.CharField(max_length=200, blank=True)
@@ -319,7 +363,10 @@ class Aggregate(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields", "custom_validators", "graphql", "relationships",
+    "custom_fields",
+    "custom_validators",
+    "graphql",
+    "relationships",
 )
 class Role(OrganizationalModel):
     """
@@ -330,7 +377,10 @@ class Role(OrganizationalModel):
     name = models.CharField(max_length=100, unique=True)
     slug = models.SlugField(max_length=100, unique=True)
     weight = models.PositiveSmallIntegerField(default=1000)
-    description = models.CharField(max_length=200, blank=True,)
+    description = models.CharField(
+        max_length=200,
+        blank=True,
+    )
 
     csv_headers = ["name", "slug", "weight", "description"]
 
@@ -369,18 +419,42 @@ class Prefix(PrimaryModel, StatusModel):
     assigned to a VLAN where appropriate.
     """
 
-    network = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 network address",)
+    network = VarbinaryIPField(
+        null=False,
+        db_index=True,
+        help_text="IPv4 or IPv6 network address",
+    )
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
-    site = models.ForeignKey(to="dcim.Site", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True,)
+    site = models.ForeignKey(
+        to="dcim.Site",
+        on_delete=models.PROTECT,
+        related_name="prefixes",
+        blank=True,
+        null=True,
+    )
     vrf = models.ForeignKey(
-        to="ipam.VRF", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True, verbose_name="VRF",
+        to="ipam.VRF",
+        on_delete=models.PROTECT,
+        related_name="prefixes",
+        blank=True,
+        null=True,
+        verbose_name="VRF",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="prefixes",
+        blank=True,
+        null=True,
     )
     vlan = models.ForeignKey(
-        to="ipam.VLAN", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True, verbose_name="VLAN",
+        to="ipam.VLAN",
+        on_delete=models.PROTECT,
+        related_name="prefixes",
+        blank=True,
+        null=True,
+        verbose_name="VLAN",
     )
     role = models.ForeignKey(
         to="ipam.Role",
@@ -391,7 +465,9 @@ class Prefix(PrimaryModel, StatusModel):
         help_text="The primary function of this prefix",
     )
     is_pool = models.BooleanField(
-        verbose_name="Is a pool", default=False, help_text="All IP addresses within this prefix are considered usable",
+        verbose_name="Is a pool",
+        default=False,
+        help_text="All IP addresses within this prefix are considered usable",
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -483,7 +559,8 @@ class Prefix(PrimaryModel, StatusModel):
                     raise ValidationError(
                         {
                             "prefix": "Duplicate prefix found in {}: {}".format(
-                                "VRF {}".format(self.vrf) if self.vrf else "global table", duplicate_prefixes.first(),
+                                "VRF {}".format(self.vrf) if self.vrf else "global table",
+                                duplicate_prefixes.first(),
                             )
                         }
                     )
@@ -583,7 +660,12 @@ class Prefix(PrimaryModel, StatusModel):
             return available_ips
 
         # Omit first and last IP address from the available set
-        available_ips -= netaddr.IPSet([netaddr.IPAddress(self.prefix.first), netaddr.IPAddress(self.prefix.last),])
+        available_ips -= netaddr.IPSet(
+            [
+                netaddr.IPAddress(self.prefix.first),
+                netaddr.IPAddress(self.prefix.last),
+            ]
+        )
 
         return available_ips
 
@@ -649,17 +731,33 @@ class IPAddress(PrimaryModel, StatusModel):
     which has a NAT outside IP, that Interface's Device can use either the inside or outside IP as its primary IP.
     """
 
-    host = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 host address",)
+    host = VarbinaryIPField(
+        null=False,
+        db_index=True,
+        help_text="IPv4 or IPv6 host address",
+    )
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
     vrf = models.ForeignKey(
-        to="ipam.VRF", on_delete=models.PROTECT, related_name="ip_addresses", blank=True, null=True, verbose_name="VRF",
+        to="ipam.VRF",
+        on_delete=models.PROTECT,
+        related_name="ip_addresses",
+        blank=True,
+        null=True,
+        verbose_name="VRF",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="ip_addresses", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="ip_addresses",
+        blank=True,
+        null=True,
     )
     role = models.CharField(
-        max_length=50, choices=IPAddressRoleChoices, blank=True, help_text="The functional role of this IP",
+        max_length=50,
+        choices=IPAddressRoleChoices,
+        blank=True,
+        help_text="The functional role of this IP",
     )
     assigned_object_type = models.ForeignKey(
         to=ContentType,
@@ -754,7 +852,7 @@ class IPAddress(PrimaryModel, StatusModel):
         if self.address:
 
             # /0 masks are not acceptable
-            if self.prefixlen == 0:
+            if self.address.prefixlen == 0:
                 raise ValidationError({"address": "Cannot create IP address with /0 mask."})
 
             # Enforce unique IP space (if applicable)
@@ -766,7 +864,8 @@ class IPAddress(PrimaryModel, StatusModel):
                     raise ValidationError(
                         {
                             "address": "Duplicate IP address found in {}: {}".format(
-                                "VRF {}".format(self.vrf) if self.vrf else "global table", duplicate_ips.first(),
+                                "VRF {}".format(self.vrf) if self.vrf else "global table",
+                                duplicate_ips.first(),
                             )
                         }
                     )
@@ -864,7 +963,10 @@ class IPAddress(PrimaryModel, StatusModel):
 
 
 @extras_features(
-    "custom_fields", "custom_validators", "graphql", "relationships",
+    "custom_fields",
+    "custom_validators",
+    "graphql",
+    "relationships",
 )
 class VLANGroup(OrganizationalModel):
     """
@@ -874,7 +976,11 @@ class VLANGroup(OrganizationalModel):
     name = models.CharField(max_length=100)
     slug = models.SlugField(max_length=100)
     site = models.ForeignKey(
-        to="dcim.Site", on_delete=models.PROTECT, related_name="vlan_groups", blank=True, null=True,
+        to="dcim.Site",
+        on_delete=models.PROTECT,
+        related_name="vlan_groups",
+        blank=True,
+        null=True,
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -937,18 +1043,38 @@ class VLAN(PrimaryModel, StatusModel):
     or more Prefixes assigned to it.
     """
 
-    site = models.ForeignKey(to="dcim.Site", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,)
+    site = models.ForeignKey(
+        to="dcim.Site",
+        on_delete=models.PROTECT,
+        related_name="vlans",
+        blank=True,
+        null=True,
+    )
     group = models.ForeignKey(
-        to="ipam.VLANGroup", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,
+        to="ipam.VLANGroup",
+        on_delete=models.PROTECT,
+        related_name="vlans",
+        blank=True,
+        null=True,
     )
     vid = models.PositiveSmallIntegerField(
         verbose_name="ID", validators=[MinValueValidator(1), MaxValueValidator(4094)]
     )
     name = models.CharField(max_length=64)
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="vlans",
+        blank=True,
+        null=True,
     )
-    role = models.ForeignKey(to="ipam.Role", on_delete=models.SET_NULL, related_name="vlans", blank=True, null=True,)
+    role = models.ForeignKey(
+        to="ipam.Role",
+        on_delete=models.SET_NULL,
+        related_name="vlans",
+        blank=True,
+        null=True,
+    )
     description = models.CharField(max_length=200, blank=True)
 
     csv_headers = [
@@ -1022,7 +1148,13 @@ class VLAN(PrimaryModel, StatusModel):
 
 
 @extras_features(
-    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
+    "custom_fields",
+    "custom_links",
+    "custom_validators",
+    "export_templates",
+    "graphql",
+    "relationships",
+    "webhooks",
 )
 class Service(PrimaryModel):
     """
@@ -1039,18 +1171,28 @@ class Service(PrimaryModel):
         blank=True,
     )
     virtual_machine = models.ForeignKey(
-        to="virtualization.VirtualMachine", on_delete=models.CASCADE, related_name="services", null=True, blank=True,
+        to="virtualization.VirtualMachine",
+        on_delete=models.CASCADE,
+        related_name="services",
+        null=True,
+        blank=True,
     )
     name = models.CharField(max_length=100)
     protocol = models.CharField(max_length=50, choices=ServiceProtocolChoices)
     ports = JSONArrayField(
         base_field=models.PositiveIntegerField(
-            validators=[MinValueValidator(SERVICE_PORT_MIN), MaxValueValidator(SERVICE_PORT_MAX),]
+            validators=[
+                MinValueValidator(SERVICE_PORT_MIN),
+                MaxValueValidator(SERVICE_PORT_MAX),
+            ]
         ),
         verbose_name="Port numbers",
     )
     ipaddresses = models.ManyToManyField(
-        to="ipam.IPAddress", related_name="services", blank=True, verbose_name="IP addresses",
+        to="ipam.IPAddress",
+        related_name="services",
+        blank=True,
+        verbose_name="IP addresses",
     )
     description = models.CharField(max_length=200, blank=True)
 

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -849,10 +849,14 @@ class IPAddress(PrimaryModel, StatusModel):
     def clean(self):
         super().clean()
 
-        if self.address:
+        # Set necessary instance attributes after parsing temp_address field
+        if hasattr(self, "form_address"):
+            self._deconstruct_address(self.form_address)
+
+        if self.address or hasattr(self, "temp_address"):
 
             # /0 masks are not acceptable
-            if self.address.prefixlen == 0:
+            if self.prefix_length == 0:
                 raise ValidationError({"address": "Cannot create IP address with /0 mask."})
 
             # Enforce unique IP space (if applicable)

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -851,10 +851,6 @@ class IPAddress(PrimaryModel, StatusModel):
 
         if self.address:
 
-            # /0 masks are not acceptable
-            if self.address.prefixlen == 0:
-                raise ValidationError({"address": "Cannot create IP address with /0 mask."})
-
             # Enforce unique IP space (if applicable)
             if self.role not in IPADDRESS_ROLES_NONUNIQUE and (
                 (self.vrf is None and settings.ENFORCE_GLOBAL_UNIQUE) or (self.vrf and self.vrf.enforce_unique)

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -38,7 +38,13 @@ __all__ = (
 
 
 @extras_features(
-    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
+    "custom_fields",
+    "custom_links",
+    "custom_validators",
+    "export_templates",
+    "graphql",
+    "relationships",
+    "webhooks",
 )
 class VRF(PrimaryModel):
     """
@@ -57,7 +63,11 @@ class VRF(PrimaryModel):
         help_text="Unique route distinguisher (as defined in RFC 4364)",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="vrfs", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="vrfs",
+        blank=True,
+        null=True,
     )
     enforce_unique = models.BooleanField(
         default=True,
@@ -103,7 +113,13 @@ class VRF(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
+    "custom_fields",
+    "custom_links",
+    "custom_validators",
+    "export_templates",
+    "graphql",
+    "relationships",
+    "webhooks",
 )
 class RouteTarget(PrimaryModel):
     """
@@ -117,7 +133,11 @@ class RouteTarget(PrimaryModel):
     )
     description = models.CharField(max_length=200, blank=True)
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="route_targets", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="route_targets",
+        blank=True,
+        null=True,
     )
 
     csv_headers = ["name", "description", "tenant"]
@@ -140,7 +160,10 @@ class RouteTarget(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields", "custom_validators", "graphql", "relationships",
+    "custom_fields",
+    "custom_validators",
+    "graphql",
+    "relationships",
 )
 class RIR(OrganizationalModel):
     """
@@ -151,7 +174,9 @@ class RIR(OrganizationalModel):
     name = models.CharField(max_length=100, unique=True)
     slug = models.SlugField(max_length=100, unique=True)
     is_private = models.BooleanField(
-        default=False, verbose_name="Private", help_text="IP space managed by this RIR is considered private",
+        default=False,
+        verbose_name="Private",
+        help_text="IP space managed by this RIR is considered private",
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -178,7 +203,13 @@ class RIR(OrganizationalModel):
 
 
 @extras_features(
-    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
+    "custom_fields",
+    "custom_links",
+    "custom_validators",
+    "export_templates",
+    "graphql",
+    "relationships",
+    "webhooks",
 )
 class Aggregate(PrimaryModel):
     """
@@ -186,12 +217,25 @@ class Aggregate(PrimaryModel):
     the hierarchy and track the overall utilization of available address space. Each Aggregate is assigned to a RIR.
     """
 
-    network = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 network address",)
+    network = VarbinaryIPField(
+        null=False,
+        db_index=True,
+        help_text="IPv4 or IPv6 network address",
+    )
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
-    rir = models.ForeignKey(to="ipam.RIR", on_delete=models.PROTECT, related_name="aggregates", verbose_name="RIR",)
+    rir = models.ForeignKey(
+        to="ipam.RIR",
+        on_delete=models.PROTECT,
+        related_name="aggregates",
+        verbose_name="RIR",
+    )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="aggregates", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="aggregates",
+        blank=True,
+        null=True,
     )
     date_added = models.DateField(blank=True, null=True)
     description = models.CharField(max_length=200, blank=True)
@@ -319,7 +363,10 @@ class Aggregate(PrimaryModel):
 
 
 @extras_features(
-    "custom_fields", "custom_validators", "graphql", "relationships",
+    "custom_fields",
+    "custom_validators",
+    "graphql",
+    "relationships",
 )
 class Role(OrganizationalModel):
     """
@@ -330,7 +377,10 @@ class Role(OrganizationalModel):
     name = models.CharField(max_length=100, unique=True)
     slug = models.SlugField(max_length=100, unique=True)
     weight = models.PositiveSmallIntegerField(default=1000)
-    description = models.CharField(max_length=200, blank=True,)
+    description = models.CharField(
+        max_length=200,
+        blank=True,
+    )
 
     csv_headers = ["name", "slug", "weight", "description"]
 
@@ -369,18 +419,42 @@ class Prefix(PrimaryModel, StatusModel):
     assigned to a VLAN where appropriate.
     """
 
-    network = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 network address",)
+    network = VarbinaryIPField(
+        null=False,
+        db_index=True,
+        help_text="IPv4 or IPv6 network address",
+    )
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
-    site = models.ForeignKey(to="dcim.Site", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True,)
+    site = models.ForeignKey(
+        to="dcim.Site",
+        on_delete=models.PROTECT,
+        related_name="prefixes",
+        blank=True,
+        null=True,
+    )
     vrf = models.ForeignKey(
-        to="ipam.VRF", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True, verbose_name="VRF",
+        to="ipam.VRF",
+        on_delete=models.PROTECT,
+        related_name="prefixes",
+        blank=True,
+        null=True,
+        verbose_name="VRF",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="prefixes",
+        blank=True,
+        null=True,
     )
     vlan = models.ForeignKey(
-        to="ipam.VLAN", on_delete=models.PROTECT, related_name="prefixes", blank=True, null=True, verbose_name="VLAN",
+        to="ipam.VLAN",
+        on_delete=models.PROTECT,
+        related_name="prefixes",
+        blank=True,
+        null=True,
+        verbose_name="VLAN",
     )
     role = models.ForeignKey(
         to="ipam.Role",
@@ -391,7 +465,9 @@ class Prefix(PrimaryModel, StatusModel):
         help_text="The primary function of this prefix",
     )
     is_pool = models.BooleanField(
-        verbose_name="Is a pool", default=False, help_text="All IP addresses within this prefix are considered usable",
+        verbose_name="Is a pool",
+        default=False,
+        help_text="All IP addresses within this prefix are considered usable",
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -483,7 +559,8 @@ class Prefix(PrimaryModel, StatusModel):
                     raise ValidationError(
                         {
                             "prefix": "Duplicate prefix found in {}: {}".format(
-                                "VRF {}".format(self.vrf) if self.vrf else "global table", duplicate_prefixes.first(),
+                                "VRF {}".format(self.vrf) if self.vrf else "global table",
+                                duplicate_prefixes.first(),
                             )
                         }
                     )
@@ -583,7 +660,12 @@ class Prefix(PrimaryModel, StatusModel):
             return available_ips
 
         # Omit first and last IP address from the available set
-        available_ips -= netaddr.IPSet([netaddr.IPAddress(self.prefix.first), netaddr.IPAddress(self.prefix.last),])
+        available_ips -= netaddr.IPSet(
+            [
+                netaddr.IPAddress(self.prefix.first),
+                netaddr.IPAddress(self.prefix.last),
+            ]
+        )
 
         return available_ips
 
@@ -649,17 +731,33 @@ class IPAddress(PrimaryModel, StatusModel):
     which has a NAT outside IP, that Interface's Device can use either the inside or outside IP as its primary IP.
     """
 
-    host = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 host address",)
+    host = VarbinaryIPField(
+        null=False,
+        db_index=True,
+        help_text="IPv4 or IPv6 host address",
+    )
     broadcast = VarbinaryIPField(null=False, db_index=True, help_text="IPv4 or IPv6 broadcast address")
     prefix_length = models.IntegerField(null=False, db_index=True, help_text="Length of the Network prefix, in bits.")
     vrf = models.ForeignKey(
-        to="ipam.VRF", on_delete=models.PROTECT, related_name="ip_addresses", blank=True, null=True, verbose_name="VRF",
+        to="ipam.VRF",
+        on_delete=models.PROTECT,
+        related_name="ip_addresses",
+        blank=True,
+        null=True,
+        verbose_name="VRF",
     )
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="ip_addresses", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="ip_addresses",
+        blank=True,
+        null=True,
     )
     role = models.CharField(
-        max_length=50, choices=IPAddressRoleChoices, blank=True, help_text="The functional role of this IP",
+        max_length=50,
+        choices=IPAddressRoleChoices,
+        blank=True,
+        help_text="The functional role of this IP",
     )
     assigned_object_type = models.ForeignKey(
         to=ContentType,
@@ -770,7 +868,8 @@ class IPAddress(PrimaryModel, StatusModel):
                     raise ValidationError(
                         {
                             "address": "Duplicate IP address found in {}: {}".format(
-                                "VRF {}".format(self.vrf) if self.vrf else "global table", duplicate_ips.first(),
+                                "VRF {}".format(self.vrf) if self.vrf else "global table",
+                                duplicate_ips.first(),
                             )
                         }
                     )
@@ -868,7 +967,10 @@ class IPAddress(PrimaryModel, StatusModel):
 
 
 @extras_features(
-    "custom_fields", "custom_validators", "graphql", "relationships",
+    "custom_fields",
+    "custom_validators",
+    "graphql",
+    "relationships",
 )
 class VLANGroup(OrganizationalModel):
     """
@@ -878,7 +980,11 @@ class VLANGroup(OrganizationalModel):
     name = models.CharField(max_length=100)
     slug = models.SlugField(max_length=100)
     site = models.ForeignKey(
-        to="dcim.Site", on_delete=models.PROTECT, related_name="vlan_groups", blank=True, null=True,
+        to="dcim.Site",
+        on_delete=models.PROTECT,
+        related_name="vlan_groups",
+        blank=True,
+        null=True,
     )
     description = models.CharField(max_length=200, blank=True)
 
@@ -941,18 +1047,38 @@ class VLAN(PrimaryModel, StatusModel):
     or more Prefixes assigned to it.
     """
 
-    site = models.ForeignKey(to="dcim.Site", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,)
+    site = models.ForeignKey(
+        to="dcim.Site",
+        on_delete=models.PROTECT,
+        related_name="vlans",
+        blank=True,
+        null=True,
+    )
     group = models.ForeignKey(
-        to="ipam.VLANGroup", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,
+        to="ipam.VLANGroup",
+        on_delete=models.PROTECT,
+        related_name="vlans",
+        blank=True,
+        null=True,
     )
     vid = models.PositiveSmallIntegerField(
         verbose_name="ID", validators=[MinValueValidator(1), MaxValueValidator(4094)]
     )
     name = models.CharField(max_length=64)
     tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.PROTECT, related_name="vlans", blank=True, null=True,
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="vlans",
+        blank=True,
+        null=True,
     )
-    role = models.ForeignKey(to="ipam.Role", on_delete=models.SET_NULL, related_name="vlans", blank=True, null=True,)
+    role = models.ForeignKey(
+        to="ipam.Role",
+        on_delete=models.SET_NULL,
+        related_name="vlans",
+        blank=True,
+        null=True,
+    )
     description = models.CharField(max_length=200, blank=True)
 
     csv_headers = [
@@ -1026,7 +1152,13 @@ class VLAN(PrimaryModel, StatusModel):
 
 
 @extras_features(
-    "custom_fields", "custom_links", "custom_validators", "export_templates", "graphql", "relationships", "webhooks",
+    "custom_fields",
+    "custom_links",
+    "custom_validators",
+    "export_templates",
+    "graphql",
+    "relationships",
+    "webhooks",
 )
 class Service(PrimaryModel):
     """
@@ -1043,18 +1175,28 @@ class Service(PrimaryModel):
         blank=True,
     )
     virtual_machine = models.ForeignKey(
-        to="virtualization.VirtualMachine", on_delete=models.CASCADE, related_name="services", null=True, blank=True,
+        to="virtualization.VirtualMachine",
+        on_delete=models.CASCADE,
+        related_name="services",
+        null=True,
+        blank=True,
     )
     name = models.CharField(max_length=100)
     protocol = models.CharField(max_length=50, choices=ServiceProtocolChoices)
     ports = JSONArrayField(
         base_field=models.PositiveIntegerField(
-            validators=[MinValueValidator(SERVICE_PORT_MIN), MaxValueValidator(SERVICE_PORT_MAX),]
+            validators=[
+                MinValueValidator(SERVICE_PORT_MIN),
+                MaxValueValidator(SERVICE_PORT_MAX),
+            ]
         ),
         verbose_name="Port numbers",
     )
     ipaddresses = models.ManyToManyField(
-        to="ipam.IPAddress", related_name="services", blank=True, verbose_name="IP addresses",
+        to="ipam.IPAddress",
+        related_name="services",
+        blank=True,
+        verbose_name="IP addresses",
     )
     description = models.CharField(max_length=200, blank=True)
 

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -5,7 +5,7 @@ from nautobot.extras.models.statuses import Status
 from nautobot.ipam.forms import IPAddressForm
 
 
-class EoxFormTest(TestCase):
+class IPAddressFormTest(TestCase):
     def test_valid_ip_address(self):
         form = IPAddressForm(data={"address": "192.168.1.0/24", "status": Status.objects.get(slug="dhcp")})
         self.assertTrue(form.is_valid())

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -17,3 +17,18 @@ class IPAddressFormTest(TestCase):
         )
         self.assertTrue(form.is_valid())
         self.assertTrue(form.save())
+
+    def test_slaac_status_invalid_ipv4(self):
+        form = IPAddressForm(data={"address": "192.168.0.1/32", "status": Status.objects.get(slug="slaac")})
+        self.assertFalse(form.is_valid())
+        self.assertEquals("Only IPv6 addresses can be assigned SLAAC status", form.errors["status"])
+
+    def test_address_invalid_ipv4(self):
+        form = IPAddressForm(data={"address": "192.168.0.1/64", "status": Status.objects.get(slug="dhcp")})
+        self.assertFalse(form.is_valid())
+        self.assertIn("Please specify a valid IPv4 or IPv6 address.", form.errors)
+
+    def test_address_missing_cidr_mask(self):
+        form = IPAddressForm(data={"address": "192.168.0.1/0", "status": Status.objects.get(slug="dhcp")})
+        self.assertFalse(form.is_valid())
+        self.assertIn("CIDR mask (e.g. /24) is required.", form.errors)

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -21,14 +21,14 @@ class IPAddressFormTest(TestCase):
     def test_slaac_status_invalid_ipv4(self):
         form = IPAddressForm(data={"address": "192.168.0.1/32", "status": Status.objects.get(slug="slaac")})
         self.assertFalse(form.is_valid())
-        self.assertEquals("Only IPv6 addresses can be assigned SLAAC status", form.errors["status"])
+        self.assertEquals("Only IPv6 addresses can be assigned SLAAC status", form.errors["status"][0])
 
     def test_address_invalid_ipv4(self):
         form = IPAddressForm(data={"address": "192.168.0.1/64", "status": Status.objects.get(slug="dhcp")})
         self.assertFalse(form.is_valid())
-        self.assertIn("Please specify a valid IPv4 or IPv6 address.", form.errors)
+        self.assertEquals("Please specify a valid IPv4 or IPv6 address.", form.errors["address"][0])
 
     def test_address_missing_cidr_mask(self):
         form = IPAddressForm(data={"address": "192.168.0.1/0", "status": Status.objects.get(slug="dhcp")})
         self.assertFalse(form.is_valid())
-        self.assertIn("CIDR mask (e.g. /24) is required.", form.errors)
+        self.assertEquals("CIDR mask (e.g. /24) is required.", form.errors["address"][0])

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -28,7 +28,12 @@ class IPAddressFormTest(TestCase):
         self.assertFalse(form.is_valid())
         self.assertEquals("Please specify a valid IPv4 or IPv6 address.", form.errors["address"][0])
 
-    def test_address_missing_cidr_mask(self):
+    def test_address_zero_mask(self):
         form = IPAddressForm(data={"address": "192.168.0.1/0", "status": Status.objects.get(slug="dhcp")})
+        self.assertFalse(form.is_valid())
+        self.assertEquals("Cannot create IP address with /0 mask.", form.errors["address"][0])
+
+    def test_address_missing_mask(self):
+        form = IPAddressForm(data={"address": "192.168.0.1", "status": Status.objects.get(slug="dhcp")})
         self.assertFalse(form.is_valid())
         self.assertEquals("CIDR mask (e.g. /24) is required.", form.errors["address"][0])

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -1,0 +1,19 @@
+"""Test IPAM forms."""
+from django.test import TestCase
+
+from nautobot.extras.models.statuses import Status
+from nautobot.ipam.forms import IPAddressForm
+
+
+class EoxFormTest(TestCase):
+    def test_valid_ip_address(self):
+        form = IPAddressForm(data={"address": "192.168.1.0/24", "status": Status.objects.get(slug="dhcp")})
+        self.assertTrue(form.is_valid())
+        self.assertTrue(form.save())
+
+    def test_slaac_valid_ipv6(self):
+        form = IPAddressForm(
+            data={"address": "2001:0db8:0000:0000:0000:ff00:0042:8329/128", "status": Status.objects.get(slug="slaac")}
+        )
+        self.assertTrue(form.is_valid())
+        self.assertTrue(form.save())


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes

- Fixes #304 
- Fixes #318

<!--
    Please include a summary of the proposed changes below.
-->
I'm not sure this is the best way, but the way I seem to have fix that the validation errors will be thrown. I think due to the `self.address` now being a computed field, it was messing with fields being passed in with the form. I believe `self.address` is still required for ORM related stuff and possibly API things (I prob need to validate API works as intended as well).

Tests still need to be written for testing forms so I was going to start adding more tomorrow, but wanted to get this fix in front to see what changes I need to make to it.
