### PR TITLE
Serve computed fields from DeviceWithConfigContextSerializer.

### DIFF
--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -759,11 +759,13 @@ class DeviceWithConfigContextSerializer(DeviceSerializer):
             "local_context_schema",
             "local_context_data",
             "tags",
+            "computed_fields",
             "custom_fields",
             "config_context",
             "created",
             "last_updated",
         ]
+        opt_in_fields = ["computed_fields"]
 
     @swagger_serializer_method(serializer_or_field=serializers.DictField)
     def get_config_context(self, obj):


### PR DESCRIPTION
### Fixes: #661

Adds "computed_fields" to the `fields` list of `DeviceWithConfigContextSerializer` and defines the `opt_in_fields` property.
