### PR TITLE
Docs Update Only - add simple note on jobs around worker restarts

### DIFF
--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -54,7 +54,7 @@ You can implement the entire job within the `run()` function, but for more compl
 It's important to understand that jobs execute on the server asynchronously as background tasks; they log messages and report their status to the database as [`JobResult`](../models/extras/jobresult.md) records.
 
 !!! note
-    When actively developing a Job utilizing a development environment it's important to understand that the reload on save debug functionality does **not** automatically restart the `nautobot_worker`; therefore, it is required to restart the `worker` after each update to `jobs.py`.
+    When actively developing a Job utilizing a development environment it's important to understand that the "reload on code changes" debugging functionality does **not** automatically restart the `nautobot_worker`; therefore, it is required to restart the `worker` after each update to your Job source code.
 
 ### Module Attributes
 

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -53,6 +53,9 @@ You can implement the entire job within the `run()` function, but for more compl
 
 It's important to understand that jobs execute on the server asynchronously as background tasks; they log messages and report their status to the database as [`JobResult`](../models/extras/jobresult.md) records.
 
+!!! note
+    When actively developing a Job utilizing a development environment it's important to understand that the reload on save debug functionality does **not** automatically restart the `nautobot_worker`; therefore, it is required to restart the `worker` after each update to `jobs.py`.
+
 ### Module Attributes
 
 #### `name`


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #<ISSUE NUMBER GOES HERE>
<!--
    Please include a summary of the proposed changes below.
-->
Add a note to jobs docs about the necessity of reloading/restarting the worker for updates to `jobs.py` to be utilized.