### PR TITLE
Backup and Restore commands added to invoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ docker-compose.override.yml
 override.env
 *.egg-info
 .python-version
+db_output.json
+db_output.xml
+db_output.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,4 @@ docker-compose.override.yml
 override.env
 *.egg-info
 .python-version
-db_output.json
-db_output.xml
-db_output.yaml
+db_output.*

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -148,9 +148,11 @@ Available tasks:
   build               Build all docker images.
   cli                 Launch a bash shell inside the running Nautobot container.
   createsuperuser     Create a new Nautobot superuser account (default: "admin"), will prompt for password.
+  dumpdata            Dump database data into file, only for development environment use.
   debug               Start Nautobot and its dependencies in debug mode.
   destroy             Destroy all containers and volumes.
   flake8              Check for PEP8 compliance and other style issues.
+  loaddata            Load data from file into database, only for development environment use.
   makemigrations      Perform makemigrations operation in Django.
   migrate             Perform migrate operation in Django.
   nbshell             Launch an interactive nbshell session.

--- a/tasks.py
+++ b/tasks.py
@@ -344,7 +344,7 @@ def post_upgrade(context):
 @task()
 def dumpdata(context, format="json"):
     """Dump data from database to db_output file."""
-    command = f"nautobot-server dumpdata -e extras.job --indent 4 -o db_output.{format} --format {format}"
+    command = f"nautobot-server dumpdata --exclude extras.job --indent 4 --output db_output.{format} --format {format}"
     run_command(context, command)
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -341,14 +341,18 @@ def post_upgrade(context):
     run_command(context, command)
 
 
-@task()
+@task(help={
+    "format": "Output type for file ('json', 'xml', 'yaml')."
+})
 def dumpdata(context, format="json"):
     """Dump data from database to db_output file."""
     command = f"nautobot-server dumpdata --exclude extras.job --indent 4 --output db_output.{format} --format {format}"
     run_command(context, command)
 
 
-@task()
+@task(help={
+    "file_name": "Name and path of file to load."
+})
 def loaddata(context, file_name):
     """Load data from file."""
     command = f"nautobot-server loaddata {file_name}"

--- a/tasks.py
+++ b/tasks.py
@@ -341,6 +341,20 @@ def post_upgrade(context):
     run_command(context, command)
 
 
+@task()
+def dumpdata(context, format="json"):
+    """Dump data from database to db_output file."""
+    command = f"nautobot-server dumpdata -e extras.job --indent 4 -o db_output.{format} --format {format}"
+    run_command(context, command)
+
+
+@task()
+def loaddata(context, file_name):
+    """Load data from file."""
+    command = f"nautobot-server loaddata {file_name}"
+    run_command(context, command)
+
+
 # ------------------------------------------------------------------------------
 # TESTS
 # ------------------------------------------------------------------------------

--- a/tasks.py
+++ b/tasks.py
@@ -341,18 +341,14 @@ def post_upgrade(context):
     run_command(context, command)
 
 
-@task(help={
-    "format": "Output type for file ('json', 'xml', 'yaml')."
-})
+@task(help={"format": "Output type for file ('json', 'xml', 'yaml')."})
 def dumpdata(context, format="json"):
     """Dump data from database to db_output file."""
     command = f"nautobot-server dumpdata --exclude extras.job --indent 4 --output db_output.{format} --format {format}"
     run_command(context, command)
 
 
-@task(help={
-    "file_name": "Name and path of file to load."
-})
+@task(help={"file_name": "Name and path of file to load."})
 def loaddata(context, file_name):
     """Load data from file."""
     command = f"nautobot-server loaddata {file_name}"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #162
<!--
    Please include a summary of the proposed changes below.
-->
Backup command:
```
invoke dumpdata --format json
```
The data is outputted to the root of the project called `db_output.json`. The file extension depends on the format specified in the command.

Load command:
```
invoke loaddata [file_name]
```

Caveat, `extras.job` is excluded from backup command as it is causing SQL errors.