### PR TITLE
Eliminate need for `toml` in `tasks.py`

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -13,12 +13,13 @@ limitations under the License.
 """
 
 from distutils.util import strtobool
+import os
+import re
+from time import sleep
+
 from invoke import Collection, task as invoke_task
 from invoke.exceptions import Exit
-import os
 import requests
-from time import sleep
-import toml
 
 
 def is_truthy(arg):
@@ -174,6 +175,15 @@ def buildx(
     context.run(command, env={"PYTHON_VER": context.nautobot.python_ver})
 
 
+def get_nautobot_version():
+    """Directly parse `pyproject.toml` and extract the version."""
+    with open("pyproject.toml", "r") as fh:
+        content = fh.read()
+
+    version_match = re.findall(r"version = \"(.*)\"\n", content)
+    return version_match[0]
+
+
 @task(
     help={
         "branch": "Source branch used to push.",
@@ -183,10 +193,7 @@ def buildx(
 )
 def docker_push(context, branch, commit="", datestamp=""):
     """Tags and pushes docker images to the appropriate repos, intended for CI use only."""
-    with open("pyproject.toml", "r") as pyproject:
-        parsed_toml = toml.load(pyproject)
-
-    nautobot_version = parsed_toml["tool"]["poetry"]["version"]
+    nautobot_version = get_nautobot_version()
 
     docker_image_tags_main = [
         f"latest-py{context.nautobot.python_ver}",


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #602 
<!--
    Please include a summary of the proposed changes below.
-->
- This drops the dependency on `toml` inside of `tasks.py`
- Adds a custom `get_nautobot_version()` function that directly parses the version string using regex.