### PR TITLE
Allow UI to unset a RelationshipAssociation

### DIFF
--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -4,6 +4,7 @@ import pytz
 import yaml
 
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 
 # from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
@@ -13,7 +14,8 @@ from netaddr import EUI
 from nautobot.dcim.choices import *
 from nautobot.dcim.constants import *
 from nautobot.dcim.models import *
-from nautobot.extras.models import Status
+from nautobot.extras.choices import CustomFieldTypeChoices, RelationshipTypeChoices
+from nautobot.extras.models import CustomField, CustomFieldChoice, Relationship, RelationshipAssociation, Status
 from nautobot.ipam.models import VLAN, IPAddress
 from nautobot.utilities.testing import ViewTestCases, post_data
 
@@ -77,9 +79,52 @@ class SiteTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         status_active = statuses.get(slug="active")
         status_planned = statuses.get(slug="planned")
 
-        Site.objects.create(name="Site 1", slug="site-1", region=regions[0], status=status_planned)
-        Site.objects.create(name="Site 2", slug="site-2", region=regions[0], status=status_planned)
-        Site.objects.create(name="Site 3", slug="site-3", region=regions[0], status=status_planned)
+        cls.custom_fields = (
+            CustomField.objects.create(type=CustomFieldTypeChoices.TYPE_TEXT, name="contact_slack", default=""),
+        )
+        for custom_field in cls.custom_fields:
+            custom_field.content_types.set([ContentType.objects.get_for_model(Site)])
+
+        sites = (
+            Site.objects.create(
+                name="Site 1",
+                slug="site-1",
+                region=regions[0],
+                status=status_planned,
+                _custom_field_data={"contact_slack": "@site-1-manager"},
+            ),
+            Site.objects.create(
+                name="Site 2",
+                slug="site-2",
+                region=regions[0],
+                status=status_planned,
+                _custom_field_data={"contact_slack": "@site-2-manager"},
+            ),
+            Site.objects.create(
+                name="Site 3",
+                slug="site-3",
+                region=regions[0],
+                status=status_planned,
+                _custom_field_data={"contact_slack": "@site-3-manager"},
+            ),
+        )
+
+        cls.relationships = (
+            Relationship.objects.create(
+                name="Region related sites",
+                slug="region-related-sites",
+                type=RelationshipTypeChoices.TYPE_ONE_TO_MANY,
+                source_type=ContentType.objects.get_for_model(Region),
+                source_label="Related sites",
+                destination_type=ContentType.objects.get_for_model(Site),
+                destination_label="Related region",
+            ),
+        )
+
+        for site in sites:
+            RelationshipAssociation.objects.create(
+                relationship=cls.relationships[0], source=site, destination=regions[1]
+            )
 
         tags = cls.create_tags("Alpha", "Bravo", "Charlie")
 
@@ -102,6 +147,8 @@ class SiteTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "contact_email": "hank@stricklandpropane.com",
             "comments": "Test site",
             "tags": [t.pk for t in tags],
+            "cf_contact_slack": "@site-x-manager",
+            "cr_region-related-sites__destination": regions[0].pk,
         }
 
         cls.csv_data = (
@@ -241,9 +288,41 @@ class RackTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         statuses = Status.objects.get_for_model(Rack)
         status_active = statuses.get(slug="active")
 
-        Rack.objects.create(name="Rack 1", site=sites[0], status=status_active)
-        Rack.objects.create(name="Rack 2", site=sites[0], status=status_active)
-        Rack.objects.create(name="Rack 3", site=sites[0], status=status_active)
+        cls.custom_fields = (
+            CustomField.objects.create(type=CustomFieldTypeChoices.TYPE_MULTISELECT, name="rack-colors", default=[]),
+        )
+        CustomFieldChoice.objects.create(field=cls.custom_fields[0], value="red")
+        CustomFieldChoice.objects.create(field=cls.custom_fields[0], value="green")
+        CustomFieldChoice.objects.create(field=cls.custom_fields[0], value="blue")
+        for custom_field in cls.custom_fields:
+            custom_field.content_types.set([ContentType.objects.get_for_model(Rack)])
+
+        racks = (
+            Rack.objects.create(
+                name="Rack 1", site=sites[0], status=status_active, _custom_field_data={"rack-colors": ["red"]}
+            ),
+            Rack.objects.create(
+                name="Rack 2", site=sites[0], status=status_active, _custom_field_data={"rack-colors": ["green"]}
+            ),
+            Rack.objects.create(
+                name="Rack 3", site=sites[0], status=status_active, _custom_field_data={"rack-colors": ["blue"]}
+            ),
+        )
+
+        cls.relationships = (
+            Relationship.objects.create(
+                name="Backup Sites",
+                slug="backup-sites",
+                type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
+                source_type=ContentType.objects.get_for_model(Rack),
+                source_label="Backup site(s)",
+                destination_type=ContentType.objects.get_for_model(Site),
+                destination_label="Racks using this site as a backup",
+            ),
+        )
+
+        for rack in racks:
+            RelationshipAssociation.objects.create(relationship=cls.relationships[0], source=rack, destination=sites[1])
 
         tags = cls.create_tags("Alpha", "Bravo", "Charlie")
 
@@ -266,6 +345,8 @@ class RackTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "outer_unit": RackDimensionUnitChoices.UNIT_MILLIMETER,
             "comments": "Some comments",
             "tags": [t.pk for t in tags],
+            "cf_rack-colors": ["red", "green", "blue"],
+            "cr_backup-sites__destination": [sites[0].pk],
         }
 
         cls.csv_data = (
@@ -931,33 +1012,66 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         statuses = Status.objects.get_for_model(Device)
         status_active = statuses.get(slug="active")
 
-        Device.objects.create(
-            name="Device 1",
-            site=sites[0],
-            rack=racks[0],
-            device_type=devicetypes[0],
-            device_role=deviceroles[0],
-            platform=platforms[0],
-            status=status_active,
+        cls.custom_fields = (
+            CustomField.objects.create(type=CustomFieldTypeChoices.TYPE_INTEGER, name="crash-counter", default=0),
         )
-        Device.objects.create(
-            name="Device 2",
-            site=sites[0],
-            rack=racks[0],
-            device_type=devicetypes[0],
-            device_role=deviceroles[0],
-            platform=platforms[0],
-            status=status_active,
+        cls.custom_fields[0].content_types.set([ContentType.objects.get_for_model(Device)])
+
+        devices = (
+            Device.objects.create(
+                name="Device 1",
+                site=sites[0],
+                rack=racks[0],
+                device_type=devicetypes[0],
+                device_role=deviceroles[0],
+                platform=platforms[0],
+                status=status_active,
+                _custom_field_data={"crash-counter": 5},
+            ),
+            Device.objects.create(
+                name="Device 2",
+                site=sites[0],
+                rack=racks[0],
+                device_type=devicetypes[0],
+                device_role=deviceroles[0],
+                platform=platforms[0],
+                status=status_active,
+                _custom_field_data={"crash-counter": 10},
+            ),
+            Device.objects.create(
+                name="Device 3",
+                site=sites[0],
+                rack=racks[0],
+                device_type=devicetypes[0],
+                device_role=deviceroles[0],
+                platform=platforms[0],
+                status=status_active,
+                _custom_field_data={"crash-counter": 15},
+            ),
         )
-        Device.objects.create(
-            name="Device 3",
-            site=sites[0],
-            rack=racks[0],
-            device_type=devicetypes[0],
-            device_role=deviceroles[0],
-            platform=platforms[0],
-            status=status_active,
+
+        cls.relationships = (
+            Relationship.objects.create(
+                name="BGP Router-ID",
+                slug="router-id",
+                type=RelationshipTypeChoices.TYPE_ONE_TO_ONE,
+                source_type=ContentType.objects.get_for_model(Device),
+                source_label="BGP Router ID",
+                destination_type=ContentType.objects.get_for_model(IPAddress),
+                destination_label="Device using this as BGP router-ID",
+            ),
         )
+
+        ipaddresses = (
+            IPAddress.objects.create(address="1.1.1.1/32"),
+            IPAddress.objects.create(address="2.2.2.2/32"),
+            IPAddress.objects.create(address="3.3.3.3/32"),
+        )
+
+        for device, ipaddress in zip(devices, ipaddresses):
+            RelationshipAssociation.objects.create(
+                relationship=cls.relationships[0], source=device, destination=ipaddress
+            )
 
         tags = cls.create_tags("Alpha", "Bravo", "Charlie")
 
@@ -983,6 +1097,8 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "comments": "A new device",
             "tags": [t.pk for t in tags],
             "local_context_data": None,
+            "cf_crash-counter": -1,
+            "cr_router-id": None,
         }
 
         cls.csv_data = (

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -246,11 +246,11 @@ class RelationshipModelForm(forms.ModelForm):
                 self.relationships.append(field_name)
 
     def _save_relationships(self):
-        """Save all Relationships on form save."""
+        """Update RelationshipAssociations for all Relationships on form save."""
 
         for field_name in self.relationships:
 
-            # Extract the sidefrom the field_name
+            # Extract the side from the field_name
             # Based on the side, find the list of existing RelationshipAssociation
             side = field_name.split("__")[-1]
             peer_side = RelationshipSideChoices.OPPOSITE[side]
@@ -259,41 +259,50 @@ class RelationshipModelForm(forms.ModelForm):
                 f"{side}_type": self.obj_type,
                 f"{side}_id": self.instance.pk,
             }
-            existing_cras = RelationshipAssociation.objects.filter(**filters)
+            existing_associations = RelationshipAssociation.objects.filter(**filters)
 
-            # Extract the list of ids of the target peers
+            # Get the list of target peer ids (PKs) that are specified in the form
             target_peer_ids = []
             if hasattr(self.cleaned_data[field_name], "__iter__"):
+                # One-to-many or many-to-many association
                 target_peer_ids = [item.pk for item in self.cleaned_data[field_name]]
             elif self.cleaned_data[field_name]:
+                # Many-to-one or one-to-one association
                 target_peer_ids = [self.cleaned_data[field_name].pk]
             else:
-                continue
+                # Unset/delete case
+                target_peer_ids = []
 
-            # Delete all existing CRA that are not in cleaned_data/target_peer_ids list
-            # Remove from target_peer_ids all peers that already exist
-            for cra in existing_cras:
-                found_peer = False
+            # Create/delete RelationshipAssociations as needed to match the target_peer_ids list
+
+            # First, for each existing association, if it's one that's already in target_peer_ids,
+            # we can discard it from target_peer_ids (no update needed to this association).
+            # Conversely, if it's *not* in target_peer_ids, we should delete it.
+            for association in existing_associations:
                 for peer_id in target_peer_ids:
-                    if peer_id == getattr(cra, f"{peer_side}_id"):
-                        found_peer = peer_id
-                if not found_peer:
-                    cra.delete()
+                    if peer_id == getattr(association, f"{peer_side}_id"):
+                        # This association already exists, so we can ignore it
+                        target_peer_ids.remove(peer_id)
+                        break
                 else:
-                    target_peer_ids.remove(found_peer)
+                    # This association is not in target_peer_ids, so delete it
+                    association.delete()
 
-            for cra_peer_id in target_peer_ids:
+            # Anything remaining in target_peer_ids now does not exist yet and needs to be created.
+            for peer_id in target_peer_ids:
                 relationship = self.fields[field_name].model
-                cra = RelationshipAssociation(
+                association = RelationshipAssociation(
                     relationship=relationship,
+                    **{
+                        f"{side}_type": self.obj_type,
+                        f"{side}_id": self.instance.pk,
+                        f"{peer_side}_type": getattr(relationship, f"{peer_side}_type"),
+                        f"{peer_side}_id": peer_id,
+                    },
                 )
-                setattr(cra, f"{side}_id", self.instance.pk)
-                setattr(cra, f"{side}_type", self.obj_type)
-                setattr(cra, f"{peer_side}_id", cra_peer_id)
-                setattr(cra, f"{peer_side}_type", getattr(relationship, f"{peer_side}_type"))
 
                 # FIXME Run Clean
-                cra.save()
+                association.save()
 
     def save(self, commit=True):
 

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -294,11 +294,12 @@ class ViewTestCases:
             # If any Relationships are defined, they should appear in the response
             if self.relationships:
                 for relationship in self.relationships:
-                    if ContentType.objects.get_for_model(instance) == relationship.source_type:
+                    content_type = ContentType.objects.get_for_model(instance)
+                    if content_type == relationship.source_type:
                         self.assertIn(
                             relationship.get_label(RelationshipSideChoices.SIDE_SOURCE), str(response.content)
                         )
-                    if ContentType.objects.get_for_model(instance) == relationship.destination_type:
+                    if content_type == relationship.destination_type:
                         self.assertIn(
                             relationship.get_label(RelationshipSideChoices.SIDE_DESTINATION), str(response.content)
                         )

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -12,6 +12,7 @@ from django.utils.text import slugify
 from netaddr import IPNetwork
 from taggit.managers import TaggableManager
 
+from nautobot.extras.choices import CustomFieldTypeChoices, RelationshipSideChoices
 from nautobot.extras.models import Tag
 from nautobot.users.models import ObjectPermission
 from nautobot.utilities.permissions import resolve_permission_ct
@@ -196,6 +197,12 @@ class ModelTestCase(TestCase):
     """
 
     model = None
+    # Optional, list of Relationships populated in setUpTestData for testing with this model
+    # Be sure to also create RelationshipAssociations using these Relationships!
+    relationships = None
+    # Optional, list of CustomFields populated in setUpTestData for testing with this model
+    # Be sure to also populate these fields on your test data!
+    custom_fields = None
 
     def _get_queryset(self):
         """
@@ -278,7 +285,33 @@ class ViewTestCases:
             obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
 
             # Try GET with model-level permission
-            self.assertHttpStatus(self.client.get(instance.get_absolute_url()), 200)
+            response = self.client.get(instance.get_absolute_url())
+            self.assertHttpStatus(response, 200)
+
+            # The object's display name or string representation should appear in the response
+            self.assertIn(getattr(instance, "display", str(instance)), str(response.content))
+
+            # If any Relationships are defined, they should appear in the response
+            if self.relationships:
+                for relationship in self.relationships:
+                    if ContentType.objects.get_for_model(instance) == relationship.source_type:
+                        self.assertIn(
+                            relationship.get_label(RelationshipSideChoices.SIDE_SOURCE), str(response.content)
+                        )
+                    if ContentType.objects.get_for_model(instance) == relationship.destination_type:
+                        self.assertIn(
+                            relationship.get_label(RelationshipSideChoices.SIDE_DESTINATION), str(response.content)
+                        )
+
+            # If any Custom Fields are defined, they should appear in the response
+            if self.custom_fields:
+                for custom_field in self.custom_fields:
+                    self.assertIn(str(custom_field), str(response.content))
+                    if custom_field.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
+                        for value in instance.cf.get(custom_field.name):
+                            self.assertIn(str(value), str(response.content))
+                    else:
+                        self.assertIn(str(instance.cf.get(custom_field.name) or ""), str(response.content))
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
         def test_get_object_with_constrained_permission(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #325
<!--
    Please include a summary of the proposed changes below.
-->

- The generic ModelViewTestCase did not include any tests for object create/update/view using custom fields or relationships.
  - I've added the option to define `cls.relationships` and `cls.custom_fields` in any test case inheriting from this. If either or both of these are defined, the "view" test case will automatically check whether the "view" HTTP response correctly includes these pieces of information. (We've in the past had some model detail views accidentally omitting custom fields and relationships, though all those should be fixed now)
  - I added such relationships and custom fields to the DCIM SiteTestCase, RackTestCase, and DeviceTestCase -- we can add more later as and when desired -- including adding to the `form_data` for these tests so that create/update tests exercise setting and unsetting custom fields and relationship associations on these models.
- I refactored the RelationshipModelForm `_save_relationships` method for readability, as well as fixing the actual issue in #325 - in the loop over all relationships, if we had an empty value for a relationship we were `continue`ing without making any change to existing associations; now we correctly handle this empty value as meaning "remove all existing".