### PR TITLE
Fix link to Docker from installation page.

### DIFF
--- a/nautobot/docs/installation/index.md
+++ b/nautobot/docs/installation/index.md
@@ -82,7 +82,7 @@ Nautobot should work on any POSIX-compliant system including practically any fla
 
 ### Running Nautobot in Docker
 
-Nautobot docker images are available for use in a containerized deployment for an easier installation, see the [Docker overview](/docker) for more information.
+Nautobot docker images are available for use in a containerized deployment for an easier installation, see the [Docker overview](../docker) for more information.
 
 ## Upgrading
 

--- a/nautobot/docs/installation/index.md
+++ b/nautobot/docs/installation/index.md
@@ -1,6 +1,6 @@
 # Installation
 
-This set of documents will help you get Nautobot up and running.  As an alternative, you can also [run Nautobot in Docker](/docker).
+This set of documents will help you get Nautobot up and running.  As an alternative, you can also [run Nautobot in Docker](../docker).
 
 ## About Dependencies
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: n/a
<!--
    Please include a summary of the proposed changes below.
-->

The link to the Docker docs were hard-coded to the wrong path.