### PR TITLE
Fix 649 -  Multiple plugin register navbar error

### DIFF
--- a/nautobot/core/apps/__init__.py
+++ b/nautobot/core/apps/__init__.py
@@ -238,10 +238,11 @@ class NavMenuItem(NavMenuBase, PermissionsMixin):
         self.name = name
         self.weight = weight
 
-        if buttons is not None and not isinstance(buttons, (list, tuple)):
-            raise TypeError("Buttons must be passed as a tuple or list.")
-        elif not all(isinstance(button, NavMenuButton) for button in buttons):
-            raise TypeError("All buttons defined in an item must be an instance or subclass of NavMenuButton")
+        if buttons is not None:
+            if not isinstance(buttons, (list, tuple)):
+                raise TypeError("Buttons must be passed as a tuple or list.")
+            elif not all(isinstance(button, NavMenuButton) for button in buttons):
+                raise TypeError("All buttons defined in an item must be an instance or subclass of NavMenuButton")
         self.buttons = buttons
 
 

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -377,7 +377,9 @@ def register_plugin_menu_items(section_name, menu_items):
         # wrap bare item/button list into the default "Plugins" menu tab and appropriate grouping
         if registry["nav_menu"]["tabs"].get("Plugins"):
             weight = (
-                registry["nav_menu"]["tabs"]["Plugins"][list(registry["nav_menu"]["tabs"]["Plugins"])[-1]]["weight"]
+                registry["nav_menu"]["tabs"]["Plugins"]["groups"][
+                    list(registry["nav_menu"]["tabs"]["Plugins"]["groups"])[-1]
+                ]["weight"]
                 + 100
             )
         else:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #649 
<!--
    Please include a summary of the proposed changes below.
-->

Added correct dict path to find previous plugin.
Added if statement for when buttons are not defined in a button.
