### PR TITLE
Fix cables status choice being provided by OPTIONS

### DIFF
--- a/nautobot/circuits/tests/test_api.py
+++ b/nautobot/circuits/tests/test_api.py
@@ -79,6 +79,7 @@ class CircuitTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "status": "planned",
     }
+    choices_fields = ["status"]
 
     @classmethod
     def setUpTestData(cls):
@@ -147,6 +148,7 @@ class CircuitTest(APIViewTestCases.APIViewTestCase):
 class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
     model = CircuitTermination
     brief_fields = ["cable", "circuit", "display", "id", "term_side", "url"]
+    choices_fields = ["term_side"]
 
     @classmethod
     def setUpTestData(cls):

--- a/nautobot/core/api/metadata.py
+++ b/nautobot/core/api/metadata.py
@@ -69,10 +69,6 @@ class StatusFieldMetadata(ContentTypeMetadata):
     """Emit `Status` serializer fields as a choice enum."""
 
     def get_field_info(self, field):
-        # Keep backwards compatible behavior if serializer also has `ContentTypeField` fields specified
-        if isinstance(field, ContentTypeField):
-            return super().get_field_info(field)
-
         # Gather field_info and determine if we need to add `Status` choices
         field_info = super().get_field_info(field)
         if (

--- a/nautobot/core/api/metadata.py
+++ b/nautobot/core/api/metadata.py
@@ -65,10 +65,15 @@ class ContentTypeMetadata(BulkOperationMetadata):
         return field_info
 
 
-class StatusFieldMetadata(BulkOperationMetadata):
+class StatusFieldMetadata(ContentTypeMetadata):
     """Emit `Status` serializer fields as a choice enum."""
 
     def get_field_info(self, field):
+        # Keep backwards compatible behavior if serializer also has `ContentTypeField` fields specified
+        if isinstance(field, ContentTypeField):
+            return super().get_field_info(field)
+
+        # Gather field_info and determine if we need to add `Status` choices
         field_info = super().get_field_info(field)
         if (
             not field_info.get("read_only")

--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -622,7 +622,6 @@ class InterfaceConnectionViewSet(ListModelMixin, GenericViewSet):
 
 
 class CableViewSet(StatusViewSetMixin, ModelViewSet):
-    metadata_class = ContentTypeMetadata
     queryset = Cable.objects.prefetch_related("status", "termination_a", "termination_b")
     serializer_class = serializers.CableSerializer
     filterset_class = filters.CableFilterSet

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -125,6 +125,7 @@ class SiteTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "status": "planned",
     }
+    choices_fields = ["status"]
 
     @classmethod
     def setUpTestData(cls):
@@ -267,6 +268,7 @@ class RackTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "status": "planned",
     }
+    choices_fields = ["outer_unit", "status", "type", "width"]
 
     @classmethod
     def setUpTestData(cls):
@@ -478,6 +480,7 @@ class DeviceTypeTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "part_number": "ABC123",
     }
+    choices_fields = ["subdevice_role"]
 
     @classmethod
     def setUpTestData(cls):
@@ -516,6 +519,7 @@ class ConsolePortTemplateTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -548,6 +552,7 @@ class ConsoleServerPortTemplateTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -580,6 +585,7 @@ class PowerPortTemplateTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -612,6 +618,7 @@ class PowerOutletTemplateTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["feed_leg", "type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -644,6 +651,7 @@ class InterfaceTemplateTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -679,6 +687,7 @@ class FrontPortTemplateTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -768,6 +777,7 @@ class RearPortTemplateTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -913,6 +923,7 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "status": "failed",
     }
+    choices_fields = ["face", "status"]
 
     @classmethod
     def setUpTestData(cls):
@@ -1063,6 +1074,7 @@ class ConsolePortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCa
         "description": "New description",
     }
     peer_termination_type = ConsoleServerPort
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -1099,6 +1111,7 @@ class ConsoleServerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIView
         "description": "New description",
     }
     peer_termination_type = ConsolePort
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -1135,6 +1148,7 @@ class PowerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
         "description": "New description",
     }
     peer_termination_type = PowerOutlet
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -1171,6 +1185,7 @@ class PowerOutletTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCa
         "description": "New description",
     }
     peer_termination_type = PowerPort
+    choices_fields = ["feed_leg", "type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -1207,6 +1222,7 @@ class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
         "description": "New description",
     }
     peer_termination_type = Interface
+    choices_fields = ["mode", "type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -1261,6 +1277,7 @@ class FrontPortTest(APIViewTestCases.APIViewTestCase):
         "description": "New description",
     }
     peer_termination_type = Interface
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -1330,6 +1347,7 @@ class RearPortTest(APIViewTestCases.APIViewTestCase):
         "description": "New description",
     }
     peer_termination_type = Interface
+    choices_fields = ["type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -1485,7 +1503,7 @@ class CableTest(APIViewTestCases.APIViewTestCase):
         "length": 100,
         "length_unit": "m",
     }
-    choices = ["termination_a_type", "termination_b_type", "type", "status", "length_unit"]
+    choices_fields = ["termination_a_type", "termination_b_type", "type", "status", "length_unit"]
 
     # TODO: Allow updating cable terminations
     test_update_object = None
@@ -1821,6 +1839,7 @@ class PowerFeedTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "status": "planned",
     }
+    choices_fields = ["phase", "status", "supply", "type"]
 
     @classmethod
     def setUpTestData(cls):

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -1485,6 +1485,7 @@ class CableTest(APIViewTestCases.APIViewTestCase):
         "length": 100,
         "length_unit": "m",
     }
+    choices = ["termination_a_type", "termination_b_type", "type", "status", "length_unit"]
 
     # TODO: Allow updating cable terminations
     test_update_object = None

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -397,12 +397,14 @@ class StatusViewSetMixin(ModelViewSet):
 
 
 class RelationshipViewSet(ModelViewSet):
+    metadata_class = ContentTypeMetadata
     queryset = Relationship.objects.all()
     serializer_class = serializers.RelationshipSerializer
     filterset_class = filters.RelationshipFilterSet
 
 
 class RelationshipAssociationViewSet(ModelViewSet):
+    metadata_class = ContentTypeMetadata
     queryset = RelationshipAssociation.objects.all()
     serializer_class = serializers.RelationshipAssociationSerializer
     filterset_class = filters.RelationshipAssociationFilterSet

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -86,6 +86,7 @@ class CustomFieldTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["filter_logic", "type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -123,6 +124,7 @@ class ExportTemplateTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["owner_content_type", "content_type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -197,6 +199,7 @@ class GitRepositoryTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "branch": "develop",
     }
+    choices_fields = ["provided_contents"]
 
     @classmethod
     def setUpTestData(cls):
@@ -241,6 +244,7 @@ class ImageAttachmentTest(
 ):
     model = ImageAttachment
     brief_fields = ["display", "id", "image", "name", "url"]
+    choices_fields = ["content_type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -613,6 +617,7 @@ class CustomLinkTest(APIViewTestCases.APIViewTestCase):
             "new_window": False,
         },
     ]
+    choices_fields = ["button_class"]
 
     @classmethod
     def setUpTestData(cls):
@@ -676,6 +681,7 @@ class WebhookTest(APIViewTestCases.APIViewTestCase):
             "ssl_verification": True,
         },
     ]
+    choices_fields = ["http_method"]
 
     @classmethod
     def setUpTestData(cls):
@@ -788,6 +794,7 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "destination_filter": {"role": {"slug": "controller"}},
     }
+    choices_fields = ["destination_type", "source_type", "type"]
 
     @classmethod
     def setUpTestData(cls):
@@ -820,6 +827,7 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase):
 class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
     model = RelationshipAssociation
     brief_fields = ["destination_id", "display", "id", "relationship", "source_id", "url"]
+    choices_fields = ["destination_type", "source_type"]
 
     @classmethod
     def setUpTestData(cls):

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -216,6 +216,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["status"]
 
     def setUp(self):
         super().setUp()
@@ -464,6 +465,7 @@ class IPAddressTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["assigned_object_type", "role", "status"]
 
     @classmethod
     def setUpTestData(cls):
@@ -521,6 +523,7 @@ class VLANTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["status"]
 
     @classmethod
     def setUpTestData(cls):
@@ -590,6 +593,7 @@ class ServiceTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["protocol"]
 
     @classmethod
     def setUpTestData(cls):

--- a/nautobot/utilities/testing/api.py
+++ b/nautobot/utilities/testing/api.py
@@ -134,7 +134,7 @@ class APIViewTestCases:
 
     class ListObjectsViewTestCase(APITestCase):
         brief_fields = []
-        choices = None
+        choices_fields = None
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
         def test_list_objects_anonymous(self):
@@ -237,11 +237,11 @@ class APIViewTestCases:
         @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
         def test_options_returns_expected_choices(self):
             """
-            Make an OPTIONS request for a list endpoint and validate choices match expected choices.
+            Make an OPTIONS request for a list endpoint and validate choice fields match expected choice fields for serializer.
             """
-            # Skip test if test case does not supply a list of choices to test against.
-            if not self.choices:
-                self.skipTest("choices was not provided by test case.")
+            # Set to self.choices_fields as empty set to compare classes that shouldn't have any choice fields on serializer.
+            if not self.choices_fields:
+                self.choices_fields = set()
 
             # Save self.user as superuser to be able to view available choices on list views.
             self.user.is_superuser = True
@@ -253,7 +253,7 @@ class APIViewTestCases:
             # Grab any field name that has choices defined (fields with enums)
             field_choices = {k for k, v in response.json()["actions"]["POST"].items() if "choices" in v}
 
-            self.assertEqual(set(self.choices), field_choices)
+            self.assertEqual(set(self.choices_fields), field_choices)
 
     class CreateObjectViewTestCase(APITestCase):
         create_data = []

--- a/nautobot/utilities/testing/api.py
+++ b/nautobot/utilities/testing/api.py
@@ -5,7 +5,6 @@ from django.urls import reverse
 from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APIClient, APITransactionTestCase as _APITransactionTestCase
-import unittest
 
 from nautobot.users.models import ObjectPermission, Token
 from .utils import disable_warnings
@@ -33,7 +32,6 @@ class APITestCase(ModelTestCase):
 
     client_class: Test client class
     view_namespace: Namespace for API views. If None, the model's app_label will be used.
-    choices: List of choices to validate are returned via OPTIONS. If None, do not do anything.
     """
 
     client_class = APIClient

--- a/nautobot/virtualization/tests/test_api.py
+++ b/nautobot/virtualization/tests/test_api.py
@@ -130,6 +130,7 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "status": "staged",
     }
+    choices_fields = ["status"]
 
     @classmethod
     def setUpTestData(cls):
@@ -231,6 +232,7 @@ class VMInterfaceTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         "description": "New description",
     }
+    choices_fields = ["mode"]
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #452 452
<!--
    Please include a summary of the proposed changes below.
-->
Remove the `metadata_class` as `StatusViewSetMixin` uses it to properly set the metadata returned.
