### PR TITLE
Avoid FieldError when JobResult links to a model with no 'name' field

### DIFF
--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -1,3 +1,5 @@
+import inspect
+
 import django_tables2 as tables
 
 from django.conf import settings
@@ -15,7 +17,7 @@ from nautobot.utilities.tables import (
     ContentTypesColumn,
     ToggleColumn,
 )
-from .jobs import get_job_classpaths
+from .jobs import get_job_classpaths, Job
 from .models import (
     ConfigContext,
     CustomLink,
@@ -207,23 +209,14 @@ class GitRepositoryBulkTable(BaseTable):
 
 
 def job_creator_link(value, record):
-    if record.obj_type == ContentType.objects.get(app_label="extras", model="job"):
-        # JobResult associated with a Job by classpath?
-        if record.name in get_job_classpaths():
-            return reverse("extras:job", kwargs={"class_path": record.name})
-    else:
-        # JobResult associated with a model such as GitRepository by name?
-        model_class = record.obj_type.model_class()
-        if hasattr(model_class, "name"):
-            try:
-                return model_class.objects.get(name=record.name).get_absolute_url()
-            except model_class.DoesNotExist:
-                pass
-        # JobResult associated with a model instance by job_id?
-        try:
-            return model_class.objects.get(id=record.job_id).get_absolute_url()
-        except model_class.DoesNotExist:
-            pass
+    """
+    Get a link to the related object, if any, associated with the given JobResult record.
+    """
+    related_object = record.related_object
+    if inspect.isclass(related_object) and issubclass(related_object, Job):
+        return reverse("extras:job", kwargs={"class_path": related_object.class_path})
+    elif related_object:
+        return related_object.get_absolute_url()
     return None
 
 
@@ -231,6 +224,7 @@ class JobResultTable(BaseTable):
     pk = ToggleColumn()
     obj_type = tables.Column(verbose_name="Object Type", accessor="obj_type.name")
     name = tables.Column(linkify=job_creator_link)
+    job_id = tables.Column(linkify=job_creator_link, verbose_name="Job ID")
     created = tables.DateTimeColumn(linkify=True, format=settings.SHORT_DATETIME_FORMAT)
     status = tables.TemplateColumn(
         template_code="{% include 'extras/inc/job_label.html' with result=record %}",
@@ -254,6 +248,7 @@ class JobResultTable(BaseTable):
             "created",
             "obj_type",
             "name",
+            "job_id",
             "duration",
             "completed",
             "user",

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -208,12 +208,20 @@ class GitRepositoryBulkTable(BaseTable):
 
 def job_creator_link(value, record):
     if record.obj_type == ContentType.objects.get(app_label="extras", model="job"):
+        # JobResult associated with a Job by classpath?
         if record.name in get_job_classpaths():
             return reverse("extras:job", kwargs={"class_path": record.name})
     else:
+        # JobResult associated with a model such as GitRepository by name?
         model_class = record.obj_type.model_class()
+        if hasattr(model_class, "name"):
+            try:
+                return model_class.objects.get(name=record.name).get_absolute_url()
+            except model_class.DoesNotExist:
+                pass
+        # JobResult associated with a model instance by job_id?
         try:
-            return model_class.objects.get(name=record.name).get_absolute_url()
+            return model_class.objects.get(id=record.job_id).get_absolute_url()
         except model_class.DoesNotExist:
             pass
     return None

--- a/nautobot/extras/templates/extras/jobresult.html
+++ b/nautobot/extras/templates/extras/jobresult.html
@@ -14,10 +14,12 @@
         <div class="col-md-12">
             <ol class="breadcrumb">
                 <li><a href="{% url 'extras:jobresult_list' %}">Job Results</a></li>
-                {% if associated_record %}
+                {% if associated_record and associated_record.name %}
                     <li><a href="{% url 'extras:jobresult_list' %}?name={{ associated_record.name|urlencode }}">
                         {{ associated_record.name }}
                     </a></li>
+                {% elif associated_record %}
+                    <li>{{ associated_record }}</li>
                 {% elif job %}
                     <li><a href="{% url 'extras:jobresult_list' %}?name={{ job.class_path|urlencode }}">
                         {{ job.class_path }}

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -1,7 +1,9 @@
 import os
 import tempfile
+import uuid
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError
 from django.db.utils import IntegrityError
@@ -16,7 +18,9 @@ from nautobot.dcim.models import (
     Site,
     Region,
 )
-from nautobot.extras.models import ConfigContext, GitRepository, Status, Tag
+from nautobot.extras.jobs import get_job, Job
+from nautobot.extras.models import ConfigContext, GitRepository, JobResult, Status, Tag
+from nautobot.ipam.models import IPAddress
 from nautobot.tenancy.models import Tenant, TenantGroup
 from nautobot.utilities.choices import ColorChoices
 from nautobot.virtualization.models import (
@@ -279,6 +283,67 @@ class GitRepositoryTest(TransactionTestCase):
                 new_path = self.repo.filesystem_path
                 self.assertIn(self.repo.slug, new_path)
                 self.assertTrue(os.path.isdir(new_path))
+
+
+class JobResultTest(TestCase):
+    """
+    Tests for the `JobResult` model class.
+    """
+
+    def test_related_object(self):
+        """Test that the `related_object` property is computed properly."""
+        # Case 1: Job, identified by class_path.
+        with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+            job_class = get_job("local/test_pass/TestPass")
+            job_result = JobResult(
+                name=job_class.class_path,
+                obj_type=ContentType.objects.get(app_label="extras", model="job"),
+                job_id=uuid.uuid4(),
+            )
+
+            # Can't just do self.assertEqual(job_result.related_object, job_class) here for some reason
+            self.assertEqual(type(job_result.related_object), type)
+            self.assertTrue(issubclass(job_result.related_object, Job))
+            self.assertEqual(job_result.related_object.class_path, "local/test_pass/TestPass")
+
+            job_result.name = "local/no_such_job/NoSuchJob"
+            self.assertIsNone(job_result.related_object)
+
+            job_result.name = "not-a-class-path"
+            self.assertIsNone(job_result.related_object)
+
+        # Case 2: GitRepository, identified by name.
+        repo = GitRepository(
+            name="Test Git Repository",
+            slug="test-git-repo",
+            remote_url="http://localhost/git.git",
+            username="oauth2",
+        )
+        repo.save(trigger_resync=False)
+
+        job_result = JobResult(
+            name=repo.name,
+            obj_type=ContentType.objects.get_for_model(repo),
+            job_id=uuid.uuid4(),
+        )
+
+        self.assertEqual(job_result.related_object, repo)
+
+        job_result.name = "No such GitRepository"
+        self.assertIsNone(job_result.related_object)
+
+        # Case 3: Related object with no name, identified by PK/ID
+        ip_address = IPAddress.objects.create(address="1.1.1.1/32")
+        job_result = JobResult(
+            name="irrelevant",
+            obj_type=ContentType.objects.get_for_model(ip_address),
+            job_id=ip_address.pk,
+        )
+
+        self.assertEqual(job_result.related_object, ip_address)
+
+        job_result.job_id = uuid.uuid4()
+        self.assertIsNone(job_result.related_object)
 
 
 class StatusTest(TestCase):

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1,3 +1,5 @@
+import inspect
+
 from django import template
 from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
@@ -35,7 +37,7 @@ from .models import (
     TaggedItem,
     Webhook,
 )
-from .jobs import get_job, get_jobs, run_job
+from .jobs import get_job, get_jobs, run_job, Job
 from .datasources import (
     get_datasource_contents,
     enqueue_pull_git_repository_and_refresh_data,
@@ -643,25 +645,11 @@ class JobResultView(ContentTypePermissionRequiredMixin, View):
 
         associated_record = None
         job = None
-        job_content_type = ContentType.objects.get(app_label="extras", model="job")
-        if job_result.obj_type == job_content_type:
-            # JobResult associated with a Job by classpath?
-            job_class = get_job(job_result.name)
-            if job_class is not None:
-                job = job_class()
-        else:
-            # JobResult associated with a model such as GitRepository by name?
-            model_class = job_result.obj_type.model_class()
-            if hasattr(model_class, "name"):
-                try:
-                    associated_record = model_class.objects.get(name=job_result.name)
-                except model_class.DoesNotExist:
-                    pass
-            # JobResult associated with a model instance by job_id?
-            try:
-                associated_record = model_class.objects.get(id=job_result.job_id)
-            except model_class.DoesNotExist:
-                pass
+        related_object = job_result.related_object
+        if inspect.isclass(related_object) and issubclass(related_object, Job):
+            job = related_object()
+        elif related_object:
+            associated_record = related_object
 
         return render(
             request,

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -645,13 +645,21 @@ class JobResultView(ContentTypePermissionRequiredMixin, View):
         job = None
         job_content_type = ContentType.objects.get(app_label="extras", model="job")
         if job_result.obj_type == job_content_type:
+            # JobResult associated with a Job by classpath?
             job_class = get_job(job_result.name)
             if job_class is not None:
                 job = job_class()
         else:
+            # JobResult associated with a model such as GitRepository by name?
             model_class = job_result.obj_type.model_class()
+            if hasattr(model_class, "name"):
+                try:
+                    associated_record = model_class.objects.get(name=job_result.name)
+                except model_class.DoesNotExist:
+                    pass
+            # JobResult associated with a model instance by job_id?
             try:
-                associated_record = model_class.objects.get(name=job_result.name)
+                associated_record = model_class.objects.get(id=job_result.job_id)
             except model_class.DoesNotExist:
                 pass
 


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #482 
<!--
    Please include a summary of the proposed changes below.
-->

In the JobResult table view and detail view, don't try to look up the related record by `name` if the selected model doesn't have a `name` field (#482).

Additionally, as a fallback option, try to look up a related record by the JobResult's `job_id` field (essentially allowing us to use `obj_type` and `job_id` in concert as an ersatz GenericForeignKey, albeit one with `unique=True` since `job_id` must be unique). 