### PR TITLE
Add missing "project_name" to invoke.yml.example

### DIFF
--- a/invoke.yml.example
+++ b/invoke.yml.example
@@ -1,5 +1,6 @@
 ---
 nautobot:
+  project_name: "nautobot"
   local: False
   python_ver: "3.7"
   compose_dir: "/full/path/to/nautobot/development"


### PR DESCRIPTION
In the example file, the project_name is missing

see tasks.py:

```python
namespace = Collection("nautobot")
namespace.configure(
    {
        "nautobot": {
            "project_name": "nautobot",
            "python_ver": "3.6",
            "local": False,
            "compose_dir": os.path.join(os.path.dirname(__file__), "development/"),
            "compose_file": "docker-compose.yml",
```

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #<ISSUE NUMBER GOES HERE>
<!--
    Please include a summary of the proposed changes below.
-->
