### PR TITLE
Fix migrations in MySQL by hard-coding `VarbinaryIPField` to `varbinary(16)`

### DIFF
--- a/nautobot/ipam/fields.py
+++ b/nautobot/ipam/fields.py
@@ -24,8 +24,7 @@ class VarbinaryIPField(models.BinaryField):
             return "bytea"
 
         # Or 'varbinary' for everyone else.
-        max_length = DictWrapper(self.__dict__, connection.ops.quote_name, "qn_")
-        return "varbinary(%(max_length)s)" % max_length
+        return "varbinary(16)"
 
     def value_to_string(self, obj):
         """IPField is serialized as str(IPAddress())"""


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #488 
<!--
    Please include a summary of the proposed changes below.
-->

- There is no use-case for having a variable `max_length` value on this field, so this just explicitly returns `varbinary(16)` for non-PostgreSQL databases.