### PR TITLE
Fix default Redis settings to not have `None` as a password

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 from nautobot.core.settings import *
-from nautobot.core.settings_funcs import is_truthy
+from nautobot.core.settings_funcs import is_truthy, parse_redis_connection
 
 ALLOWED_HOSTS = os.environ.get("NAUTOBOT_ALLOWED_HOSTS", "").split(" ")
 
@@ -67,15 +67,6 @@ if not TESTING:
 
 
 # Redis variables
-REDIS_HOST = os.getenv("NAUTOBOT_REDIS_HOST", "localhost")
-REDIS_PORT = os.getenv("NAUTOBOT_REDIS_PORT", 6379)
-REDIS_PASSWORD = os.getenv("NAUTOBOT_REDIS_PASSWORD", "")
-
-# Check for Redis SSL
-REDIS_SCHEME = "redis"
-REDIS_SSL = is_truthy(os.environ.get("NAUTOBOT_REDIS_SSL", False))
-if REDIS_SSL:
-    REDIS_SCHEME = "rediss"
 
 # The django-redis cache is used to establish concurrent locks using Redis. The
 # django-rq settings will use the same instance/database by default.
@@ -85,7 +76,7 @@ if REDIS_SSL:
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": f"{REDIS_SCHEME}://{REDIS_HOST}:{REDIS_PORT}/0",
+        "LOCATION": parse_redis_connection(redis_database=0),
         "TIMEOUT": 300,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
@@ -98,7 +89,7 @@ CACHES = {
 # up top via `from nautobot.core.settings import *`.
 
 # REDIS CACHEOPS
-CACHEOPS_REDIS = f"{REDIS_SCHEME}://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/1"
+CACHEOPS_REDIS = parse_redis_connection(redis_database=1)
 
 HIDE_RESTRICTED_UI = os.environ.get("HIDE_RESTRICTED_UI", False)
 

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -80,7 +80,6 @@ CACHES = {
         "TIMEOUT": 300,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "PASSWORD": REDIS_PASSWORD,
         },
     }
 }

--- a/nautobot/core/settings_funcs.py
+++ b/nautobot/core/settings_funcs.py
@@ -1,6 +1,8 @@
-"""Helper functions to detect settings after app initialization.  AKA 'dynamic settings'"""
+"""Helper functions to detect settings after app initialization (AKA 'dynamic settings')."""
+
 from distutils.util import strtobool
 from functools import lru_cache
+import os
 
 
 #
@@ -41,10 +43,13 @@ def _ldap_auth_enabled(auth_backends):
 
 
 def is_truthy(arg):
-    """Convert "truthy" strings into Booleans.
+    """
+    Convert "truthy" strings into Booleans.
+
     Examples:
         >>> is_truthy('yes')
         True
+
     Args:
         arg (str): Truthy string (True values are y, yes, t, true, on and 1; false values are n, no,
         f, false, off and 0. Raises ValueError if val is anything else.
@@ -52,3 +57,31 @@ def is_truthy(arg):
     if isinstance(arg, bool):
         return arg
     return bool(strtobool(str(arg)))
+
+
+def parse_redis_connection(redis_database):
+    """
+    Parse environment variables to emit a Redis connection URL.
+
+    Args:
+        redis_database (int): Redis database number to use for the connection
+
+    Returns:
+        Redis connection URL (str)
+    """
+    # The following `_redis_*` variables are used to generate settings based on
+    # environment variables.
+    redis_scheme = "rediss" if is_truthy(os.getenv("NAUTOBOT_REDIS_SSL", False)) else "redis"
+    redis_host = os.getenv("NAUTOBOT_REDIS_HOST", "localhost")
+    redis_port = int(os.getenv("NAUTOBOT_REDIS_PORT", 6379))
+    redis_username = os.getenv("NAUTOBOT_REDIS_USERNAME", "")
+    redis_password = os.getenv("NAUTOBOT_REDIS_PASSWORD", "")
+
+    # Default Redis credentials to being empty unless a username or password is
+    # provided. Then map it to "username:password@". We're not URL-encoding the
+    # password because the Redis Python client already does this.
+    redis_creds = ""
+    if redis_username or redis_password:
+        redis_creds = f"{redis_username}:{redis_password}@"
+
+    return f"{redis_scheme}://{redis_creds}{redis_host}:{redis_port}/{redis_database}"

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -14,7 +14,7 @@ from nautobot.core.settings_funcs import is_truthy
 # access to the server via any other hostnames. The first FQDN in the list will be treated as the preferred name.
 #
 # Example: ALLOWED_HOSTS = ['nautobot.example.com', 'nautobot.internal.local']
-ALLOWED_HOSTS = os.getenv("NAUTOBOT_ALLOWED_HOSTS").split(",")
+ALLOWED_HOSTS = os.getenv("NAUTOBOT_ALLOWED_HOSTS", "").split(",")
 
 # PostgreSQL database configuration. See the Django documentation for a complete list of available parameters:
 #   https://docs.djangoproject.com/en/stable/ref/settings/#databases
@@ -53,9 +53,9 @@ RQ_QUEUES = {
 # For detailed configuration see: https://github.com/Suor/django-cacheops#setup
 # Set Cache Ops variables
 redis_protocol = "rediss" if is_truthy(os.getenv("NAUTOBOT_REDIS_SSL", False)) else "redis"
-cache_ops_pwd = os.getenv("NAUTOBOT_REDIS_PASSWORD")
+cache_ops_pwd = os.getenv("NAUTOBOT_REDIS_PASSWORD", "")
 cache_ops_host = os.getenv("NAUTOBOT_REDIS_HOST", "localhost")
-cache_ops_user = os.getenv("NAUTOBOT_REDIS_USER")
+cache_ops_user = os.getenv("NAUTOBOT_REDIS_USER", "")
 cache_ops_port = int(os.getenv("NAUTOBOT_REDIS_PORT", 6379))
 
 CACHEOPS_REDIS = os.getenv("NAUTOBOT_CACHEOPS_REDIS", f"{redis_protocol}://:{cache_ops_pwd}@{cache_ops_host}:{cache_ops_port}/1")

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -2,7 +2,7 @@ import os
 import sys
 
 from nautobot.core.settings import *  # noqa F401,F403
-from nautobot.core.settings_funcs import is_truthy
+from nautobot.core.settings_funcs import is_truthy, parse_redis_connection
 
 #########################
 #                       #
@@ -14,7 +14,7 @@ from nautobot.core.settings_funcs import is_truthy
 # access to the server via any other hostnames. The first FQDN in the list will be treated as the preferred name.
 #
 # Example: ALLOWED_HOSTS = ['nautobot.example.com', 'nautobot.internal.local']
-ALLOWED_HOSTS = os.getenv("NAUTOBOT_ALLOWED_HOSTS", "").split(",")
+ALLOWED_HOSTS = os.getenv("NAUTOBOT_ALLOWED_HOSTS", "").split(" ")
 
 # PostgreSQL database configuration. See the Django documentation for a complete list of available parameters:
 #   https://docs.djangoproject.com/en/stable/ref/settings/#databases
@@ -49,29 +49,16 @@ RQ_QUEUES = {
     },
 }
 
-# The following `_redis_*` variables are used to generate settings based on environment variables. Please do NOT override any of the following variables that begin with `_redis_`. If you need to override a default setting manually, either use the environment variables or the CAPITALIZED setting name.
-_redis_protocol = "rediss" if is_truthy(os.getenv("NAUTOBOT_REDIS_SSL", False)) else "redis"
-_redis_host = os.getenv("NAUTOBOT_REDIS_HOST", "localhost")
-_redis_port = int(os.getenv("NAUTOBOT_REDIS_PORT", 6379))
-_redis_password = os.getenv("NAUTOBOT_REDIS_PASSWORD", "")
-
-# Default Redis credentials to being empty unless a password is provided. Then map it to ":password@"
-_redis_creds = ""
-if _redis_password:
-    _redis_creds = f":{_redis_password}@"
-
 # Nautobot uses Cacheops for database query caching. These are the following defaults.
 # For detailed configuration see: https://github.com/Suor/django-cacheops#setup
-CACHEOPS_REDIS = os.getenv(
-    "NAUTOBOT_CACHEOPS_REDIS", f"{_redis_protocol}://{_redis_creds}{_redis_host}:{_redis_port}/1"
-)
+CACHEOPS_REDIS = os.getenv("NAUTOBOT_CACHEOPS_REDIS", parse_redis_connection(redis_database=1))
 
 # The django-redis cache is used to establish concurrent locks using Redis. The
 # django-rq settings will use the same instance/database by default.
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": f"{_redis_protocol}://{_redis_creds}{_redis_host}:{_redis_port}/0",
+        "LOCATION": parse_redis_connection(redis_database=0),
         "TIMEOUT": 300,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -62,7 +62,6 @@ CACHES = {
         "TIMEOUT": 300,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "PASSWORD": "",
         },
     }
 }

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -49,23 +49,29 @@ RQ_QUEUES = {
     },
 }
 
+# The following `_redis_*` variables are used to generate settings based on environment variables. Please do NOT override any of the following variables that begin with `_redis_`. If you need to override a default setting manually, either use the environment variables or the CAPITALIZED setting name.
+_redis_protocol = "rediss" if is_truthy(os.getenv("NAUTOBOT_REDIS_SSL", False)) else "redis"
+_redis_host = os.getenv("NAUTOBOT_REDIS_HOST", "localhost")
+_redis_port = int(os.getenv("NAUTOBOT_REDIS_PORT", 6379))
+_redis_password = os.getenv("NAUTOBOT_REDIS_PASSWORD", "")
+
+# Default Redis credentials to being empty unless a password is provided. Then map it to ":password@"
+_redis_creds = ""
+if _redis_password:
+    _redis_creds = f":{_redis_password}@"
+
 # Nautobot uses Cacheops for database query caching. These are the following defaults.
 # For detailed configuration see: https://github.com/Suor/django-cacheops#setup
-# Set Cache Ops variables
-redis_protocol = "rediss" if is_truthy(os.getenv("NAUTOBOT_REDIS_SSL", False)) else "redis"
-cache_ops_pwd = os.getenv("NAUTOBOT_REDIS_PASSWORD", "")
-cache_ops_host = os.getenv("NAUTOBOT_REDIS_HOST", "localhost")
-cache_ops_user = os.getenv("NAUTOBOT_REDIS_USER", "")
-cache_ops_port = int(os.getenv("NAUTOBOT_REDIS_PORT", 6379))
-
-CACHEOPS_REDIS = os.getenv("NAUTOBOT_CACHEOPS_REDIS", f"{redis_protocol}://:{cache_ops_pwd}@{cache_ops_host}:{cache_ops_port}/1")
+CACHEOPS_REDIS = os.getenv(
+    "NAUTOBOT_CACHEOPS_REDIS", f"{_redis_protocol}://{_redis_creds}{_redis_host}:{_redis_port}/1"
+)
 
 # The django-redis cache is used to establish concurrent locks using Redis. The
 # django-rq settings will use the same instance/database by default.
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": f"{redis_protocol}://:{cache_ops_pwd}@{cache_ops_host}:{cache_ops_port}/0",
+        "LOCATION": f"{_redis_protocol}://{_redis_creds}{_redis_host}:{_redis_port}/0",
         "TIMEOUT": 300,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -44,7 +44,6 @@ CACHES = {
         "TIMEOUT": 300,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "PASSWORD": REDIS_PASSWORD,
         },
     }
 }

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -6,7 +6,7 @@
 import os
 
 from nautobot.core.settings import *  # noqa: F401,F403
-from nautobot.core.settings_funcs import is_truthy
+from nautobot.core.settings_funcs import is_truthy, parse_redis_connection
 
 
 ALLOWED_HOSTS = ["*"]
@@ -31,15 +31,6 @@ SECRET_KEY = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 
 # Redis variables
-REDIS_HOST = os.getenv("NAUTOBOT_REDIS_HOST", "localhost")
-REDIS_PORT = os.getenv("NAUTOBOT_REDIS_PORT", 6379)
-REDIS_PASSWORD = os.getenv("NAUTOBOT_REDIS_PASSWORD", "")
-
-# Check for Redis SSL
-REDIS_SCHEME = "redis"
-REDIS_SSL = is_truthy(os.environ.get("NAUTOBOT_REDIS_SSL", False))
-if REDIS_SSL:
-    REDIS_SCHEME = "rediss"
 
 # The django-redis cache is used to establish concurrent locks using Redis. The
 # django-rq settings will use the same instance/database by default.
@@ -49,7 +40,7 @@ if REDIS_SSL:
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": f"{REDIS_SCHEME}://{REDIS_HOST}:{REDIS_PORT}/2",
+        "LOCATION": parse_redis_connection(redis_database=2),
         "TIMEOUT": 300,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
@@ -62,4 +53,4 @@ CACHES = {
 # up top via `from nautobot.core.settings import *`.
 
 # REDIS CACHEOPS
-CACHEOPS_REDIS = f"{REDIS_SCHEME}://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/3"
+CACHEOPS_REDIS = parse_redis_connection(redis_database=3)

--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -169,7 +169,6 @@ CACHES = {
         "TIMEOUT": 300,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "PASSWORD": "",
         },
     }
 }
@@ -254,6 +253,9 @@ The following environment variables may also be set for some of the above values
 * `NAUTOBOT_REDIS_USERNAME`
 * `NAUTOBOT_REDIS_SSL`
 * `NAUTOBOT_REDIS_TIMEOUT`
+
+!!! note
+    If you overload any of the default values in [`CACHES`](#caches) or [`RQ_QUEUES`](#rq_queues) you may be unable to utilize the environment variables, depending on what you change.
 
 For more details on configuring RQ, please see the documentation for [Django RQ installation](https://github.com/rq/django-rq#installation).
 

--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -2,7 +2,7 @@
 
 ## ALLOWED_HOSTS
 
-Environment Variable: `NAUTOBOT_ALLOWED_HOSTS` specified as a comma separated list.
+Environment Variable: `NAUTOBOT_ALLOWED_HOSTS` specified as a space-separated quoted string (e.g. `NAUTOBOT_ALLOWED_HOSTS="localhost 127.0.01 example.com"`).
 
 This is a list of valid fully-qualified domain names (FQDNs) and/or IP addresses that can be used to reach the Nautobot service. Usually this is the same as the hostname for the Nautobot server, but can also be different; for example, when using a reverse proxy serving the Nautobot website under a different FQDN than the hostname of the Nautobot server. To help guard against [HTTP Host header attacks](https://docs.djangoproject.com/en/stable/topics/security/#host-headers-virtual-hosting), Nautobot will not permit access to the server via any other hostnames (or IPs).
 
@@ -251,6 +251,7 @@ The following environment variables may also be set for some of the above values
 * `NAUTOBOT_REDIS_HOST`
 * `NAUTOBOT_REDIS_PORT`
 * `NAUTOBOT_REDIS_PASSWORD`
+* `NAUTOBOT_REDIS_USERNAME`
 * `NAUTOBOT_REDIS_SSL`
 * `NAUTOBOT_REDIS_TIMEOUT`
 

--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -2,7 +2,7 @@
 
 ## ALLOWED_HOSTS
 
-Environment Variable: `NAUTOBOT_ALLOWED_HOSTS` specified as a space-separated quoted string (e.g. `NAUTOBOT_ALLOWED_HOSTS="localhost 127.0.01 example.com"`).
+Environment Variable: `NAUTOBOT_ALLOWED_HOSTS` specified as a space-separated quoted string (e.g. `NAUTOBOT_ALLOWED_HOSTS="localhost 127.0.0.1 example.com"`).
 
 This is a list of valid fully-qualified domain names (FQDNs) and/or IP addresses that can be used to reach the Nautobot service. Usually this is the same as the hostname for the Nautobot server, but can also be different; for example, when using a reverse proxy serving the Nautobot website under a different FQDN than the hostname of the Nautobot server. To help guard against [HTTP Host header attacks](https://docs.djangoproject.com/en/stable/topics/security/#host-headers-virtual-hosting), Nautobot will not permit access to the server via any other hostnames (or IPs).
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #436 
<!--
    Please include a summary of the proposed changes below.
-->

The default settings from the config generated from template using `nautobot-server init` were changed in v1.0.1 to look for certain settings from environment variables. This was done to facilitate a 12-factor application pattern in coordination with publishing an official Docker image.

- This fix corrects this to satisfy a working default configuration, and to support customizing settings using `NAUTOBOT_*` environment variables. This also fixes the default `ALLOWED_HOSTS` to fallback to an empty list. 
  - Additionally to bring it into parity w/ the development config (which has been around longer), the `NAUTOBOT_ALLOWED_HOSTS` environment variable now splits on a SPACE, not a comma.
- This refactors private variables for Redis settings generation from environment variables:
- Redis connection string now processed by `nautobot.core.settings_funcs.parse_redis_connection` which reads everything from the same environment variables, with the desired database as a required argument
- The username/password values are not URL-encoded beacuse the Redis.py client already does this.
- The template config at `nautobot/core/templates/nautobot_config.py.j2` is now using `parse_redis_connection`

- The test config at `nautobot/core/tests/nautobot_config.py` is now using `parse_redis_connection`
- The development config at `development/nautobot_config.py` is now using `parse_redis_connection`
- Documentation has been updated
- Also fixed a small typo I found in the docs related to `generate_secret_key`
- Asserted that they work:

Without password:

```python
In [1]: from django.conf import settings

In [2]: settings.CACHEOPS_REDIS
Out[2]: 'redis://localhost:6379/1'

In [3]: settings.CACHES["default"]["LOCATION"]
Out[3]: 'redis://localhost:6379/0'
```

With password:

```python
In [1]: from django.conf import settings

In [2]: settings.CACHEOPS_REDIS
Out[2]: 'redis://:abc123@localhost:6379/1'

In [3]: settings.CACHES["default"]["LOCATION"]
Out[3]: 'redis://:abc123@localhost:6379/0'
```