### PR TITLE
Log in to dockerhub to avoid rate limit issues in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,6 @@ install:
 before_script:
   - psql -U postgres -c 'create database nautobot;'
   - pip install docker-compose
+  - echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin || travis_terminate 1
 script:
   - poetry run ./scripts/cibuild.sh


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #N/A
<!--
    Please include a summary of the proposed changes below.
-->

Since #514, our CI now has a Docker dependency. As a result CI is failing intermittently due to Docker's rate limiting on anonymous image pulls. Adding login info to the Travis environment and using it in our CI should resolve this issue.