### PR TITLE
Disallow non-unique names for unowned ConfigContext and ExportTemplates

### DIFF
--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -292,6 +292,17 @@ class ExportTemplate(BaseModel, ChangeLoggedModel, RelationshipModel):
         if self.file_extension.startswith("."):
             self.file_extension = self.file_extension[1:]
 
+        # Don't allow two ExportTemplates with the same name, content_type, and owner.
+        # This is necessary because Django doesn't consider NULL=NULL, and so if owner is NULL the unique_together
+        # condition will never be matched even if name and content_type are the same.
+        if ExportTemplate.objects.exclude(pk=self.pk).filter(
+            name=self.name,
+            content_type=self.content_type,
+            owner_content_type=self.owner_content_type,
+            owner_object_id=self.owner_object_id,
+        ):
+            raise ValidationError({"name": "An ExportTemplate with this name and content type already exists."})
+
 
 #
 # Image attachments
@@ -422,6 +433,13 @@ class ConfigContext(BaseModel, ChangeLoggedModel):
         # Verify that JSON data is provided as an object
         if type(self.data) is not dict:
             raise ValidationError({"data": 'JSON data must be in object form. Example: {"foo": 123}'})
+
+        # Check for a duplicated `name`. This is necessary because Django does not consider two NULL fields to be equal,
+        # and thus if the `owner` is NULL, a duplicate `name` will not otherwise automatically raise an exception.
+        if ConfigContext.objects.exclude(pk=self.pk).filter(
+            name=self.name, owner_content_type=self.owner_content_type, owner_object_id=self.owner_object_id
+        ):
+            raise ValidationError({"name": "A ConfigContext with this name already exists."})
 
 
 class ConfigContextModel(models.Model):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #431 
<!--
    Please include a summary of the proposed changes below.
-->

This fixes a regression that was created by the introduction of Git repository ownership of ConfigContext and ExportTemplate records. Before we added this feature (i.e., originally in NetBox), uniqueness constraints in the DB forbid the following:
- Multiple ConfigContexts with the same `name`
- Multiple ExportTemplates with the same `name` and `content_type`.

When the option for Git repository ownership of these models was introduced, these constraints were meant to have been relaxed so that multiples could coexist *if they had different ownership*, as a way of simplifying the potential for unintended interactions between multiple repositories defining similar data. However, because of good old `NULL != NULL`, this had the undesired side effect of allowing unowned (manually created, i.e. `owner = NULL`) records of these two models to be multiply defined with identical attributes.

This PR adds `clean()` logic to both models to handle the `NULL != NULL` case and restore the prior behavior of disallowing duplicate records with no `owner`. Test coverage is included.