### PR TITLE
GraphQL fixes: handling for BigIntegerField (ASNField) and ContentType

### DIFF
--- a/nautobot/core/graphql/__init__.py
+++ b/nautobot/core/graphql/__init__.py
@@ -1,18 +1,44 @@
-import graphene
-from django.db.models import JSONField
+from django.db.models import JSONField, BigIntegerField
 from django.db.models.fields import BinaryField
 
+import graphene
 from graphene.types import generic
 from graphene_django.converter import convert_django_field
+from graphql.language import ast
 
 
 @convert_django_field.register(JSONField)
-def convert_field_to_string(field, registry=None):
+def convert_json(field, registry=None):
     """Convert JSONField to GenericScalar."""
     return generic.GenericScalar()
 
 
-@convert_django_field.register(BinaryField)  # noqa: F811
-def convert_field_to_string(field, registry=None):  # noqa: F811
+@convert_django_field.register(BinaryField)
+def convert_binary(field, registry=None):
     """Convert BinaryField to String."""
     return graphene.String()
+
+
+# See also:
+# https://github.com/graphql-python/graphene-django/issues/241
+# https://github.com/graphql-python/graphene/pull/1261 (graphene 3.0)
+class BigInteger(graphene.types.Scalar):
+    """An integer which, unlike GraphQL's native Int type, doesn't reject values outside (-2^31, 2^31-1).
+
+    Currently only used for ASNField, which goes up to 2^32-1 (i.e., unsinged 32-bit int); it's possible
+    that this approach may fail for values in excess of 2^53-1 (the largest integer value supported in JavaScript).
+    """
+
+    serialize = int
+    parse_value = int
+
+    @staticmethod
+    def parse_literal(node):
+        if isinstance(node, ast.IntValue):
+            return int(node.value)
+
+
+@convert_django_field.register(BigIntegerField)
+def convert_biginteger(field, registry=None):
+    """Convert BigIntegerField to BigInteger scalar."""
+    return BigInteger()

--- a/nautobot/core/graphql/__init__.py
+++ b/nautobot/core/graphql/__init__.py
@@ -25,7 +25,7 @@ def convert_binary(field, registry=None):
 class BigInteger(graphene.types.Scalar):
     """An integer which, unlike GraphQL's native Int type, doesn't reject values outside (-2^31, 2^31-1).
 
-    Currently only used for ASNField, which goes up to 2^32-1 (i.e., unsinged 32-bit int); it's possible
+    Currently only used for ASNField, which goes up to 2^32-1 (i.e., unsigned 32-bit int); it's possible
     that this approach may fail for values in excess of 2^53-1 (the largest integer value supported in JavaScript).
     """
 

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -17,9 +17,17 @@ RESOLVER_PREFIX = "resolve_"
 
 
 def generate_restricted_queryset():
-    """Generate a function to return a restricted queryset compatible with the internal permissions system."""
+    """
+    Generate a function to return a restricted queryset compatible with the internal permissions system.
+
+    Note that for built-in models such as ContentType the queryset has no `restrict` method, so we have to
+    fail gracefully in that case.
+    """
 
     def get_queryset(queryset, info):
+        if not hasattr(queryset, "restrict"):
+            logger.debug(f"Queryset {queryset} is not restrictable")
+            return queryset
         return queryset.restrict(info.context.user, "view")
 
     return get_queryset

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -17,6 +17,7 @@ from nautobot.core.graphql.generators import (
     generate_restricted_queryset,
     generate_attrs_for_schema_type,
 )
+from nautobot.core.graphql.types import ContentTypeType
 from nautobot.dcim.graphql.types import (
     SiteType,
     DeviceType,
@@ -34,6 +35,7 @@ from nautobot.ipam.graphql.types import AggregateType, IPAddressType, PrefixType
 logger = logging.getLogger("nautobot.graphql.schema")
 
 registry["graphql_types"] = OrderedDict()
+registry["graphql_types"]["contenttypes.contenttype"] = ContentTypeType
 registry["graphql_types"]["dcim.site"] = SiteType
 registry["graphql_types"]["dcim.device"] = DeviceType
 registry["graphql_types"]["dcim.interface"] = InterfaceType

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -31,22 +31,24 @@ from nautobot.extras.models import CustomField, Relationship
 from nautobot.extras.choices import CustomFieldTypeChoices, RelationshipSideChoices
 from nautobot.extras.graphql.types import TagType
 from nautobot.ipam.graphql.types import AggregateType, IPAddressType, PrefixType
+from nautobot.virtualization.graphql.types import VMInterfaceType
 
 logger = logging.getLogger("nautobot.graphql.schema")
 
 registry["graphql_types"] = OrderedDict()
+registry["graphql_types"]["circuits.circuittermination"] = CircuitTerminationType
 registry["graphql_types"]["contenttypes.contenttype"] = ContentTypeType
-registry["graphql_types"]["dcim.site"] = SiteType
+registry["graphql_types"]["dcim.cable"] = CableType
+registry["graphql_types"]["dcim.consoleserverport"] = ConsoleServerPortType
 registry["graphql_types"]["dcim.device"] = DeviceType
 registry["graphql_types"]["dcim.interface"] = InterfaceType
 registry["graphql_types"]["dcim.rack"] = RackType
-registry["graphql_types"]["dcim.cable"] = CableType
-registry["graphql_types"]["dcim.consoleserverport"] = ConsoleServerPortType
+registry["graphql_types"]["dcim.site"] = SiteType
+registry["graphql_types"]["extras.tag"] = TagType
 registry["graphql_types"]["ipam.aggregate"] = AggregateType
 registry["graphql_types"]["ipam.ipaddress"] = IPAddressType
 registry["graphql_types"]["ipam.prefix"] = PrefixType
-registry["graphql_types"]["circuits.circuittermination"] = CircuitTerminationType
-registry["graphql_types"]["extras.tag"] = TagType
+registry["graphql_types"]["virtualization.vminterface"] = VMInterfaceType
 
 
 STATIC_TYPES = registry["graphql_types"].keys()

--- a/nautobot/core/graphql/types.py
+++ b/nautobot/core/graphql/types.py
@@ -1,0 +1,14 @@
+from django.contrib.contenttypes.models import ContentType
+
+from graphene_django import DjangoObjectType
+
+
+class ContentTypeType(DjangoObjectType):
+    """
+    Graphene-Django object type for ContentType records.
+
+    Needed because ContentType is a built-in model, not one that we own and can auto-generate types for.
+    """
+
+    class Meta:
+        model = ContentType

--- a/nautobot/core/graphql/utils.py
+++ b/nautobot/core/graphql/utils.py
@@ -1,7 +1,8 @@
 from django_filters.filters import BooleanFilter, NumberFilter, MultipleChoiceFilter
 import graphene
 
-from nautobot.utilities.filters import MultiValueNumberFilter
+from nautobot.core.graphql import BigInteger
+from nautobot.utilities.filters import MultiValueBigNumberFilter, MultiValueNumberFilter
 
 
 def str_to_var_name(verbose_name):
@@ -37,7 +38,9 @@ def get_filtering_args_from_filterset(filterset_class):
         field_type = graphene.String
         filter_field_class = type(filter_field)
 
-        if issubclass(filter_field_class, MultiValueNumberFilter):
+        if issubclass(filter_field_class, MultiValueBigNumberFilter):
+            field_type = graphene.List(BigInteger)
+        elif issubclass(filter_field_class, MultiValueNumberFilter):
             field_type = graphene.List(graphene.Int)
         else:
             if issubclass(filter_field_class, BooleanFilter):

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -12,7 +12,6 @@ from nautobot.dcim.filters import (
     CableFilterSet,
     ConsoleServerPortFilterSet,
 )
-from nautobot.ipam.graphql.types import IPAddressType
 from nautobot.extras.graphql.types import TagType  # noqa: F401
 
 
@@ -83,7 +82,7 @@ class InterfaceType(DjangoObjectType, CableTerminationMixin):
         filterset_class = InterfaceFilterSet
         exclude = ["_name"]
 
-    ip_addresses = graphene.List(IPAddressType)
+    ip_addresses = graphene.List("nautobot.ipam.graphql.types.IPAddressType")
 
     def resolve_ip_addresses(self, args):
         return self.ip_addresses.all()

--- a/nautobot/docs/release-notes/version-1.0.md
+++ b/nautobot/docs/release-notes/version-1.0.md
@@ -4,6 +4,22 @@ This document describes all new features and changes in Nautobot 1.0, a divergen
 
 Users migrating from NetBox to Nautobot should also refer to the ["Migrating from NetBox"](../installation/migrating-from-netbox.md) documentation as well.
 
+## Unreleased (2021-MM-DD)
+
+### Added
+
+- [#430](https://github.com/nautobot/nautobot/pull/430) - GraphQL `ip_addresses` now includes an `assigned_object` field
+
+### Changed
+
+### Fixed
+
+- [#428](https://github.com/nautobot/nautobot/issues/428) - Fix GraphQL error when handling ASNs greater than 2147483647
+- [#430](https://github.com/nautobot/nautobot/pull/430) - Fix missing `ContentType` foreign keys in GraphQL.
+
+### Removed
+
+
 ## v1.0.1 (2021-05-06)
 
 ### Added

--- a/nautobot/ipam/graphql/types.py
+++ b/nautobot/ipam/graphql/types.py
@@ -2,8 +2,10 @@ import graphene
 from graphene_django import DjangoObjectType
 from graphene_django.converter import convert_django_field, convert_field_to_string
 
+from nautobot.dcim.graphql.types import InterfaceType
 from nautobot.ipam import models, filters, fields
 from nautobot.extras.graphql.types import TagType  # noqa: F401
+from nautobot.virtualization.graphql.types import VMInterfaceType
 
 
 # Register VarbinaryIPField to be converted to a string type
@@ -20,10 +22,26 @@ class AggregateType(DjangoObjectType):
         filterset_class = filters.AggregateFilterSet
 
 
+class AssignedObjectType(graphene.Union):
+    """GraphQL type object for IPAddress's assigned_object field."""
+
+    class Meta:
+        types = (InterfaceType, VMInterfaceType)
+
+    @classmethod
+    def resolve_type(cls, instance, info):
+        if type(instance).__name__ == "Interface":
+            return InterfaceType
+        elif type(instance).__name__ == "VMInterface":
+            return VMInterfaceType
+        return None
+
+
 class IPAddressType(DjangoObjectType):
     """Graphql Type Object for IPAddress model."""
 
     address = graphene.String()
+    assigned_object = AssignedObjectType()
 
     class Meta:
         model = models.IPAddress

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -60,6 +60,10 @@ class MultiValueNumberFilter(django_filters.MultipleChoiceFilter):
     field_class = multivalue_field_factory(forms.IntegerField)
 
 
+class MultiValueBigNumberFilter(MultiValueNumberFilter):
+    """Subclass of MultiValueNumberFilter used for BigInteger model fields."""
+
+
 class MultiValueTimeFilter(django_filters.MultipleChoiceFilter):
     field_class = multivalue_field_factory(forms.TimeField)
 
@@ -213,6 +217,7 @@ class BaseFilterSet(django_filters.FilterSet):
     FILTER_DEFAULTS.update(
         {
             models.AutoField: {"filter_class": MultiValueNumberFilter},
+            models.BigIntegerField: {"filter_class": MultiValueBigNumberFilter},
             models.CharField: {"filter_class": MultiValueCharFilter},
             models.DateField: {"filter_class": MultiValueDateFilter},
             models.DateTimeField: {"filter_class": MultiValueDateTimeFilter},

--- a/nautobot/virtualization/graphql/types.py
+++ b/nautobot/virtualization/graphql/types.py
@@ -1,0 +1,20 @@
+import graphene
+from graphene_django import DjangoObjectType
+
+from nautobot.dcim.graphql.types import CableTerminationMixin
+from nautobot.virtualization.models import VMInterface
+from nautobot.virtualization.filters import VMInterfaceFilterSet
+
+
+class VMInterfaceType(DjangoObjectType, CableTerminationMixin):
+    """GraphQL type object for VMInterface model."""
+
+    class Meta:
+        model = VMInterface
+        filterset_class = VMInterfaceFilterSet
+        exclude = ["_name"]
+
+    ip_addresses = graphene.List("nautobot.ipam.graphql.types.IPAddressType")
+
+    def resolve_ip_addresses(self, args):
+        return self.ip_addresses.all()

--- a/nautobot/virtualization/tests/test_models.py
+++ b/nautobot/virtualization/tests/test_models.py
@@ -10,7 +10,7 @@ class VirtualMachineTestCase(TestCase):
     def setUp(self):
         statuses = Status.objects.get_for_model(VirtualMachine)
 
-        cluster_type = ClusterType.objects.create(name="Test Cluster Type 1", slug="Test Cluster Type 1")
+        cluster_type = ClusterType.objects.create(name="Test Cluster Type 1", slug="test-cluster-type-1")
         self.cluster = Cluster.objects.create(name="Test Cluster 1", type=cluster_type)
         self.status = statuses.get(slug="active")
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #428
<!--
    Please include a summary of the proposed changes below.
-->

For fields of type `BigIntegerField` (currently, AFAIK, only used as our subclass `ASNField`), use a custom scalar type that allows arbitrarily large integer values. This pattern will probably fail for values over 2^53ish since that is the limit supported by JavaScript, but as ASNField only allows numbers up to 2^32-1, that's a non-issue at this time.

Verified in GraphiQL that large ASN values are accepted as query parameters and are also permissible in the returned data:

![image](https://user-images.githubusercontent.com/5603551/117851464-5b148300-b254-11eb-9332-066837ece13e.png)

![image](https://user-images.githubusercontent.com/5603551/117851559-6ebfe980-b254-11eb-8406-17b1c96b156e.png)

![image](https://user-images.githubusercontent.com/5603551/117851190-112b9d00-b254-11eb-8eda-2aa827825de4.png)

Added regression test coverage as well.