### PR TITLE
Revise caching/queueing configs and docs for Redis locking

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -1,4 +1,5 @@
-"""Nautobot configuration file."""
+"""Nautobot development configuration file."""
+
 from distutils.util import strtobool
 import os
 import sys
@@ -79,48 +80,39 @@ def is_truthy(arg):
         return arg
     return bool(strtobool(str(arg)))
 
+# Redis variables
+REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
+REDIS_PORT = os.getenv('REDIS_PORT', 6379)
+REDIS_PASSWORD = os.getenv('REDIS_PASSWORD', '')
 
-RQ_QUEUES = {
+# Check for Redis SSL
+REDIS_SCHEME = "redis"
+REDIS_SSL = is_truthy(os.environ.get("REDIS_SSL", False))
+if REDIS_SSL:
+    REDIS_SCHEME = "rediss"
+
+# The django-redis cache is used to establish concurrent locks using Redis. The
+# django-rq settings will use the same instance/database by default.
+#
+# This "default" server is now used by RQ_QUEUES.
+# >> See: nautobot.core.settings.RQ_QUEUES
+CACHES = {
     "default": {
-        "HOST": os.environ["REDIS_HOST"],
-        "PORT": int(os.environ.get("REDIS_PORT", 6379)),
-        "DB": 0,
-        "PASSWORD": os.environ["REDIS_PASSWORD"],
-        "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
-        "DEFAULT_TIMEOUT": 300,
-    },
-    "webhooks": {
-        "HOST": os.environ["REDIS_HOST"],
-        "PORT": int(os.environ.get("REDIS_PORT", 6379)),
-        "DB": 0,
-        "PASSWORD": os.environ["REDIS_PASSWORD"],
-        "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
-        "DEFAULT_TIMEOUT": 300,
-    },
-    "check_releases": {
-        "HOST": os.environ["REDIS_HOST"],
-        "PORT": int(os.environ.get("REDIS_PORT", 6379)),
-        "DB": 0,
-        "PASSWORD": os.environ["REDIS_PASSWORD"],
-        "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
-        "DEFAULT_TIMEOUT": 300,
-    },
-    "custom_fields": {
-        "HOST": os.environ["REDIS_HOST"],
-        "PORT": int(os.environ.get("REDIS_PORT", 6379)),
-        "DB": 0,
-        "PASSWORD": os.environ["REDIS_PASSWORD"],
-        "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
-        "DEFAULT_TIMEOUT": 900,
-    },
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"{REDIS_SCHEME}://{REDIS_HOST}:{REDIS_PORT}/0",
+        "TIMEOUT": 300,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "PASSWORD": REDIS_PASSWORD,
+        },
+    }
 }
 
-# Base URL path if accessing Nautobot within a directory. For example, if installed at https://example.com/nautobot/, set:
-# BASE_PATH = 'nautobot/'
-BASE_PATH = os.environ.get("BASE_PATH", "")
+# RQ_QUEUES is not set here because it just uses the default that gets imported
+# up top via `from nautobot.core.settings import *`.
 
 # REDIS CACHEOPS
-CACHEOPS_REDIS = f"redis://:{os.getenv('REDIS_PASSWORD')}@{os.getenv('REDIS_HOST')}:{os.getenv('REDIS_PORT')}/2"
+CACHEOPS_REDIS = f"{REDIS_SCHEME}://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/1"
 
 HIDE_RESTRICTED_UI = os.environ.get("HIDE_RESTRICTED_UI", False)
 

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -432,6 +432,8 @@ GRAPHQL_RELATIONSHIP_PREFIX = "rel"
 # Caching
 #
 
+# The django-cacheops plugin is used to cache querysets. The built-in Django
+# caching is not used.
 CACHEOPS = {
     "auth.user": {"ops": "get", "timeout": 60 * 15},
     "auth.*": {"ops": ("fetch", "get")},
@@ -453,12 +455,16 @@ CACHEOPS_ENABLED = True
 CACHEOPS_REDIS = "redis://localhost:6379/1"
 CACHEOPS_DEFAULTS = {"timeout": 900}
 
+# The django-redis cache is used to establish concurrent locks using Redis. The
+# django-rq settings will use the same instance/database by default.
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "redis://127.0.0.1:6379/1",
+        "LOCATION": "redis://localhost:6379/0",
+        "TIMEOUT": 300,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "PASSWORD": "",
         },
     }
 }
@@ -467,37 +473,19 @@ CACHES = {
 # Django RQ (Webhooks backend)
 #
 
+# These defaults utilize the Django caches setting defined for django-redis.
+# See: https://github.com/rq/django-rq#support-for-django-redis-and-django-redis-cache
 RQ_QUEUES = {
     "default": {
-        "HOST": "localhost",
-        "PORT": 6379,
-        "DB": 0,
-        "PASSWORD": "",
-        "SSL": False,
-        "DEFAULT_TIMEOUT": 300,
-    },
-    "webhooks": {
-        "HOST": "localhost",
-        "PORT": 6379,
-        "DB": 0,
-        "PASSWORD": "",
-        "SSL": False,
-        "DEFAULT_TIMEOUT": 300,
+        "USE_REDIS_CACHE": "default",
     },
     "check_releases": {
-        "HOST": "localhost",
-        "PORT": 6379,
-        "DB": 0,
-        "PASSWORD": "",
-        "SSL": False,
-        "DEFAULT_TIMEOUT": 300,
+        "USE_REDIS_CACHE": "default",
     },
     "custom_fields": {
-        "HOST": "localhost",
-        "PORT": 6379,
-        "DB": 0,
-        "PASSWORD": "",
-        "SSL": False,
-        "DEFAULT_TIMEOUT": 300,
+        "USE_REDIS_CACHE": "default",
+    },
+    "webhooks": {
+        "USE_REDIS_CACHE": "default",
     },
 }

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -28,63 +28,42 @@ DATABASES = {
     }
 }
 
+# The django-redis cache is used to establish concurrent locks using Redis. The
+# django-rq settings will use the same instance/database by default.
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://localhost:6379/0",
+        "TIMEOUT": 300,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "PASSWORD": "",
+        },
+    }
+}
+
 # Nautobot uses RQ for task scheduling. These are the following defaults.
 # For detailed configuration see: https://github.com/rq/django-rq#installation
+# These defaults utilize the Django `CACHES` setting defined above for django-redis.
+# See: https://github.com/rq/django-rq#support-for-django-redis-and-django-redis-cache
 RQ_QUEUES = {
-    "default": {"HOST": "localhost", "PORT": 6379, "DB": 0, "PASSWORD": "", "SSL": False, "DEFAULT_TIMEOUT": 300},
-    # "with-sentinel": {
-    #     "SENTINELS": [
-    #         ("mysentinel.redis.example.com", 6379)
-    #         ("othersentinel.redis.example.com", 6379)
-    #     ],
-    #     "MASTER_NAME": 'nautobot",
-    #     "DB": 0,
-    #     "PASSWORD": "",
-    #     "SOCKET_TIMEOUT": None,
-    #     'CONNECTION_KWARGS': {
-    #         'socket_connect_timeout': 10,
-    #     },
-    # },
-    "webhooks": {
-        "HOST": "localhost",
-        "PORT": 6379,
-        "DB": 0,
-        "PASSWORD": "",
-        "SSL": False,
-        "DEFAULT_TIMEOUT": 300,
+    "default": {
+        "USE_REDIS_CACHE": "default",
     },
     "check_releases": {
-        "HOST": "localhost",
-        "PORT": 6379,
-        "DB": 0,
-        "PASSWORD": "",
-        "SSL": False,
-        "DEFAULT_TIMEOUT": 300,
+        "USE_REDIS_CACHE": "default",
     },
     "custom_fields": {
-        "HOST": "localhost",
-        "PORT": 6379,
-        "DB": 0,
-        "PASSWORD": "",
-        "SSL": False,
-        "DEFAULT_TIMEOUT": 900,
+        "USE_REDIS_CACHE": "default",
+    },
+    "webhooks": {
+        "USE_REDIS_CACHE": "default",
     },
 }
 
 # Nautobot uses Cacheops for database query caching. These are the following defaults.
 # For detailed configuration see: https://github.com/Suor/django-cacheops#setup
 CACHEOPS_REDIS = "redis://localhost:6379/1"
-
-# This is used for configuring Redis locks via django caching backend.
-CACHES = {
-    "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "redis://127.0.0.1:6379/1",
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        },
-    }
-}
 
 # This key is used for secure generation of random numbers and strings. It must never be exposed outside of this file.
 # For optimal security, SECRET_KEY should be at least 50 characters in length and contain a mix of letters, numbers, and

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -3,10 +3,10 @@
 #  only. It is not intended for production use.                   #
 ###################################################################
 
-from nautobot.core.settings import *  # noqa: F401,F403
+import os
 from distutils.util import strtobool
 
-import os
+from nautobot.core.settings import *  # noqa: F401,F403
 
 ALLOWED_HOSTS = ["*"]
 
@@ -43,40 +43,36 @@ def is_truthy(arg):
     return bool(strtobool(str(arg)))
 
 
-# Here we are setting up a separate DB for the tests to use.
-# This allows us to keep the rqworker running when working
-# through the devcontainer or when using invoke.
-RQ_QUEUES = {
+# Redis variables
+REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_PORT = os.getenv("REDIS_PORT", 6379)
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", "")
+
+# Check for Redis SSL
+REDIS_SCHEME = "redis"
+REDIS_SSL = is_truthy(os.environ.get("REDIS_SSL", False))
+if REDIS_SSL:
+    REDIS_SCHEME = "rediss"
+
+# The django-redis cache is used to establish concurrent locks using Redis. The
+# django-rq settings will use the same instance/database by default.
+#
+# This "default" server is now used by RQ_QUEUES.
+# >> See: nautobot.core.settings.RQ_QUEUES
+CACHES = {
     "default": {
-        "HOST": os.getenv("REDIS_HOST", "localhost"),
-        "PORT": int(os.environ.get("REDIS_PORT", 6379)),
-        "DB": 2,
-        "PASSWORD": os.getenv("REDIS_PASSWORD", ""),
-        "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
-        "DEFAULT_TIMEOUT": 300,
-    },
-    "webhooks": {
-        "HOST": "localhost",
-        "PORT": 6379,
-        "DB": 0,
-        "PASSWORD": "",
-        "SSL": False,
-        "DEFAULT_TIMEOUT": 300,
-    },
-    "check_releases": {
-        "HOST": os.getenv("REDIS_HOST", "localhost"),
-        "PORT": int(os.environ.get("REDIS_PORT", 6379)),
-        "DB": 2,
-        "PASSWORD": os.getenv("REDIS_PASSWORD", ""),
-        "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
-        "DEFAULT_TIMEOUT": 300,
-    },
-    "custom_fields": {
-        "HOST": os.getenv("REDIS_HOST", "localhost"),
-        "PORT": int(os.environ.get("REDIS_PORT", 6379)),
-        "DB": 2,
-        "PASSWORD": os.getenv("REDIS_PASSWORD", ""),
-        "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
-        "DEFAULT_TIMEOUT": 900,
-    },
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"{REDIS_SCHEME}://{REDIS_HOST}:{REDIS_PORT}/2",
+        "TIMEOUT": 300,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "PASSWORD": REDIS_PASSWORD,
+        },
+    }
 }
+
+# RQ_QUEUES is not set here because it just uses the default that gets imported
+# up top via `from nautobot.core.settings import *`.
+
+# REDIS CACHEOPS
+CACHEOPS_REDIS = f"{REDIS_SCHEME}://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/3"

--- a/nautobot/docs/additional-features/caching.md
+++ b/nautobot/docs/additional-features/caching.md
@@ -1,8 +1,12 @@
 # Caching
 
-Nautobot supports database query caching using [django-cacheops](https://github.com/Suor/django-cacheops) and Redis. When a query is made, the results are cached in Redis for a short period of time, as defined by the [CACHEOPS_DEFAULTS](../../configuration/optional-settings/#cacheops_defaults) parameter (15 minutes by default). Within that time, all recurrences of that specific query will return the pre-fetched results from the cache.
+Nautobot supports database query caching using [django-cacheops](https://github.com/Suor/django-cacheops) and Redis. When a query is made, the results are cached in Redis for a short period of time, as defined by the [`CACHEOPS_DEFAULTS`](../../configuration/optional-settings/#cacheops_defaults) parameter (15 minutes by default). Within that time, all recurrences of that specific query will return the pre-fetched results from the cache.
 
 If a change is made to any of the objects returned by the query within that time, or if the timeout expires, the results are automatically invalidated and the next request for those results will be sent to the database.
+
+!!! important
+    Cacheops does not utilize the built-in [Django cache
+framework](https://docs.djangoproject.com/en/stable/topics/cache/) to perform caching. Therefore it does not rely upon the `CACHES` setting. Instead it monkey patches the underlying queryset methods to intercept calls to get and set cached items in Redis.
 
 ## Invalidating Cached Data
 

--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -72,10 +72,7 @@ caching, task queueing, and webhook features. The connection settings are explai
 to different Redis instances/databases per feature.
 
 !!! warning
-    It is highly recommended to keep the Redis databases for caching and tasks separate. Using the same database number on the
-    same Redis instance for both may result in queued background tasks being lost during cache flushing events.
-
-    For this reason, the default settings utilize database `1` for caching and database `0` for tasks.
+    It is highly recommended to keep the Redis databases for caching and tasks separate. Using the same database number on the same Redis instance for both may result in queued background tasks being lost during cache flushing events. For this reason, the default settings utilize database `1` for caching and database `0` for tasks.
 
 !!! tip
     The default Redis settings in your `nautobot_config.py` should be suitable for most deployments and should only require customization for more advanced configurations.
@@ -88,6 +85,9 @@ Nautobot supports database query caching using [`django-cacheops`](https://githu
 Caching is configured by defining the [`CACHEOPS_REDIS`](#cacheops_redis) setting which in its simplest form is just a URL.
 
 For more details Nautobot's caching see the guide on [Caching](../../additional-features/caching).
+
+!!! important
+	Cacheops does not utilize the built-in [Django cache framework](https://docs.djangoproject.com/en/stable/topics/cache/) to perform caching. Instead it monkey patches the underlying queryset methods to intercept calls to get and set cached items in Redis.
 
 #### CACHEOPS_REDIS
 
@@ -105,12 +105,10 @@ This setting may also be a dictionary style, but that is not covered here. Pleas
 
 Default: `undefined`
 
-If you are using [Redis Sentinel](https://redis.io/topics/sentinel) for high-availability purposes, you must replace the
-[`CACHEOPS_REDIS`](#cacheops_redis) setting with [`CACHEOPS_SENTINEL`](#cacheops_sentinel).
+If you are using [Redis Sentinel](https://redis.io/topics/sentinel) for high-availability purposes, you must replace the [`CACHEOPS_REDIS`](#cacheops_redis) setting with [`CACHEOPS_SENTINEL`](#cacheops_sentinel).
 
 !!! warning
-    [`CACHEOPS_REDIS`](#cacheops_redis) and [`CACHEOPS_SENTINEL`](#cacheops_sentinel) are mutually exclusive and will
-    result in an error if both are set.
+    [`CACHEOPS_REDIS`](#cacheops_redis) and [`CACHEOPS_SENTINEL`](#cacheops_sentinel) are mutually exclusive and will result in an error if both are set.
 
 Example:
 
@@ -135,11 +133,61 @@ setup](https://github.com/Suor/django-cacheops#setup).
 
 ### Task Queuing
 
-Task queues are configured by defining the `RQ_QUEUES` setting. Nautobot's core functionality relies on four distinct queues and these represent the minimum required set of queues that must be defined. By default, these are identical. It is up to you to modify them for your environment and know that other use cases like specific plugins may require additional queues to be defined.
+Task queues are configured by defining them within the [`RQ_QUEUES`](#rq_queues) setting. 
+
+Nautobot's core functionality relies on several distinct queues and these represent the minimum required set of queues that must be defined. By default, these use identical connection settings as defined in [`CACHES`](#caches) (yes, that's confusing and we'll explain below).
+
+It is up to you to modify the task queues for your environment and know that other use cases such as utilizing specific plugins may require additional queues to be defined. In most cases the default settings will be suitable for production use.
+
+#### CACHES
+
+The [`django-redis`](https://github.com/jazzband/django-redis) Django plugin is used to provide the backend for Redis as a concurrent write lock for preventing race conditions when allocating IP address objects and to define centralized Redis connection settings that will be used by RQ. This setting is used to to simplify the configuration for defining queues. *It is not used for caching at this time.* 
+
+!!! important
+	Nautobot does not utilize the built-in [Django cache framework](https://docs.djangoproject.com/en/stable/topics/cache/) to perform caching because Cacheops is being used instead as detailed just above. *Yes, we know this is confusing, which is why this is being called out explicitly!*
+
+Default:
+
+```python
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://localhost:6379/0",
+        "TIMEOUT": 300,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "PASSWORD": "",
+        },
+    }
+}
+```
 
 #### RQ_QUEUES
 
+The default value for this setting defines the queues and instructs RQ to use the `default` Redis connection defined in [`CACHES`](#caches). This is intended to simplify default configuration for the common case.
+
+ Please see the [official `django-rq` documentation on support for django-redis connection settings](https://github.com/rq/django-rq#support-for-django-redis-and-django-redis-cache) for more information.
+
 Default:
+
+```python
+RQ_QUEUES = {
+    "default": {
+        "USE_REDIS_CACHE": "default",
+    },
+    "check_releases": {
+        "USE_REDIS_CACHE": "default",
+    },
+    "custom_fields": {
+        "USE_REDIS_CACHE": "default",
+    },
+    "webhooks": {
+        "USE_REDIS_CACHE": "default",
+    },
+}
+```
+
+More verbose dictionary-style configuration is still supported, but is not required unless you absolutely need more advanced task queuing configuration. An example configuration follows:
 
 ```python
 RQ_QUEUES = {
@@ -185,11 +233,11 @@ RQ_QUEUES = {
 - `SSL` - Use SSL connection to Redis
 - `DEFAULT_TIMEOUT` - The maximum execution time of a background task (such as running a [Job](../additional-features/jobs.md)), in seconds.
 
+For more details on configuring RQ, please see the documentation for [Django RQ installation](https://github.com/rq/django-rq#installation).
+
 #### Using Redis Sentinel
 
-If you are using [Redis Sentinel](https://redis.io/topics/sentinel) for high-availability purposes, you must modify the
-connection settings. It requires the removal of the `HOST`, `PORT`, and `DEFAULT_TIMEOUT` keys from above and the
-addition of three new keys.
+If you are using [Redis Sentinel](https://redis.io/topics/sentinel) for high-availability purposes, you must be using dictionary-style settings, and modify the connection settings. This requires the removal of the `HOST`, `PORT`, and `DEFAULT_TIMEOUT` keys from the example above and the addition of three new keys.
 
 * `SENTINELS`: List of tuples or tuple of tuples with each inner tuple containing the name or IP address
 of the Redis server and port for each sentinel instance to connect to
@@ -235,8 +283,7 @@ RQ_QUEUES = {
 !!! note
     It is permissible to use Sentinel for only one database and not the other.
 
-For more details on configuring RQ, please see the documentation for [Django RQ
-installation](https://github.com/rq/django-rq#installation).
+For more details on configuring RQ with Redis Sentinel, please see the documentation for [Django RQ installation](https://github.com/rq/django-rq#installation).
 
 ---
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Follow up to: #245 
<!--
    Please include a summary of the proposed changes below.
-->

In #245, Redis locking with `django-redis` introduced `CACHES` setting which is easily confused with `CACHEOPS*` settings, so I clarified the documentation and streamlined the `RQ_QUEUES` setting to leverage the `CACHES['default']` value.

Settings changes
- In `nautobot.core.settings.RQ_QUEUES` was changed to use `"USE_REDIS_CACHE": "default"` for each queue, instructing `django-rq` to use the central connection settings, simplifying
the configuration.
- In `nautobot.core.settings.CACHES`, the hostname is now `localhost`, and the `PASSWORD` k
ey (default empty) has been added to `OPTIONS`.
- The `nautobot_config.py` for `development` and `tests` has been updated to leverage the new settings, and neither of them define `RQ_QUEUES` any longer, and instead just use the default setting imported from `nautobot.core.settings`
- The `CACHEOPS_REDIS` setting in `nautobot_config.py` for `tests` has been updated to use
Redis database number `3` to avoid confusion that may arise when swithcing between dev/test
 databases
- The template configuration at `nautobot/core/templates/nautobot_config.py.j2` has been up
dated with the `CACHES` and `RQ_QUEUES` settings
- Documentation for "Caching" now includes an admonition warning that Cacheops is not using
 the built-in `CACHES` config (because it's confusing)
- Documentation for required settings updated to be as verbose as reasonably possible abou
t the new streamlined settings and the introduction of `CACHES`, with admonitions in both t
he Caching and the Task Queueing sections warning about the distinctions between that and `
`CACHOPS_REDIS` settings.
