### PR TITLE
Rework dockerhub login approach

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,5 @@ install:
 before_script:
   - psql -U postgres -c 'create database nautobot;'
   - pip install docker-compose
-  - echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin || travis_terminate 1
 script:
   - poetry run ./scripts/cibuild.sh

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -53,6 +53,11 @@ if [[ ! -z $SYNTAX ]]; then
 	exit 1
 fi
 
+if [[ -n "$DOCKER_HUB_PASSWORD" ]]; then
+    echo -e "\n>> Attempting login to Docker Hub..."
+    echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin
+fi
+
 echo -e "\n>> Starting Selenium container in background..."
 invoke start --service selenium
 RC=$?


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: N/A
<!--
    Please include a summary of the proposed changes below.
-->

The dockerhub login logic added in #540 causes issues with forks because (for security reasons) Travis-CI doesn't expose secure environment variables to builds triggered by forks. As a result contributors' PRs are failing with:

```shell
$ echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin || travis_terminate 1
Must provide --username with --password-stdin
```

This PR reworks things so that the login is only attempted if `$DOCKER_HUB_PASSWORD` is actually set.