### PR TITLE
Add GraphQL filter tests and missing unit tests for filtersets

### DIFF
--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -581,8 +581,11 @@ class GraphQLQuery(TestCase):
             name="Int1", type=InterfaceTypeChoices.TYPE_VIRTUAL, device=self.device3
         )
         self.interface31 = Interface.objects.create(
-            name="Mgmt1", type=InterfaceTypeChoices.TYPE_VIRTUAL,
-            device=self.device3, mgmt_only=True, enabled=False,
+            name="Mgmt1",
+            type=InterfaceTypeChoices.TYPE_VIRTUAL,
+            device=self.device3,
+            mgmt_only=True,
+            enabled=False,
         )
 
         self.cable1 = Cable.objects.create(
@@ -803,8 +806,8 @@ class GraphQLQuery(TestCase):
             ('mac_address: "00:11:11:11:11:11"', 1),
             ('vlan: "100"', 1),
             (f'vlan_id: "{self.vlan1.id}"', 1),
-            ('mgmt_only: true', 1),
-            ('enabled: false', 1),
+            ("mgmt_only: true", 1),
+            ("enabled: false", 1),
         )
 
         for filter, nbr_expected_results in filters:

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -804,7 +804,7 @@ class GraphQLQuery(TestCase):
             ('device: ["Device 1", "Device 3"]', 4),
             ('kind: "virtual"', 5),
             ('mac_address: "00:11:11:11:11:11"', 1),
-            ('vlan: "100"', 1),
+            ("vlan: 100", 1),
             (f'vlan_id: "{self.vlan1.id}"', 1),
             ("mgmt_only: true", 1),
             ("enabled: false", 1),

--- a/nautobot/dcim/filters.py
+++ b/nautobot/dcim/filters.py
@@ -826,7 +826,7 @@ class CableTerminationFilterSet(django_filters.FilterSet):
 
 
 class PathEndpointFilterSet(django_filters.FilterSet):
-    connected = django_filters.BooleanFilter(method="filter_connected")
+    connected = django_filters.BooleanFilter(method="filter_connected", label="BBQ PIZZA")
 
     def filter_connected(self, queryset, name, value):
         if value:
@@ -904,7 +904,7 @@ class InterfaceFilterSet(
         field_name="name",
         label="Device",
     )
-    device_id = MultiValueNumberFilter(
+    device_id = MultiValueCharFilter(
         method="filter_device_id",
         field_name="pk",
         label="Device (ID)",
@@ -1181,7 +1181,7 @@ class ConsoleConnectionFilterSet(ConnectionFilterSet, BaseFilterSet):
         method="filter_site",
         label="Site (slug)",
     )
-    device_id = MultiValueNumberFilter(method="filter_device")
+    device_id = MultiValueCharFilter(method="filter_device")
     device = MultiValueCharFilter(method="filter_device", field_name="device__name")
 
     class Meta:
@@ -1194,7 +1194,7 @@ class PowerConnectionFilterSet(ConnectionFilterSet, BaseFilterSet):
         method="filter_site",
         label="Site (slug)",
     )
-    device_id = MultiValueNumberFilter(method="filter_device")
+    device_id = MultiValueCharFilter(method="filter_device")
     device = MultiValueCharFilter(method="filter_device", field_name="device__name")
 
     class Meta:
@@ -1207,7 +1207,7 @@ class InterfaceConnectionFilterSet(ConnectionFilterSet, BaseFilterSet):
         method="filter_site",
         label="Site (slug)",
     )
-    device_id = MultiValueNumberFilter(method="filter_device")
+    device_id = MultiValueCharFilter(method="filter_device")
     device = MultiValueCharFilter(method="filter_device", field_name="device__name")
 
     class Meta:

--- a/nautobot/dcim/filters.py
+++ b/nautobot/dcim/filters.py
@@ -826,7 +826,7 @@ class CableTerminationFilterSet(django_filters.FilterSet):
 
 
 class PathEndpointFilterSet(django_filters.FilterSet):
-    connected = django_filters.BooleanFilter(method="filter_connected", label="BBQ PIZZA")
+    connected = django_filters.BooleanFilter(method="filter_connected", label="Connected status (bool)")
 
     def filter_connected(self, queryset, name, value):
         if value:
@@ -902,7 +902,7 @@ class InterfaceFilterSet(
     device = MultiValueCharFilter(
         method="filter_device",
         field_name="name",
-        label="Device",
+        label="Device (name)",
     )
     device_id = MultiValueCharFilter(
         method="filter_device_id",
@@ -1138,14 +1138,14 @@ class CableFilterSet(StatusModelFilterSetMixin, BaseFilterSet):
     )
     type = django_filters.MultipleChoiceFilter(choices=CableTypeChoices)
     color = django_filters.MultipleChoiceFilter(choices=ColorChoices)
-    device_id = MultiValueCharFilter(method="filter_device")
-    device = MultiValueCharFilter(method="filter_device", field_name="device__name")
-    rack_id = MultiValueCharFilter(method="filter_device", field_name="device__rack_id")
-    rack = MultiValueCharFilter(method="filter_device", field_name="device__rack__name")
-    site_id = MultiValueCharFilter(method="filter_device", field_name="device__site_id")
-    site = MultiValueCharFilter(method="filter_device", field_name="device__site__slug")
-    tenant_id = MultiValueCharFilter(method="filter_device", field_name="device__tenant_id")
-    tenant = MultiValueCharFilter(method="filter_device", field_name="device__tenant__slug")
+    device_id = MultiValueCharFilter(method="filter_device", label="Device (ID)")
+    device = MultiValueCharFilter(method="filter_device", field_name="device__name", label="Device (name)")
+    rack_id = MultiValueCharFilter(method="filter_device", field_name="device__rack_id", label="Rack (ID)")
+    rack = MultiValueCharFilter(method="filter_device", field_name="device__rack__name", label="Rack (name)")
+    site_id = MultiValueCharFilter(method="filter_device", field_name="device__site_id", label="Site (ID)")
+    site = MultiValueCharFilter(method="filter_device", field_name="device__site__slug", label="Site (name)")
+    tenant_id = MultiValueCharFilter(method="filter_device", field_name="device__tenant_id", label="Tenant (ID)")
+    tenant = MultiValueCharFilter(method="filter_device", field_name="device__tenant__slug", label="Tenant (name)")
     tag = TagFilter()
 
     class Meta:
@@ -1181,8 +1181,8 @@ class ConsoleConnectionFilterSet(ConnectionFilterSet, BaseFilterSet):
         method="filter_site",
         label="Site (slug)",
     )
-    device_id = MultiValueCharFilter(method="filter_device")
-    device = MultiValueCharFilter(method="filter_device", field_name="device__name")
+    device_id = MultiValueCharFilter(method="filter_device", label="Device (ID)")
+    device = MultiValueCharFilter(method="filter_device", field_name="device__name", label="Device (nam;e)")
 
     class Meta:
         model = ConsolePort
@@ -1194,8 +1194,8 @@ class PowerConnectionFilterSet(ConnectionFilterSet, BaseFilterSet):
         method="filter_site",
         label="Site (slug)",
     )
-    device_id = MultiValueCharFilter(method="filter_device")
-    device = MultiValueCharFilter(method="filter_device", field_name="device__name")
+    device_id = MultiValueCharFilter(method="filter_device", label="Device (ID)")
+    device = MultiValueCharFilter(method="filter_device", field_name="device__name", label="Device (name)")
 
     class Meta:
         model = PowerPort
@@ -1207,8 +1207,8 @@ class InterfaceConnectionFilterSet(ConnectionFilterSet, BaseFilterSet):
         method="filter_site",
         label="Site (slug)",
     )
-    device_id = MultiValueCharFilter(method="filter_device")
-    device = MultiValueCharFilter(method="filter_device", field_name="device__name")
+    device_id = MultiValueCharFilter(method="filter_device", label="Device (ID)")
+    device = MultiValueCharFilter(method="filter_device", field_name="device__name", label="Device (name)")
 
     class Meta:
         model = Interface

--- a/nautobot/dcim/filters.py
+++ b/nautobot/dcim/filters.py
@@ -1182,7 +1182,7 @@ class ConsoleConnectionFilterSet(ConnectionFilterSet, BaseFilterSet):
         label="Site (slug)",
     )
     device_id = MultiValueCharFilter(method="filter_device", label="Device (ID)")
-    device = MultiValueCharFilter(method="filter_device", field_name="device__name", label="Device (nam;e)")
+    device = MultiValueCharFilter(method="filter_device", field_name="device__name", label="Device (name)")
 
     class Meta:
         model = ConsolePort

--- a/nautobot/dcim/filters.py
+++ b/nautobot/dcim/filters.py
@@ -921,7 +921,7 @@ class InterfaceFilterSet(
     mac_address = MultiValueMACAddressFilter()
     tag = TagFilter()
     vlan_id = django_filters.CharFilter(method="filter_vlan_id", label="Assigned VLAN")
-    vlan = django_filters.CharFilter(method="filter_vlan", label="Assigned VID")
+    vlan = django_filters.NumberFilter(method="filter_vlan", label="Assigned VID")
     type = django_filters.MultipleChoiceFilter(choices=InterfaceTypeChoices, null_value=None)
 
     class Meta:
@@ -965,7 +965,7 @@ class InterfaceFilterSet(
         return queryset.filter(Q(untagged_vlan_id=value) | Q(tagged_vlans=value))
 
     def filter_vlan(self, queryset, name, value):
-        value = value.strip()
+        value = str(value).strip()
         if not value:
             return queryset
         return queryset.filter(Q(untagged_vlan_id__vid=value) | Q(tagged_vlans__vid=value))

--- a/nautobot/dcim/tests/test_filters.py
+++ b/nautobot/dcim/tests/test_filters.py
@@ -2366,7 +2366,6 @@ class InterfaceTestCase(TestCase):
         tagged_interface = interfaces[-1]
         tagged_interface.tagged_vlans.add(vlan3)
 
-
         cable_statuses = Status.objects.get_for_model(Cable)
         status_connected = cable_statuses.get(slug="connected")
 
@@ -3689,5 +3688,6 @@ class PowerFeedTestCase(TestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {"connected": False}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
 
 # TODO: Connection filters

--- a/nautobot/dcim/tests/test_filters.py
+++ b/nautobot/dcim/tests/test_filters.py
@@ -38,7 +38,7 @@ from nautobot.dcim.models import (
     VirtualChassis,
 )
 from nautobot.extras.models import Status
-from nautobot.ipam.models import IPAddress
+from nautobot.ipam.models import IPAddress, VLAN
 from nautobot.tenancy.models import Tenant, TenantGroup
 from nautobot.virtualization.models import Cluster, ClusterType
 
@@ -2299,6 +2299,10 @@ class InterfaceTestCase(TestCase):
             ),  # For cable connections
         )
 
+        vlan1 = VLAN.objects.create(name="VLAN 1", vid=1)
+        vlan2 = VLAN.objects.create(name="VLAN 2", vid=2)
+        vlan3 = VLAN.objects.create(name="VLAN 3", vid=3)
+
         interfaces = (
             Interface.objects.create(
                 device=devices[0],
@@ -2309,6 +2313,7 @@ class InterfaceTestCase(TestCase):
                 mtu=100,
                 mode=InterfaceModeChoices.MODE_ACCESS,
                 mac_address="00-00-00-00-00-01",
+                untagged_vlan=vlan1,
                 description="First",
             ),
             Interface.objects.create(
@@ -2320,6 +2325,7 @@ class InterfaceTestCase(TestCase):
                 mtu=200,
                 mode=InterfaceModeChoices.MODE_TAGGED,
                 mac_address="00-00-00-00-00-02",
+                untagged_vlan=vlan2,
                 description="Second",
             ),
             Interface.objects.create(
@@ -2355,6 +2361,11 @@ class InterfaceTestCase(TestCase):
                 mgmt_only=False,
             ),
         )
+
+        # Tagged VLAN interface is "Interface 6"
+        tagged_interface = interfaces[-1]
+        tagged_interface.tagged_vlans.add(vlan3)
+
 
         cable_statuses = Status.objects.get_for_model(Cable)
         status_connected = cable_statuses.get(slug="connected")
@@ -2458,6 +2469,14 @@ class InterfaceTestCase(TestCase):
             ]
         }
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_vlan(self):
+        params = {"vlan": VLAN.objects.first().vid}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_vlan_id(self):
+        params = {"vlan_id": VLAN.objects.last().id}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class FrontPortTestCase(TestCase):
@@ -3658,6 +3677,18 @@ class PowerFeedTestCase(TestCase):
         racks = Rack.objects.all()[:2]
         params = {"rack_id": [racks[0].pk, racks[1].pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_cabled(self):
+        params = {"cabled": "true"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {"cabled": "false"}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_connected(self):
+        params = {"connected": True}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {"connected": False}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_cabled(self):
         params = {"cabled": "true"}

--- a/nautobot/dcim/tests/test_filters.py
+++ b/nautobot/dcim/tests/test_filters.py
@@ -3690,17 +3690,4 @@ class PowerFeedTestCase(TestCase):
         params = {"connected": False}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_cabled(self):
-        params = {"cabled": "true"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-        params = {"cabled": "false"}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
-
-    def test_connected(self):
-        params = {"connected": True}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-        params = {"connected": False}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
-
-
 # TODO: Connection filters

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -302,7 +302,7 @@ class PrefixFilterSet(
         queryset=VLAN.objects.all(),
         label="VLAN (ID)",
     )
-    vlan_vid = django_filters.NumberFilter(
+    vlan_vid = django_filters.CharFilter(
         field_name="vlan__vid",
         label="VLAN number (1-4095)",
     )
@@ -465,7 +465,7 @@ class IPAddressFilterSet(
         field_name="name",
         label="Device (name)",
     )
-    device_id = MultiValueNumberFilter(
+    device_id = MultiValueCharFilter(
         method="filter_device",
         field_name="pk",
         label="Device (ID)",
@@ -475,7 +475,7 @@ class IPAddressFilterSet(
         field_name="name",
         label="Virtual machine (name)",
     )
-    virtual_machine_id = MultiValueNumberFilter(
+    virtual_machine_id = MultiValueCharFilter(
         method="filter_virtual_machine",
         field_name="pk",
         label="Virtual machine (ID)",

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -302,7 +302,7 @@ class PrefixFilterSet(
         queryset=VLAN.objects.all(),
         label="VLAN (ID)",
     )
-    vlan_vid = django_filters.CharFilter(
+    vlan_vid = django_filters.NumberFilter(
         field_name="vlan__vid",
         label="VLAN number (1-4095)",
     )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #365 

- Also added missing unit tests for `InterfaceFilterSet` in `nautobot.dcim.tests.test_filters`
- Adds/adjusts labels on all filter fields with "method" arguments
- Changes all filter types for "id" fields that were `MultiValueNumberFilter ` to `MultiValueCharFilter `
