### PR TITLE
Give the user some help on empty repos.

### DIFF
--- a/nautobot/docs/models/extras/gitrepository.md
+++ b/nautobot/docs/models/extras/gitrepository.md
@@ -22,6 +22,9 @@ The token implementation can vary from Git provider to Git provider, the followi
 
 Whenever a Git repository record is created, updated, or deleted, Nautobot automatically enqueues a background task that will asynchronously execute to clone, fetch, or delete a local copy of the Git repository on the filesystem (located under [`GIT_ROOT`](../../../configuration/optional-settings/#git_root)) and then create, update, and/or delete any database records managed by this repository. The progress and eventual outcome of this background task are recorded as a `JobResult` record that may be viewed from the Git repository user interface.
 
+!!! important
+    The repository branch must exist and have a commit against it. At this time, Nautobot will not initialize an empty repository.
+
 ## Repository Structure
 
 ### Jobs

--- a/nautobot/utilities/git.py
+++ b/nautobot/utilities/git.py
@@ -33,12 +33,13 @@ class GitRepo:
         """
         Check out the given branch, and optionally the specified commit within that branch.
         """
+        # Short-circuit logic - do we already have this commit checked out?
+        if commit_hexsha and commit_hexsha == self.repo.head.commit.hexsha:
+            logger.debug(f"Commit {commit_hexsha} is already checked out.")
+            return commit_hexsha
+        
         self.fetch()
         if commit_hexsha:
-            # Short-circuit logic - do we already have this commit checked out?
-            if commit_hexsha == self.repo.head.commit.hexsha:
-                logger.debug(f"Commit {commit_hexsha} is already checked out.")
-                return commit_hexsha
             # Sanity check - GitPython doesn't provide a handy API for this so we just call a raw Git command:
             # $ git branch <branch> --contains <commit>
             # prints the branch name if it DOES contain the commit, and nothing if it DOES NOT contain the commit.

--- a/nautobot/utilities/git.py
+++ b/nautobot/utilities/git.py
@@ -37,7 +37,7 @@ class GitRepo:
         if commit_hexsha and commit_hexsha == self.repo.head.commit.hexsha:
             logger.debug(f"Commit {commit_hexsha} is already checked out.")
             return commit_hexsha
-        
+
         self.fetch()
         if commit_hexsha:
             # Sanity check - GitPython doesn't provide a handy API for this so we just call a raw Git command:

--- a/nautobot/utilities/git.py
+++ b/nautobot/utilities/git.py
@@ -9,6 +9,10 @@ from git import Repo
 logger = logging.getLogger("nautobot.utilities.git")
 
 
+class BranchDoesNotExist(Exception):
+    pass
+
+
 class GitRepo:
     def __init__(self, path, url):
         """
@@ -29,13 +33,12 @@ class GitRepo:
         """
         Check out the given branch, and optionally the specified commit within that branch.
         """
-        # Short-circuit logic - do we already have this commit checked out?
-        if commit_hexsha == self.repo.head.commit.hexsha:
-            logger.debug(f"Commit {commit_hexsha} is already checked out.")
-            return commit_hexsha
-
         self.fetch()
         if commit_hexsha:
+            # Short-circuit logic - do we already have this commit checked out?
+            if commit_hexsha == self.repo.head.commit.hexsha:
+                logger.debug(f"Commit {commit_hexsha} is already checked out.")
+                return commit_hexsha
             # Sanity check - GitPython doesn't provide a handy API for this so we just call a raw Git command:
             # $ git branch <branch> --contains <commit>
             # prints the branch name if it DOES contain the commit, and nothing if it DOES NOT contain the commit.
@@ -48,8 +51,17 @@ class GitRepo:
         if branch in self.repo.heads:
             branch_head = self.repo.heads[branch]
         else:
-            branch_head = self.repo.create_head(branch, self.repo.remotes.origin.refs[branch])
-            branch_head.set_tracking_branch(self.repo.remotes.origin.refs[branch])
+            try:
+                branch_head = self.repo.create_head(branch, self.repo.remotes.origin.refs[branch])
+                branch_head.set_tracking_branch(self.repo.remotes.origin.refs[branch])
+            except IndexError as git_error:
+                logger.error(
+                    "Branch %s does not exist at %s. %s", branch, list(self.repo.remotes.origin.urls)[0], git_error
+                )
+                raise BranchDoesNotExist(
+                    f"Please create branch '{branch}' in upstream and try again."
+                    f" If this is a new repo, please add a commit before syncing. {git_error}"
+                )
 
         logger.info(f"Checking out latest commit on branch `{branch}`...")
         branch_head.checkout()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #421
<!--
    Please include a summary of the proposed changes below.
-->
This PR adds a warning when the user tries to use an empty repo, or a branch that does not exist upstream.

This also moves the commit.hexsha check as an empty repo won't have a commit.
This allows the user to fix the repo without needing to delete the git
repository record.