### PR TITLE
Fix the `DOCS_ROOT` to serve inline help docs from `BASE_DIR`

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -54,7 +54,7 @@ BANNER_TOP = ""
 NAUTOBOT_ROOT = os.getenv("NAUTOBOT_ROOT", os.path.expanduser("~/.nautobot"))
 
 CHANGELOG_RETENTION = 90
-DOCS_ROOT = os.path.join(os.path.dirname(BASE_DIR), "docs")
+DOCS_ROOT = os.path.join(BASE_DIR, "docs")
 HIDE_RESTRICTED_UI = False
 
 # By default, Nautobot will permit users to create duplicate prefixes and IP addresses in the global


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #665 
<!--
    Please include a summary of the proposed changes below.
-->

Self-explanatory. Tested and confirmed this fixes it in deployments, containers, and localhost all the same.