### PR TITLE
Field tweaks/tests for supporting MySQL

### DIFF
--- a/nautobot/ipam/fields.py
+++ b/nautobot/ipam/fields.py
@@ -23,7 +23,7 @@ class VarbinaryIPField(models.BinaryField):
 
         # Use 'bytea' type for Postgres.
         if "postgres" in engine:
-            return super().db_type(connection)
+            return "bytea"
 
         # Or 'varbinary' for everyone else.
         max_length = DictWrapper(self.__dict__, connection.ops.quote_name, "qn_")

--- a/nautobot/ipam/fields.py
+++ b/nautobot/ipam/fields.py
@@ -18,11 +18,10 @@ class VarbinaryIPField(models.BinaryField):
         super().__init__(**kwargs)
 
     def db_type(self, connection):
-        """Returns the correct field type for a given database engine."""
-        engine = connection.settings_dict["ENGINE"]
+        """Returns the correct field type for a given database vendor."""
 
-        # Use 'bytea' type for Postgres.
-        if "postgres" in engine:
+        # Use 'bytea' type for PostgreSQL.
+        if connection.vendor == "postgresql":
             return "bytea"
 
         # Or 'varbinary' for everyone else.
@@ -72,12 +71,11 @@ class VarbinaryIPField(models.BinaryField):
         if value is None:
             return value
 
-        # Parse the address and then pack it to binary
+        # Parse the address and then pack it to binary.
         value = self._parse_address(value).packed
 
-        # Use defaults for Postgres
-        engine = connection.settings_dict["ENGINE"]
-        if "postgres" in engine:
+        # Use defaults for PostgreSQL
+        if connection.vendor == "postgresql":
             return super().get_db_prep_value(value, connection, prepared)
 
         return value

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -25,14 +25,13 @@ class TestVarbinaryIPField(TestCase):
 
     def test_db_type(self):
         """Test `VarbinaryIPField.db_type`."""
-        # Mapping of engine -> db_type
+        # Mapping of vendor -> db_type
         db_types = {
-            "django.db.backends.postgresql": "bytea",
-            "django.db.backends.mysql": "varbinary(16)",
+            "postgresql": "bytea",
+            "mysql": "varbinary(16)",
         }
 
-        engine = connection.settings_dict["ENGINE"]
-        expected = db_types[engine]
+        expected = db_types[connection.vendor]
         self.assertEqual(self.field.db_type(connection), expected)
 
     def test_value_to_string(self):
@@ -80,7 +79,7 @@ class TestVarbinaryIPField(TestCase):
         self.assertEqual(self.field.to_python(self.prefix.prefix.ip), self.network)
 
     @skipIf(
-        "postgres" not in connection.settings_dict["ENGINE"],
+        connection.vendor != "postgresql",
         "postgres is not the database driver",
     )
     def test_get_db_prep_value_postgres(self):
@@ -93,7 +92,7 @@ class TestVarbinaryIPField(TestCase):
         self.assertEqual(prepped.getquoted(), manual.getquoted())
 
     @skipIf(
-        "mysql" not in connection.settings_dict["ENGINE"],
+        connection.vendor != "mysql",
         "mysql is not the database driver",
     )
     def test_get_db_prep_value_mysql(self):

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -1,4 +1,5 @@
 import copy
+from unittest import skipIf
 
 import netaddr
 from django.core.exceptions import ValidationError
@@ -10,48 +11,29 @@ from nautobot.ipam.choices import IPAddressRoleChoices
 from nautobot.ipam.models import Aggregate, IPAddress, Prefix, RIR, VLAN, VLANGroup, VRF
 
 
-class DummyConnection:
-    """
-    Behaves like a connection but with a copy of the `settings_dict`.
-    """
-
-    def __init__(self, connection):
-        self._connection = connection
-        self.settings_dict = copy.deepcopy(connection.settings_dict)
-        self.ops = connection.ops
-        self.data_types = connection.data_types
-        self.Database = connection.Database
-
-    def set_engine(self, engine):
-        self.settings_dict["ENGINE"] = f"django.db.backends.{engine}"
-
-
 class TestVarbinaryIPField(TestCase):
     """Tests for `nautobot.ipam.fields.VarbinaryIPField`."""
 
     def setUp(self):
         super().setUp()
 
-        # Reusable dummy connection object
-        self.connection = DummyConnection(connection)
-
         # Field is a VarbinaryIPField we'll use to test.
         self.prefix = Prefix.objects.create(prefix="10.0.0.0/24")
         self.field = self.prefix._meta.get_field("network")
-        self.network = "10.0.0.0"
-        self.network_packed = bytes(self.prefix.prefix.ip)
+        self.network = self.prefix.network
+        self.network_packed = bytes(self.prefix.prefix.network)
 
     def test_db_type(self):
         """Test `VarbinaryIPField.db_type`."""
         # Mapping of engine -> db_type
         db_types = {
-            "postgres": "bytea",
-            "mysql": "varbinary(16)",
+            "django.db.backends.postgresql": "bytea",
+            "django.db.backends.mysql": "varbinary(16)",
         }
 
-        for engine, expected in db_types.items():
-            self.connection.set_engine(engine)
-            self.assertEqual(self.field.db_type(self.connection), expected)
+        engine = connection.settings_dict["ENGINE"]
+        expected = db_types[engine]
+        self.assertEqual(self.field.db_type(connection), expected)
 
     def test_value_to_string(self):
         """"Test `VarbinaryIPField.value_to_string`."""
@@ -97,18 +79,28 @@ class TestVarbinaryIPField(TestCase):
         # netaddr.IPAddress => str
         self.assertEqual(self.field.to_python(self.prefix.prefix.ip), self.network)
 
-    def test_get_db_prep_value(self):
+    @skipIf(
+        "postgres" not in connection.settings_dict["ENGINE"],
+        "postgres is not the database driver",
+    )
+    def test_get_db_prep_value_postgres(self):
         """"Test `VarbinaryIPField.get_db_prep_value`."""
 
-        # PostgreSQL quotes `bytes` in `::bytea`
-        self.connection.set_engine("postgresql")
-        prepped = self.field.get_db_prep_value(self.network, self.connection)
+        # PostgreSQL escapes `bytes` in `::bytea` and you must call
+        # `getquoted()` to extract the value.
+        prepped = self.field.get_db_prep_value(self.network, connection)
         manual = connection.Database.Binary(self.network_packed)
         self.assertEqual(prepped.getquoted(), manual.getquoted())
 
+    @skipIf(
+        "mysql" not in connection.settings_dict["ENGINE"],
+        "mysql is not the database driver",
+    )
+    def test_get_db_prep_value_mysql(self):
+        """"Test `VarbinaryIPField.get_db_prep_value` for MySQL."""
+
         # MySQL uses raw `bytes`
-        self.connection.set_engine("mysql")
-        prepped = self.field.get_db_prep_value(self.network, self.connection)
+        prepped = self.field.get_db_prep_value(self.network, connection)
         manual = bytes(self.network_packed)
         self.assertEqual(prepped, manual)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Related to: #17 
<!--
    Please include a summary of the proposed changes below.
-->

- This refactors the tests for the `VarbinaryIPField` to only test if the driver for PostgreSQL or MySQL is active.
- This also refactors all use of `engine` in field-related/query code with `connection.vendor` because it's more correct

This changes things so that we run MySQL tests only when actually using MySQL, and PostgreSQL tests only when actually using PostgreSQL, rather than previously where we were simulating both types of backends and testing both.

This has been tested against both PG and MySQL to make sure the tests run all the way through without quirks.

