### PR TITLE
resolves #342 issue with emitting null time_zone attr on Site object.

### DIFF
--- a/nautobot/core/api/__init__.py
+++ b/nautobot/core/api/__init__.py
@@ -2,7 +2,6 @@ from .fields import (
     ChoiceField,
     ContentTypeField,
     SerializedPKRelatedField,
-    TimeZoneField,
 )
 from .routers import OrderedDefaultRouter
 from .serializers import (
@@ -20,7 +19,6 @@ __all__ = (
     "ContentTypeField",
     "OrderedDefaultRouter",
     "SerializedPKRelatedField",
-    "TimeZoneField",
     "ValidatedModelSerializer",
     "WritableNestedSerializer",
 )

--- a/nautobot/core/api/fields.py
+++ b/nautobot/core/api/fields.py
@@ -102,22 +102,6 @@ class ContentTypeField(RelatedField):
         return f"{obj.app_label}.{obj.model}"
 
 
-class TimeZoneField(serializers.Field):
-    """
-    Represent a pytz time zone.
-    """
-
-    def to_representation(self, obj):
-        return obj.zone if obj else None
-
-    def to_internal_value(self, data):
-        if not data:
-            return ""
-        if data not in pytz.common_timezones:
-            raise ValidationError('Unknown time zone "{}" (see pytz.common_timezones for all options)'.format(data))
-        return pytz.timezone(data)
-
-
 class SerializedPKRelatedField(PrimaryKeyRelatedField):
     """
     Extends PrimaryKeyRelatedField to return a serialized object on read. This is useful for representing related

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -3,12 +3,12 @@ from django.contrib.contenttypes.models import ContentType
 from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 from rest_framework.validators import UniqueTogetherValidator
+from timezone_field.rest_framework import TimeZoneSerializerField
 
 from nautobot.core.api import (
     ChoiceField,
     ContentTypeField,
     SerializedPKRelatedField,
-    TimeZoneField,
     ValidatedModelSerializer,
     WritableNestedSerializer,
 )
@@ -147,7 +147,7 @@ class SiteSerializer(TaggedObjectSerializer, StatusModelSerializerMixin, CustomF
     url = serializers.HyperlinkedIdentityField(view_name="dcim-api:site-detail")
     region = NestedRegionSerializer(required=False, allow_null=True)
     tenant = NestedTenantSerializer(required=False, allow_null=True)
-    time_zone = TimeZoneField(required=False)
+    time_zone = TimeZoneSerializerField(required=False, allow_null=True)
     circuit_count = serializers.IntegerField(read_only=True)
     device_count = serializers.IntegerField(read_only=True)
     prefix_count = serializers.IntegerField(read_only=True)

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -170,7 +170,7 @@ class SiteTest(APIViewTestCases.APIViewTestCase):
 
     def test_time_zone_field_post_null(self):
         """
-        Test non-null constraint to time_zone field on site.
+        Test allow_null to time_zone field on site.
 
         See: https://github.com/nautobot/nautobot/issues/342
         """
@@ -185,7 +185,7 @@ class SiteTest(APIViewTestCases.APIViewTestCase):
 
     def test_time_zone_field_post_blank(self):
         """
-        Test blank time_zone field on site.
+        Test disallowed blank time_zone field on site.
 
         See: https://github.com/nautobot/nautobot/issues/342
         """

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -168,6 +168,85 @@ class SiteTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+    def test_time_zone_field_post_null(self):
+        """
+        Test non-null constraint to time_zone field on site.
+
+        See: https://github.com/nautobot/nautobot/issues/342
+        """
+        self.add_permissions("dcim.add_site")
+        url = reverse("dcim-api:site-list")
+        site = {"name": "foo", "slug": "foo", "status": "active", "time_zone": None}
+
+        # Attempt to create new site with null time_zone attr.
+        response = self.client.post(url, **self.header, data=site, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["time_zone"], None)
+
+    def test_time_zone_field_post_blank(self):
+        """
+        Test blank time_zone field on site.
+
+        See: https://github.com/nautobot/nautobot/issues/342
+        """
+        self.add_permissions("dcim.add_site")
+        url = reverse("dcim-api:site-list")
+        site = {"name": "foo", "slug": "foo", "status": "active", "time_zone": ""}
+
+        # Attempt to create new site with blank time_zone attr.
+        response = self.client.post(url, **self.header, data=site, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["time_zone"], ["A valid timezone is required."])
+
+    def test_time_zone_field_post_valid(self):
+        """
+        Test valid time_zone field on site.
+
+        See: https://github.com/nautobot/nautobot/issues/342
+        """
+        self.add_permissions("dcim.add_site")
+        url = reverse("dcim-api:site-list")
+        time_zone = "UTC"
+        site = {"name": "foo", "slug": "foo", "status": "active", "time_zone": time_zone}
+
+        # Attempt to create new site with valid time_zone attr.
+        response = self.client.post(url, **self.header, data=site, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["time_zone"], time_zone)
+
+    def test_time_zone_field_post_invalid(self):
+        """
+        Test invalid time_zone field on site.
+
+        See: https://github.com/nautobot/nautobot/issues/342
+        """
+        self.add_permissions("dcim.add_site")
+        url = reverse("dcim-api:site-list")
+        time_zone = "IDONOTEXIST"
+        site = {"name": "foo", "slug": "foo", "status": "active", "time_zone": time_zone}
+
+        # Attempt to create new site with invalid time_zone attr.
+        response = self.client.post(url, **self.header, data=site, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()["time_zone"],
+            ["A valid timezone is required."],
+        )
+
+    def test_time_zone_field_get_blank(self):
+        """
+        Test that a site's time_zone field defaults to null.
+
+        See: https://github.com/nautobot/nautobot/issues/342
+        """
+
+        self.add_permissions("dcim.view_site")
+        site = Site.objects.get(slug="site-1")
+        url = reverse("dcim-api:site-detail", kwargs={"pk": site.pk})
+        response = self.client.get(url, **self.header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["time_zone"], None)
+
 
 class RackGroupTest(APIViewTestCases.APIViewTestCase):
     model = RackGroup

--- a/nautobot/utilities/fields.py
+++ b/nautobot/utilities/fields.py
@@ -3,11 +3,6 @@ import json
 from django.core.validators import RegexValidator
 from django.db import models
 from django.core import exceptions
-from django.utils.encoding import force_str
-import pytz
-from rest_framework.exceptions import ValidationError
-from timezone_field.fields import TimeZoneField as TZField
-from timezone_field.utils import is_pytz_instance
 
 from nautobot.utilities.ordering import naturalize
 from .forms import ColorSelect
@@ -194,18 +189,3 @@ class JSONArrayField(models.JSONField):
                 **kwargs,
             }
         )
-
-
-class TimeZoneField(TZField):
-    """Overloads time_zone.TimeZoneField to represent blank value as "" instead of null."""
-
-    def _get_python_and_db_repr(self, value):
-        "Returns a tuple of (python representation, db representation)"
-        if value is None or value == "":
-            return ("", "")
-        if is_pytz_instance(value):
-            return (value, value.zone)
-        try:
-            return (pytz.timezone(force_str(value)), force_str(value))
-        except pytz.UnknownTimeZoneError:
-            raise ValidationError(f"Invalid timezone '{value}'")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #342
<!--
    Please include a summary of the proposed changes below.
-->
Issue initially appeared to be with the serializer field but on further investigation it was caused by the `timezone_field.fields.TimeZoneField._get_python_and_db_repr` returning None when expecting to return empty string.