### PR TITLE
200 read only jobs

### DIFF
--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -93,7 +93,7 @@ A list of strings (field names) representing the order your form fields should a
 
 #### `read_only`
 
-A boolean that designates whether the job is able to make changes to data in the database. The value defaults to `False` but when set to `True`, any data modifications executed from the job's code will be automatically aborted at the end of the job. The job input form is also modified to remove the `commit` checkbox as it is irrelevant for read-only jobs. When a job is marked as read only, log messages that are normally automatically emitted about the DB transaction state are not included because no changes to data are allowed. Note that user input may still be optionally collected with read-only jobs via job variables, as described bellow.
+A boolean that designates whether the job is able to make changes to data in the database. The value defaults to `False` but when set to `True`, any data modifications executed from the job's code will be automatically aborted at the end of the job. The job input form is also modified to remove the `commit` checkbox as it is irrelevant for read-only jobs. When a job is marked as read only, log messages that are normally automatically emitted about the DB transaction state are not included because no changes to data are allowed. Note that user input may still be optionally collected with read-only jobs via job variables, as described below.
 
 ### Variables
 

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -12,7 +12,7 @@ Jobs are a way for users to execute custom logic on demand from within the Nauto
 ...and so on. Jobs are Python code and exist outside of the official Nautobot code base, so they can be updated and changed without interfering with the core Nautobot installation. And because they're completely customizable, there's practically no limit to what a job can accomplish.
 
 !!! note
-    Jobs unify and supersede the functionality previously provided in NetBox by "custom scripts" and "reports". Jobs are backwards-compatible for now with the `Script` and `Report` class APIs, but you are urged to move to the new `Job` class API described below.
+    Jobs unify and supersede the functionality previously provided in NetBox by "custom scripts" and "reports". Jobs are backwards-compatible for now with the `Script` and `Report` class APIs, but you are urged to move to the new `Job` class API described below. Jobs may be optionally marked as [read-only](./#read_only) which equates to the `Report` functionally, but in all cases, user input is supported via [job variables](./#variables).
 
 ## Writing Jobs
 
@@ -90,6 +90,10 @@ class MyJob(Job):
 #### `field_order`
 
 A list of strings (field names) representing the order your form fields should appear. If not defined, fields will appear in order of their definition in the code.
+
+#### `read_only`
+
+A boolean that designates whether the job is able to make changes to data in the database. The value defaults to `False` but when set to `True`, any data modifications executed from the job's code will be automatically aborted at the end of the job. The job input form is also modified to remove the `commit` checkbox as it is irrelevant for read-only jobs. When a job is marked as read only, log messages that are normally automatically emitted about the DB transaction state are not included because no changes to data are allowed. Note that user input may still be optionally collected with read-only jobs via job variables, as described bellow.
 
 ### Variables
 

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -93,7 +93,7 @@ A list of strings (field names) representing the order your form fields should a
 
 #### `read_only`
 
-A boolean that designates whether the job is able to make changes to data in the database. The value defaults to `False` but when set to `True`, any data modifications executed from the job's code will be automatically aborted at the end of the job. The job input form is also modified to remove the `commit` checkbox as it is irrelevant for read-only jobs. When a job is marked as read only, log messages that are normally automatically emitted about the DB transaction state are not included because no changes to data are allowed. Note that user input may still be optionally collected with read-only jobs via job variables, as described below.
+A boolean that designates whether the job is able to make changes to data in the database. The value defaults to `False` but when set to `True`, any data modifications executed from the job's code will be automatically aborted at the end of the job. The job input form is also modified to remove the `commit` checkbox as it is irrelevant for read-only jobs. When a job is marked as read-only, log messages that are normally automatically emitted about the DB transaction state are not included because no changes to data are allowed. Note that user input may still be optionally collected with read-only jobs via job variables, as described below.
 
 ### Variables
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -81,6 +81,7 @@ class BaseJob:
         - description (str)
         - commit_default (bool)
         - field_order (list)
+        - read_only (bool)
         """
 
         pass
@@ -175,6 +176,10 @@ class BaseJob:
     def description(cls):
         return getattr(cls.Meta, "description", "")
 
+    @classproperty
+    def read_only(cls):
+        return getattr(cls.Meta, "read_only", False)
+
     @classmethod
     def _get_vars(cls):
         vars = OrderedDict()
@@ -263,8 +268,13 @@ class BaseJob:
 
         form = FormClass(data, files, initial=initial)
 
-        # Set initial "commit" checkbox state based on the Meta parameter
-        form.fields["_commit"].initial = getattr(self.Meta, "commit_default", True)
+        if self.read_only:
+            # Hide the commit field for read only jobs
+            form.fields["_commit"].widget = forms.HiddenInput()
+            form.fields["_commit"].initial = False
+        else:
+            # Set initial "commit" checkbox state based on the Meta parameter
+            form.fields["_commit"].initial = getattr(self.Meta, "commit_default", True)
 
         field_order = getattr(self.Meta, "field_order", None)
 
@@ -801,6 +811,10 @@ def run_job(data, request, job_result, commit=True, *args, **kwargs):
     job = job_class()
     job.job_result = job_result
 
+    if job.read_only:
+        # Force commit to false for read only jobs.
+        commit = False
+
     # TODO: validate that all args required by this job are set in the data or else log helpful errors?
 
     job.logger.info(f"Running job (commit={commit})")
@@ -823,6 +837,9 @@ def run_job(data, request, job_result, commit=True, *args, **kwargs):
 
         We capture this within a subfunction to allow for conditionally wrapping it with the change_logging
         context manager (which is only relevant if commit == True).
+
+        If the job is marked as read_only == True, then commit is forced to False and no log messages will be
+        emitted related to reverting database changes.
         """
         job.results["output"] = ""
         try:
@@ -851,12 +868,14 @@ def run_job(data, request, job_result, commit=True, *args, **kwargs):
                     raise AbortTransaction()
 
         except AbortTransaction:
-            job.log_info(message="Database changes have been reverted automatically.")
+            if not job.read_only:
+                job.log_info(message="Database changes have been reverted automatically.")
 
         except Exception as exc:
             stacktrace = traceback.format_exc()
             job.log_failure(message=f"An exception occurred: `{type(exc).__name__}: {exc}`\n```\n{stacktrace}\n```")
-            job.log_info(message="Database changes have been reverted due to error.")
+            if not job.read_only:
+                job.log_info(message="Database changes have been reverted due to error.")
             job_result.set_status(JobResultStatusChoices.STATUS_ERRORED)
 
         finally:

--- a/nautobot/extras/templates/extras/job.html
+++ b/nautobot/extras/templates/extras/job.html
@@ -17,6 +17,9 @@
         </div>
     </div>
     <h1>{{ job }}</h1>
+    {% if job.read_only %}
+        <label class="label label-default">Read-only</label>
+    {% endif %}
     <p>{{ job.description }}</p>
     <ul class="nav nav-tabs" role="tablist">
         <li role="presentation" class="active">

--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -34,6 +34,9 @@
                                        id="{{ job.class_path }}">
                                         <strong>{{ job }}</strong>
                                     </a>
+                                    {% if job.read_only %}
+                                        <label class="label label-default">Read-only</label>
+                                    {% endif %}
                                 </td>
                                 <td>{{ job.description | placeholder }}</td>
                                 <td class="text-right text-nowrap">

--- a/nautobot/extras/tests/dummy_jobs/test_read_only_fail.py
+++ b/nautobot/extras/tests/dummy_jobs/test_read_only_fail.py
@@ -1,0 +1,23 @@
+from nautobot.dcim.models import Site
+from nautobot.extras.jobs import Job
+
+
+class TestReadOnlyFail(Job):
+    """
+    Read only Job with fail result.
+    """
+
+    description = "Validate job import"
+
+    class Meta:
+        read_only = True
+
+    def run(self, data, commit):
+        """
+        Job function.
+        """
+
+        site = Site.objects.create(name="Site", slug="site")
+
+        self.log_success(obj=site)
+        raise Exception("Test failure")

--- a/nautobot/extras/tests/dummy_jobs/test_read_only_no_commit_field.py
+++ b/nautobot/extras/tests/dummy_jobs/test_read_only_no_commit_field.py
@@ -1,0 +1,10 @@
+from nautobot.extras.jobs import Job, StringVar
+
+
+class TestReadOnlyNoCommitField(Job):
+    """My job demo."""
+
+    var = StringVar(description="Hello")
+
+    class Meta:
+        read_only = True

--- a/nautobot/extras/tests/dummy_jobs/test_read_only_pass.py
+++ b/nautobot/extras/tests/dummy_jobs/test_read_only_pass.py
@@ -1,0 +1,22 @@
+from nautobot.dcim.models import Site
+from nautobot.extras.jobs import Job
+
+
+class TestReadOnlyPass(Job):
+    """
+    Ready only Job with pass result.
+    """
+
+    description = "Validate job import"
+
+    class Meta:
+        read_only = True
+
+    def run(self, data, commit):
+        """
+        Job function.
+        """
+
+        site = Site.objects.create(name="Site", slug="site")
+
+        self.log_success(obj=site)

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -154,7 +154,7 @@ class JobTest(TestCase):
                 job_result.data["run"]["log"][-1][-1], "Database changes have been reverted due to error."
             )
 
-    def test_field_order(self):
+    def test_read_only_no_commit_field(self):
         """
         Job read only test commit field is not shown.
         """

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -4,6 +4,7 @@ import uuid
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 
+from nautobot.dcim.models import Site
 from nautobot.extras.choices import JobResultStatusChoices
 from nautobot.extras.jobs import get_job, run_job
 from nautobot.extras.models import JobResult
@@ -105,4 +106,69 @@ class JobTest(TestCase):
 <tr><th><label for="id__commit">Commit changes:</label></th><td>
 <input checked id="id__commit" name="_commit" placeholder="Commit changes" type="checkbox">
 <br><span class="helptext">Commit changes to the database (uncheck for a dry-run)</span></td></tr>""",
+            )
+
+    def test_ready_only_job_pass(self):
+        """
+        Job read only test with pass result.
+        """
+        with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+
+            module = "test_read_only_pass"
+            name = "TestReadOnlyPass"
+            job_class = get_job(f"local/{module}/{name}")
+            job_content_type = ContentType.objects.get(app_label="extras", model="job")
+
+            job_result = JobResult.objects.create(
+                name=job_class.class_path,
+                obj_type=job_content_type,
+                user=None,
+                job_id=uuid.uuid4(),
+            )
+
+            run_job(data={}, request=None, commit=False, job_result=job_result)
+            self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
+            self.assertEqual(Site.objects.count(), 0)  # Ensure DB transaction was aborted
+
+    def test_read_only_job_fail(self):
+        """
+        Job read only test with fail result.
+        """
+        with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+
+            module = "test_read_only_fail"
+            name = "TestReadOnlyFail"
+            job_class = get_job(f"local/{module}/{name}")
+            job_content_type = ContentType.objects.get(app_label="extras", model="job")
+            job_result = JobResult.objects.create(
+                name=job_class.class_path,
+                obj_type=job_content_type,
+                user=None,
+                job_id=uuid.uuid4(),
+            )
+            run_job(data={}, request=None, commit=False, job_result=job_result)
+            self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_ERRORED)
+            self.assertEqual(Site.objects.count(), 0)  # Ensure DB transaction was aborted
+            # Also ensure the standard log message about aborting the transaction is *not* present
+            self.assertNotEqual(
+                job_result.data["run"]["log"][-1][-1], "Database changes have been reverted due to error."
+            )
+
+    def test_field_order(self):
+        """
+        Job read only test commit field is not shown.
+        """
+        with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+
+            module = "test_read_only_no_commit_field"
+            name = "TestReadOnlyNoCommitField"
+            job_class = get_job(f"local/{module}/{name}")
+
+            form = job_class().as_form()
+
+            self.assertHTMLEqual(
+                form.as_table(),
+                """<tr><th><label for="id_var">Var:</label></th><td>
+<input class="form-control form-control" id="id_var" name="var" placeholder="None" required type="text">
+<br><span class="helptext">Hello</span><input id="id__commit" name="_commit" type="hidden" value="False"></td></tr>""",
             )

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -518,6 +518,7 @@ class JobView(ContentTypePermissionRequiredMixin, View):
         return "extras.view_job"
 
     def get(self, request, class_path):
+        print("hello")
         job_class = get_job(class_path)
         if job_class is None:
             raise Http404

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -518,7 +518,6 @@ class JobView(ContentTypePermissionRequiredMixin, View):
         return "extras.view_job"
 
     def get(self, request, class_path):
-        print("hello")
         job_class = get_job(class_path)
         if job_class is None:
             raise Http404


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #200 

This PR implements a new `read_only` Meta attribute to the `BaseJob` class which forces `commit=False` during execution, and augments the UX to hide the commit field and clarify read-only jobs.

![Screen Shot 2021-05-30 at 2 13 10 AM](https://user-images.githubusercontent.com/1297132/120094200-fdee4d80-c0ec-11eb-8601-7a77afc5e276.png)
![Screen Shot 2021-05-30 at 2 13 00 AM](https://user-images.githubusercontent.com/1297132/120094204-021a6b00-c0ed-11eb-93e4-d38fdbc3ac84.png)

