### PR TITLE
Return `null/None` for GraphQL fields that require choices, but DB field is null.

### DIFF
--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -33,6 +33,24 @@ def generate_restricted_queryset():
     return get_queryset
 
 
+def generate_null_choices_resolver(name, resolver_name):
+    """Generate function to resolve fields that can be null, but blank=True, and choices defined.
+
+    Args:
+        name (str): name of the field to resolve
+        resolver_name (str): name of the resolver as declare in DjangoObjectType
+    """
+
+    def resolve_fields_w_choices(model, info, **kwargs):
+        field_value = getattr(model, name)
+        if field_value:
+            return field_value
+        return None
+
+    resolve_fields_w_choices.__name__ = resolver_name
+    return resolve_fields_w_choices
+
+
 def generate_custom_field_resolver(name, resolver_name):
     """Generate function to resolve each custom field within each DjangoObjectType.
 

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -17,6 +17,7 @@ from nautobot.core.graphql.generators import (
     generate_relationship_resolver,
     generate_restricted_queryset,
     generate_schema_type,
+    generate_single_item_resolver,
 )
 from nautobot.core.graphql.types import ContentTypeType
 from nautobot.dcim.graphql.types import (
@@ -113,6 +114,44 @@ def extend_schema_type(schema_type):
     # Computed Fields
     #
     schema_type = extend_schema_type_computed_field(schema_type, model)
+
+    #
+    # Add CharField that can null=False, blank=True, and choices defined
+    schema_type = extend_schema_type_blank_choices_fields(schema_type, model)
+
+    return schema_type
+
+
+def extend_schema_type_blank_choices_fields(schema_type, model):
+    """Extends the schema fields to add fields that cannot be null, but can be blank, and choices are defined.
+
+    Args:
+        schema_type (DjangoObjectType): GraphQL Object type for a given model
+        model (Model): Django model
+
+    Returns:
+        schema_type (DjangoObjectType)
+    """
+    # This is a workaround implemented for https://github.com/nautobot/nautobot/issues/466#issuecomment-877991184
+    # We want to iterate over fields and see if they meet the criteria: null=False, blank=True, and choices defined
+    for field in model._meta.fields:
+        if all((not field.null, field.blank, field.choices)):
+            field_name = f"{str_to_var_name(field.name)}"
+            resolver_name = f"resolve_{field_name}"
+
+            if hasattr(schema_type, field_name):
+                logger.warning(
+                    f"Unable to add {field.name} to {schema_type._meta.name} "
+                    f"because there is already an attribute with the same name ({field_name})"
+                )
+                continue
+
+            setattr(
+                schema_type,
+                resolver_name,
+                generate_single_item_resolver(schema_type, resolver_name),
+            )
+            # schema_type._meta.fields[field.name] = graphene.Field(graphene.String, source=field.name)
 
     return schema_type
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #466
<!--
    Please include a summary of the proposed changes below.
-->
This root of the issue is due to it not returning an appropriate choice when a field has `null=False` (default), `blank=True`, and choices defined. We now provide a `resolve_{field.name}` method that returns `null` on any fields that meet the conditions above.

This a known bug upstream in Graphene, but this puts in a workaround and more details can be found in the above issue.
