### PR TITLE
Add custom links and plugin template content to JobResult detail views

### DIFF
--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -498,7 +498,10 @@ class Job(models.Model):
 #
 # Job results
 #
-@extras_features("graphql")
+@extras_features(
+    "custom_links",
+    "graphql",
+)
 class JobResult(BaseModel):
     """
     This model stores the results from running a user-defined report.

--- a/nautobot/extras/templates/extras/job_jobresult.html
+++ b/nautobot/extras/templates/extras/job_jobresult.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% load helpers %}
+{% load custom_links %}
 {% load form_helpers %}
 {% load log_levels %}
+{% load plugins %}
 {% load static %}
 
 {% block header %}
@@ -21,12 +23,23 @@
             </ol>
         </div>
     </div>
+    <div class="pull-right noprint">
+        {% plugin_buttons result %}
+        {% if perms.extras.delete_jobresult %}
+            <a href="{% url 'extras:jobresult_delete' pk=result.pk %}" class="btn btn-danger">
+                <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
+            </a>
+        {% endif %}
+    </div>
     <h1>
         {% block title %}
             {% if job %}{{ job }}{% else %}{{ result.name }}{% endif %} - Job Result
         {% endblock %}
     </h1>
 
+    <div class="pull-right noprint">
+        {% custom_links result %}
+    </div>
     {% if job %}
         <p>{{ job.description }}</p>
     {% endif %}
@@ -63,6 +76,11 @@
                 <pre>{{ job.source }}</pre>
             </div>
         {% endif %}
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            {% plugin_full_width_page result %}
+        </div>
     </div>
 {% endblock %}
 

--- a/nautobot/extras/templates/extras/jobresult.html
+++ b/nautobot/extras/templates/extras/jobresult.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% load helpers %}
+{% load custom_links %}
 {% load form_helpers %}
 {% load log_levels %}
+{% load plugins %}
 {% load static %}
 
 {% block title %}
@@ -31,6 +33,14 @@
             </ol>
         </div>
     </div>
+    <div class="pull-right noprint">
+        {% plugin_buttons result %}
+        {% if perms.extras.delete_jobresult %}
+            <a href="{% url 'extras:jobresult_delete' pk=result.pk %}" class="btn btn-danger">
+                <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
+            </a>
+        {% endif %}
+    </div>
     <h1>
         {% if associated_record %}
             {{ associated_record }}
@@ -42,19 +52,19 @@
         - Job Result
     </h1>
     <div class="pull-right noprint">
-        {% if perms.extras.delete_jobresult %}
-            <a href="{% url 'extras:jobresult_delete' pk=result.pk %}" class="btn btn-danger">
-                <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
-            </a>
-        {% endif %}
+        {% custom_links result %}
     </div>
-
     {% if job %}
         <p>{{ job.description }}</p>
     {% endif %}
     <div class="row">
         <div class="col-md-12">
             {% include 'extras/inc/jobresult.html' with result=result %}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            {% plugin_full_width_page result %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #N/A
<!--
    Please include a summary of the proposed changes below.
-->

- Add support for Custom Links to be defined for the JobResult model and rendered in the JobResult detail view and the Job's JobResult detail view (yes, these are two separate views; the former is generic for all JobResults, while the latter adds more Job-specific context for results that were derived from a Job, such as embedding the associated Job's source code)
- Also add `plugin_buttons` and `plugin_full_width_page` template tags to both of these views so that plugins can add either of these types of content to these views if desired. (I did not add `plugin_left_page` and `plugin_right_page` as these views are full-width views only and don't have left/right columns at this time.)

![image](https://user-images.githubusercontent.com/5603551/122078303-7d0ca280-cdca-11eb-93df-1820654d3ec9.png)

![image](https://user-images.githubusercontent.com/5603551/122078411-901f7280-cdca-11eb-8836-cdf756b90165.png)
