### PR TITLE
Fix monkey patch of Django storages to look in global settings as well

### DIFF
--- a/nautobot/core/cli.py
+++ b/nautobot/core/cli.py
@@ -165,8 +165,7 @@ def _configure_settings(config):
             def _setting(name, default=None):
                 if name in settings.STORAGE_CONFIG:
                     return settings.STORAGE_CONFIG[name]
-                # This is mainly accounting for USE_TZ used in main settings.py as
-                # that is a global setting used by django-storages and django collectstatic
+                # This is mainly accounting for USE_TZ that should be found within the main settings
                 elif name in settings:
                     return getattr(settings, name)
                 return globals().get(name, default)

--- a/nautobot/core/cli.py
+++ b/nautobot/core/cli.py
@@ -165,6 +165,10 @@ def _configure_settings(config):
             def _setting(name, default=None):
                 if name in settings.STORAGE_CONFIG:
                     return settings.STORAGE_CONFIG[name]
+                # This is mainly accounting for USE_TZ used in main settings.py as
+                # that is a global setting used by django-storages and django collectstatic
+                elif name in settings:
+                    return getattr(settings, name)
                 return globals().get(name, default)
 
             storages.utils.setting = _setting

--- a/nautobot/core/cli.py
+++ b/nautobot/core/cli.py
@@ -161,14 +161,11 @@ def _configure_settings(config):
                     )
                 raise e
 
-            # Monkey-patch django-storages to fetch settings from STORAGE_CONFIG
+            # Monkey-patch django-storages to fetch settings from STORAGE_CONFIG or fall back to settings
             def _setting(name, default=None):
                 if name in settings.STORAGE_CONFIG:
                     return settings.STORAGE_CONFIG[name]
-                # This is mainly accounting for USE_TZ that should be found within the main settings
-                elif name in settings:
-                    return getattr(settings, name)
-                return globals().get(name, default)
+                return getattr(settings, name, default)
 
             storages.utils.setting = _setting
 

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -42,7 +42,9 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": parse_redis_connection(redis_database=2),
         "TIMEOUT": 300,
-        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient",},
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
     }
 }
 

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -53,3 +53,12 @@ CACHES = {
 
 # REDIS CACHEOPS
 CACHEOPS_REDIS = parse_redis_connection(redis_database=3)
+
+# Testing storages within cli.py
+STORAGE_BACKEND = "storages.backends.s3boto3.S3Boto3Storage"
+STORAGE_CONFIG = {
+    "AWS_ACCESS_KEY_ID": "ASFWDAMWWOQMEOQMWPMDA<WPDA",
+    "AWS_SECRET_ACCESS_KEY": "ASFKMWADMsacasdaw/dawrt1231541231231",
+    "AWS_STORAGE_BUCKET_NAME": "nautobot",
+    "AWS_S3_REGION_NAME": "us-west-1",
+}

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -42,9 +42,7 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": parse_redis_connection(redis_database=2),
         "TIMEOUT": 300,
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        },
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient",},
     }
 }
 
@@ -55,7 +53,6 @@ CACHES = {
 CACHEOPS_REDIS = parse_redis_connection(redis_database=3)
 
 # Testing storages within cli.py
-STORAGE_BACKEND = "storages.backends.s3boto3.S3Boto3Storage"
 STORAGE_CONFIG = {
     "AWS_ACCESS_KEY_ID": "ASFWDAMWWOQMEOQMWPMDA<WPDA",
     "AWS_SECRET_ACCESS_KEY": "ASFKMWADMsacasdaw/dawrt1231541231231",

--- a/nautobot/core/tests/test_cli.py
+++ b/nautobot/core/tests/test_cli.py
@@ -1,0 +1,25 @@
+"""Initial testing of cli.py"""
+
+from nautobot.core import cli
+
+
+class TestCli:
+    def test_cli_setting_monkey_patch_return_value(self):
+        """Validate _setting works provides the expected return value."""
+        storages_config = {
+            "AWS_ACCESS_KEY_ID": "ASFWDAMWWOQMEOQMWPMDA<WPDA",
+            "AWS_SECRET_ACCESS_KEY": "ASFKMWADMsacasdaw/dawrt1231541231231",
+            "AWS_STORAGE_BUCKET_NAME": "nautobot",
+            "AWS_S3_REGION_NAME": "us-west-1",
+        }
+        global_config = {"USE_TZ": True}
+        configs = storages_config.update(global_config)
+        for setting, value in configs.items():
+            result = cli._configure_settings._setting(setting)
+            assert result == value
+
+    def test_cli_setting_monkey_patch_return_none(self):
+        """Validate _setting returns none for non-existent setting."""
+        configs = ("AWS_NON_EXISTENT_KEY", "STORAGE_NON_EXISTENT_KEY")
+        for setting in configs:
+            assert not cli._configure_settings._setting(setting)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #363 
<!--
    Please include a summary of the proposed changes below.
-->
Bug: Django collectstatic cannot compare timezone aware time object to a non timezone aware object. This was due to us only looking with `settings.STORAGE_CONFIG` for possible storage configs

We're monkey patching `storages.utils.setting` with our own function to check within `settings.STORAGE_CONFIG`. This breaks S3 and potentially other Django storages backends due to `USE_TZ` not being defined within `settings.STORAGE_CONFIG`. I added an `elif` statement to also check within the root settings which resolves this issue.