### PR TITLE
Fix unit test with ordered test assertion

### DIFF
--- a/nautobot/core/tests/test_authentication.py
+++ b/nautobot/core/tests/test_authentication.py
@@ -154,7 +154,7 @@ class ExternalAuthenticationTestCase(TestCase):
             new_user.pk,
             msg="Authentication failed",
         )
-        self.assertListEqual([groups[0], groups[1]], list(new_user.groups.all()))
+        self.assertSetEqual({groups[0], groups[1]}, set(new_user.groups.all()))
 
     @override_settings(
         AUTHENTICATION_BACKENDS=TEST_AUTHENTICATION_BACKENDS,


### PR DESCRIPTION
When testing Nautobot against Dolt, we're seeing a test failure due to result ordering. The underlying test doesn't specify an order, but the test assertion depends on the ordering of the results. MySQL has deterministic result ordering even for queries without and `ORDER BY` clause, but this is not part of the SQL spec and is not the case in Dolt.

```
======================================================================
FAIL: test_EXTERNAL_AUTH_DEFAULT_groups (nautobot.core.tests.test_authentication.ExternalAuthenticationTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/andyarthur/Library/Caches/pypoetry/virtualenvs/nautobot-UlGRRLVI-py3.7/lib/python3.7/site-packages/django/test/utils.py", line 381, in inner
    return func(*args, **kwargs)
  File "/Users/andyarthur/NTC/nautobot/nautobot/core/tests/test_authentication.py", line 157, in test_EXTERNAL_AUTH_DEFAULT_groups
    self.assertListEqual([groups[0], groups[1]], list(new_user.groups.all()))
AssertionError: Lists differ: [<Group: Group 1>, <Group: Group 2>] != [<Group: Group 2>, <Group: Group 1>]

First differing element 0:
<Group: Group 1>
<Group: Group 2>

- [<Group: Group 1>, <Group: Group 2>]
?                ^                 ^

+ [<Group: Group 2>, <Group: Group 1>]
?                ^                 ^
```
