### PR TITLE
Fixing RQ Warning

### DIFF
--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -112,12 +112,12 @@ def get_worker_count(request):
     # Try RQ first since, it's faster.
     rq_count = Worker.count(get_connection("default"))
 
-    # FIXME(jathan): If both RQ/Celery workers are running, this warning is
-    # displayed but barely seen because of the redirect after task execution.
-    if rq_count:
-        messages.warning(request, "RQ workers are deprecated. Please migrate your worker to Celery.")
-
     # Celery next, since it's slower.
     inspect = app.control.inspect()
     active = inspect.active()  # None if no active workers
-    return len(active) if active is not None else 0
+    celery_count = len(active) if active is not None else 0
+
+    if rq_count and not celery_count:
+        messages.warning(request, "RQ workers are deprecated. Please migrate your workers to Celery.")
+
+    return celery_count


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #680
<!--
    Please include a summary of the proposed changes below.
-->

While the warning is only briefly displayed it is still misleading.  We are already getting a count of celery workers just add the logic to check if there are rq workers but no celery workers.