### PR TITLE
Fix duplicate tags field on cable creation

### DIFF
--- a/nautobot/dcim/templates/dcim/inc/cable_form.html
+++ b/nautobot/dcim/templates/dcim/inc/cable_form.html
@@ -29,7 +29,6 @@
                 {% endif %}
             </div>
         </div>
-        {% render_field form.tags %}
     </div>
 </div>
 {% include 'inc/extras_features_edit_form_fields.html' %}


### PR DESCRIPTION
Removed redundant `render_field` for tags in `templates/dcim/inc/cable_form.html` due to the logic existing in `core/templates/inc/extra_features_edit_form_fields.html` that was implemented a few months ago.

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #361 
<!--
    Please include a summary of the proposed changes below.
-->
