### PR TITLE
Correctly handle 'broadcast' for point-to-point network prefixes (/31, /127)

### DIFF
--- a/nautobot/ipam/migrations/0004_fixup_p2p_broadcast.py
+++ b/nautobot/ipam/migrations/0004_fixup_p2p_broadcast.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+import netaddr
+
+
+def fixup_p2p_broadcast(apps, schema_editor):
+    """Correct the "broadcast" field for /31 and /127, as per https://github.com/nautobot/nautobot/pull/509."""
+    Aggregate = apps.get_model("ipam", "Aggregate")
+    Prefix = apps.get_model("ipam", "Prefix")
+    IPAddress = apps.get_model("ipam", "IPAddress")
+
+    # If the above models were our actual fully-implemented IPAM model classes, we could simply
+    # call model.prefix = model.prefix to force recalculation of the broadcast address,
+    # but the models we have access to here do not have any custom methods available.
+    # So we have to fixup the broadcast addresses ourselves.
+
+    for prefixlen in (31, 127):
+        for aggregate in Aggregate.objects.filter(prefix_length=prefixlen):
+            network = netaddr.IPNetwork(f"{aggregate.network}/{aggregate.prefix_length}")
+            # Last address in the network is our "broadcast" address.
+            aggregate.broadcast = network[-1]
+            aggregate.save()
+
+        for prefix in Prefix.objects.filter(prefix_length=prefixlen):
+            network = netaddr.IPNetwork(f"{prefix.network}/{prefix.prefix_length}")
+            # Last address in the network is our "broadcast" address.
+            prefix.broadcast = network[-1]
+            prefix.save()
+
+        for ipaddress in IPAddress.objects.filter(prefix_length=prefixlen):
+            network = netaddr.IPNetwork(f"{ipaddress.host}/{ipaddress.prefix_length}")
+            # Last address in the network is our "broadcast" address.
+            ipaddress.broadcast = network[-1]
+            ipaddress.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ipam", "0003_remove_max_length"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=fixup_p2p_broadcast,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -198,6 +198,18 @@ class TestPrefix(TestCase):
         # VRF container is limited to its own VRF
         self.assertSetEqual(child_ip_pks, {ips[1].pk})
 
+        # Make sure /31 is handled correctly
+        parent_prefix_31 = Prefix.objects.create(
+            prefix=netaddr.IPNetwork("10.0.4.0/31"), status=Prefix.STATUS_CONTAINER
+        )
+        ips_31 = (
+            IPAddress.objects.create(address=netaddr.IPNetwork("10.0.4.0/31"), vrf=None),
+            IPAddress.objects.create(address=netaddr.IPNetwork("10.0.4.1/31"), vrf=None),
+        )
+
+        child_ip_pks = {p.pk for p in parent_prefix_31.get_child_ips()}
+        self.assertSetEqual(child_ip_pks, {ips_31[0].pk, ips_31[1].pk})
+
     def test_get_available_prefixes(self):
 
         prefixes = Prefix.objects.bulk_create(

--- a/nautobot/ipam/tests/test_querysets.py
+++ b/nautobot/ipam/tests/test_querysets.py
@@ -95,6 +95,7 @@ class IPAddressQuerySet(TestCase):
     def test_net_host_contained(self):
         self.assertEqual(self.queryset.net_host_contained(netaddr.IPNetwork("10.0.0.0/24")).count(), 5)
         self.assertEqual(self.queryset.net_host_contained(netaddr.IPNetwork("10.0.0.0/30")).count(), 4)
+        self.assertEqual(self.queryset.net_host_contained(netaddr.IPNetwork("10.0.0.0/31")).count(), 2)
         self.assertEqual(self.queryset.net_host_contained(netaddr.IPNetwork("10.0.10.0/24")).count(), 0)
 
     def test_net_in(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #476 
<!--
    Please include a summary of the proposed changes below.
-->

`netaddr` correctly reports no `broadcast` address for /31 (IPv4) or /127 (IPv6) networks. However, our own usage of the "broadcast" field is not for packet forwarding, but for filtering and containment queries, where we really mean "last IP address in this network". Because of this mismatch, for /31 and /127 networks we were incorrectly using the "network" address in place of the nonexistent "broadcast" address when we should be using the last IP in the network instead. This caused various incorrect net/host "contains" checks when dealing with /31 or /127 addresses, including #476.

This fix simply changes things so that we use the "last available IP" when dealing with subnets that do not have a true broadcast address.

![image](https://user-images.githubusercontent.com/5603551/120046198-aca46800-bfdf-11eb-9fbc-78cf8b3ffb4d.png)
