### PR TITLE
True up all OPTIONS return display instead of display_name

### DIFF
--- a/nautobot/core/api/metadata.py
+++ b/nautobot/core/api/metadata.py
@@ -38,6 +38,17 @@ class BulkOperationMetadata(SimpleMetadata):
 
         return actions
 
+    def get_field_info(self, field):
+        """
+        Replace DRF choices `display_name` to `display` to match new pattern.
+
+        See `ContentTypeMetadata` and `StatusFieldMetadata` classes below.
+        """
+        field_info = super().get_field_info(field)
+        for choice in field_info.get("choices", []):
+            choice["display"] = choice.pop("display_name")
+        return field_info
+
 
 class ContentTypeMetadata(BulkOperationMetadata):
     def get_field_info(self, field):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #382 
<!--
    Please include a summary of the proposed changes below.
-->
Copy and pasted code from @jathanism who walked me through problem/fix.

I attempted to add tests or extend the test to validate all choices provide `display` and `value` within https://github.com/nautobot/nautobot/blob/develop/nautobot/utilities/testing/api.py#L123, but it seems like the test client when using the `options` method leaves out the `actions` key within the response so we cannot do any assertions for this.

Not sure really how to add tests due to lack of appropriate return.