### PR TITLE
Improve relationship filter(s) validation in clean() method

### DIFF
--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -337,7 +337,9 @@ class Relationship(BaseModel, ChangeLoggedModel):
             filterset_class = get_filterset_for_model(side_model)
             if not filterset_class:
                 raise ValidationError(
-                    {f"{side}_filter": f"Filters are not supported for {model_name} object (Unable to find a FilterSet)"}
+                    {
+                        f"{side}_filter": f"Filters are not supported for {model_name} object (Unable to find a FilterSet)"
+                    }
                 )
             filterset = filterset_class(filter, side_model.objects.all())
 

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -337,7 +337,7 @@ class Relationship(BaseModel, ChangeLoggedModel):
             filterset_class = get_filterset_for_model(side_model)
             if not filterset_class:
                 raise ValidationError(
-                    {f"{side}_filter": f"Filter are not supported for {model_name} object (Unable to find a FilterSet)"}
+                    {f"{side}_filter": f"Filters are not supported for {model_name} object (Unable to find a FilterSet)"}
                 )
             filterset = filterset_class(filter, side_model.objects.all())
 

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -90,8 +90,10 @@ class RelationshipTest(RelationshipBaseTest):
             type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
         )
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as handler:
             m2m.clean()
+        expected_errors = {"source_filter": ["Filter for dcim.Site must be a dictionary"]}
+        self.assertEqual(handler.exception.message_dict, expected_errors)
 
     def test_clean_filter_not_valid(self):
         m2m = Relationship(
@@ -103,8 +105,10 @@ class RelationshipTest(RelationshipBaseTest):
             type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
         )
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as handler:
             m2m.clean()
+        expected_errors = {"source_filter": ["'notvalid' is not a valid filter parameter for dcim.Site object"]}
+        self.assertEqual(handler.exception.message_dict, expected_errors)
 
         m2m = Relationship(
             name="Another Vlan to Rack",
@@ -115,8 +119,10 @@ class RelationshipTest(RelationshipBaseTest):
             type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
         )
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as handler:
             m2m.clean()
+        expected_errors = {"source_filter": ["'site' is not a valid filter parameter for dcim.Site object"]}
+        self.assertEqual(handler.exception.message_dict, expected_errors)
 
         m2m = Relationship(
             name="Another Vlan to Rack",
@@ -127,8 +133,10 @@ class RelationshipTest(RelationshipBaseTest):
             type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
         )
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as handler:
             m2m.clean()
+        expected_errors = {"source_filter": ["'site' is not a valid filter parameter for dcim.Site object"]}
+        self.assertEqual(handler.exception.message_dict, expected_errors)
 
     def test_clean_same_object(self):
         m2m = Relationship(
@@ -210,14 +218,18 @@ class RelationshipTest(RelationshipBaseTest):
 class RelationshipAssociationTest(RelationshipBaseTest):
     def test_clean_wrong_type(self):
         # Create with the wrong source Type
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as handler:
             cra = RelationshipAssociation(relationship=self.m2m_1, source=self.sites[0], destination=self.vlans[0])
             cra.clean()
+        expected_errors = {"source_type": ["source_type has a different value than defined in Vlan to Rack"]}
+        self.assertEqual(handler.exception.message_dict, expected_errors)
 
         # Create with the wrong destination Type
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as handler:
             cra = RelationshipAssociation(relationship=self.m2m_1, source=self.racks[0], destination=self.racks[0])
             cra.clean()
+        expected_errors = {"destination_type": ["destination_type has a different value than defined in Vlan to Rack"]}
+        self.assertEqual(handler.exception.message_dict, expected_errors)
 
     def test_clean_check_quantity_o2o(self):
         """Validate that one-to-one relationships can't have more than one relationship association per side. """
@@ -230,13 +242,22 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         cra.clean()
         cra.save()
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as handler:
             cra = RelationshipAssociation(relationship=self.o2o_1, source=self.racks[0], destination=self.sites[2])
             cra.clean()
 
-        with self.assertRaises(ValidationError):
+        expected_errors = {
+            "source": ["Unable to create more than one Primary Rack per Site association to Rack A (source)"]
+        }
+        self.assertEqual(handler.exception.message_dict, expected_errors)
+
+        with self.assertRaises(ValidationError) as handler:
             cra = RelationshipAssociation(relationship=self.o2o_1, source=self.racks[2], destination=self.sites[0])
             cra.clean()
+        expected_errors = {
+            "destination": ["Unable to create more than one Primary Rack per Site association to Site A (destination)"]
+        }
+        self.assertEqual(handler.exception.message_dict, expected_errors)
 
     def test_clean_check_quantity_o2m(self):
         """Validate that one-to-many relationships can't have more than one relationship association per source. """
@@ -253,9 +274,11 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         cra.clean()
         cra.save()
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as handler:
             cra = RelationshipAssociation(relationship=self.o2o_1, source=self.sites[2], destination=self.vlans[0])
             cra.clean()
+        expected_errors = {"source_type": ["source_type has a different value than defined in Primary Rack per Site"]}
+        self.assertEqual(handler.exception.message_dict, expected_errors)
 
     def test_clean_check_quantity_m2m(self):
         """Validate that many-to-many relationship can have many relationship associations."""

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -106,6 +106,30 @@ class RelationshipTest(RelationshipBaseTest):
         with self.assertRaises(ValidationError):
             m2m.clean()
 
+        m2m = Relationship(
+            name="Another Vlan to Rack",
+            slug="vlan-rack-2",
+            source_type=self.site_ct,
+            source_filter={"site": "not a list"},
+            destination_type=self.rack_ct,
+            type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
+        )
+
+        with self.assertRaises(ValidationError):
+            m2m.clean()
+
+        m2m = Relationship(
+            name="Another Vlan to Rack",
+            slug="vlan-rack-2",
+            source_type=self.site_ct,
+            source_filter={"site": ["not a valid site"]},
+            destination_type=self.rack_ct,
+            type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
+        )
+
+        with self.assertRaises(ValidationError):
+            m2m.clean()
+
     def test_clean_same_object(self):
         m2m = Relationship(
             name="Another Vlan to Rack",
@@ -123,14 +147,13 @@ class RelationshipTest(RelationshipBaseTest):
             name="Another Vlan to Rack",
             slug="vlan-rack-2",
             source_type=self.site_ct,
-            source_filter={"region": "myregion"},
+            source_filter={"name": ["site-b"]},
             destination_type=self.rack_ct,
-            destination_filter={"site": "mysite"},
+            destination_filter={"site": ["site-a"]},
             type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
         )
 
         m2m.clean()
-
         self.assertTrue(True)
 
     def test_get_label_input(self):

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -114,28 +114,32 @@ class RelationshipTest(RelationshipBaseTest):
             name="Another Vlan to Rack",
             slug="vlan-rack-2",
             source_type=self.site_ct,
-            source_filter={"site": "not a list"},
+            source_filter={"region": "not a list"},
             destination_type=self.rack_ct,
             type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
         )
 
         with self.assertRaises(ValidationError) as handler:
             m2m.clean()
-        expected_errors = {"source_filter": ["'site' is not a valid filter parameter for dcim.Site object"]}
+        expected_errors = {"source_filter": ["'region': Enter a list of values."]}
         self.assertEqual(handler.exception.message_dict, expected_errors)
 
         m2m = Relationship(
             name="Another Vlan to Rack",
             slug="vlan-rack-2",
             source_type=self.site_ct,
-            source_filter={"site": ["not a valid site"]},
+            source_filter={"region": ["not a valid region"]},
             destination_type=self.rack_ct,
             type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
         )
 
         with self.assertRaises(ValidationError) as handler:
             m2m.clean()
-        expected_errors = {"source_filter": ["'site' is not a valid filter parameter for dcim.Site object"]}
+        expected_errors = {
+            "source_filter": [
+                "'region': Select a valid choice. not a valid region is not one of the available choices."
+            ]
+        }
         self.assertEqual(handler.exception.message_dict, expected_errors)
 
     def test_clean_same_object(self):

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -433,7 +433,7 @@ class RelationshipTestCase(
             "source_type": vlan_type.pk,
             "source_label": "Interfaces",
             "source_hidden": False,
-            "source_filter": '{"status": {"slug": "active"}}',
+            "source_filter": '{"status": ["active"]}',
             "destination_type": interface_type.pk,
             "destination_label": "VLANs",
             "destination_hidden": True,


### PR DESCRIPTION
### Fixes: #396 

This PR improves how we are validating the `source_filter` and `destination_filter` in a Relationship object during clean() by loading the value of the filter in the right filterset. Any error reported by the filterset will raise a ValidationError.

In the process I had to fix some unit tests that were using non valid parameters