### PR TITLE
Correctly handle single values when prepopulating a DynamicModelMultipleChoiceField

### DIFF
--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -477,6 +477,20 @@ class DynamicModelMultipleChoiceField(DynamicModelChoiceMixin, forms.ModelMultip
     filter = django_filters.ModelMultipleChoiceFilter
     widget = widgets.APISelectMultiple
 
+    def prepare_value(self, value):
+        """
+        Ensure that a single string value (i.e. UUID) is accurately represented as a list of one item.
+
+        This is necessary because otherwise the superclass will split the string into individual characters,
+        resulting in an error (https://github.com/nautobot/nautobot/issues/512).
+
+        Note that prepare_value() can also be called with an object instance or list of instances; in that case,
+        we do *not* want to convert a single instance to a list of one entry.
+        """
+        if isinstance(value, str):
+            value = [value]
+        return super().prepare_value(value)
+
 
 class LaxURLField(forms.URLField):
     """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #512 
<!--
    Please include a summary of the proposed changes below.
-->

When we're pre-populating a form based on GET request query parameters (e.g. `/dcim/devices/add/?tags=c671a001-4c17-4ca1-80fd-fe1609bcadec`), when a single value is provided for a given parameter, the generic request handling has no way to know whether this string value is a value for a single-value field (`DynamicModelChoiceField`) or a list of one value to use for a multi-value field (`DynamicModelMultipleChoiceField`). In the latter case, if we provide a string to initialize a multi-value field, something in Django and/or `django-filter` (I have had trouble tracking down exactly where and why) ends up misinterpreting the string as a list of single characters, and of course single characters are not valid UUIDs, resulting in the error reported in #512.

> Interestingly, this appears to be something of a baseline bug inherited from NetBox, although the symptom is different there due to the use of integer PKs instead of UUIDs - a single-value integer PK passed as a parameter actually works correctly **so long as it is a single-digit PK**, but a request providing a single multi-digit PK appears to silently fail somewhere in the code and the field gets an empty value instead of being pre-populated as intended.

The best solution I've found is to implement the `prepare_value` function for `DynamicModelMultipleChoiceField` to intercept single string values and wrap them into a single-entry list before passing them up the chain. Interestingly, `prepare_value` can also be called with an object instance rather than a string/PK, and in that case we need to preserve the single value as such and *not* wrap it into a list, as doing so causes the field to not correctly pre-populate (although no error is reported). Again, I'm not entirely sure why, but can confirm this behavior.