### PR TITLE
URL escape special characters in Git repository username/password

### DIFF
--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 import logging
 import os
 import re
+from urllib.parse import quote
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -124,9 +125,9 @@ def ensure_git_repository(repository_record, job_result=None, logger=None, head=
     if token and token not in from_url:
         # Some git repositories require a user as well as a token.
         if user:
-            from_url = re.sub("//", f"//{user}:{token}@", from_url)
+            from_url = re.sub("//", f"//{quote(user, safe='')}:{quote(token, safe='')}@", from_url)
         else:
-            from_url = re.sub("//", f"//{token}@", from_url)
+            from_url = re.sub("//", f"//{quote(token, safe='')}@", from_url)
 
     to_path = repository_record.filesystem_path
     from_branch = repository_record.branch

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -73,13 +73,13 @@ class GitTest(TestCase):
 
     def test_pull_git_repository_and_refresh_data_with_no_data(self, MockGitRepo):
         """
-        The test_pull_git_repository_and_refresh_data job should succeeed if the given repo is empty.
+        The pull_git_repository_and_refresh_data job should succeed if the given repo is empty.
         """
         with tempfile.TemporaryDirectory() as tempdir:
             with self.settings(GIT_ROOT=tempdir):
 
                 def create_empty_repo(path, url):
-                    os.makedirs(path)
+                    os.makedirs(path, exist_ok=True)
                     return mock.DEFAULT
 
                 MockGitRepo.side_effect = create_empty_repo
@@ -94,7 +94,51 @@ class GitTest(TestCase):
                 )
                 self.repo.refresh_from_db()
                 self.assertEqual(self.repo.current_head, self.COMMIT_HEXSHA, self.job_result.data)
+                MockGitRepo.assert_called_with(os.path.join(tempdir, self.repo.slug), "http://localhost/git.git")
                 # TODO: inspect the logs in job_result.data?
+
+                # Check that token-based authentication is handled as expected
+                self.repo._token = "1:3@/?=ab@"
+                self.repo.save()
+                # For verisimilitude, don't re-use the old request and job_result
+                self.dummy_request.id = uuid.uuid4()
+                self.job_result = JobResult(
+                    name=self.repo.name,
+                    obj_type=ContentType.objects.get_for_model(GitRepository),
+                    job_id=uuid.uuid4(),
+                )
+                pull_git_repository_and_refresh_data(self.repo.pk, self.dummy_request, self.job_result)
+
+                self.assertEqual(
+                    self.job_result.status,
+                    JobResultStatusChoices.STATUS_COMPLETED,
+                    self.job_result.data,
+                )
+                MockGitRepo.assert_called_with(
+                    os.path.join(tempdir, self.repo.slug), "http://1%3A3%40%2F%3F%3Dab%40@localhost/git.git"
+                )
+
+                # Check that username/password authentication is handled as expected
+                self.repo.username = "núñez"
+                self.repo.save()
+                # For verisimilitude, don't re-use the old request and job_result
+                self.dummy_request.id = uuid.uuid4()
+                self.job_result = JobResult(
+                    name=self.repo.name,
+                    obj_type=ContentType.objects.get_for_model(GitRepository),
+                    job_id=uuid.uuid4(),
+                )
+                pull_git_repository_and_refresh_data(self.repo.pk, self.dummy_request, self.job_result)
+
+                self.assertEqual(
+                    self.job_result.status,
+                    JobResultStatusChoices.STATUS_COMPLETED,
+                    self.job_result.data,
+                )
+                MockGitRepo.assert_called_with(
+                    os.path.join(tempdir, self.repo.slug),
+                    "http://n%C3%BA%C3%B1ez:1%3A3%40%2F%3F%3Dab%40@localhost/git.git",
+                )
 
     def test_pull_git_repository_and_refresh_data_with_valid_data(self, MockGitRepo):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #397 
<!--
    Please include a summary of the proposed changes below.
-->

Use `urllib` to escape any special characters that may appear in the username or password, such as `/`, `:`, and `@`, that would otherwise cause an error when attempting to git clone the repository.