### PR TITLE
Handle non-Device connections in PowerConnectionsListView and InterfaceConnectionsListView

### DIFF
--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1814,10 +1814,10 @@ class ConsoleConnectionsTestCase(ViewTestCases.ListObjectsViewTestCase):
         self.assertEqual(response.get("Content-Type"), "text/csv")
         self.assertEqual(
             """\
-console_server,port,device,console_port,reachable
-Device 2,Console Server Port 1,Device 1,Console Port 1,True
-Device 2,Console Server Port 2,Device 1,Console Port 2,True
-,,Device 1,Console Port 3,False""",
+device,console_port,console_server,port,reachable
+Device 1,Console Port 1,Device 2,Console Server Port 1,True
+Device 1,Console Port 2,Device 2,Console Server Port 2,True
+Device 1,Console Port 3,,,False""",
             response.content.decode(response.charset),
         )
 
@@ -1872,10 +1872,10 @@ class PowerConnectionsTestCase(ViewTestCases.ListObjectsViewTestCase):
         self.assertEqual(response.get("Content-Type"), "text/csv")
         self.assertEqual(
             """\
-pdu,outlet,device,power_port,reachable
-Device 2,Power Outlet 1,Device 1,Power Port 1,True
-Device 2,Power Outlet 2,Device 1,Power Port 2,True
-,Power Feed 1,Device 1,Power Port 3,True""",
+device,power_port,pdu,outlet,reachable
+Device 1,Power Port 1,Device 2,Power Outlet 1,True
+Device 1,Power Port 2,Device 2,Power Outlet 2,True
+Device 1,Power Port 3,,Power Feed 1,True""",
             response.content.decode(response.charset),
         )
 

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1812,12 +1812,12 @@ class ConsoleConnectionsTestCase(ViewTestCases.ListObjectsViewTestCase):
         self.assertHttpStatus(response, 200)
         self.assertEqual(response.get("Content-Type"), "text/csv")
         self.assertEqual(
-            response.content.decode(response.charset),
             """\
 console_server,port,device,console_port,reachable
 Device 2,Console Server Port 1,Device 1,Console Port 1,True
 Device 2,Console Server Port 2,Device 1,Console Port 2,True
 ,,Device 1,Console Port 3,False""",
+            response.content.decode(response.charset),
         )
 
 
@@ -1870,12 +1870,12 @@ class PowerConnectionsTestCase(ViewTestCases.ListObjectsViewTestCase):
         self.assertHttpStatus(response, 200)
         self.assertEqual(response.get("Content-Type"), "text/csv")
         self.assertEqual(
-            response.content.decode(response.charset),
             """\
 pdu,outlet,device,power_port,reachable
 Device 2,Power Outlet 1,Device 1,Power Port 1,True
 Device 2,Power Outlet 2,Device 1,Power Port 2,True
 ,Power Feed 1,Device 1,Power Port 3,True""",
+            response.content.decode(response.charset),
         )
 
 
@@ -1931,11 +1931,12 @@ class InterfaceConnectionsTestCase(ViewTestCases.ListObjectsViewTestCase):
         self.assertHttpStatus(response, 200)
         self.assertEqual(response.get("Content-Type"), "text/csv")
         self.assertEqual(
-            response.content.decode(response.charset),
             """\
 device_a,interface_a,device_b,interface_b,reachable
-Device 2,Interface 1,Device 1,Interface 1,True
-,,Device 1,Interface 2,True""",
+Device 1,Interface 1,Device 2,Interface 1,True
+Device 1,Interface 2,,,True
+Device 1,Interface 3,,,False""",
+            response.content.decode(response.charset),
         )
 
 

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -10,6 +10,8 @@ from django.test import override_settings
 from django.urls import reverse
 from netaddr import EUI
 
+from nautobot.circuits.choices import CircuitTerminationSideChoices
+from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, Provider
 from nautobot.dcim.choices import *
 from nautobot.dcim.constants import *
 from nautobot.dcim.models import *
@@ -1764,6 +1766,177 @@ class CableTestCase(
             "length": 50,
             "length_unit": CableLengthUnitChoices.UNIT_METER,
         }
+
+
+class ConsoleConnectionsTestCase(ViewTestCases.ListObjectsViewTestCase):
+    """
+    Test the ConsoleConnectionsListView.
+    """
+
+    def _get_base_url(self):
+        return "dcim:console_connections_{}"
+
+    model = ConsolePort
+
+    @classmethod
+    def setUpTestData(cls):
+        device_1 = create_test_device("Device 1")
+        device_2 = create_test_device("Device 2")
+
+        serverports = (
+            ConsoleServerPort.objects.create(device=device_2, name="Console Server Port 1"),
+            ConsoleServerPort.objects.create(device=device_2, name="Console Server Port 2"),
+        )
+        rearport = RearPort.objects.create(device=device_2, type=PortTypeChoices.TYPE_8P8C)
+
+        consoleports = (
+            ConsolePort.objects.create(device=device_1, name="Console Port 1"),
+            ConsolePort.objects.create(device=device_1, name="Console Port 2"),
+            ConsolePort.objects.create(device=device_1, name="Console Port 3"),
+        )
+
+        Cable.objects.create(
+            termination_a=consoleports[0], termination_b=serverports[0], status=Status.objects.get(slug="connected")
+        )
+        Cable.objects.create(
+            termination_a=consoleports[1], termination_b=serverports[1], status=Status.objects.get(slug="connected")
+        )
+        Cable.objects.create(
+            termination_a=consoleports[2], termination_b=rearport, status=Status.objects.get(slug="connected")
+        )
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_queryset_to_csv(self):
+        """This view has a custom queryset_to_csv() implementation."""
+        response = self.client.get("{}?export".format(self._get_url("list")))
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(response.get("Content-Type"), "text/csv")
+        self.assertEqual(
+            response.content.decode(response.charset),
+            """\
+console_server,port,device,console_port,reachable
+Device 2,Console Server Port 1,Device 1,Console Port 1,True
+Device 2,Console Server Port 2,Device 1,Console Port 2,True
+,,Device 1,Console Port 3,False""",
+        )
+
+
+class PowerConnectionsTestCase(ViewTestCases.ListObjectsViewTestCase):
+    """
+    Test the PowerConnectionsListView.
+    """
+
+    def _get_base_url(self):
+        return "dcim:power_connections_{}"
+
+    model = PowerPort
+
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name="Site 1", slug="site-1")
+
+        device_1 = create_test_device("Device 1")
+        device_2 = create_test_device("Device 2")
+
+        powerports = (
+            PowerPort.objects.create(device=device_1, name="Power Port 1"),
+            PowerPort.objects.create(device=device_1, name="Power Port 2"),
+            PowerPort.objects.create(device=device_1, name="Power Port 3"),
+        )
+
+        poweroutlets = (
+            PowerOutlet.objects.create(device=device_2, name="Power Outlet 1", power_port=powerports[0]),
+            PowerOutlet.objects.create(device=device_2, name="Power Outlet 2", power_port=powerports[1]),
+        )
+
+        powerpanel = PowerPanel.objects.create(site=site, name="Power Panel 1")
+        powerfeed = PowerFeed.objects.create(power_panel=powerpanel, name="Power Feed 1")
+
+        Cable.objects.create(
+            termination_a=powerports[2], termination_b=powerfeed, status=Status.objects.get(slug="connected")
+        )
+        # Creating a PowerOutlet with a PowerPort via the ORM does *not* automatically cable the two together. Bug?
+        Cable.objects.create(
+            termination_a=powerports[0], termination_b=poweroutlets[0], status=Status.objects.get(slug="connected")
+        )
+        Cable.objects.create(
+            termination_a=powerports[1], termination_b=poweroutlets[1], status=Status.objects.get(slug="connected")
+        )
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_queryset_to_csv(self):
+        """This view has a custom queryset_to_csv() implementation."""
+        response = self.client.get("{}?export".format(self._get_url("list")))
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(response.get("Content-Type"), "text/csv")
+        self.assertEqual(
+            response.content.decode(response.charset),
+            """\
+pdu,outlet,device,power_port,reachable
+Device 2,Power Outlet 1,Device 1,Power Port 1,True
+Device 2,Power Outlet 2,Device 1,Power Port 2,True
+,Power Feed 1,Device 1,Power Port 3,True""",
+        )
+
+
+class InterfaceConnectionsTestCase(ViewTestCases.ListObjectsViewTestCase):
+    """
+    Test the InterfaceConnectionsListView.
+    """
+
+    def _get_base_url(self):
+        return "dcim:interface_connections_{}"
+
+    model = Interface
+
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name="Site 1", slug="site-1")
+
+        device_1 = create_test_device("Device 1")
+        device_2 = create_test_device("Device 2")
+
+        interfaces = (
+            Interface.objects.create(device=device_1, name="Interface 1", type=InterfaceTypeChoices.TYPE_1GE_SFP),
+            Interface.objects.create(device=device_1, name="Interface 2", type=InterfaceTypeChoices.TYPE_1GE_SFP),
+            Interface.objects.create(device=device_1, name="Interface 3", type=InterfaceTypeChoices.TYPE_1GE_SFP),
+        )
+
+        device_2_interface = Interface.objects.create(
+            device=device_2, name="Interface 1", type=InterfaceTypeChoices.TYPE_1GE_SFP
+        )
+        rearport = RearPort.objects.create(device=device_2, type=PortTypeChoices.TYPE_8P8C)
+
+        provider = Provider.objects.create(name="Provider 1", slug="provider-1")
+        circuittype = CircuitType.objects.create(name="Circuit Type A", slug="circuit-type-a")
+        circuit = Circuit.objects.create(cid="Circuit 1", provider=provider, type=circuittype)
+        circuittermination = CircuitTermination.objects.create(
+            circuit=circuit, term_side=CircuitTerminationSideChoices.SIDE_A, site=site
+        )
+
+        Cable.objects.create(
+            termination_a=interfaces[0], termination_b=device_2_interface, status=Status.objects.get(slug="connected")
+        )
+        Cable.objects.create(
+            termination_a=interfaces[1], termination_b=circuittermination, status=Status.objects.get(slug="connected")
+        )
+        Cable.objects.create(
+            termination_a=interfaces[2], termination_b=rearport, status=Status.objects.get(slug="connected")
+        )
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_queryset_to_csv(self):
+        """This view has a custom queryset_to_csv() implementation."""
+        response = self.client.get("{}?export".format(self._get_url("list")))
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(response.get("Content-Type"), "text/csv")
+        self.assertEqual(
+            response.content.decode(response.charset),
+            """\
+device_a,interface_a,device_b,interface_b,reachable
+Device 2,Interface 1,Device 1,Interface 1,True
+,,Device 1,Interface 2,True""",
+        )
 
 
 class VirtualChassisTestCase(ViewTestCases.PrimaryObjectViewTestCase):


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #307 
<!--
    Please include a summary of the proposed changes below.
-->

The CSV export for "Power Connections" and "Interface Connections" would throw errors if a PowerPort or Interface were connected to something non-Device-associated (a PowerFeed or a CircuitTermination, respectively), because they were unconditionally dereferencing `_path.destination.device`. This PR fixes things so that those columns in the CSV will be empty in such a case; a future enhancement might be to add new columns to the CSV describing these alternate connection types.

There were no existing test cases covering `PowerConnectionsListView`, `ConsoleConnectionsListView`, or `InterfaceConnectionsListView`, so I've added those.