### PR TITLE
Add migrations check to `cibuild.sh` script

### DIFF
--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -8,28 +8,20 @@ info()
 
 # Track number of seconds required to run script
 START=$(date +%s)
-echo "$(info) starting build checks."
+echo "$(info) Starting build checks..."
 
 # invoke defaults to running tests in a docker container for travis we want to execute them locally
 export INVOKE_NAUTOBOT_LOCAL=True
 
-# Syntax check all python source files
-SYNTAX=$(find . -name "*.py" -type f -exec python -m py_compile {} \; 2>&1)
-if [[ ! -z $SYNTAX ]]; then
-	echo -e "$SYNTAX"
-	echo -e "\n$(info) detected one or more syntax errors; failing build."
-	exit 1
-fi
-
-# Check all built-in python source files for PEP 8 compliance
-invoke flake8
+echo -e "\n>> Checking that there aren't any missing or failing migrations..."
+invoke check-migrations
 RC=$?
 if [[ $RC != 0 ]]; then
-	echo -e "\n$(info) one or more PEP 8 errors detected; failing build."
+	echo -e "\n$(info) one or more Django migration errors detected; failing build."
 	exit $RC
 fi
 
-# Check that all files conform to Black.
+echo -e "\n>> Checking that Python files conform to Black..."
 invoke black
 RC=$?
 if [[ $RC != 0 ]]; then
@@ -37,7 +29,23 @@ if [[ $RC != 0 ]]; then
 	exit $RC
 fi
 
-# Run Nautobot tests
+echo -e "\n>> Checking that Python files confirm to PEP 8..."
+invoke flake8
+RC=$?
+if [[ $RC != 0 ]]; then
+	echo -e "\n$(info) one or more PEP 8 errors detected; failing build."
+	exit $RC
+fi
+
+echo -e "\n>> Checking syntax of Python files..."
+SYNTAX=$(find . -name "*.py" -type f -exec python -m py_compile {} \; 2>&1)
+if [[ ! -z $SYNTAX ]]; then
+	echo -e "$SYNTAX"
+	echo -e "\n$(info) detected one or more syntax errors; failing build."
+	exit 1
+fi
+
+echo -e "\n>> Running unit tests..."
 invoke unittest --failfast
 RC=$?
 if [[ $RC != 0 ]]; then
@@ -45,7 +53,7 @@ if [[ $RC != 0 ]]; then
 	exit $RC
 fi
 
-# Show code coverage report
+echo -e "\n>> Displaying code coverage report..."
 invoke unittest-coverage
 RC=$?
 if [[ $RC != 0 ]]; then
@@ -55,6 +63,6 @@ fi
 
 # Show build duration
 END=$(date +%s)
-echo "$(info) all checks passed after $(($END - $START)) seconds."
+echo "$(info) All checks passed after $(($END - $START)) seconds."
 
 exit 0


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Related to: #343 
<!--
    Please include a summary of the proposed changes below.
-->

The goal of this is to make sure that any issues with running migrations are surfaced ASAP in the test suite. We ran into an issue introduced in #322 and fixed in #343, that were not caught by unit tests. This will surface them from here on out.

- This adds `invoke check-migrations` to `scripts/cibuild.sh` as the first item
- This also reorders the operations ran inside of `cibuild.sh` to run from fastest to slowest, so that the checks that finish quicker, run first.
- This also prints the current step to stdout to improve visibility.
