### PR TITLE
Fix model validation on IPAM network objects

### DIFF
--- a/nautobot/ipam/formfields.py
+++ b/nautobot/ipam/formfields.py
@@ -44,15 +44,6 @@ class IPNetworkFormField(forms.Field):
         "invalid": "Enter a valid IPv4 or IPv6 address (with CIDR mask).",
     }
 
-    def __init__(self, allow_zero_prefix=True, *args, **kwargs):
-        """Initialize any arguments that will be used for field validation.
-
-        Args:
-            allow_zero_prefix (bool, optional): Use for IPAddress validation to invalidate /0 CIDR masks. Defaults to True.
-        """
-        self.allow_zero_prefix = allow_zero_prefix
-        super().__init__(*args, **kwargs)
-
     def to_python(self, value):
         if not value:
             return None
@@ -65,13 +56,6 @@ class IPNetworkFormField(forms.Field):
             raise ValidationError("CIDR mask (e.g. /24) is required.")
 
         try:
-            address = IPNetwork(value)
+            return IPNetwork(value)
         except AddrFormatError:
             raise ValidationError("Please specify a valid IPv4 or IPv6 address.")
-
-        # If we're expecting an IPAddress, we set self.allow_zero_prefix to false
-        # to validate that IP address does not have a 0 CIDR mask
-        if not self.allow_zero_prefix and address.prefixlen == 0:
-            raise ValidationError("Cannot create IP address with /0 mask.")
-
-        return address

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -324,7 +324,7 @@ class Aggregate(PrimaryModel):
 
     @property
     def cidr_str(self):
-        if self.network and self.prefix_length:
+        if self.network is not None and self.prefix_length is not None:
             return "%s/%s" % (self.network, self.prefix_length)
 
     @property
@@ -590,7 +590,7 @@ class Prefix(PrimaryModel, StatusModel):
 
     @property
     def cidr_str(self):
-        if self.network and self.prefix_length:
+        if self.network is not None and self.prefix_length is not None:
             return "%s/%s" % (self.network, self.prefix_length)
 
     @property
@@ -851,6 +851,10 @@ class IPAddress(PrimaryModel, StatusModel):
 
         if self.address:
 
+            # /0 masks are not acceptable
+            if self.address.prefixlen == 0:
+                raise ValidationError({"address": "Cannot create IP address with /0 mask."})
+
             # Enforce unique IP space (if applicable)
             if self.role not in IPADDRESS_ROLES_NONUNIQUE and (
                 (self.vrf is None and settings.ENFORCE_GLOBAL_UNIQUE) or (self.vrf and self.vrf.enforce_unique)
@@ -930,7 +934,7 @@ class IPAddress(PrimaryModel, StatusModel):
 
     @property
     def address(self):
-        if self.host and self.prefix_length:
+        if self.host is not None and self.prefix_length is not None:
             cidr = "%s/%s" % (self.host, self.prefix_length)
             return netaddr.IPNetwork(cidr)
 

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -1,39 +1,84 @@
 """Test IPAM forms."""
+
+from unittest import skipIf
+
 from django.test import TestCase
 
 from nautobot.extras.models.statuses import Status
-from nautobot.ipam.forms import IPAddressForm
+from nautobot.ipam import forms, models
 
 
-class IPAddressFormTest(TestCase):
+class BaseNetworkFormTest:
+    form_class = None
+    field_name = None
+    object_name = None
+    extra_data = {}
+
     def test_valid_ip_address(self):
-        form = IPAddressForm(data={"address": "192.168.1.0/24", "status": Status.objects.get(slug="dhcp")})
+        data = {self.field_name: "192.168.1.0/24", "status": Status.objects.get(slug="active")}
+        data.update(self.extra_data)
+        form = self.form_class(data)
+
         self.assertTrue(form.is_valid())
         self.assertTrue(form.save())
 
+    def test_address_invalid_ipv4(self):
+        data = {self.field_name: "192.168.0.1/64", "status": Status.objects.get(slug="active")}
+        data.update(self.extra_data)
+        form = self.form_class(data)
+
+        self.assertFalse(form.is_valid())
+        self.assertEquals("Please specify a valid IPv4 or IPv6 address.", form.errors[self.field_name][0])
+
+    def test_address_zero_mask(self):
+        data = {self.field_name: "192.168.0.1/0", "status": Status.objects.get(slug="active")}
+        data.update(self.extra_data)
+        form = self.form_class(data)
+
+        self.assertFalse(form.is_valid())
+        self.assertEquals(f"Cannot create {self.object_name} with /0 mask.", form.errors[self.field_name][0])
+
+    def test_address_missing_mask(self):
+        data = {self.field_name: "192.168.0.1", "status": Status.objects.get(slug="active")}
+        data.update(self.extra_data)
+        form = self.form_class(data)
+
+        self.assertFalse(form.is_valid())
+        self.assertEquals("CIDR mask (e.g. /24) is required.", form.errors[self.field_name][0])
+
+
+class AggregateFormTest(BaseNetworkFormTest, TestCase):
+    form_class = forms.AggregateForm
+    field_name = "prefix"
+    object_name = "aggregate"
+
+    def setUp(self):
+        super().setUp()
+        self.extra_data = {"rir": models.RIR.objects.create(name="RIR", slug="rir")}
+
+
+class PrefixFormTest(BaseNetworkFormTest, TestCase):
+    form_class = forms.PrefixForm
+    field_name = "prefix"
+    object_name = "prefix"
+
+
+class IPAddressFormTest(BaseNetworkFormTest, TestCase):
+    form_class = forms.IPAddressForm
+    field_name = "address"
+    object_name = "IP address"
+
     def test_slaac_valid_ipv6(self):
-        form = IPAddressForm(
-            data={"address": "2001:0db8:0000:0000:0000:ff00:0042:8329/128", "status": Status.objects.get(slug="slaac")}
+        form = self.form_class(
+            data={
+                self.field_name: "2001:0db8:0000:0000:0000:ff00:0042:8329/128",
+                "status": Status.objects.get(slug="slaac"),
+            }
         )
         self.assertTrue(form.is_valid())
         self.assertTrue(form.save())
 
     def test_slaac_status_invalid_ipv4(self):
-        form = IPAddressForm(data={"address": "192.168.0.1/32", "status": Status.objects.get(slug="slaac")})
+        form = self.form_class(data={self.field_name: "192.168.0.1/32", "status": Status.objects.get(slug="slaac")})
         self.assertFalse(form.is_valid())
         self.assertEquals("Only IPv6 addresses can be assigned SLAAC status", form.errors["status"][0])
-
-    def test_address_invalid_ipv4(self):
-        form = IPAddressForm(data={"address": "192.168.0.1/64", "status": Status.objects.get(slug="dhcp")})
-        self.assertFalse(form.is_valid())
-        self.assertEquals("Please specify a valid IPv4 or IPv6 address.", form.errors["address"][0])
-
-    def test_address_zero_mask(self):
-        form = IPAddressForm(data={"address": "192.168.0.1/0", "status": Status.objects.get(slug="dhcp")})
-        self.assertFalse(form.is_valid())
-        self.assertEquals("Cannot create IP address with /0 mask.", form.errors["address"][0])
-
-    def test_address_missing_mask(self):
-        form = IPAddressForm(data={"address": "192.168.0.1", "status": Status.objects.get(slug="dhcp")})
-        self.assertFalse(form.is_valid())
-        self.assertEquals("CIDR mask (e.g. /24) is required.", form.errors["address"][0])

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -1,7 +1,5 @@
 """Test IPAM forms."""
 
-from unittest import skipIf
-
 from django.test import TestCase
 
 from nautobot.extras.models.statuses import Status

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -26,7 +26,7 @@ class BaseNetworkFormTest:
         form = self.form_class(data)
 
         self.assertFalse(form.is_valid())
-        self.assertEquals("Please specify a valid IPv4 or IPv6 address.", form.errors[self.field_name][0])
+        self.assertEqual("Please specify a valid IPv4 or IPv6 address.", form.errors[self.field_name][0])
 
     def test_address_zero_mask(self):
         data = {self.field_name: "192.168.0.1/0", "status": Status.objects.get(slug="active")}
@@ -34,7 +34,7 @@ class BaseNetworkFormTest:
         form = self.form_class(data)
 
         self.assertFalse(form.is_valid())
-        self.assertEquals(f"Cannot create {self.object_name} with /0 mask.", form.errors[self.field_name][0])
+        self.assertEqual(f"Cannot create {self.object_name} with /0 mask.", form.errors[self.field_name][0])
 
     def test_address_missing_mask(self):
         data = {self.field_name: "192.168.0.1", "status": Status.objects.get(slug="active")}
@@ -42,7 +42,7 @@ class BaseNetworkFormTest:
         form = self.form_class(data)
 
         self.assertFalse(form.is_valid())
-        self.assertEquals("CIDR mask (e.g. /24) is required.", form.errors[self.field_name][0])
+        self.assertEqual("CIDR mask (e.g. /24) is required.", form.errors[self.field_name][0])
 
 
 class AggregateFormTest(BaseNetworkFormTest, TestCase):
@@ -79,4 +79,4 @@ class IPAddressFormTest(BaseNetworkFormTest, TestCase):
     def test_slaac_status_invalid_ipv4(self):
         form = self.form_class(data={self.field_name: "192.168.0.1/32", "status": Status.objects.get(slug="slaac")})
         self.assertFalse(form.is_valid())
-        self.assertEquals("Only IPv6 addresses can be assigned SLAAC status", form.errors["status"][0])
+        self.assertEqual("Only IPv6 addresses can be assigned SLAAC status", form.errors["status"][0])


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #320 
<!--
    Please include a summary of the proposed changes below.
-->

This applies to `IPAddress.address`, `Prefix.prefix`, and `Aggregate.prefix`

- Reverted the `/0` validation fixes for `IPAddress` from #314
  - `IPAddress.address` validation moved back to the model's `clean()`
  - `allow_zero_prefix` argument removed from `IPNetworkFormField`
  - initial `address` check and cleaned data population moved to `AddressFieldMixin`
- Remove the `save() methods from `Address/PrefixFieldMixin` because they are no longer needed when setting the field value in `clean()`
- All places where `host/network` & `prefix_length` are checked on the model, replaced to check `if foo is None`. In the case where `prefix_length == 0` it was causing this check to fail, and the string repr to be `None`, causing model validation to be skipped.
- Added tests for `AggregateForm` and `PrefixForm` and refactored the form tests to be a little more dynamic so we didn't have to duplicate them all.