### PR TITLE
Fix systemd unit file for `nautobot-worker` to correctly start/stop/restart

### DIFF
--- a/nautobot/docs/installation/services.md
+++ b/nautobot/docs/installation/services.md
@@ -138,15 +138,15 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=forking
+Type=exec
 Environment="NAUTOBOT_ROOT=/opt/nautobot"
 
 User=nautobot
 Group=nautobot
-PIDFile=/var/tmp/nautobot-celery.pid
+PIDFile=/var/tmp/nautobot-worker.pid
 WorkingDirectory=/opt/nautobot
 
-ExecStart=/opt/nautobot/bin/nautobot-server celery worker --loglevel INFO --pidfile /var/tmp/nautobot-celery.pid
+ExecStart=/opt/nautobot/bin/nautobot-server celery worker --loglevel INFO --pidfile /var/tmp/nautobot-worker.pid
 
 Restart=always
 RestartSec=30


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #653 
<!--
    Please include a summary of the proposed changes below.
-->

- This changes the service type for the Celery worker from `forking` to `exec` since we are not actually backgrounding or demonizing the worker processes.
- Also renamed the `pidfile` to `nautobot-worker.pid`.