### PR TITLE
Ensure that deleting a record deletes its associated RelationshipAssociations

### DIFF
--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -1,7 +1,7 @@
 import logging
 from collections import OrderedDict
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import ValidationError
 from django.db import models
@@ -31,6 +31,19 @@ class RelationshipModel(models.Model):
 
     class Meta:
         abstract = True
+
+    # Define GenericRelations so that deleting a RelationshipModel instance
+    # cascades to deleting any RelationshipAssociations that were using this instance
+    source_for_associations = GenericRelation(
+        "extras.RelationshipAssociation",
+        content_type_field="source_type",
+        object_id_field="source_id",
+    )
+    destination_for_associations = GenericRelation(
+        "extras.RelationshipAssociation",
+        content_type_field="destination_type",
+        object_id_field="destination_id",
+    )
 
     def get_relationships(self, include_hidden=False):
         """

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -33,16 +33,19 @@ class RelationshipModel(models.Model):
         abstract = True
 
     # Define GenericRelations so that deleting a RelationshipModel instance
-    # cascades to deleting any RelationshipAssociations that were using this instance
+    # cascades to deleting any RelationshipAssociations that were using this instance,
+    # and also for convenience in looking up the RelationshipModels associated to any given RelationshipAssociation
     source_for_associations = GenericRelation(
         "extras.RelationshipAssociation",
         content_type_field="source_type",
         object_id_field="source_id",
+        related_query_name="source_%(app_label)s_%(class)s",  # e.g. 'source_dcim_site', 'source_ipam_vlan'
     )
     destination_for_associations = GenericRelation(
         "extras.RelationshipAssociation",
         content_type_field="destination_type",
         object_id_field="destination_id",
+        related_query_name="destination_%(app_label)s_%(class)s",  # e.g. 'destination_dcim_rack'
     )
 
     def get_relationships(self, include_hidden=False):

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -343,7 +343,28 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         for association in associations:
             association.validated_save()
 
+        # Check that the GenericRelation lookup works correctly
         self.assertEqual(3, self.racks[0].source_for_associations.count())
         self.assertEqual(0, self.racks[0].destination_for_associations.count())
         self.assertEqual(0, self.vlans[0].source_for_associations.count())
         self.assertEqual(1, self.vlans[0].destination_for_associations.count())
+
+        # Check that the related_query_names work correctly for each individual RelationshipAssociation
+        self.assertEqual([self.racks[0]], list(associations[0].source_dcim_rack.all()))
+        self.assertEqual([self.vlans[0]], list(associations[0].destination_ipam_vlan.all()))
+        self.assertEqual([], list(associations[0].destination_dcim_site.all()))
+
+        self.assertEqual([self.racks[0]], list(associations[1].source_dcim_rack.all()))
+        self.assertEqual([self.vlans[1]], list(associations[1].destination_ipam_vlan.all()))
+        self.assertEqual([], list(associations[1].destination_dcim_site.all()))
+
+        self.assertEqual([self.racks[0]], list(associations[2].source_dcim_rack.all()))
+        self.assertEqual([], list(associations[2].destination_ipam_vlan.all()))
+        self.assertEqual([self.sites[0]], list(associations[2].destination_dcim_site.all()))
+
+        # Check that the related query names can be used for filtering as well
+        self.assertEqual(3, RelationshipAssociation.objects.filter(source_dcim_rack=self.racks[0]).count())
+        self.assertEqual(2, RelationshipAssociation.objects.filter(destination_ipam_vlan__isnull=False).count())
+        self.assertEqual(1, RelationshipAssociation.objects.filter(destination_ipam_vlan=self.vlans[0]).count())
+        self.assertEqual(1, RelationshipAssociation.objects.filter(destination_ipam_vlan=self.vlans[1]).count())
+        self.assertEqual(1, RelationshipAssociation.objects.filter(destination_dcim_site=self.sites[0]).count())

--- a/tasks.py
+++ b/tasks.py
@@ -501,13 +501,14 @@ def integration_test(
 @task(
     help={
         "lint-only": "Only run linters; unit tests will be excluded.",
+        "keepdb": "Save and re-use test database between test runs for faster re-testing.",
     }
 )
-def tests(context, lint_only=False):
+def tests(context, lint_only=False, keepdb=False):
     """Run all tests and linters."""
     black(context)
     flake8(context)
     hadolint(context)
     check_migrations(context)
     if not lint_only:
-        unittest(context)
+        unittest(context, keepdb=keepdb)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #460 
<!--
    Please include a summary of the proposed changes below.
-->

Where GenericForeignKeys are involved, if we define a corresponding GenericRelation on the targeted model, then we get behavior equivalent to a regular ForeignKey's `on_delete=CASCADE`. So I've done that.