### PR TITLE
Implements #557 - Add IPv4 /32 and IPv6 /128 prefix support

### DIFF
--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -651,8 +651,8 @@ class Prefix(PrimaryModel, StatusModel):
         child_ips = netaddr.IPSet([ip.address.ip for ip in self.get_child_ips()])
         available_ips = prefix - child_ips
 
-        # IPv6, pool, or IPv4 /31 sets are fully usable
-        if self.family == 6 or self.is_pool or self.prefix.prefixlen == 31:
+        # IPv6, pool, or IPv4 /31-32 sets are fully usable
+        if self.family == 6 or self.is_pool or (self.family == 4 and self.prefix.prefixlen >= 31):
             return available_ips
 
         # All IP addresses within a prefix are considered usable

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -655,7 +655,6 @@ class Prefix(PrimaryModel, StatusModel):
         if self.family == 6 or self.is_pool or (self.family == 4 and self.prefix.prefixlen >= 31):
             return available_ips
 
-
         # Omit first and last IP address from the available set
         # For "normal" IPv4 prefixes, omit first and last addresses
         available_ips -= netaddr.IPSet(
@@ -664,7 +663,6 @@ class Prefix(PrimaryModel, StatusModel):
                 netaddr.IPAddress(self.prefix.last),
             ]
         )
-
         return available_ips
 
     def get_first_available_prefix(self):

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -651,8 +651,8 @@ class Prefix(PrimaryModel, StatusModel):
         child_ips = netaddr.IPSet([ip.address.ip for ip in self.get_child_ips()])
         available_ips = prefix - child_ips
 
-        # All IP addresses within a pool are considered usable
-        if self.is_pool:
+        # IPv6, pool, or IPv4 /31 sets are fully usable
+        if self.family == 6 or self.is_pool or self.prefix.prefixlen == 31:
             return available_ips
 
         # All IP addresses within a prefix are considered usable
@@ -662,6 +662,7 @@ class Prefix(PrimaryModel, StatusModel):
             return available_ips
 
         # Omit first and last IP address from the available set
+        # For "normal" IPv4 prefixes, omit first and last addresses
         available_ips -= netaddr.IPSet(
             [
                 netaddr.IPAddress(self.prefix.first),

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -655,11 +655,6 @@ class Prefix(PrimaryModel, StatusModel):
         if self.family == 6 or self.is_pool or (self.family == 4 and self.prefix.prefixlen >= 31):
             return available_ips
 
-        # All IP addresses within a prefix are considered usable
-        if (self.prefix.version == 4 and self.prefix.prefixlen >= 31) or (  # RFC 3021
-            self.prefix.version == 6 and self.prefix.prefixlen >= 127  # RFC 6164
-        ):
-            return available_ips
 
         # Omit first and last IP address from the available set
         # For "normal" IPv4 prefixes, omit first and last addresses


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #557 - Add IPv4 /32 and IPv6 /128 prefix support
<!--
    Please include a summary of the proposed changes below.
-->
Allow /32 and /128 prefixes