### PR TITLE
Improve global/partial string searching for IPv4/IPv6

### DIFF
--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -195,15 +195,7 @@ class AggregateFilterSet(BaseFilterSet, TenancyFilterSet, CustomFieldModelFilter
             return queryset.none()
 
     def filter_ip_family(self, queryset, name, value):
-        if value == 4:
-            length = IPV4_BYTE_LENGTH
-        elif value == 6:
-            length = IPV6_BYTE_LENGTH
-        else:
-            raise ValueError("invalid IP family {}".format(value))
-        return queryset.annotate(network_len=Length(F("network"))).filter(
-            network_len=length,
-        )
+        return queryset.ip_family(value)
 
 
 class RoleFilterSet(
@@ -408,15 +400,7 @@ class PrefixFilterSet(
         return queryset.filter(Q(vrf=vrf) | Q(vrf__export_targets__in=vrf.import_targets.all()))
 
     def filter_ip_family(self, queryset, name, value):
-        if value == 4:
-            length = IPV4_BYTE_LENGTH
-        elif value == 6:
-            length = IPV6_BYTE_LENGTH
-        else:
-            raise ValueError("invalid IP family {}".format(value))
-        return queryset.annotate(network_len=Length(F("network"))).filter(
-            network_len=length,
-        )
+        return queryset.ip_family(value)
 
 
 class IPAddressFilterSet(

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -187,7 +187,7 @@ class AggregateFilterSet(BaseFilterSet, TenancyFilterSet, CustomFieldModelFilter
             return queryset.none()
 
     def filter_ip_family(self, queryset, name, value):
-        return queryset.ip_family(value.strip())
+        return queryset.ip_family(value)
 
 
 class RoleFilterSet(
@@ -378,7 +378,7 @@ class PrefixFilterSet(
         return queryset.filter(Q(vrf=vrf) | Q(vrf__export_targets__in=vrf.import_targets.all()))
 
     def filter_ip_family(self, queryset, name, value):
-        return queryset.ip_family(value.strip())
+        return queryset.ip_family(value)
 
 
 class IPAddressFilterSet(
@@ -515,7 +515,7 @@ class IPAddressFilterSet(
         return queryset.filter(Q(vrf=vrf) | Q(vrf__export_targets__in=vrf.import_targets.all()))
 
     def filter_ip_family(self, queryset, name, value):
-        return queryset.ip_family(value.strip())
+        return queryset.ip_family(value)
 
     def filter_device(self, queryset, name, value):
         devices = Device.objects.filter(**{"{}__in".format(name): value})

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -324,8 +324,11 @@ class PrefixFilterSet(
 
     def search(self, queryset, name, value):
         value = value.strip()
+
         if not value:
             return queryset
+
+        """
         qs_filter = Q(description__icontains=value)
         try:
             # filter for Prefixes containing |value|
@@ -338,6 +341,8 @@ class PrefixFilterSet(
         except (AddrFormatError, ValueError):
             pass
         return queryset.filter(qs_filter)
+        """
+        return queryset.string_search(value)
 
     def filter_prefix(self, queryset, name, value):
         value = value.strip()

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -187,7 +187,7 @@ class AggregateFilterSet(BaseFilterSet, TenancyFilterSet, CustomFieldModelFilter
             return queryset.none()
 
     def filter_ip_family(self, queryset, name, value):
-        return queryset.ip_family(value)
+        return queryset.ip_family(value.strip())
 
 
 class RoleFilterSet(
@@ -378,7 +378,7 @@ class PrefixFilterSet(
         return queryset.filter(Q(vrf=vrf) | Q(vrf__export_targets__in=vrf.import_targets.all()))
 
     def filter_ip_family(self, queryset, name, value):
-        return queryset.ip_family(value)
+        return queryset.ip_family(value.strip())
 
 
 class IPAddressFilterSet(
@@ -515,7 +515,7 @@ class IPAddressFilterSet(
         return queryset.filter(Q(vrf=vrf) | Q(vrf__export_targets__in=vrf.import_targets.all()))
 
     def filter_ip_family(self, queryset, name, value):
-        return queryset.ip_family(value)
+        return queryset.ip_family(value.strip())
 
     def filter_device(self, queryset, name, value):
         devices = Device.objects.filter(**{"{}__in".format(name): value})

--- a/nautobot/ipam/querysets.py
+++ b/nautobot/ipam/querysets.py
@@ -20,16 +20,138 @@ from nautobot.ipam.constants import IPV4_BYTE_LENGTH, IPV6_BYTE_LENGTH
 from nautobot.utilities.querysets import RestrictedQuerySet
 
 
-class NetworkQuerySet(QuerySet):
-    @staticmethod
-    def _get_last_ip(prefix):
-        """
-        Get the last IP address in the given prefix.
+class BaseNetworkQuerySet(RestrictedQuerySet):
+    """Base class for network-related querysets."""
 
-        This is distinct from prefix.broadcast in the case of point-to-point or host network prefixes
+    ip_family_map = {
+        4: IPV4_BYTE_LENGTH,
+        6: IPV6_BYTE_LENGTH,
+    }
+
+    # Match string with ending in "::"
+    RE_COLON = re.compile(".*::$")
+
+    # Match string from "0000" to "ffff" with no trailing ":"
+    RE_HEXTET = re.compile("^[a-f0-9]{4}$")
+
+    @staticmethod
+    def _get_last_ip(network):
+        """
+        Get the last IP address in the given network.
+
+        This is distinct from network.broadcast in the case of point-to-point or host networks
         (neither of which technically have a "broadcast" address).
         """
-        return prefix.broadcast if prefix.broadcast else prefix[-1]
+        return network.broadcast if network.broadcast else network[-1]
+
+    def parse_network_string(self, search):
+        """
+        Attempts to parse a (potentially incomplete) IPAddress and return an IPNetwork.
+        eg: '10.10' should be interpreted as netaddr.IPNetwork('10.10.0.0/16')
+        """
+        version = 4
+
+        try:
+            # Disregard netmask
+            search = search.split("/")[0]
+
+            # Attempt to quickly assess v6
+            if ":" in search:
+                version = 6
+
+            # (IPv6) If the value ends with ":" but it's not "::", make it so.
+            if search.endswith(":") and not self.RE_COLON.match(search):
+                search += ":"
+            # (IPv6) If the value has a colon in it, but doesn't end with one:
+            elif not search.endswith(":") and version == 6:
+                search += ":"
+            # (IPv6) If the value is numeric and > 255, append "::"
+            # (IPv6) If the value is a hextet (e.g. "fe80"), append "::"
+            elif any(
+                [
+                    search.isdigit() and int(search) > 255,
+                    self.RE_HEXTET.match(search),
+                ]
+            ):
+                search += "::"
+                version = 6
+
+            call_map = {
+                4: self.parse_ipv4,
+                6: self.parse_ipv6,
+            }
+            return call_map[version](search)
+
+        except netaddr.core.AddrFormatError:
+            ver_map = {4: "0/32", 6: "::/128"}
+            return netaddr.IPNetwork(ver_map[version])
+
+    def parse_ipv6(self, value):
+        """IPv6 addresses are 8, 16-bit fields."""
+
+        # Get non-empty octets from search string
+        hextets = value.split(":")
+
+        # Before we normalize, check that final value is a digit.
+        if hextets[-1].isalnum():
+            fill_zeroes = False  # Leave "" in there.
+            prefix_len = 128  # Force /128
+        else:
+            fill_zeroes = True  # Replace "" w/ "0"
+            hextets = list(filter(lambda h: h, hextets))
+            prefix_len = 16 * len(hextets)
+
+        # Create an netaddr.IPNetwork to search within
+        if fill_zeroes:
+            hextets.extend(["0" for _ in range(len(hextets), 8)])
+
+        network = ":".join(hextets)
+        ip = f"{network}/{prefix_len}"
+        return netaddr.IPNetwork(ip)
+
+    def parse_ipv4(self, value):
+        """IPv4 addresses are 4, 8-bit fields."""
+
+        # Get non-empty octets from search string
+        octets = value.split(".")
+        octets = list(filter(lambda o: o, octets))
+        prefix_len = 8 * len(octets)
+
+        # Create an netaddr.IPNetwork to search within
+        octets.extend(["0" for _ in range(len(octets), 4)])
+        network = ".".join(octets)
+        ip = f"{network}/{prefix_len}"
+        return netaddr.IPNetwork(ip)
+
+    def string_search(self, search):
+        """
+        Interpret a search string and return useful results.
+        """
+        if not search:
+            return self.none()
+
+        network = self.parse_network_string(search)
+        last_ip = self._get_last_ip(network)
+
+        return self.filter(
+            Q(description__icontains=search)
+            | Q(network__gte=network.network, broadcast__lte=last_ip)  # same as `net_contained()`
+            | Q(prefix_length__lte=network.prefixlen,
+                network__lte=network.network,
+                broadcast__gte=last_ip)  # same as `net_contains_or_equals()`
+        )
+
+
+class NetworkQuerySet(BaseNetworkQuerySet):
+    """Base class for Prefix/Aggregate querysets."""
+
+    def ip_family(self, family):
+        try:
+            byte_len = self.ip_family_map[family]
+        except KeyError:
+            raise ValueError("invalid IP family {}".format(family))
+
+        return self.annotate(address_len=Length(F("prefix"))).filter(address_len=byte_len)
 
     def net_equals(self, prefix):
         prefix = netaddr.IPNetwork(prefix)
@@ -99,11 +221,13 @@ class NetworkQuerySet(QuerySet):
         return super().filter(*args, **kwargs)
 
 
-class AggregateQuerySet(NetworkQuerySet, RestrictedQuerySet):
-    pass
+class AggregateQuerySet(NetworkQuerySet):
+    """Queryset for `Aggregate` objects."""
 
 
-class PrefixQuerySet(NetworkQuerySet, RestrictedQuerySet):
+class PrefixQuerySet(NetworkQuerySet):
+    """Queryset for `Prefix` objects."""
+
     def annotate_tree(self):
         """
         Annotate the number of parent and child prefixes for each Prefix.
@@ -170,27 +294,8 @@ class PrefixQuerySet(NetworkQuerySet, RestrictedQuerySet):
         )
 
 
-class IPAddressQuerySet(RestrictedQuerySet):
-    ip_family_map = {
-        4: IPV4_BYTE_LENGTH,
-        6: IPV6_BYTE_LENGTH,
-    }
-
-    # Match string with ending in "::"
-    RE_COLON = re.compile(".*::$")
-
-    # Match string from "0000" to "ffff" with no trailing ":"
-    RE_HEXTET = re.compile("^[a-f0-9]{4}$")
-
-    @staticmethod
-    def _get_last_ip(network):
-        """
-        Get the last IP address in the given network.
-
-        This is distinct from network.broadcast in the case of point-to-point or host networks
-        (neither of which technically have a "broadcast" address).
-        """
-        return network.broadcast if network.broadcast else network[-1]
+class IPAddressQuerySet(BaseNetworkQuerySet):
+    """Queryset for `IPAddress` objects."""
 
     def get_queryset(self):
         """
@@ -202,97 +307,6 @@ class IPAddressQuerySet(RestrictedQuerySet):
         """
         return super().order_by("host")
 
-    def string_search(self, search):
-        """
-        Interpret a search string and return useful results.
-        """
-        if not search:
-            return self.none()
-
-        network = self._parse_as_network_string(search)
-        last_ip = self._get_last_ip(network)
-        return self.filter(
-            Q(dns_name__icontains=search)
-            | Q(description__icontains=search)
-            | Q(host__lte=last_ip, host__gte=network.network)  # same as `net_host_contained()`
-        )
-
-    def _parse_as_network_string(self, search):
-        """
-        Attempts to parse a (potentially incomplete) IPAddress and return an IPNetwork.
-        eg: '10.10' should be interpreted as netaddr.IPNetwork('10.10.0.0/16')
-        """
-        version = 4
-
-        try:
-            # Disregard netmask
-            search = search.split("/")[0]
-
-            # Attempt to quickly assess v6
-            if ":" in search:
-                version = 6
-
-            # (IPv6) If the value ends with ":" but it's not "::", make it so.
-            if search.endswith(":") and not self.RE_COLON.match(search):
-                search += ":"
-            # (IPv6) If the value is numeric and > 255, append "::"
-            # (IPv6) If the value is a hextet (e.g. "fe80"), append "::"
-            elif any(
-                [
-                    search.isdigit() and int(search) > 255,
-                    self.RE_HEXTET.match(search),
-                ]
-            ):
-                search += "::"
-                version = 6
-
-            call_map = {
-                4: self._parse_ipv4,
-                6: self._parse_ipv6,
-            }
-            return call_map[version](search)
-
-        except netaddr.core.AddrFormatError:
-            ver_map = {4: "0/32", 6: "::/128"}
-            return netaddr.IPNetwork(ver_map[version])
-
-    def _parse_ipv6(self, value):
-        """IPv6 addresses are 8, 16-bit fields."""
-
-        # Get non-empty octets from search string
-        hextets = value.split(":")
-
-        # Before we normalize, check that final value is a digit.
-        if hextets[-1].isalnum():
-            fill_zeroes = False  # Leave "" in there.
-            prefix_len = 128  # Force /128
-        else:
-            fill_zeroes = True  # Replace "" w/ "0"
-            hextets = list(filter(lambda h: h, hextets))
-            prefix_len = 16 * len(hextets)
-
-        # Create an netaddr.IPNetwork to search within
-        if fill_zeroes:
-            hextets.extend(["0" for _ in range(len(hextets), 8)])
-
-        network = ":".join(hextets)
-        ip = f"{network}/{prefix_len}"
-        return netaddr.IPNetwork(ip)
-
-    def _parse_ipv4(self, value):
-        """IPv4 addresses are 4, 8-bit fields."""
-
-        # Get non-empty octets from search string
-        octets = value.split(".")
-        octets = list(filter(lambda o: o, octets))
-        prefix_len = 8 * len(octets)
-
-        # Create an netaddr.IPNetwork to search within
-        octets.extend(["0" for _ in range(len(octets), 4)])
-        network = ".".join(octets)
-        ip = f"{network}/{prefix_len}"
-        return netaddr.IPNetwork(ip)
-
     def ip_family(self, family):
         try:
             byte_len = self.ip_family_map[family]
@@ -300,6 +314,21 @@ class IPAddressQuerySet(RestrictedQuerySet):
             raise ValueError("invalid IP family {}".format(family))
 
         return self.annotate(address_len=Length(F("host"))).filter(address_len=byte_len)
+
+    def string_search(self, search):
+        """
+        Interpret a search string and return useful results.
+        """
+        if not search:
+            return self.none()
+
+        network = self.parse_network_string(search)
+        last_ip = self._get_last_ip(network)
+        return self.filter(
+            Q(dns_name__icontains=search)
+            | Q(description__icontains=search)
+            | Q(host__lte=last_ip, host__gte=network.network)  # same as `net_host_contained()`
+        )
 
     def net_host_contained(self, network):
         # consider only host ip address when

--- a/nautobot/ipam/tests/test_querysets.py
+++ b/nautobot/ipam/tests/test_querysets.py
@@ -116,7 +116,7 @@ class IPAddressQuerySet(TestCase):
         address = self.queryset.net_in(["10.0.0.1/24"])[0]
         self.assertEqual(self.queryset.filter(address="10.0.0.1/24")[0], address)
 
-    def test_string_search_parse_as_network_string(self):
+    def test_string_search_parse_network_string(self):
         """
         Tests that the parsing underlying `string_search` behaves as expected.
         """
@@ -131,6 +131,7 @@ class IPAddressQuerySet(TestCase):
             "2001": "2001::/16",
             "2001:": "2001::/16",
             "2001::": "2001::/16",
+            "2001:db8": "2001:db8::/32",
             "2001:db8:": "2001:db8::/32",
             "2001:0db8::": "2001:db8::/32",
             "2001:db8:abcd:0012::0/64": "2001:db8:abcd:12::/128",
@@ -142,7 +143,7 @@ class IPAddressQuerySet(TestCase):
         }
 
         for test, expected in tests.items():
-            self.assertEqual(str(self.queryset._parse_as_network_string(test)), expected)
+            self.assertEqual(str(self.queryset.parse_network_string(test)), expected)
 
     def test_string_search(self):
         search_terms = {
@@ -154,6 +155,8 @@ class IPAddressQuerySet(TestCase):
             "11": 0,
             "2001": 3,
             "2001::": 3,
+            "2001:db8": 3,
+            "2001:db8:": 3,
             "2001:db8::": 3,
             "2001:db8::1": 1,
             "fe80::": 0,

--- a/nautobot/ipam/tests/test_querysets.py
+++ b/nautobot/ipam/tests/test_querysets.py
@@ -249,3 +249,31 @@ class PrefixQuerysetTestCase(TestCase):
     def test_filter_by_prefix(self):
         prefix = self.queryset.net_equals(netaddr.IPNetwork("192.168.0.0/16"))[0]
         self.assertEqual(self.queryset.filter(prefix="192.168.0.0/16")[0], prefix)
+
+    def test_string_search(self):
+        # This test case also applies to Aggregate objects.
+        search_terms = {
+            "192": 7,
+            "192.": 7,
+            "192.168": 7,
+            "192.168.": 7,
+            "192.168.1": 2,
+            "192.168.1.0": 2,
+            "192.168.3": 5,
+            "192.168.3.192/26": 3,
+            "192.168.0.0/16": 1,
+            "11": 0,
+            "fd78": 3,
+            "fd78::": 3,
+            "fd78:da4f": 3,
+            "fd78:da4f:": 3,
+            "fd78:da4f:e596": 3,
+            "fd78:da4f:e596:c217": 3,
+            "fd78:da4f:e596:c217::": 3,
+            "fd78:da4f:e596:c217::/64": 3,
+            "fd78:da4f:e596:c217::/120": 3,
+            "fd78:da4f:e596:c217::/122": 3,
+            "fe80::": 0,
+        }
+        for term, cnt in search_terms.items():
+            self.assertEqual(self.queryset.string_search(term).count(), cnt)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #495 
### Fixes: #554  
<!--
    Please include a summary of the proposed changes below.
-->
- This refactors parsing of network strings to be part of what is now `BaseNetworkQuerySet`
  - `NetworkQuerySet` now inherits from this base, from which `(Aggregate|Prefix)QuerySet` objects inherit 
  - `IPAddressQuerySet` now inherits from this base
- Due to this change `Prefix` and `Aggregate` objects now support an `ip_family` filter and the filter field on each respective filterset (`nautobot.ipam.filters.PrefixFilterSet` & `nautobot.ipam.filters.AggregateFilterSet` have been updated to match
- IPv6 string searching is more robust and can now support queries with or without trailing colons (`:`)