### PR TITLE
Assert that tags persist in changelog on API PATCH requests

### DIFF
--- a/nautobot/extras/tests/test_changelog.py
+++ b/nautobot/extras/tests/test_changelog.py
@@ -204,7 +204,7 @@ class ChangeLogAPITest(APITestCase):
         self.assertEqual(oc_list[1].object_data["tags"], ["Tag 1", "Tag 2"])
 
     def test_update_object(self):
-        """Test PUT wi/ changelogs."""
+        """Test PUT with changelogs."""
         site = Site.objects.create(
             name="Test Site 1",
             slug="test-site-1",

--- a/nautobot/extras/tests/test_changelog.py
+++ b/nautobot/extras/tests/test_changelog.py
@@ -240,7 +240,7 @@ class ChangeLogAPITest(APITestCase):
         self.assertEqual(oc.object_data["tags"], ["Tag 3"])
 
     def test_partial_update_object(self):
-        """Test PATCH w/ changelogs."""
+        """Test PATCH with changelogs."""
         site = Site.objects.create(
             name="Test Site 1",
             slug="test-site-1",

--- a/nautobot/extras/tests/test_changelog.py
+++ b/nautobot/extras/tests/test_changelog.py
@@ -204,12 +204,12 @@ class ChangeLogAPITest(APITestCase):
         self.assertEqual(oc_list[1].object_data["tags"], ["Tag 1", "Tag 2"])
 
     def test_update_object(self):
-        site = Site(
+        """Test PUT wi/ changelogs."""
+        site = Site.objects.create(
             name="Test Site 1",
             slug="test-site-1",
             status=self.statuses.get(slug="planned"),
         )
-        site.save()
 
         data = {
             "name": "Test Site X",
@@ -237,6 +237,44 @@ class ChangeLogAPITest(APITestCase):
         self.assertEqual(oc.changed_object, site)
         self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_UPDATE)
         self.assertEqual(oc.object_data["custom_fields"], data["custom_fields"])
+        self.assertEqual(oc.object_data["tags"], ["Tag 3"])
+
+    def test_partial_update_object(self):
+        """Test PATCH w/ changelogs."""
+        site = Site.objects.create(
+            name="Test Site 1",
+            slug="test-site-1",
+            status=self.statuses.get(slug="planned"),
+            _custom_field_data={
+                "my_field": "DEF",
+                "my_field_select": "Foo",
+            },
+        )
+        site.tags.add(Tag.objects.get(name="Tag 3"))
+
+        # We only want to update a single field.
+        data = {
+            "description": "new description",
+        }
+
+        self.assertEqual(ObjectChange.objects.count(), 0)
+        self.add_permissions("dcim.change_site", "extras.view_status")
+        url = reverse("dcim-api:site-detail", kwargs={"pk": site.pk})
+
+        # Perform a PATCH (partial update)
+        response = self.client.patch(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        site = Site.objects.get(pk=response.data["id"])
+
+        # Get only the most recent OC
+        oc = ObjectChange.objects.filter(
+            changed_object_type=ContentType.objects.get_for_model(Site),
+            changed_object_id=site.pk,
+        ).first()
+        self.assertEqual(oc.changed_object, site)
+        self.assertEqual(oc.object_data["description"], data["description"])
+        self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_UPDATE)
+        self.assertEqual(oc.object_data["custom_fields"], site.custom_field_data)
         self.assertEqual(oc.object_data["tags"], ["Tag 3"])
 
     def test_delete_object(self):

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -122,7 +122,7 @@ def serialize_object(obj, extra=None, exclude=None):
 
     # Include any tags. Check for tags cached on the instance; fall back to using the manager.
     if is_taggable(obj):
-        tags = getattr(obj, "_tags", obj.tags.all())
+        tags = getattr(obj, "_tags", []) or obj.tags.all()
         data["tags"] = [tag.name for tag in tags]
 
     # Append any extra data


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #499 
<!--
    Please include a summary of the proposed changes below.
-->
This also adds a regression test for API PATCH requests (partial updates) for changelogs.