### PR TITLE
Don't change vc_position if already set on device.

### DIFF
--- a/nautobot/dcim/signals.py
+++ b/nautobot/dcim/signals.py
@@ -96,7 +96,7 @@ def assign_virtualchassis_master(instance, created, **kwargs):
     if created and instance.master:
         master = Device.objects.get(pk=instance.master.pk)
         master.virtual_chassis = instance
-        if not instance.master.vc_position:
+        if instance.master.vc_position is None:
             master.vc_position = 1
         master.save()
 

--- a/nautobot/dcim/signals.py
+++ b/nautobot/dcim/signals.py
@@ -96,7 +96,8 @@ def assign_virtualchassis_master(instance, created, **kwargs):
     if created and instance.master:
         master = Device.objects.get(pk=instance.master.pk)
         master.virtual_chassis = instance
-        master.vc_position = 1
+        if not instance.master.vc_position:
+            master.vc_position = 1
         master.save()
 
 

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -1770,30 +1770,6 @@ class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
             "domain": "newdomain",
         }
 
-    def test_master_device_vc_assignment(self):
-        """Test device assigned vc_position keeps assignment after being set to master.
-
-        This test is for https://github.com/nautobot/nautobot/issues/393
-        """
-        device = Device.objects.get(name="Device 12")
-        device.vc_position = 3
-        device.save()
-        self.assertEquals(device.vc_position, 3)
-        VirtualChassis.objects.create(name="Virtual Chassis 1", master=device, domain="domain-1")
-        device = Device.objects.get(name="Device 12")
-        self.assertEquals(device.vc_position, 3)
-
-    def test_master_device_null_vc_assignment(self):
-        """Test device with null vc_position gets assigned 1 after being set to master.
-
-        This test is for https://github.com/nautobot/nautobot/issues/393
-        """
-        device = Device.objects.get(name="Device 11")
-        self.assertIsNone(device.vc_position)
-        VirtualChassis.objects.create(name="Virtual Chassis 1", master=device, domain="domain-1")
-        device = Device.objects.get(name="Device 11")
-        self.assertEquals(device.vc_position, 1)
-
 
 class PowerPanelTest(APIViewTestCases.APIViewTestCase):
     model = PowerPanel

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -1770,6 +1770,30 @@ class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
             "domain": "newdomain",
         }
 
+    def test_master_device_vc_assignment(self):
+        """Test device assigned vc_position keeps assignment after being set to master.
+
+        This test is for https://github.com/nautobot/nautobot/issues/393
+        """
+        device = Device.objects.get(name="Device 12")
+        device.vc_position = 3
+        device.save()
+        self.assertEquals(device.vc_position, 3)
+        VirtualChassis.objects.create(name="Virtual Chassis 1", master=device, domain="domain-1")
+        device = Device.objects.get(name="Device 12")
+        self.assertEquals(device.vc_position, 3)
+
+    def test_master_device_null_vc_assignment(self):
+        """Test device with null vc_position gets assigned 1 after being set to master.
+
+        This test is for https://github.com/nautobot/nautobot/issues/393
+        """
+        device = Device.objects.get(name="Device 11")
+        self.assertIsNone(device.vc_position)
+        VirtualChassis.objects.create(name="Virtual Chassis 1", master=device, domain="domain-1")
+        device = Device.objects.get(name="Device 11")
+        self.assertEquals(device.vc_position, 1)
+
 
 class PowerPanelTest(APIViewTestCases.APIViewTestCase):
     model = PowerPanel

--- a/nautobot/dcim/tests/test_signals.py
+++ b/nautobot/dcim/tests/test_signals.py
@@ -1,0 +1,64 @@
+"""Tests for DCIM Signals.py """
+
+from django.test import TestCase
+
+from nautobot.dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Manufacturer,
+    Site,
+    VirtualChassis,
+)
+
+
+class VirtualChassisTest(TestCase):
+    """Class to test signals for VirtualChassis."""
+
+    def setUp(self):
+        """Setup Test Data for VirtualChassis Signal tests."""
+        site = Site.objects.create(name="Test Site", slug="test-site")
+        manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
+        devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="Device Type", slug="device-type")
+        devicerole = DeviceRole.objects.create(name="Device Role", slug="device-role", color="ff0000")
+
+        self.device = Device.objects.create(
+            name="Device 1",
+            device_type=devicetype,
+            device_role=devicerole,
+            site=site,
+        )
+
+    def test_master_device_vc_assignment(self):
+        """Test device assigned vc_position keeps assignment after being set to master.
+
+        This test is for https://github.com/nautobot/nautobot/issues/393
+        """
+        self.device.vc_position = 3
+        self.device.save()
+        self.assertEqual(self.device.vc_position, 3)
+        VirtualChassis.objects.create(name="Virtual Chassis 1", master=self.device, domain="domain-1")
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.vc_position, 3)
+
+    def tert_master_device_vc_position_is_0(self):
+        """Test device assigned vc_position 0 keeps assignment after being set to master.
+
+        This test is for https://github.com/nautobot/nautobot/issues/393
+        """
+        self.device.vc_position = 0
+        self.device.save()
+        self.assertEqual(self.device.vc_position, 0)
+        VirtualChassis.objects.create(name="Virtual Chassis 1", master=self.device, domain="domain-1")
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.vc_position, 0)
+
+    def test_master_device_null_vc_assignment(self):
+        """Test device with null vc_position gets assigned 1 after being set to master.
+
+        This test is for https://github.com/nautobot/nautobot/issues/393
+        """
+        self.assertIsNone(self.device.vc_position)
+        VirtualChassis.objects.create(name="Virtual Chassis 1", master=self.device, domain="domain-1")
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.vc_position, 1)

--- a/nautobot/dcim/tests/test_signals.py
+++ b/nautobot/dcim/tests/test_signals.py
@@ -37,11 +37,12 @@ class VirtualChassisTest(TestCase):
         self.device.vc_position = 3
         self.device.save()
         self.assertEqual(self.device.vc_position, 3)
-        VirtualChassis.objects.create(name="Virtual Chassis 1", master=self.device, domain="domain-1")
+        virtualchassis = VirtualChassis.objects.create(name="Virtual Chassis 1", master=self.device, domain="domain-1")
         self.device.refresh_from_db()
         self.assertEqual(self.device.vc_position, 3)
+        self.assertEqual(self.device.virtual_chassis, virtualchassis)
 
-    def tert_master_device_vc_position_is_0(self):
+    def test_master_device_vc_position_is_0(self):
         """Test device assigned vc_position 0 keeps assignment after being set to master.
 
         This test is for https://github.com/nautobot/nautobot/issues/393
@@ -49,9 +50,10 @@ class VirtualChassisTest(TestCase):
         self.device.vc_position = 0
         self.device.save()
         self.assertEqual(self.device.vc_position, 0)
-        VirtualChassis.objects.create(name="Virtual Chassis 1", master=self.device, domain="domain-1")
+        virtualchassis = VirtualChassis.objects.create(name="Virtual Chassis 1", master=self.device, domain="domain-1")
         self.device.refresh_from_db()
         self.assertEqual(self.device.vc_position, 0)
+        self.assertEqual(self.device.virtual_chassis, virtualchassis)
 
     def test_master_device_null_vc_assignment(self):
         """Test device with null vc_position gets assigned 1 after being set to master.
@@ -59,6 +61,7 @@ class VirtualChassisTest(TestCase):
         This test is for https://github.com/nautobot/nautobot/issues/393
         """
         self.assertIsNone(self.device.vc_position)
-        VirtualChassis.objects.create(name="Virtual Chassis 1", master=self.device, domain="domain-1")
+        virtualchassis = VirtualChassis.objects.create(name="Virtual Chassis 1", master=self.device, domain="domain-1")
         self.device.refresh_from_db()
         self.assertEqual(self.device.vc_position, 1)
+        self.assertEqual(self.device.virtual_chassis, virtualchassis)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #393
<!--
    Please include a summary of the proposed changes below.
-->
Only set vc_position to 1 on the master device if the device does not already have a vc_position.  Created tests for both scenarios.
