### PR TITLE
Fix "null" key for /api/plugins/ root for plugin related URLs

### DIFF
--- a/nautobot/extras/plugins/urls.py
+++ b/nautobot/extras/plugins/urls.py
@@ -30,7 +30,7 @@ plugin_admin_patterns = [
 for plugin_path in settings.PLUGINS:
     plugin_name = plugin_path.split(".")[-1]
     app = apps.get_app_config(plugin_name)
-    base_url = getattr(app, "base_url", app.label)
+    base_url = getattr(app, "base_url") or app.label.replace("_", "-")
 
     # Check if the plugin specifies any base URLs
     urlpatterns = import_object(f"{plugin_path}.urls.urlpatterns")

--- a/nautobot/extras/plugins/urls.py
+++ b/nautobot/extras/plugins/urls.py
@@ -30,7 +30,7 @@ plugin_admin_patterns = [
 for plugin_path in settings.PLUGINS:
     plugin_name = plugin_path.split(".")[-1]
     app = apps.get_app_config(plugin_name)
-    base_url = getattr(app, "base_url") or app.label.replace("_", "-")
+    base_url = app.base_url or app.label.replace("_", "-")
 
     # Check if the plugin specifies any base URLs
     urlpatterns = import_object(f"{plugin_path}.urls.urlpatterns")

--- a/nautobot/extras/plugins/urls.py
+++ b/nautobot/extras/plugins/urls.py
@@ -30,7 +30,7 @@ plugin_admin_patterns = [
 for plugin_path in settings.PLUGINS:
     plugin_name = plugin_path.split(".")[-1]
     app = apps.get_app_config(plugin_name)
-    base_url = app.base_url or app.label.replace("_", "-")
+    base_url = app.base_url or app.label
 
     # Check if the plugin specifies any base URLs
     urlpatterns = import_object(f"{plugin_path}.urls.urlpatterns")

--- a/nautobot/extras/plugins/urls.py
+++ b/nautobot/extras/plugins/urls.py
@@ -30,7 +30,7 @@ plugin_admin_patterns = [
 for plugin_path in settings.PLUGINS:
     plugin_name = plugin_path.split(".")[-1]
     app = apps.get_app_config(plugin_name)
-    base_url = getattr(app, "base_url") or app.label
+    base_url = getattr(app, "base_url", app.label)
 
     # Check if the plugin specifies any base URLs
     urlpatterns = import_object(f"{plugin_path}.urls.urlpatterns")

--- a/nautobot/extras/plugins/views.py
+++ b/nautobot/extras/plugins/views.py
@@ -71,7 +71,7 @@ class PluginsAPIRootView(APIView):
         api_app_name = f"{app_config.name}-api"
         try:
             entry = (
-                getattr(app_config, "base_url") or app_config.label.replace("_", "-"),
+                app_config.base_url or app_config.label,
                 reverse(
                     f"plugins-api:{api_app_name}:api-root",
                     request=request,

--- a/nautobot/extras/plugins/views.py
+++ b/nautobot/extras/plugins/views.py
@@ -48,7 +48,7 @@ class InstalledPluginsAPIView(APIView):
             "author": plugin_app_config.author,
             "author_email": plugin_app_config.author_email,
             "description": plugin_app_config.description,
-            "verison": plugin_app_config.version,
+            "version": plugin_app_config.version,
         }
 
     def get(self, request, format=None):
@@ -69,7 +69,7 @@ class PluginsAPIRootView(APIView):
         api_app_name = f"{app_config.name}-api"
         try:
             entry = (
-                getattr(app_config, "base_url", app_config.label),
+                getattr(app_config, "base_url", app_config.name.replace("_", "-")),
                 reverse(
                     f"plugins-api:{api_app_name}:api-root",
                     request=request,

--- a/nautobot/extras/plugins/views.py
+++ b/nautobot/extras/plugins/views.py
@@ -71,7 +71,7 @@ class PluginsAPIRootView(APIView):
         api_app_name = f"{app_config.name}-api"
         try:
             entry = (
-                getattr(app_config, "base_url", app_config.label),
+                getattr(app_config, "base_url") or app_config.label.replace("_", "-"),
                 reverse(
                     f"plugins-api:{api_app_name}:api-root",
                     request=request,

--- a/nautobot/extras/plugins/views.py
+++ b/nautobot/extras/plugins/views.py
@@ -48,6 +48,8 @@ class InstalledPluginsAPIView(APIView):
             "author": plugin_app_config.author,
             "author_email": plugin_app_config.author_email,
             "description": plugin_app_config.description,
+            # TODO: Remove verison key/value when bumping to major revision
+            "verison": plugin_app_config.version,
             "version": plugin_app_config.version,
         }
 
@@ -69,7 +71,7 @@ class PluginsAPIRootView(APIView):
         api_app_name = f"{app_config.name}-api"
         try:
             entry = (
-                getattr(app_config, "base_url", app_config.name.replace("_", "-")),
+                getattr(app_config, "base_url", app_config.label),
                 reverse(
                     f"plugins-api:{api_app_name}:api-root",
                     request=request,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #337 
<!--
    Please include a summary of the proposed changes below.
-->
- Additionally, fixes typo when viewing the list of installed-plugins

If a plugin doesn't specify a `base_url` in `PluginConfig`, but has API urls defined, when browsing to `/api/plugins/`, you'd see the following:

![image](https://user-images.githubusercontent.com/29315002/116785668-086ae800-aa58-11eb-9503-5cd2bb737d29.png)

With this change, you'd see the `name` with any `_` replaced as `-` to match core app keys.

![image](https://user-images.githubusercontent.com/29315002/116785707-2e908800-aa58-11eb-92c4-7e927ad9226e.png)

I attempted to add tests for this, but ran into several issues. I will attempt to summarize the issues here.

- `core/tests/nautobot_config.py` defines `nautobot.extras.tests.dummy_plugin` and this will cause a 500 error when attempting to browse to `/api/plugins/` saying `nautobot.extras.tests.dummy_plugin` is not an installed app even though we can browse to `/api/plugins/dummy-plugin/dummy-models/`.
- If we add a `sys.path.append('/opt/nautobot/nautobot/extras/tests')` in `core/tests/nautobot_config.py` and attempt to use `PLUGINS = ['dummy_plugin']` it then will throw SQL table errors and requires a migration within the actual **extras** application which is obviously not desired.
- Last thing I tried to account for was splitting on `.` and then taking the last element, e.g. **dummy_plugin** with `extras/plugins/views.py`, but I think we'd have to do this in several other spots as I was getting different failures.

If I could potentially get some help on adding tests that would be great unless we don't see the value in the tests for this functionality.
