### PR TITLE
Fixing db timeout typing

### DIFF
--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -25,7 +25,7 @@ DATABASES = {
         "PASSWORD": os.getenv("NAUTOBOT_DB_PASSWORD", ""),  # Database password
         "HOST": os.getenv("NAUTOBOT_DB_HOST", "localhost"),  # Database server
         "PORT": os.getenv("NAUTOBOT_DB_PORT", ""),  # Database port (leave blank for default)
-        "CONN_MAX_AGE": os.getenv("NAUTOBOT_DB_TIMEOUT", 300),  # Database timeout
+        "CONN_MAX_AGE": int(os.getenv("NAUTOBOT_DB_TIMEOUT", 300)),  # Database timeout
         "ENGINE": "django.db.backends.postgresql",  # Database driver (Postgres only supported!)
     }
 }

--- a/nautobot/docs/release-notes/version-1.0.md
+++ b/nautobot/docs/release-notes/version-1.0.md
@@ -188,6 +188,7 @@ The "Related Devices" table has been removed from the detailed Device view.
 - [#417](https://github.com/nautobot/nautobot/pull/417) - Fixed incorrect link to Docker docs from installation docs
 - [#428](https://github.com/nautobot/nautobot/issues/428) - Fixed GraphQL error when handling ASNs greater than 2147483647
 - [#430](https://github.com/nautobot/nautobot/pull/430) - Fixed missing `ContentType` foreign keys in GraphQL
+- [#461](https://github.com/nautobot/nautobot/issues/461) - Fixed NAUTOBOT_DB_TIMEOUT read as string in default config
 
 ### Removed
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #461
<!--
    Please include a summary of the proposed changes below.
-->

Type casting the NAUTOBOT_DB_TIMEOUT environment variable to int.