### PR TITLE
Add autodetection of mime_type on git datasourced export_template.

### DIFF
--- a/nautobot/docs/models/extras/gitrepository.md
+++ b/nautobot/docs/models/extras/gitrepository.md
@@ -119,5 +119,5 @@ Files in a `config_contexts/devices/` and/or `config_contexts/virtual_machines/`
 Export templates may be provided as files located in `/export_templates/<grouping>/<model>/<template_file>`; for example, a JSON export template for Device records might be `/export_templates/dcim/device/mytemplate.json`.
 
 * The name of a discovered export template will be presented in Nautobot as `<repository name>: <filename>`.
-* The MIME type of a file rendered from a discovered export template will always be the default `text/plain`.
+* The MIME type of a file rendered from a discovered export template will try to match the extension to [`IANA's list`](https://www.iana.org/assignments/media-types/media-types.xhtml). If not detected, it will default to `text/plain`.
 * The file extension of a file rendered from a discovered export template will match that of the template itself (so, in the above example, the extension would be `.json`)

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 import logging
+import mimetypes
 import os
 import re
 from urllib.parse import quote
@@ -631,8 +632,12 @@ def update_git_export_templates(repository_record, job_result):
                 template_record.template_code = template_content
                 modified = True
 
-            if template_record.mime_type != "text/plain":
-                template_record.mime_type = "text/plain"
+            # mimetypes.guess_type returns a tuple (type, encoding)
+            mime_type = mimetypes.guess_type(file_path)[0]
+            if mime_type is None:
+                mime_type = "text/plain"
+            if template_record.mime_type != mime_type:
+                template_record.mime_type = mime_type
                 modified = True
 
             if template_record.file_extension != file_name.rsplit(os.extsep, 1)[-1]:


### PR DESCRIPTION
This uses the list of IAMA's media types and defaults to text/plain.

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #561 
<!--
    Please include a summary of the proposed changes below.
-->
This change tries to auto-detect the mime_type from the export template extension.
If not found, defaults to `text/plain`   I thought about adding `.j2` to the known filetypes,
but I didn't know if we wanted to track that or allow it to default to `text/plain`.
