### PR TITLE
Initial integration test suite with Selenium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ services:
   - redis
 addons:
   postgresql: "9.6"
-  hosts:
-    - host.docker.internal
 language: python
 env:
-  - INVOKE_NAUTOBOT_LOCAL=True NAUTOBOT_SELENIUM_URL=http://localhost:4444/wd/hub NAUTOBOT_SELENIUM_HOST=host.docker.internal
+  global:
+    - INVOKE_NAUTOBOT_LOCAL=True
+    - NAUTOBOT_SELENIUM_URL=http://localhost:4444/wd/hub
+    - NAUTOBOT_SELENIUM_HOST=$(hostname -f)
 jobs:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ services:
   - redis
 addons:
   postgresql: "9.6"
+  hosts:
+    - host.docker.internal
 language: python
 env:
   - INVOKE_NAUTOBOT_LOCAL=True NAUTOBOT_SELENIUM_URL=http://localhost:4444/wd/hub NAUTOBOT_SELENIUM_HOST=host.docker.internal

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ install:
   - poetry config installer.parallel false
   - poetry install
 before_script:
-  - psql --version
-  - psql -U postgres -c 'SELECT version();'
   - psql -U postgres -c 'create database nautobot;'
+  - pip install docker-compose
 script:
   - poetry run ./scripts/cibuild.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
   postgresql: "9.6"
 language: python
 env:
-  - INVOKE_NAUTOBOT_LOCAL=True
+  - INVOKE_NAUTOBOT_LOCAL=True NAUTOBOT_SELENIUM_URL=http://localhost:4444/wd/hub NAUTOBOT_SELENIUM_HOST=host.docker.internal
 jobs:
   fast_finish: true
   include:

--- a/development/dev.env
+++ b/development/dev.env
@@ -23,6 +23,6 @@ POSTGRES_USER=nautobot
 # Needed for Redis should match the values for Nautobot above
 REDIS_PASSWORD=decinablesprewad
 
-# Needed for Selenium integration tets
+# Needed for Selenium integration tests
 NAUTOBOT_SELENIUM_URL=http://selenium:4444/wd/hub  # WebDriver (Selenium client)
 NAUTOBOT_SELENIUM_HOST=nautobot  # LiveServer (Nautobot server)

--- a/development/dev.env
+++ b/development/dev.env
@@ -22,3 +22,8 @@ POSTGRES_USER=nautobot
 
 # Needed for Redis should match the values for Nautobot above
 REDIS_PASSWORD=decinablesprewad
+
+# Needed for Selenium integration tets
+NAUTOBOT_SELENIUM_URL=http://selenium:4444/wd/hub  # WebDriver (Selenium client)
+NAUTOBOT_SELENIUM_HOST=nautobot  # LiveServer (Nautobot server)
+NAUTOBOT_INTEGRATION_TEST=True  # Temporarily hard-coded to prove it works.

--- a/development/dev.env
+++ b/development/dev.env
@@ -26,4 +26,3 @@ REDIS_PASSWORD=decinablesprewad
 # Needed for Selenium integration tets
 NAUTOBOT_SELENIUM_URL=http://selenium:4444/wd/hub  # WebDriver (Selenium client)
 NAUTOBOT_SELENIUM_HOST=nautobot  # LiveServer (Nautobot server)
-NAUTOBOT_INTEGRATION_TEST=True  # Temporarily hard-coded to prove it works.

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     depends_on:
       - postgres
       - redis
+      - selenium
     env_file:
       - dev.env
     tty: true
@@ -43,7 +44,6 @@ services:
     image: selenium/standalone-firefox:latest
     ports: 
         - "4444:4444"
-    # privileged: true
     shm_size: 2g
 volumes:
   pgdata_nautobot:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -39,5 +39,11 @@ services:
       - redis-server --appendonly yes --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
     env_file:
       - dev.env
+  selenium:
+    image: selenium/standalone-firefox:latest
+    ports: 
+        - "4444:4444"
+    # privileged: true
+    shm_size: 2g
 volumes:
   pgdata_nautobot:

--- a/nautobot/core/fixtures/user-data.json
+++ b/nautobot/core/fixtures/user-data.json
@@ -1,0 +1,21 @@
+[
+{
+    "model": "users.user",
+    "pk": "90798182-9d19-479a-899f-a415fc2c62fd",
+    "fields": {
+        "password": "pbkdf2_sha256$216000$TtNpNWboQq6C$6vh6qqRXUGSuLZlwvvGRbz35BS6avrdEFudnjJv2HXY=",
+        "last_login": null,
+        "is_superuser": true,
+        "username": "bob",
+        "first_name": "",
+        "last_name": "",
+        "email": "bob@localhost",
+        "is_staff": true,
+        "is_active": true,
+        "date_joined": "2021-05-25T23:49:55.008Z",
+        "config_data": {},
+        "groups": [],
+        "user_permissions": []
+    }
+}
+]

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -120,6 +120,9 @@ SOCIAL_AUTH_POSTGRES_JSONFIELD = False
 STORAGE_BACKEND = None
 STORAGE_CONFIG = {}
 
+# Test runner that is aware of our use of "integration" tags and only runs
+# integration tests if explicitly passed in with `nautobot-server test --tag integration`.
+TEST_RUNNER = "nautobot.core.tests.runner.NautobotTestRunner"
 
 #
 # Django cryptography

--- a/nautobot/core/tests/integration/test_home.py
+++ b/nautobot/core/tests/integration/test_home.py
@@ -1,0 +1,70 @@
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+# from selenium.webdriver.firefox.webdriver import WebDriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium import webdriver
+
+
+class MySeleniumTests(StaticLiveServerTestCase):
+    fixtures = ['user-data.json']
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # cls.selenium = WebDriver()
+
+        # Firefox driver
+        firefox_options = webdriver.FirefoxOptions()
+        firefox_options.headless = True
+
+        # Chrome driver
+        chrome_options = webdriver.ChromeOptions()
+        chrome_options.add_argument("--headless")
+        chrome_options.add_argument('--disable-gpu')
+        # options.add_argument('--window-size=1280x1696')
+        chrome_options.add_argument('--no-sandbox')
+        chrome_options.add_argument('--hide-scrollbars')
+        chrome_options.add_argument('--ignore-certificate-errors')
+        # options.disablegpu = True        
+
+        chrome_options.add_argument("start-maximized")
+        chrome_options.add_argument("disable-infobars")
+        chrome_options.add_argument("--disable-extensions")
+
+        # Experimental options
+        '''
+        options.add_experimental_option(
+            'prefs',
+            {
+                "download.default_directory": self._download_path,
+                "download.prompt_for_download": False,
+                "download.directory_upgrade": True,
+                "plugins.always_open_pdf_externally": True
+            },
+        )
+        '''
+
+        # options.set_capability("browserVersion", "67")
+        # options.set_capability("platformName", "Windows XP")
+
+        cls.selenium = webdriver.Remote(
+            # command_executor="http://localhost:4444/wd/hub",
+            command_executor="http://potato.local:4444/wd/hub",
+            # options=chrome_options,
+            # desired_capabilities=DesiredCapabilities.CHROME
+            options=firefox_options,
+            desired_capabilities=DesiredCapabilities.FIREFOX
+        )
+        cls.selenium.implicitly_wait(10)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.selenium.quit()
+        super().tearDownClass()
+
+    def test_login(self):
+        self.selenium.get('%s%s' % (self.live_server_url, '/login/'))
+        username_input = self.selenium.find_element_by_name("username")
+        username_input.send_keys('bob')
+        password_input = self.selenium.find_element_by_name("password")
+        password_input.send_keys('bob')
+        self.selenium.find_element_by_xpath('//input[@value="Log in"]').click()

--- a/nautobot/core/tests/integration/test_home.py
+++ b/nautobot/core/tests/integration/test_home.py
@@ -1,64 +1,17 @@
-import logging
-import os
-from unittest import skipIf
-
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from selenium import webdriver
-from selenium.webdriver.support.wait import WebDriverWait
+from nautobot.utilities.testing.integration import SeleniumTestCase
 
 
-# URL used to connect to the Selenium host
-SELENIUM_URL = os.getenv("NAUTOBOT_SELENIUM_URL", "http://localhost:4444/wd/hub")
-logging.debug("SELENIUM_URL = %s", SELENIUM_URL)
+class HomeTestCase(SeleniumTestCase):
+    """Integration tests against the home page."""
 
-# Hostname used by Selenium client to talk to Nautobot
-SELENIUM_HOST = os.getenv("NAUTOBOT_SELENIUM_HOST", "localhost")
-logging.debug("SELENIUM_HOST = %s", SELENIUM_HOST)
-
-
-@skipIf(
-    "NAUTOBOT_INTEGRATION_TEST" not in os.environ,
-    "NAUTOBOT_INTEGRATION_TEST environment variable not set",
-)
-class MySeleniumTests(StaticLiveServerTestCase):
-    host = SELENIUM_HOST  # Docker: `nautobot`; else `localhost`
     fixtures = ["user-data.json"]  # bob/bob
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        # Firefox driver
-        firefox_options = webdriver.FirefoxOptions()
-        firefox_options.headless = True
-        # firefox_options.add_argument("-headless")
-        # firefox_options.add_argument("--screenshot")
-        # firefox_options.add_argument("--no-sandbox")
-        # firefox_options.add_argument("--disable-dev-shm-usage")
-        firefox_options.add_argument("-disable-gpu")
-
-        # Selenium remote client
-        cls.selenium = webdriver.Remote(
-            command_executor=SELENIUM_URL,
-            options=firefox_options,
-        )
-
-        # Wait for the DOM in case an element is not yet rendered.
-        cls.selenium.implicitly_wait(10)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.selenium.quit()
-        super().tearDownClass()
-
     def test_login(self):
-        self.selenium.get("%s%s" % (self.live_server_url, "/login/"))
-        username_input = self.selenium.find_element_by_name("username")
-        username_input.send_keys("bob")
-        password_input = self.selenium.find_element_by_name("password")
-        password_input.send_keys("bob")
-        self.selenium.find_element_by_xpath('//button[text()="Log In"]').click()
+        """
+        Perform a UI login.
+        """
+
+        self.login("bob", "bob")
 
         # Wait for the page to render and make sure we got a body.
-        WebDriverWait(self.selenium, timeout=2).until(lambda driver: driver.find_element_by_tag_name("body"))
-        # self.selenium.find_element_by_xpath('//div[text()="Logged in as "]').click()
+        self.selenium.wait_for_html("body")

--- a/nautobot/core/tests/runner.py
+++ b/nautobot/core/tests/runner.py
@@ -1,0 +1,32 @@
+from django.test.runner import DiscoverRunner
+
+
+class NautobotTestRunner(DiscoverRunner):
+    """
+    Custom test runner that excludes integration tests by default.
+
+    This test runner is aware of our use of the "integration" tag and only runs integration tests if
+    explicitly passed in with `nautobot-server test --tag integration`.
+
+    By Nautobot convention, integration tests must be tagged with "integration". The base
+    `nautobot.utilities.testing.integration.SeleniumTestCase` has this tag, therefore any test cases
+    inheriting from that class do not need to be explicitly tagged.
+
+    Only integration tests that DO NOT inherit from `SeleniumTestCase` will need to be explicitly tagged.
+    """
+
+    exclude_tags = ["integration"]
+
+    def __init__(self, **kwargs):
+        # Assert "integration" hasn't been provided w/ --tag
+        incoming_tags = kwargs.get("tags") or []
+
+        # Assert "exclude_tags" hasn't been provided w/ --exclude-tag; else default to our own.
+        incoming_exclude_tags = kwargs.get("exclude_tags") or []
+
+        # Only include our excluded tags if "integration" isn't provided w/ --tag
+        if "integration" not in incoming_tags:
+            incoming_exclude_tags.extend(self.exclude_tags)
+            kwargs["exclude_tags"] = incoming_exclude_tags
+
+        super().__init__(**kwargs)

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -612,7 +612,7 @@ Integration tests are run using the `invoke integration-test` command. All integ
 
 | Docker Compose Workflow   | Virtual Environment Workflow                                                             |
 |---------------------------|------------------------------------------------------------------------------------------|
-| `invoke integration-test` | `nautobot-server test --config=nautobot/core/tests/nautobot_config.py --tag integration `|
+| `invoke integration-test` | `nautobot-server test --config=nautobot/core/tests/nautobot_config.py --tag integration` |
 
 !!! info
     The same arguments supported by `invoke unittest` are supported by `invoke integration-test`. The key difference being the dependency upon the Selenium container, and inclusion of the `integration` tag. 

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -523,6 +523,29 @@ Throughout the course of development, it's a good idea to occasionally run Nauto
 
 Unit tests are automated tests written and run to ensure that a section of the Nautobot application (known as the "unit") meets its design and behaves as intended and expected. Most commonly as a developer of or contributor to Nautobot you will be writing unit tests to exercise the code you have written. Unit tests are not meant to test how the application behaves, only the individual blocks of code, therefore use of mock data and phony connections is common in unit test code. As a guiding principle, unit tests should be fast, because they will be executed quite often.
 
+By Nautobot convention, unit tests must be [tagged](https://docs.djangoproject.com/en/stable/topics/testing/tools/#tagging-tests) with `unit`. The base test case class `nautobot.utilities.testing.TestCase` has this tag, therefore any test cases inheriting from that class do not need to be explicitly tagged. All existing view and API test cases in the Nautobot test suite utilities inherit from this class. 
+
+!!! warning
+    New unit tests **must always** inherit from `nautobot.utilities.testing.TestCase`. Do not use `django.test.TestCase`.
+
+Wrong:
+```python
+from django.test import TestCase
+
+
+class MyTestCase(TestCase):
+    ...
+```
+
+Right:
+```python
+from nautobot.utilities.testing import TestCase
+
+
+class MyTestCase(TestCase):
+    ...
+```
+
 Unit tests are run using the `invoke unittest` command (if using the Docker development environment) or the `nautobot-server test` command:
 
 | Docker Compose Workflow | Virtual Environment Workflow                                           |
@@ -539,7 +562,7 @@ In cases where you haven't made any changes to the database (which is most of th
 | `invoke unittest --keepdb` | `nautobot-server test --keepdb --config=nautobot/core/tests/nautobot_config.py` |
 
 !!! note
-	Using the `--keepdb` argument will raise errors if you've modified any model fields since the previous test run.
+    Using the `--keepdb` argument will raise errors if you've modified any model fields since the previous test run.
 
 !!! warning
 	In some cases when tests fail and exit uncleanly it may leave the test database in an inconsistent state. If you encounter errors about missing objects, remove `--keepdb` and run the tests again.
@@ -552,7 +575,7 @@ Integration testing is much more involved, and builds on top of the foundation l
 
 Running integrations tests requires the use of Docker at this time. They can be directly invoked using `nautobot-server test` just as unit tests can, however, a headless Firefox browser provided by Selenium is required. Because Selenium installation and setup is complicated, we have included a configuration for this to work out of the box using Docker. 
 
-The Selenium contianer is running a standalone, headless Firefox "web driver" browser that can be remotely controlled by Nautobot for use in integration testing.
+The Selenium container is running a standalone, headless Firefox "web driver" browser that can be remotely controlled by Nautobot for use in integration testing.
 
 Before running integration tests, the `selenium` container must be running. If you are using the Docker Compose workflow, it is automatically started for you. For the Virtual Environment workflow, you must start it manually.
 
@@ -560,27 +583,49 @@ Before running integration tests, the `selenium` container must be running. If y
 |---------------------------|-----------------------------------|
 | (automatic)               | `invoke start --service selenium` |
 
-Integration tests are run using the `invoke integration-test` command.
-
-| Docker Compose Workflow   | Virtual Environment Workflow                                                                           |
-|---------------------------|--------------------------------------------------------------------------------------------------------|
-| `invoke integration-test` | `nautobot-server test --config=nautobot/core/tests/nautobot_config.py nautobot.core.tests.integration` |
-
-!!! info
-    The same arguments supported by `invoke unittest` are supported by `invoke integration-test`. The key difference being the dependency upon the Selenium container, and a different default test label. Additionally, you may also use `invoke integration-test` in the Virtual Environment workflow given that the container is running, and that the `INVOKE_NAUTOBOT_LOCAL=True` environment variable has been set.
-
-Unlike unit tests, where the tests live adjacent to each inner application within the Nautobot code, integration tests must only ever be defined in `nautobot.core.tests.integration`. The reason for this is that integration tests are designed to test the core application and all of its functionality in one place. Integration tests must never be added anywhere but `nautobot.core.tests.integration`. We never want to risk running the unit tests and integration tests at the same time. The isolation from each other is critical to a clean and managable continuous development cycle.
+By Nautobot convention, integration tests must be [tagged](https://docs.djangoproject.com/en/stable/topics/testing/tools/#tagging-tests) with `integration`. The base test case class `nautobot.utilities.testing.integration.SeleniumTestCase` has this tag, therefore any test cases inheriting from that class do not need to be explicitly tagged. All existing integration test cases in the Nautobot test suite utilities inherit from this class. 
 
 !!! warning
-    Integration tests must never be added anywhere but `nautobot.core.tests.integration`.
+    New integration tests **must always** inherit from `nautobot.utilities.testing.integration.SeleniumTestCase` and added in the `integration` directory in the `tests` directory of an inner Nautobot application. Do not use any other base class for integration tests.
+
+We never want to risk running the unit tests and integration tests at the same time. The isolation from each other is critical to a clean and managable continuous development cycle.
+
+Wrong:
+```python
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+
+
+class MyIntegrationTestCase(StaticLiveServerTestCase):
+    ...
+```
+
+Right:
+```python
+from nautobot.utilities.testing.integration import SeleniumTestCase
+
+
+class MyIntegrationTestCase(SeleniumTestCase):
+    ...
+```
+
+Integration tests are run using the `invoke integration-test` command. All integration tests must inherit from `nautobot.utilities.testing.integration.SeleniumTestCase`, which itself is tagged with `integration`. A custom test runner has been implemented to automatically skip any test case tagged with `integration` by default, so normal unit tests run without any concern. To run the integration tests the `--tag integration` argument must be passed to `nautobot-server test`.
+
+| Docker Compose Workflow   | Virtual Environment Workflow                                                             |
+|---------------------------|------------------------------------------------------------------------------------------|
+| `invoke integration-test` | `nautobot-server test --config=nautobot/core/tests/nautobot_config.py --tag integration `|
+
+!!! info
+    The same arguments supported by `invoke unittest` are supported by `invoke integration-test`. The key difference being the dependency upon the Selenium container, and inclusion of the `integration` tag. 
+
+!!! tip
+    You may also use `invoke integration-test` in the Virtual Environment workflow given that the `selenium` container is running, and that the `INVOKE_NAUTOBOT_LOCAL=True` environment variable has been set.
 
 ##### Customizing Integration Test Executions
 
-The following environment variables can be provided when running tests to customize where Nautobot looks for Selenium, where Selenium looks for Nautobot, and whether to allow the integration tests to run at all.
+The following environment variables can be provided when running tests to customize where Nautobot looks for Selenium and where Selenium looks for Nautobot. If using the default setup documented above, there is no need to customize these.
 
-- `NAUTOBOT_INTEGRATION_TEST` - If set, allows the integration tests to run. (Default: undefined; `invoke integration_test` sets this at runtime)
 - `NAUTOBOT_SELENIUM_URL` - The URL used by the Nautobot test runner to remotely control the headless Selenium Firefox node. You can provide your own, but it must be a [`Remote` WebDriver](https://selenium-python.readthedocs.io/getting-started.html#using-selenium-with-remote-webdriver). (Default: `http://localhost:4444/wd/hub`; for Docker: `http://selenium:4444/wd/hub`)
-- `NAUTOBOT_SELENIUM_HOST` - The hostname used by the Selenium WebDriver to access Nautobot using Firefox. (Default: `localhost`; for Docker: `nautobot`)
+- `NAUTOBOT_SELENIUM_HOST` - The hostname used by the Selenium WebDriver to access Nautobot using Firefox. (Default: `host.docker.internal`; for Docker: `nautobot`)
 
 ### Verifying Code Style
 

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -560,7 +560,7 @@ Before running integration tests, the `selenium` container must be running. If y
 |---------------------------|-----------------------------------|
 | (automatic)               | `invoke start --service selenium` |
 
-Integration tests are run using the `invoke integration_test` command.
+Integration tests are run using the `invoke integration-test` command.
 
 | Docker Compose Workflow   | Virtual Environment Workflow                                                                           |
 |---------------------------|--------------------------------------------------------------------------------------------------------|

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -564,7 +564,7 @@ Integration tests are run using the `invoke integration-test` command.
 
 | Docker Compose Workflow   | Virtual Environment Workflow                                                                           |
 |---------------------------|--------------------------------------------------------------------------------------------------------|
-| `invoke integration_test` | `nautobot-server test --config=nautobot/core/tests/nautobot_config.py nautobot.core.tests.integration` |
+| `invoke integration-test` | `nautobot-server test --config=nautobot/core/tests/nautobot_config.py nautobot.core.tests.integration` |
 
 !!! info
     The same arguments supported by `invoke unittest` are supported by `invoke integration_test`. The key difference being the dependency upon the Selenium container, and a different default test label. Additionally, you may also use `invoke integration-test` in the Virtual Environment workflow given that the container is running, and that the `INVOKE_NAUTOBOT_LOCAL=True` environment variable has been set.

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -548,13 +548,13 @@ In cases where you haven't made any changes to the database (which is most of th
 
 Integration tests are automated tests written and run to ensure that the Nautobot application behaves as expected when being used as it would be in practice. By contrast to unit tests, where individual units of code are being tested, integration tests rely upon the server code actually running, and web UI clients or API clients to make real connections to the service to exercise actual workflows, such as navigating to the login page, filling out the username/passwords fields, and clicking the "Log In" button.
 
-It goes without saying that integration testing is much more involved, and builds on top of the foundation laid by unit testing. As a guiding principle, integration tests should be comprehensive, because they are the last mile to asserting that Nautobot does what it is advertised to do. Without integration testing, we have to do it all manually, and that's no fun for anyone!
+Integration testing is much more involved, and builds on top of the foundation laid by unit testing. As a guiding principle, integration tests should be comprehensive, because they are the last mile to asserting that Nautobot does what it is advertised to do. Without integration testing, we have to do it all manually, and that's no fun for anyone!
 
 Running integrations tests requires the use of Docker at this time. They can be directly invoked using `nautobot-server test` just as unit tests can, however, a headless Firefox browser provided by Selenium is required. Because Selenium installation and setup is complicated, we have included a configuration for this to work out of the box using Docker. 
 
 The Selenium contianer is running a standalone, headless Firefox "web driver" browser that can be remotely controlled by Nautobot for use in integration testing.
 
-Before running integration tests, the `selenium` container must be running. If you are using the Docker Compose workflow, it is automatically started for yo. For the Virtual Environment workflow, you must start it manually.
+Before running integration tests, the `selenium` container must be running. If you are using the Docker Compose workflow, it is automatically started for you. For the Virtual Environment workflow, you must start it manually.
 
 | Docker Compose Workflow   | Virtual Environment Workflow      |
 |---------------------------|-----------------------------------|
@@ -567,7 +567,7 @@ Integration tests are run using the `invoke integration_test` command.
 | `invoke integration_test` | `nautobot-server test --config=nautobot/core/tests/nautobot_config.py nautobot.core.tests.integration` |
 
 !!! info
-    The same arguments supported by `invoke unittest` are supported by `invoke integration_test`. The key difference being the dependency upon the Selenium container, and a different default test label.
+    The same arguments supported by `invoke unittest` are supported by `invoke integration_test`. The key difference being the dependency upon the Selenium container, and a different default test label. Additionally, you may also use `invoke integration-test` in the Virtual Environment workflow given that the container is running, and that the `INVOKE_NAUTOBOT_LOCAL=True` environment variable has been set.
 
 Unlike unit tests, where the tests live adjacent to each inner application within the Nautobot code, integration tests must only ever be defined in `nautobot.core.tests.integration`. The reason for this is that integration tests are designed to test the core application and all of its functionality in one place. Integration tests must never be added anywhere but `nautobot.core.tests.integration`. We never want to risk running the unit tests and integration tests at the same time. The isolation from each other is critical to a clean and managable continuous development cycle.
 

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -567,7 +567,7 @@ Integration tests are run using the `invoke integration-test` command.
 | `invoke integration-test` | `nautobot-server test --config=nautobot/core/tests/nautobot_config.py nautobot.core.tests.integration` |
 
 !!! info
-    The same arguments supported by `invoke unittest` are supported by `invoke integration_test`. The key difference being the dependency upon the Selenium container, and a different default test label. Additionally, you may also use `invoke integration-test` in the Virtual Environment workflow given that the container is running, and that the `INVOKE_NAUTOBOT_LOCAL=True` environment variable has been set.
+    The same arguments supported by `invoke unittest` are supported by `invoke integration-test`. The key difference being the dependency upon the Selenium container, and a different default test label. Additionally, you may also use `invoke integration-test` in the Virtual Environment workflow given that the container is running, and that the `INVOKE_NAUTOBOT_LOCAL=True` environment variable has been set.
 
 Unlike unit tests, where the tests live adjacent to each inner application within the Nautobot code, integration tests must only ever be defined in `nautobot.core.tests.integration`. The reason for this is that integration tests are designed to test the core application and all of its functionality in one place. Integration tests must never be added anywhere but `nautobot.core.tests.integration`. We never want to risk running the unit tests and integration tests at the same time. The isolation from each other is critical to a clean and managable continuous development cycle.
 

--- a/nautobot/utilities/testing/api.py
+++ b/nautobot/utilities/testing/api.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
-from django.test import override_settings
+from django.test import override_settings, tag
 from rest_framework import status
 from rest_framework.test import APIClient, APITransactionTestCase as _APITransactionTestCase
 
@@ -63,6 +63,7 @@ class APITestCase(ModelTestCase):
         return reverse(viewname)
 
 
+@tag("unit")
 class APIViewTestCases:
     class GetObjectViewTestCase(APITestCase):
         @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
@@ -427,6 +428,7 @@ class APIViewTestCases:
         pass
 
 
+@tag("unit")
 class APITransactionTestCase(_APITransactionTestCase):
     def setUp(self):
         """

--- a/nautobot/utilities/testing/integration.py
+++ b/nautobot/utilities/testing/integration.py
@@ -1,0 +1,131 @@
+import os
+
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.conf import settings
+from django.urls import reverse
+from selenium import webdriver
+from selenium.webdriver.support.wait import WebDriverWait
+
+
+# URL used to connect to the Selenium host
+SELENIUM_URL = os.getenv("NAUTOBOT_SELENIUM_URL", "http://localhost:4444/wd/hub")
+
+# Hostname used by Selenium client to talk to Nautobot
+SELENIUM_HOST = os.getenv("NAUTOBOT_SELENIUM_HOST", "localhost")
+
+# Default login URL
+LOGIN_URL = reverse(settings.LOGIN_URL)
+
+
+class NautobotRemote(webdriver.Remote):
+    """Custom WebDriver with helpers."""
+
+    def wait_for_html(self, tag_name, timeout=2):
+        """Wait for the page to render and make sure we find `tag_name`."""
+        WebDriverWait(self, timeout=timeout).until(lambda driver: driver.find_element_by_tag_name(tag_name))
+
+    def find_button(self, button_text):
+        """Return a `<button>` element with the given `button_text`."""
+        return self.find_element_by_xpath(f'//button[text()="{button_text}"]')
+
+
+class SeleniumTestCase(StaticLiveServerTestCase):
+    """
+    Base test case for Selenium integration testing with custom helper mthods.
+
+    This extends `django.contrib.staticfiles.testing.StaticLiveServerTestCase`
+    so there is no need to run `collectstatic` prior to running tests.
+    """
+
+    host = SELENIUM_HOST  # Docker: `nautobot`; else `localhost`
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Selenium remote client
+        cls.selenium = NautobotRemote(
+            command_executor=SELENIUM_URL,
+            options=cls._create_firefox_options(),
+            browser_profile=cls._create_firefox_profile(),
+        )
+
+        # Wait for the DOM in case an element is not yet rendered.
+        cls.selenium.implicitly_wait(10)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Close down the browser after tests are ran."""
+        cls.selenium.quit()
+        super().tearDownClass()
+
+    def login(self, username, password, login_url=LOGIN_URL, button_text="Log In"):
+        """
+        Navigate to `login_url` and perform a login w/ the provided `username` and `password`.
+        """
+
+        self.selenium.get(f"{self.live_server_url}{login_url}")
+        self.selenium.find_element_by_name("username").send_keys(username)
+        self.selenium.find_element_by_name("password").send_keys(password)
+        self.selenium.find_button(button_text).click()
+
+    @classmethod
+    def _create_firefox_options(cls):
+        """
+        Return a `FirefoxOptions` with required arguments such ass disabling the GPU and enabling
+        headless mode.
+        """
+
+        options = webdriver.FirefoxOptions()
+        options.headless = True
+        options.add_argument("-disable-gpu")
+
+        return options
+
+    @classmethod
+    def _create_firefox_profile(cls):
+        """
+        Return a `FirefoxProfile` with speed-optimized preferences such as disabling image loading,
+        enabling HTTP pipelining, among others.
+
+        Credit: https://bit.ly/2TuHa9D
+        """
+
+        profile = webdriver.FirefoxProfile()
+        profile.set_preference("network.http.pipelining", True)
+        profile.set_preference("network.http.proxy.pipelining", True)
+        profile.set_preference("network.http.pipelining.maxrequests", 8)
+        profile.set_preference("content.notify.interval", 500000)
+        profile.set_preference("content.notify.ontimer", True)
+        profile.set_preference("content.switch.threshold", 250000)
+        profile.set_preference("browser.cache.memory.capacity", 65536)  # Increase the cache capacity.
+        profile.set_preference("browser.startup.homepage", "about:blank")
+        profile.set_preference("reader.parse-on-load.enabled", False)  # Disable reader, we won't need that.
+        profile.set_preference("browser.pocket.enabled", False)  # Firefox pocket too!
+        profile.set_preference("loop.enabled", False)
+        profile.set_preference("browser.chrome.toolbar_style", 1)  # Text on Toolbar instead of icons
+        profile.set_preference(
+            "browser.display.show_image_placeholders", False
+        )  # Don't show thumbnails on not loaded images.
+        profile.set_preference("browser.display.use_document_colors", False)  # Don't show document colors.
+        profile.set_preference("browser.display.use_document_fonts", 0)  # Don't load document fonts.
+        profile.set_preference("browser.display.use_system_colors", True)  # Use system colors.
+        profile.set_preference("browser.formfill.enable", False)  # Autofill on forms disabled.
+        profile.set_preference("browser.helperApps.deleteTempFileOnExit", True)  # Delete temporary files.
+        profile.set_preference("browser.shell.checkDefaultBrowser", False)
+        profile.set_preference("browser.startup.homepage", "about:blank")
+        profile.set_preference("browser.startup.page", 0)  # Blank startup page
+        profile.set_preference("browser.tabs.forceHide", True)  # Disable tabs, We won't need that.
+        profile.set_preference("browser.urlbar.autoFill", False)  # Disable autofill on URL bar.
+        profile.set_preference("browser.urlbar.autocomplete.enabled", False)  # Disable autocomplete on URL bar.
+        profile.set_preference("browser.urlbar.showPopup", False)  # Disable list of URLs when typing on URL bar.
+        profile.set_preference("browser.urlbar.showSearch", False)  # Disable search bar.
+        profile.set_preference("extensions.checkCompatibility", False)  # Addon update disabled
+        profile.set_preference("extensions.checkUpdateSecurity", False)
+        profile.set_preference("extensions.update.autoUpdateEnabled", False)
+        profile.set_preference("extensions.update.enabled", False)
+        profile.set_preference("general.startup.browser", False)
+        profile.set_preference("plugin.default_plugin_disabled", False)
+        profile.set_preference("permissions.default.image", 2)  # Image load disabled (again)
+
+        return profile

--- a/nautobot/utilities/testing/integration.py
+++ b/nautobot/utilities/testing/integration.py
@@ -37,7 +37,7 @@ class NautobotRemote(webdriver.Remote):
 )
 class SeleniumTestCase(StaticLiveServerTestCase):
     """
-    Base test case for Selenium integration testing with custom helper mthods.
+    Base test case for Selenium integration testing with custom helper methods.
 
     This extends `django.contrib.staticfiles.testing.StaticLiveServerTestCase`
     so there is no need to run `collectstatic` prior to running tests.
@@ -62,7 +62,7 @@ class SeleniumTestCase(StaticLiveServerTestCase):
 
     @classproperty
     def live_server_url(cls):
-        return "http://%s:%s" % (cls.selenium_host, cls.server_thread.port)
+        return f"http://{cls.selenium_host}:{cls.server_thread.port}"
 
     @classmethod
     def tearDownClass(cls):
@@ -83,7 +83,7 @@ class SeleniumTestCase(StaticLiveServerTestCase):
     @classmethod
     def _create_firefox_options(cls):
         """
-        Return a `FirefoxOptions` with required arguments such ass disabling the GPU and enabling
+        Return a `FirefoxOptions` with required arguments such as disabling the GPU and enabling
         headless mode.
         """
 

--- a/nautobot/utilities/testing/integration.py
+++ b/nautobot/utilities/testing/integration.py
@@ -1,8 +1,8 @@
 import os
-from unittest import skipIf
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.conf import settings
+from django.test import tag
 from django.urls import reverse
 from django.utils.functional import classproperty
 from selenium import webdriver
@@ -13,7 +13,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 SELENIUM_URL = os.getenv("NAUTOBOT_SELENIUM_URL", "http://localhost:4444/wd/hub")
 
 # Hostname used by Selenium client to talk to Nautobot
-SELENIUM_HOST = os.getenv("NAUTOBOT_SELENIUM_HOST", "localhost")
+SELENIUM_HOST = os.getenv("NAUTOBOT_SELENIUM_HOST", "host.docker.internal")
 
 # Default login URL
 LOGIN_URL = reverse(settings.LOGIN_URL)
@@ -31,10 +31,7 @@ class NautobotRemote(webdriver.Remote):
         return self.find_element_by_xpath(f'//button[text()="{button_text}"]')
 
 
-@skipIf(
-    "NAUTOBOT_INTEGRATION_TEST" not in os.environ,
-    "NAUTOBOT_INTEGRATION_TEST environment variable not set",
-)
+@tag("integration")
 class SeleniumTestCase(StaticLiveServerTestCase):
     """
     Base test case for Selenium integration testing with custom helper methods.
@@ -44,7 +41,7 @@ class SeleniumTestCase(StaticLiveServerTestCase):
     """
 
     host = "0.0.0.0"  # Always listen publicly
-    selenium_host = SELENIUM_HOST  # Docker: `nautobot`; else `localhost`
+    selenium_host = SELENIUM_HOST  # Docker: `nautobot`; else `host.docker.internal`
 
     @classmethod
     def setUpClass(cls):

--- a/nautobot/utilities/testing/integration.py
+++ b/nautobot/utilities/testing/integration.py
@@ -1,8 +1,10 @@
 import os
+from unittest import skipIf
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.conf import settings
 from django.urls import reverse
+from django.utils.functional import classproperty
 from selenium import webdriver
 from selenium.webdriver.support.wait import WebDriverWait
 
@@ -29,6 +31,10 @@ class NautobotRemote(webdriver.Remote):
         return self.find_element_by_xpath(f'//button[text()="{button_text}"]')
 
 
+@skipIf(
+    "NAUTOBOT_INTEGRATION_TEST" not in os.environ,
+    "NAUTOBOT_INTEGRATION_TEST environment variable not set",
+)
 class SeleniumTestCase(StaticLiveServerTestCase):
     """
     Base test case for Selenium integration testing with custom helper mthods.
@@ -37,7 +43,8 @@ class SeleniumTestCase(StaticLiveServerTestCase):
     so there is no need to run `collectstatic` prior to running tests.
     """
 
-    host = SELENIUM_HOST  # Docker: `nautobot`; else `localhost`
+    host = "0.0.0.0"  # Always listen publicly
+    selenium_host = SELENIUM_HOST # Docker: `nautobot`; else `localhost`
 
     @classmethod
     def setUpClass(cls):
@@ -52,6 +59,10 @@ class SeleniumTestCase(StaticLiveServerTestCase):
 
         # Wait for the DOM in case an element is not yet rendered.
         cls.selenium.implicitly_wait(10)
+
+    @classproperty
+    def live_server_url(cls):
+        return 'http://%s:%s' % (cls.selenium_host, cls.server_thread.port)
 
     @classmethod
     def tearDownClass(cls):

--- a/nautobot/utilities/testing/integration.py
+++ b/nautobot/utilities/testing/integration.py
@@ -44,7 +44,7 @@ class SeleniumTestCase(StaticLiveServerTestCase):
     """
 
     host = "0.0.0.0"  # Always listen publicly
-    selenium_host = SELENIUM_HOST # Docker: `nautobot`; else `localhost`
+    selenium_host = SELENIUM_HOST  # Docker: `nautobot`; else `localhost`
 
     @classmethod
     def setUpClass(cls):
@@ -62,7 +62,7 @@ class SeleniumTestCase(StaticLiveServerTestCase):
 
     @classproperty
     def live_server_url(cls):
-        return 'http://%s:%s' % (cls.selenium_host, cls.server_thread.port)
+        return "http://%s:%s" % (cls.selenium_host, cls.server_thread.port)
 
     @classmethod
     def tearDownClass(cls):

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.db.models import JSONField, ManyToManyField
 from django.forms.models import model_to_dict
-from django.test import Client, TestCase as _TestCase, override_settings
+from django.test import Client, TestCase as _TestCase, override_settings, tag
 from django.urls import reverse, NoReverseMatch
 from django.utils.text import slugify
 from netaddr import IPNetwork
@@ -33,7 +33,10 @@ __all__ = (
 User = get_user_model()
 
 
+@tag("unit")
 class TestCase(_TestCase):
+    """Base class for all Nautobot-specific unit tests."""
+
     user_permissions = ()
 
     def setUp(self):
@@ -252,6 +255,7 @@ class ModelViewTestCase(ModelTestCase):
         return reverse(url_format.format(action), kwargs={"pk": instance.pk})
 
 
+@tag("unit")
 class ViewTestCases:
     """
     We keep any TestCases with test_* methods inside a class to prevent unittest from trying to run them.

--- a/poetry.lock
+++ b/poetry.lock
@@ -67,7 +67,7 @@ d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "certifi"
-version = "2020.12.5"
+version = "2021.5.30"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -431,6 +431,9 @@ optional = false
 python-versions = "^3.6"
 develop = true
 
+[package.dependencies]
+importlib-metadata = {version = "~3.4.0", markers = "python_version < \"3.8\""}
+
 [package.source]
 type = "directory"
 url = "examples/dummy_plugin"
@@ -585,14 +588,14 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 
 [[package]]
 name = "importlib-resources"
-version = "5.1.3"
+version = "5.1.4"
 description = "Read resources from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-zipp = {version = ">=0.4", markers = "python_version < \"3.8\""}
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
@@ -1030,7 +1033,7 @@ redis = ">=3.5.0"
 
 [[package]]
 name = "ruamel.yaml"
-version = "0.17.4"
+version = "0.17.7"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 category = "main"
 optional = false
@@ -1060,8 +1063,19 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "selenium"
+version = "3.141.0"
+description = "Python bindings for Selenium"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+urllib3 = "*"
+
+[[package]]
 name = "singledispatch"
-version = "3.6.1"
+version = "3.6.2"
 description = "Backport functools.singledispatch from Python 3.4 to Python 2.6-3.3."
 category = "main"
 optional = false
@@ -1072,7 +1086,7 @@ six = "*"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "unittest2"]
+testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "unittest2", "pytest-checkdocs (>=2.4)"]
 
 [[package]]
 name = "six"
@@ -1181,7 +1195,7 @@ python-versions = ">= 3.5"
 
 [[package]]
 name = "tqdm"
-version = "4.60.0"
+version = "4.61.0"
 description = "Fast, Extensible Progress Meter"
 category = "dev"
 optional = false
@@ -1218,16 +1232,16 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.4"
+version = "1.26.5"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
-brotli = ["brotlipy (>=0.6.0)"]
 
 [[package]]
 name = "zipp"
@@ -1244,7 +1258,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "e28f4bef0a9f0e4cbc0c4c5bd457aef7c9a5fbe879fa6506bb04bc8eb688cfa7"
+content-hash = "c34856ee67253ec60df64c6a0527e032674a34ec0627c41d4ec25d9b77ec1f21"
 
 [metadata.files]
 aniso8601 = [
@@ -1267,8 +1281,8 @@ black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 certifi = [
-    {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
-    {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
+    {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
+    {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
 ]
 cffi = [
     {file = "cffi-1.14.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991"},
@@ -1287,24 +1301,36 @@ cffi = [
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55"},
     {file = "cffi-1.14.5-cp36-cp36m-win32.whl", hash = "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53"},
     {file = "cffi-1.14.5-cp36-cp36m-win_amd64.whl", hash = "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813"},
     {file = "cffi-1.14.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc"},
     {file = "cffi-1.14.5-cp37-cp37m-win32.whl", hash = "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62"},
     {file = "cffi-1.14.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4"},
     {file = "cffi-1.14.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76"},
     {file = "cffi-1.14.5-cp38-cp38-win32.whl", hash = "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e"},
     {file = "cffi-1.14.5-cp38-cp38-win_amd64.whl", hash = "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396"},
     {file = "cffi-1.14.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7"},
     {file = "cffi-1.14.5-cp39-cp39-win32.whl", hash = "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396"},
     {file = "cffi-1.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d"},
     {file = "cffi-1.14.5.tar.gz", hash = "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"},
@@ -1519,8 +1545,8 @@ importlib-metadata = [
     {file = "importlib_metadata-3.4.0.tar.gz", hash = "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-5.1.3-py3-none-any.whl", hash = "sha256:3b9c774e0e7e8d9c069eb2fe6aee7e9ae71759a381dec02eb45249fba7f38713"},
-    {file = "importlib_resources-5.1.3.tar.gz", hash = "sha256:0786b216556e53b34156263ab654406e543a8b0d9b1381019e25a36a09263c36"},
+    {file = "importlib_resources-5.1.4-py3-none-any.whl", hash = "sha256:e962bff7440364183203d179d7ae9ad90cb1f2b74dcb84300e88ecc42dca3351"},
+    {file = "importlib_resources-5.1.4.tar.gz", hash = "sha256:54161657e8ffc76596c4ede7080ca68cb02962a2e074a2586b695a93a925d36e"},
 ]
 inflection = [
     {file = "inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"},
@@ -1880,8 +1906,8 @@ rq = [
     {file = "rq-1.8.1.tar.gz", hash = "sha256:feec0f914e69cae2380e2f46d82901e2abbd6fb09db320acb295f486a338f89f"},
 ]
 "ruamel.yaml" = [
-    {file = "ruamel.yaml-0.17.4-py3-none-any.whl", hash = "sha256:ac79fb25f5476e8e9ed1c53b8a2286d2c3f5dde49eb37dbcee5c7eb6a8415a22"},
-    {file = "ruamel.yaml-0.17.4.tar.gz", hash = "sha256:44bc6b54fddd45e4bc0619059196679f9e8b79c027f4131bb072e6a22f4d5e28"},
+    {file = "ruamel.yaml-0.17.7-py3-none-any.whl", hash = "sha256:25c3eaf4f0c52bd15c50c39b100a32168891240f4d2177a4690d5d9b85944bbe"},
+    {file = "ruamel.yaml-0.17.7.tar.gz", hash = "sha256:5c3fa739bbedd2f23769656784e671c6335d17a5bf163c3c3901d8663c0af287"},
 ]
 "ruamel.yaml.clib" = [
     {file = "ruamel.yaml.clib-0.2.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:28116f204103cb3a108dfd37668f20abe6e3cafd0d3fd40dba126c732457b3cc"},
@@ -1920,9 +1946,13 @@ rx = [
     {file = "Rx-1.6.1-py2.py3-none-any.whl", hash = "sha256:7357592bc7e881a95e0c2013b73326f704953301ab551fbc8133a6fadab84105"},
     {file = "Rx-1.6.1.tar.gz", hash = "sha256:13a1d8d9e252625c173dc795471e614eadfe1cf40ffc684e08b8fff0d9748c23"},
 ]
+selenium = [
+    {file = "selenium-3.141.0-py2.py3-none-any.whl", hash = "sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c"},
+    {file = "selenium-3.141.0.tar.gz", hash = "sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d"},
+]
 singledispatch = [
-    {file = "singledispatch-3.6.1-py2.py3-none-any.whl", hash = "sha256:85c97f94c8957fa4e6dab113156c182fb346d56d059af78aad710bced15f16fb"},
-    {file = "singledispatch-3.6.1.tar.gz", hash = "sha256:58b46ce1cc4d43af0aac3ac9a047bdb0f44e05f0b2fa2eec755863331700c865"},
+    {file = "singledispatch-3.6.2-py2.py3-none-any.whl", hash = "sha256:0d428477703d8386eb6aeed6e522c9f22d49f4363cdf4ed6a2ba3dc276053e20"},
+    {file = "singledispatch-3.6.2.tar.gz", hash = "sha256:d5bb9405a4b8de48e36709238e8b91b4f6f300f81a5132ba2531a9a738eca391"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -2005,8 +2035,8 @@ tornado = [
     {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
 ]
 tqdm = [
-    {file = "tqdm-4.60.0-py2.py3-none-any.whl", hash = "sha256:daec693491c52e9498632dfbe9ccfc4882a557f5fa08982db1b4d3adbe0887c3"},
-    {file = "tqdm-4.60.0.tar.gz", hash = "sha256:ebdebdb95e3477ceea267decfc0784859aa3df3e27e22d23b83e9b272bf157ae"},
+    {file = "tqdm-4.61.0-py2.py3-none-any.whl", hash = "sha256:736524215c690621b06fc89d0310a49822d75e599fcd0feb7cc742b98d692493"},
+    {file = "tqdm-4.61.0.tar.gz", hash = "sha256:cd5791b5d7c3f2f1819efc81d36eb719a38e0906a7380365c556779f585ea042"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -2050,8 +2080,8 @@ uritemplate = [
     {file = "uritemplate-3.0.1.tar.gz", hash = "sha256:5af8ad10cec94f215e3f48112de2022e1d5a37ed427fbd88652fa908f2ab7cae"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
-    {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
+    {file = "urllib3-1.26.5-py2.py3-none-any.whl", hash = "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"},
+    {file = "urllib3-1.26.5.tar.gz", hash = "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"},
 ]
 zipp = [
     {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -795,16 +795,16 @@ twitter = ["twython"]
 
 [[package]]
 name = "oauthlib"
-version = "3.1.0"
+version = "3.1.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.extras]
-rsa = ["cryptography"]
-signals = ["blinker"]
-signedtoken = ["cryptography", "pyjwt (>=1.0.0)"]
+rsa = ["cryptography (>=3.0.0,<4)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0,<4)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "packaging"
@@ -1258,7 +1258,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "c34856ee67253ec60df64c6a0527e032674a34ec0627c41d4ec25d9b77ec1f21"
+content-hash = "5d101d4e19fe6d47de0bd29443f4a090c12709accfb805d42bc23a02780939a8"
 
 [metadata.files]
 aniso8601 = [
@@ -1645,8 +1645,8 @@ nltk = [
     {file = "nltk-3.6.2.zip", hash = "sha256:57d556abed621ab9be225cc6d2df1edce17572efb67a3d754630c9f8381503eb"},
 ]
 oauthlib = [
-    {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
-    {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
+    {file = "oauthlib-3.1.1-py2.py3-none-any.whl", hash = "sha256:42bf6354c2ed8c6acb54d971fce6f88193d97297e18602a3a886603f9d7730cc"},
+    {file = "oauthlib-3.1.1.tar.gz", hash = "sha256:8f0215fcc533dd8dd1bee6f4c412d4f0cd7297307d43ac61666389e3bc3198a3"},
 ]
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ mkdocs-include-markdown-plugin = "~3.0.1"
 mkdocs = "~1.1.2"
 # Integration Tests
 requests = "~2.25.1"
+selenium = "~3.141.0"
 
 [tool.poetry.scripts]
 nautobot-server = "nautobot.core.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,8 @@ mkdocs-include-markdown-plugin = "~3.0.1"
 mkdocs = "~1.1.2"
 # Integration Tests
 requests = "~2.25.1"
-selenium = "~3.141.0"
+# Selenium web drivers for live integration testing
+selenium = "=3.141.0"
 
 [tool.poetry.scripts]
 nautobot-server = "nautobot.core.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ mkdocs = "~1.1.2"
 # Integration Tests
 requests = "~2.25.1"
 # Selenium web drivers for live integration testing
-selenium = "=3.141.0"
+selenium = "~3.141.0"
 
 [tool.poetry.scripts]
 nautobot-server = "nautobot.core.cli:main"

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -62,8 +62,7 @@ if [[ $RC != 0 ]]; then
 fi
 
 echo -e "\n>> Running unit tests..."
-# invoke unittest --failfast --keepdb
-sleep 60  # Just for now. Skip unit tests and take a short nap.
+invoke unittest --failfast --keepdb
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more unit tests failed, failing build."

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -53,6 +53,14 @@ if [[ ! -z $SYNTAX ]]; then
 	exit 1
 fi
 
+echo -e "\n>> Starting Selenium..."
+invoke start --service selenium
+RC=$?
+if [[ $RC != 0 ]]; then
+	echo -e "\n$(info) Selenium failed to start."
+	exit $RC
+fi
+
 echo -e "\n>> Running unit tests..."
 invoke unittest --failfast --keepdb
 RC=$?
@@ -62,7 +70,7 @@ if [[ $RC != 0 ]]; then
 fi
 
 echo -e "\n>> Running integration tests..."
-invoke unittest --failfast --keepdb --label nautobot.core.tests.integration
+NAUTOBOT_INTEGRATION_TEST=True invoke unittest --failfast --keepdb --label nautobot.core.tests.integration
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more integration tests failed, failing build."

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -54,7 +54,7 @@ if [[ ! -z $SYNTAX ]]; then
 fi
 
 echo -e "\n>> Starting Selenium in background..."
-invoke start --service selenium&
+invoke start --service selenium &
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) Selenium failed to start."
@@ -71,7 +71,7 @@ if [[ $RC != 0 ]]; then
 fi
 
 echo -e "\n>> Running integration tests..."
-NAUTOBOT_INTEGRATION_TEST=True invoke unittest --failfast --keepdb --label nautobot.core.tests.integration
+invoke integration-test --failfast --keepdb
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more integration tests failed, failing build."

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -54,7 +54,7 @@ if [[ ! -z $SYNTAX ]]; then
 fi
 
 echo -e "\n>> Running unit tests..."
-invoke unittest --failfast --buffer --keepdb
+invoke unittest --failfast --keepdb
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more unit tests failed, failing build."
@@ -62,7 +62,7 @@ if [[ $RC != 0 ]]; then
 fi
 
 echo -e "\n>> Running integration tests..."
-invoke unittest --failfast --buffer --keepdb --label nautobot.core.tests.integration
+invoke unittest --failfast --keepdb --label nautobot.core.tests.integration
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more integration tests failed, failing build."

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -53,8 +53,8 @@ if [[ ! -z $SYNTAX ]]; then
 	exit 1
 fi
 
-echo -e "\n>> Starting Selenium..."
-invoke start --service selenium
+echo -e "\n>> Starting Selenium in background..."
+invoke start --service selenium&
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) Selenium failed to start."

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -54,7 +54,7 @@ if [[ ! -z $SYNTAX ]]; then
 fi
 
 echo -e "\n>> Starting Selenium in background..."
-invoke start --service selenium &
+invoke start --service selenium
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) Selenium failed to start."

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -54,7 +54,7 @@ if [[ ! -z $SYNTAX ]]; then
 fi
 
 echo -e "\n>> Running unit tests..."
-invoke unittest --failfast
+invoke unittest --failfast --buffer --keepdb
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more unit tests failed, failing build."
@@ -62,7 +62,7 @@ if [[ $RC != 0 ]]; then
 fi
 
 echo -e "\n>> Running integration tests..."
-invoke unittest --failfast --label nautobot.core.tests.integration
+invoke unittest --failfast --buffer --keepdb --label nautobot.core.tests.integration
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more integration tests failed, failing build."

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -63,7 +63,7 @@ fi
 
 echo -e "\n>> Running unit tests..."
 # invoke unittest --failfast --keepdb
-sleep 5  # Just for now. Skip unit tests and take a short nap.
+sleep 60  # Just for now. Skip unit tests and take a short nap.
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more unit tests failed, failing build."

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -57,7 +57,15 @@ echo -e "\n>> Running unit tests..."
 invoke unittest --failfast
 RC=$?
 if [[ $RC != 0 ]]; then
-	echo -e "\n$(info) one or more tests failed, failing build."
+	echo -e "\n$(info) one or more unit tests failed, failing build."
+	exit $RC
+fi
+
+echo -e "\n>> Running integration tests..."
+invoke unittest --failfast --label nautobot.core.tests.integration
+RC=$?
+if [[ $RC != 0 ]]; then
+	echo -e "\n$(info) one or more integration tests failed, failing build."
 	exit $RC
 fi
 

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -53,7 +53,7 @@ if [[ ! -z $SYNTAX ]]; then
 	exit 1
 fi
 
-echo -e "\n>> Starting Selenium in background..."
+echo -e "\n>> Starting Selenium container in background..."
 invoke start --service selenium
 RC=$?
 if [[ $RC != 0 ]]; then
@@ -70,7 +70,7 @@ if [[ $RC != 0 ]]; then
 fi
 
 echo -e "\n>> Running integration tests..."
-invoke integration-test --failfast --keepdb
+invoke integration-test --failfast --keepdb --append
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more integration tests failed, failing build."

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -62,7 +62,8 @@ if [[ $RC != 0 ]]; then
 fi
 
 echo -e "\n>> Running unit tests..."
-invoke unittest --failfast --keepdb
+# invoke unittest --failfast --keepdb
+sleep 5  # Just for now. Skip unit tests and take a short nap.
 RC=$?
 if [[ $RC != 0 ]]; then
 	echo -e "\n$(info) one or more unit tests failed, failing build."

--- a/tasks.py
+++ b/tasks.py
@@ -427,6 +427,7 @@ def unittest(
 
     append_arg = " --append" if append else ""
     command = f"coverage run{append_arg} --module nautobot.core.cli test {label} --config=nautobot/core/tests/nautobot_config.py"
+    # booleans
     if keepdb:
         command += " --keepdb"
     if failfast:
@@ -435,10 +436,14 @@ def unittest(
         command += " --buffer"
     if verbose:
         command += " --verbosity 2"
-    if tag is not None:
-        command += " --tag ".join([" "] + tag)
-    if exclude_tag is not None:
-        command += " --exclude-tag ".join([" "] + exclude_tag)
+
+    # lists
+    if tag:
+        for individual_tag in tag:
+            command += f" --tag {individual_tag}"
+    if exclude_tag:
+        for individual_exclude_tag in exclude_tag:
+            command += f" --tag {individual_exclude_tag}"
 
     run_command(context, command)
 

--- a/tasks.py
+++ b/tasks.py
@@ -299,13 +299,13 @@ def cli(context):
     }
 )
 def createsuperuser(context, user="admin"):
-    """Create a new Nautobot superuser account (default: admin), will prompt for password."""
+    """Create a new Nautobot superuser account (default: "admin"), will prompt for password."""
     command = f"nautobot-server createsuperuser --username {user}"
 
     run_command(context, command)
 
 
-@task(help={"name": "Use this name for migration file(s). If unspecified, a name will be generated." ""})
+@task(help={"name": "Use this name for migration file(s). If unspecified, a name will be generated."})
 def makemigrations(context, name=""):
     """Perform makemigrations operation in Django."""
     command = "nautobot-server makemigrations"
@@ -405,7 +405,7 @@ def check_migrations(context):
         "label": "Specify a directory or module to test instead of running all Nautobot tests.",
         "failfast": "Fail as soon as a single test fails don't run the entire test suite.",
         "buffer": "Discard output from passing tests.",
-        "verbose": "Toggle verbose test output.",
+        "verbose": "Enable verbose test output.",
     }
 )
 def unittest(context, keepdb=False, label="nautobot", failfast=False, buffer=True, verbose=False):
@@ -437,7 +437,7 @@ def unittest_coverage(context):
         "label": "Specify a directory or module to test instead of running all Nautobot tests.",
         "failfast": "Fail as soon as a single test fails don't run the entire test suite.",
         "buffer": "Discard output from passing tests.",
-        "verbose": "Toggle verbose test output.",
+        "verbose": "Enable verbose test output.",
     }
 )
 def integration_test(

--- a/tasks.py
+++ b/tasks.py
@@ -129,8 +129,8 @@ def run_command(context, command, **kwargs):
 # ------------------------------------------------------------------------------
 @task(
     help={
-        "force_rm": "Always remove intermediate containers",
-        "cache": "Whether to use Docker's cache when building the image (defaults to enabled)",
+        "force_rm": "Always remove intermediate containers.",
+        "cache": "Whether to use Docker's cache when building the image. (Default: enabled)",
     }
 )
 def build(context, force_rm=False, cache=True):
@@ -148,11 +148,11 @@ def build(context, force_rm=False, cache=True):
 
 @task(
     help={
-        "cache": "Whether to use Docker's cache when building the image (Default: enabled)",
-        "cache_dir": "Directory to use for caching buildx output (Default:  /home/travis/.cache/docker)",
-        "platforms": "Comma-separated list of strings for which to build (Default: linux/amd64)",
-        "tag": "Tags to be applied to the built image (Default: networktocode/nautobot-dev:local)",
-        "target": "Built target from the Dockerfile (Default: dev)",
+        "cache": "Whether to use Docker's cache when building the image. (Default: enabled)",
+        "cache_dir": "Directory to use for caching buildx output. (Default: /home/travis/.cache/docker)",
+        "platforms": "Comma-separated list of strings for which to build. (Default: linux/amd64)",
+        "tag": "Tags to be applied to the built image. (Default: networktocode/nautobot-dev:local)",
+        "target": "Build target from the Dockerfile. (Default: dev)",
     }
 )
 def buildx(
@@ -176,9 +176,9 @@ def buildx(
 
 @task(
     help={
-        "branch": "Source branch used to push",
-        "commit": "Commit hash used to tag the image",
-        "datestamp": "Datestamp used to tag the develop image",
+        "branch": "Source branch used to push.",
+        "commit": "Commit hash used to tag the image.",
+        "datestamp": "Datestamp used to tag the develop image.",
     }
 )
 def docker_push(context, branch, commit="", datestamp=""):
@@ -233,21 +233,21 @@ def docker_push(context, branch, commit="", datestamp=""):
 # ------------------------------------------------------------------------------
 # START / STOP / DEBUG
 # ------------------------------------------------------------------------------
-@task(help={"service": "If specified, only affect this service." ""})
+@task(help={"service": "If specified, only affect this service."})
 def debug(context, service=None):
     """Start Nautobot and its dependencies in debug mode."""
     print("Starting Nautobot in debug mode...")
     docker_compose(context, "up", service=service)
 
 
-@task(help={"service": "If specified, only affect this service." ""})
+@task(help={"service": "If specified, only affect this service."})
 def start(context, service=None):
     """Start Nautobot and its dependencies in detached mode."""
     print("Starting Nautobot in detached mode...")
     docker_compose(context, "up --detach", service=service)
 
 
-@task(help={"service": "If specified, only affect this service." ""})
+@task(help={"service": "If specified, only affect this service."})
 def restart(context, service=None):
     """Gracefully restart containers."""
     print("Restarting Nautobot...")
@@ -295,21 +295,17 @@ def cli(context):
 
 @task(
     help={
-        "user": "name of the superuser to create (default: admin)",
+        "user": "Name of the superuser to create. (Default: admin)",
     }
 )
 def createsuperuser(context, user="admin"):
-    """Create a new Nautobot superuser account (default: "admin"), will prompt for password."""
+    """Create a new Nautobot superuser account (default: admin), will prompt for password."""
     command = f"nautobot-server createsuperuser --username {user}"
 
     run_command(context, command)
 
 
-@task(
-    help={
-        "name": "name of the migration to be created; if unspecified, will autogenerate a name",
-    }
-)
+@task(help={"name": "Use this name for migration file(s). If unspecified, a name will be generated." ""})
 def makemigrations(context, name=""):
     """Perform makemigrations operation in Django."""
     command = "nautobot-server makemigrations"
@@ -347,7 +343,7 @@ def post_upgrade(context):
     run_command(context, command)
 
 
-@task(help={"format": "Output type for file ('json', 'xml', 'yaml')."})
+@task(help={"format": "Output serialization format for dumped data. (Choices: json, xml, yaml)"})
 def dumpdata(context, format="json"):
     """Dump data from database to db_output file."""
     command = f"nautobot-server dumpdata --exclude extras.job --indent 4 --output db_output.{format} --format {format}"
@@ -405,11 +401,11 @@ def check_migrations(context):
 
 @task(
     help={
-        "keepdb": "save and re-use test database between test runs for faster re-testing.",
-        "label": "specify a directory or module to test instead of running all Nautobot tests",
-        "failfast": "fail as soon as a single test fails don't run the entire test suite",
-        "buffer": "Discard output from passing tests",
-        "verbose": "Toggle verbose test output",
+        "keepdb": "Save and re-use test database between test runs for faster re-testing.",
+        "label": "Specify a directory or module to test instead of running all Nautobot tests.",
+        "failfast": "Fail as soon as a single test fails don't run the entire test suite.",
+        "buffer": "Discard output from passing tests.",
+        "verbose": "Toggle verbose test output.",
     }
 )
 def unittest(context, keepdb=False, label="nautobot", failfast=False, buffer=True, verbose=False):
@@ -437,11 +433,11 @@ def unittest_coverage(context):
 
 @task(
     help={
-        "keepdb": "save and re-use test database between test runs for faster re-testing.",
-        "label": "specify a directory or module to test instead of running all Nautobot tests",
-        "failfast": "fail as soon as a single test fails don't run the entire test suite",
-        "buffer": "Discard output from passing tests",
-        "verbose": "Toggle verbose test output",
+        "keepdb": "Save and re-use test database between test runs for faster re-testing.",
+        "label": "Specify a directory or module to test instead of running all Nautobot tests.",
+        "failfast": "Fail as soon as a single test fails don't run the entire test suite.",
+        "buffer": "Discard output from passing tests.",
+        "verbose": "Toggle verbose test output.",
     }
 )
 def integration_test(
@@ -454,7 +450,7 @@ def integration_test(
 
 @task(
     help={
-        "lint-only": "only run linters, unit tests will be excluded",
+        "lint-only": "Only run linters; unit tests will be excluded.",
     }
 )
 def tests(context, lint_only=False):

--- a/tasks.py
+++ b/tasks.py
@@ -98,6 +98,12 @@ def docker_compose(context, command, **kwargs):
     if os.path.isfile(compose_override_path):
         compose_command += f' -f "{compose_override_path}"'
     compose_command += f" {command}"
+
+    # If `service` was passed as a kwarg, add it to the end.
+    service = kwargs.pop("service", None)
+    if service is not None:
+        compose_command += f" {service}"
+
     print(f'Running docker-compose command "{command}"')
     return context.run(compose_command, env={"PYTHON_VER": context.nautobot.python_ver}, **kwargs)
 
@@ -227,25 +233,25 @@ def docker_push(context, branch, commit="", datestamp=""):
 # ------------------------------------------------------------------------------
 # START / STOP / DEBUG
 # ------------------------------------------------------------------------------
-@task
-def debug(context):
+@task(help={"service": "If specified, only affect this service." ""})
+def debug(context, service=None):
     """Start Nautobot and its dependencies in debug mode."""
     print("Starting Nautobot in debug mode...")
-    docker_compose(context, "up")
+    docker_compose(context, "up", service=service)
 
 
-@task
-def start(context):
+@task(help={"service": "If specified, only affect this service." ""})
+def start(context, service=None):
     """Start Nautobot and its dependencies in detached mode."""
     print("Starting Nautobot in detached mode...")
-    docker_compose(context, "up --detach")
+    docker_compose(context, "up --detach", service=service)
 
 
-@task
-def restart(context):
-    """Gracefully restart all containers."""
+@task(help={"service": "If specified, only affect this service." ""})
+def restart(context, service=None):
+    """Gracefully restart containers."""
     print("Restarting Nautobot...")
-    docker_compose(context, "restart")
+    docker_compose(context, "restart", service=service)
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -420,6 +420,12 @@ def unittest(context, keepdb=False, label="nautobot", failfast=False, buffer=Tru
         command += " --buffer"
     if verbose:
         command += " --verbosity 2"
+
+    # Append any extra args that were passed in from the `context`. Currently
+    # this is coming from `integration_test` to avoid duplicating the `unitest`
+    # code just for this. If `extra_args` aren't set, it's a noop.
+    command += getattr(context, "extra_args", "")
+
     run_command(context, command)
 
 
@@ -444,7 +450,8 @@ def integration_test(
     context, keepdb=False, label="nautobot.core.tests.integration", failfast=False, buffer=True, verbose=False
 ):
     """Run Nautobot integration tests."""
-    os.environ["NAUTOBOT_INTEGRATION_TEST"] = "True"
+    # Append extra args to the context that will be picked up by the `unittest` task.
+    context.extra_args = " --tag integration"
     unittest(context, keepdb=keepdb, label=label, failfast=failfast, buffer=buffer, verbose=verbose)
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #183 
<!--
    Please include a summary of the proposed changes below.
-->

- Docker container for Selenium Firefox (standalone) now included in `development/docker-compose.yml`
- Factored `nautobot.core.tests.integration.test_home.HomeTestCase` to use an abstract `SeleniumTestCase` base. Test code is super clean!
- Added `nautobot.utilities.testing.integration` and factored all base test code into `SeleniumTestCase`
  - Included subclass of `selenium.webdriver.Remote` w/ some reusable helpers
  - Implemented `FirefoxOptions` to the remote webdriver to optimize it for speed
  - Implemented a `SeleniumTestCase.login()` method to make logging in reusable
- Augmented `SeleniumTestCase` to
  - hard-code `host` to quad 0 so it always listens publicly
  - Added `selenium_host` class variable that maps to `NAUTOBOT_SELENIUM_HOST` environment variable
  - Overloaded `live_server_url` to return value of `selenium_host` vs. `host`
- Selenium added as a `~` (tilde) development dependency (installed w/ `poetry install`)
- Two new environment variables used for development environment and testing added to `development/dev.env` (if not set, these each default to `localhost` versions):

```
NAUTOBOT_SELENIUM_URL=http://selenium:4444/wd/hub  # WebDriver (Selenium client)
NAUTOBOT_SELENIUM_HOST=nautobot  # LiveServer (Nautobot server)
```

- Added all the environment variables required for Selenium into Travis env. as globals in `.travis.yml`
- Updated `scripts/cibuild.sh` to
  - Start Selenium via Docker prior to running unit tests
  - Execute integration tests using Selenium container
- Updated `tasks.py` debug/start/restart tasks to take optional `-s/--service` argument to facilitate single-service use-case (`invoke start -s selenium` e.g.)
- Also added the following new arguments `unittest/integration-test` Invoke tasks
  - `-a/--append` to append to coverage files
  - `-t/--tag` and -e/--exclude-tag` to include/exclude test tags
  - `-v/--verbose` flag to enable verbose test output
- Custom `nautobot.core.tests.runner.NautobotTestRunner` implemented that is aware of the `integration` tag. It will skip tests tagged with `integration` by default unless that tag has been explicitly included using `--tag integration`
- The `NautobotTestRunner` has been set as the default test runner in `nautobot.core.settings.TEST_RUNNER`
- All base test classes in `nautobot.utilities.testing.views` and `nautobot.utilities.testing.api` have been tagged with `unit`, however, more refactoring work needs to be done to account for ALL tests as many of them are inheriting from `django.test.TestCase` and cannot be easily tagged unless we tag them all. Refactoring such tests to inherit from `nautobot.utilities.testing.TestCase` will be cleaner.
- The base `nautobot.utilities.testing.integration.SeleniumTestCase` has been tagged with `integration`.
- The default value for `NAUTOBOT_SELENIUM_HOST` has been changed to `host.docker.internal` so that nothing needs to be customized or overloaded to run tests when hybrid Docker/localhost pattern is used with `INVOKE_NAUTOBOT_LOCAL=True`
- The Invoke `integration-test` task has been refactored to pass `--tag integration` to the test runner as an "extra arg", and the `unittest` task has been updated to look for this.