### PR TITLE
Update MySQL unicode settings docs to be more visible.

### DIFF
--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -29,6 +29,7 @@ DATABASES = {
         "ENGINE": os.getenv(
             "NAUTOBOT_DB_ENGINE", "django.db.backends.postgresql"
         ),  # Database driver ("mysql" or "postgresql")
+        # "OPTIONS": {"charset": "utf8mb4"},  # For MySQL unicode emoji support, uncomment this line
     }
 }
 

--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -75,6 +75,28 @@ DATABASES = {
 !!! note
     Nautobot supports all database options supported by the underlying Django framework. For a complete list of available parameters, please see [the official Django documentation on `DATABASES`](https://docs.djangoproject.com/en/stable/ref/settings/#databases).
 
+### MySQL Unicode Settings
+
+When using MySQL as a database backend, and you want to enable support for Unicode characters like the beloved poop emoji, you'll need to update your settings.
+
+If you try to use emojis without this setting, you will encounter a server error along the lines of `Incorrect string value`, because you are running afoul of the legacy implementation of Unicode (aka `utf8`) encoding in MySQL. The `utf8` encoding in MySQL is limited to 3-bytes per character. Newer Unicode emoji require 4-bytes. 
+
+To properly support using such characters, you will need to create an entry in `DATABASES` -> `default` -> `OPTIONS` with the value `{"charset": "utf8mb4"}` in your `nautobot_config.py` and restart all Nautobot services. This will tell MySQL to always use `utf8mb4` character set for database client connections.
+
+For example:
+
+```python
+DATABASES = {
+    "default": {
+        # Other setttings...
+        "OPTIONS": {"charset": "utf8mb4"},  # Add this line
+    }
+}
+```
+
+!!! tip
+    Starting in v1.1.0, if you have generated a new `nautobot_config.py` using `nautobot-server init`, this line is already there for you in your config. You'll just need to uncomment it! 
+
 ---
 
 ## Redis Settings

--- a/nautobot/docs/installation/nautobot.md
+++ b/nautobot/docs/installation/nautobot.md
@@ -193,6 +193,10 @@ Edit `$NAUTOBOT_ROOT/nautobot_config.py`, and head over to the documentation on 
 
 Save your changes to your `nautobot_config.py` and then proceed to the next step.
 
+#### MySQL Unicode Settings
+
+If you are using MySQL as your database backend, and you want to enable support for Unicode emojis, please make sure to add `"OPTIONS": {"charset": "utf8mb4"}` to your `DATABASES` setting. Please see the [configuration guide on MySQL Unicode settings](../../configuration/required-settings/#mysql-unicode-settings) for more information.
+
 ## Optional Settings
 
 All Python packages required by Nautobot will be installed automatically when running `pip3 install nautobot`.

--- a/nautobot/docs/installation/services.md
+++ b/nautobot/docs/installation/services.md
@@ -263,17 +263,6 @@ Please see [SSL error: decryption failed or bad record mac & SSL SYSCALL error: 
 
 When using MySQL as a database backend, if you encounter a server error along the lines of `Incorrect string value: '\\xF0\\x9F\\x92\\x80' for column`, it is because you are running afoul of the legacy implementation of Unicode (aka `utf8`) encoding in MySQL. This often occurs when using modern Unicode glyphs like the famous poop emoji.
 
-- Create an entry in `DATABASES` -> `default` -> `OPTIONS` with the value `{"charset": "utf8mb4"}` in your `nautobot_config.py` and restart all Nautobot services. This will tell MySQL to always use `utf8mb4` character set for encoding.
-
-For example:
-
-```python
-DATABASES = {
-    "default": {
-        # Other setttings...
-        "OPTIONS": {"charset": "utf8mb4"},  # Add this line
-    }
-}
-```
+Please see the [configuration guide on MySQL Unicode settings](../../configuration/required-settings/#mysql-unicode-settings) for instructions on how to address this.
 
 Please see [Computed fields with fallback value that is unicode results in OperationalError (#645)](https://github.com/nautobot/nautobot/issues/645) for more details.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: n/a
<!--
    Please include a summary of the proposed changes below.
-->

- Per some feedback this attempts to make the MySQL unicode settings thing for emoji more visible.
- This also adds a commented out line in the generated configuration that can be uncommented by new users.