### PR TITLE
LDAP TLS Options addition to documentation

### DIFF
--- a/nautobot/docs/configuration/authentication/ldap.md
+++ b/nautobot/docs/configuration/authentication/ldap.md
@@ -91,6 +91,8 @@ STARTTLS can be configured by setting `AUTH_LDAP_START_TLS = True` and using the
 Apply TLS settings to the internal SSL context on nautobot by configuring `ldap.OPT_X_TLS_NEWCTX` with value `0`. 
 
 ```
+AUTH_LDAP_SERVER_URI = "ldap://ad.example.com"
+AUTH_LDAP_START_TLS = True
 # Set the path to the trusted CA certificates and create a new internal SSL context.
 AUTH_LDAP_CONNECTION_OPTIONS = {
     ldap.OPT_X_TLS_CACERTFILE: "/path/to/ca.pem",

--- a/nautobot/docs/configuration/authentication/ldap.md
+++ b/nautobot/docs/configuration/authentication/ldap.md
@@ -96,6 +96,7 @@ AUTH_LDAP_CONNECTION_OPTIONS = {
     ldap.OPT_X_TLS_CACERTFILE: "/path/to/ca.pem",
     ldap.OPT_X_TLS_NEWCTX: 0
 }
+LDAP_IGNORE_CERT_ERRORS = False
 ```
 
 ### User Authentication

--- a/nautobot/docs/configuration/authentication/ldap.md
+++ b/nautobot/docs/configuration/authentication/ldap.md
@@ -84,7 +84,19 @@ AUTH_LDAP_BIND_PASSWORD = "demo"
 LDAP_IGNORE_CERT_ERRORS = True
 ```
 
+### TLS Options
+
 STARTTLS can be configured by setting `AUTH_LDAP_START_TLS = True` and using the `ldap://` URI scheme.
+
+Apply TLS settings to the internal SSL context on nautobot by configuring `ldap.OPT_X_TLS_NEWCTX` with value `0`. 
+
+```
+# Set the path to the trusted CA certificates and create a new internal SSL context.
+AUTH_LDAP_CONNECTION_OPTIONS = {
+    ldap.OPT_X_TLS_CACERTFILE: "/path/to/ca.pem",
+    ldap.OPT_X_TLS_NEWCTX: 0
+}
+```
 
 ### User Authentication
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #523 
<!--
    Please include a summary of the proposed changes below.
-->
Add TLS Options section to set SSL settings. The changes could be added to the The General Server Configuration section but then that assumes TLS is the default. Keeping it separate should be cleaner.
