### PR TITLE
Fixing Docs Dependencies

### DIFF
--- a/nautobot/docs/requirements.txt
+++ b/nautobot/docs/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs==1.1		
-git+https://github.com/cmacmackin/markdown-include.git
+mkdocs==1.1.2
+markdown-include==0.6.0


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #402 
<!--
    Please include a summary of the proposed changes below.
-->

This PR updates the mkdocs dependencies from mkdocs 1.1 to 1.1.2 and changes the markdown-include dependency to use  version 0.6.0 from pypi instead of github.