### PR TITLE
Fix issue with missing tags on MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,5 @@ install:
 before_script:
   - psql -U postgres -c 'create database nautobot;'
   - pip install docker-compose
-  - echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin || travis_terminate 1
 script:
   - poetry run ./scripts/cibuild.sh

--- a/nautobot/extras/models/tags.py
+++ b/nautobot/extras/models/tags.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.urls import reverse
 from django.utils.text import slugify
-from taggit.models import TagBase, GenericTaggedItemBase
+from taggit.models import TagBase, GenericUUIDTaggedItemBase
 
 from nautobot.extras.models import ChangeLoggedModel, CustomFieldModel
 from nautobot.extras.models.relationships import RelationshipModel
@@ -47,7 +47,7 @@ class Tag(TagBase, BaseModel, ChangeLoggedModel, CustomFieldModel, RelationshipM
         return (self.name, self.slug, self.color, self.description)
 
 
-class TaggedItem(BaseModel, GenericTaggedItemBase):
+class TaggedItem(BaseModel, GenericUUIDTaggedItemBase):
     tag = models.ForeignKey(to=Tag, related_name="%(app_label)s_%(class)s_items", on_delete=models.CASCADE)
     object_id = models.UUIDField()
 

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -53,6 +53,11 @@ if [[ ! -z $SYNTAX ]]; then
 	exit 1
 fi
 
+if [[ -n "$DOCKER_HUB_PASSWORD" ]]; then
+    echo -e "\n>> Attempting login to Docker Hub..."
+    echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin
+fi
+
 echo -e "\n>> Starting Selenium container in background..."
 invoke start --service selenium
 RC=$?


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #389 
<!--
    Please include a summary of the proposed changes below.
-->

Had to change the base class for `TaggedItem` from `GenericTaggedItemBase` to `GenericUUIDTaggedItemBase`, to get the django-taggit machinery to do a UUID-based comparison of the prefetched "tags". Without that the prefetched values weren't matching correctly, and were returning empty. (See: https://github.com/jazzband/django-taggit/pull/663)

This does not require any migrations because `TaggedItem.object_id` was already changed to a `UUIDField` in a previous commit.

This also fixed an issue that was causing tags from emitting in the API entirely. We do not yet have integration tests for that.