### PR TITLE
Add examples directory to /source for Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,6 +54,7 @@ RUN /root/.poetry/bin/poetry config virtualenvs.create false && \
 
 # Keep the project source code from NAUTOBOT_ROOT
 COPY pyproject.toml poetry.lock /source/
+COPY examples /source/examples
 WORKDIR /source
 
 # -------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #486 
<!--
    Please include a summary of the proposed changes below.
-->

Since, after #474, `examples/dummy_plugin` is a listed development dependency in `pyproject.toml`, we need to copy it into the Docker build image at the same time as we copy `pyproject.toml` and `poetry.lock`.