### PR TITLE
Update VLAN Count in VLAN Groups page

### DIFF
--- a/nautobot/ipam/templates/ipam/vlangroup.html
+++ b/nautobot/ipam/templates/ipam/vlangroup.html
@@ -82,7 +82,7 @@
                 <tr>
                     <td>VLANs</td>
                     <td>
-                        <a href="{% url 'ipam:vlan_list' %}?group={{ object.pk }}">{{ vlan_table.rows|length }}</a>
+                        <a href="{% url 'ipam:vlan_list' %}?group={{ object.pk }}">{{ vlans_count }}</a>
                     </td>
                 </tr>
             </table>

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -753,7 +753,6 @@ class VLANGroupView(generic.ObjectView):
             .filter(group=instance)
             .prefetch_related(Prefetch("prefixes", queryset=Prefix.objects.restrict(request.user)))
         )
-        
         vlans_count = vlans.count()
         vlans = add_available_vlans(instance, vlans)
 

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -753,6 +753,8 @@ class VLANGroupView(generic.ObjectView):
             .filter(group=instance)
             .prefetch_related(Prefetch("prefixes", queryset=Prefix.objects.restrict(request.user)))
         )
+        
+        vlans_count = vlans.count()
         vlans = add_available_vlans(instance, vlans)
 
         vlan_table = tables.VLANDetailTable(vlans)
@@ -779,6 +781,7 @@ class VLANGroupView(generic.ObjectView):
             "bulk_querystring": f"group_id={instance.pk}",
             "vlan_table": vlan_table,
             "permissions": permissions,
+            "vlans_count": vlans_count,
         }
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #490
<!--
    Please include a summary of the proposed changes below.
-->
To accurately reflect the total VLANs configured in a group, pass the total VLAN count from a query to the view. The table has extra fields and should not be used to reflect the total VLANs. 