### PR TITLE
Fix git imported template immediately removed during import

### DIFF
--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -691,7 +691,7 @@ def delete_git_export_templates(repository_record, job_result, preserve=None):
         owner_content_type=git_repository_content_type,
         owner_object_id=repository_record.pk,
     ):
-        key = f"{template_record.content_type.app_label}.{template_record.content_type.name}"
+        key = f"{template_record.content_type.app_label}.{template_record.content_type.model}"
         if template_record.name not in preserve.get(key, ()):
             template_record.delete()
             job_result.log(

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -11,6 +11,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, TestCase
 
 from nautobot.dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+from nautobot.ipam.models import VLAN
 
 from nautobot.extras.choices import JobResultStatusChoices
 from nautobot.extras.datasources.git import pull_git_repository_and_refresh_data
@@ -153,6 +154,7 @@ class GitTest(TestCase):
                     os.makedirs(os.path.join(path, "config_contexts"))
                     os.makedirs(os.path.join(path, "config_contexts", "devices"))
                     os.makedirs(os.path.join(path, "export_templates", "dcim", "device"))
+                    os.makedirs(os.path.join(path, "export_templates", "ipam", "vlan"))
                     with open(os.path.join(path, "config_contexts", "context.yaml"), "w") as fd:
                         yaml.dump(
                             {
@@ -176,6 +178,11 @@ class GitTest(TestCase):
                         "w",
                     ) as fd:
                         fd.write("{% for device in queryset %}\n{{ device.name }}\n{% endfor %}")
+                    with open(
+                        os.path.join(path, "export_templates", "ipam", "vlan", "template.j2"),
+                        "w",
+                    ) as fd:
+                        fd.write("{% for vlan in queryset %}\n{{ vlan.name }}\n{% endfor %}")
                     return mock.DEFAULT
 
                 MockGitRepo.side_effect = populate_repo
@@ -211,19 +218,30 @@ class GitTest(TestCase):
                 self.assertEqual(device.local_context_data_owner, self.repo)
 
                 # Make sure ExportTemplate was successfully loaded from file
-                export_template = ExportTemplate.objects.get(
+                export_template_device = ExportTemplate.objects.get(
                     owner_object_id=self.repo.pk,
                     owner_content_type=ContentType.objects.get_for_model(GitRepository),
                     content_type=ContentType.objects.get_for_model(Device),
                     name="template.j2",
                 )
-                self.assertIsNotNone(export_template)
+                self.assertIsNotNone(export_template_device)
+
+                # Make sure ExportTemplate was successfully loaded from file
+                # Case when ContentType.model != ContentType.name, template was added and deleted during sync (#570)
+                export_template_vlan = ExportTemplate.objects.get(
+                    owner_object_id=self.repo.pk,
+                    owner_content_type=ContentType.objects.get_for_model(GitRepository),
+                    content_type=ContentType.objects.get_for_model(VLAN),
+                    name="template.j2",
+                )
+                self.assertIsNotNone(export_template_vlan)
 
                 # Now "resync" the repository, but now those files no longer exist in the repository
                 def empty_repo(path, url):
                     os.remove(os.path.join(path, "config_contexts", "context.yaml"))
                     os.remove(os.path.join(path, "config_contexts", "devices", "test-device.json"))
                     os.remove(os.path.join(path, "export_templates", "dcim", "device", "template.j2"))
+                    os.remove(os.path.join(path, "export_templates", "ipam", "vlan", "template.j2"))
                     return mock.DEFAULT
 
                 MockGitRepo.side_effect = empty_repo


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #570

Use `content_type.model` instead of `content_type.name` in https://github.com/nautobot/nautobot/blob/v1.0.2/nautobot/extras/datasources/git.py#L694, as in https://github.com/nautobot/nautobot/blob/v1.0.2/nautobot/extras/datasources/git.py#L600.

Add test using VLAN model where `content_type.name != content_type.model`.