### PR TITLE
Rename `?opt_in_fields=` query param to `?include=`

### DIFF
--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -46,14 +46,11 @@ class OptInFieldsMixin:
 
         request = self.context["request"]
 
-        # NOTE: drf test framework builds a request object where the query
+        # NOTE: DRF test framework builds a request object where the query
         # parameters are found under the GET attribute.
         params = getattr(request, "query_params", getattr(request, "GET", None))
 
-        try:
-            user_opt_in_fields = params.get("include", None).split(",")
-        except AttributeError:
-            user_opt_in_fields = []
+        user_opt_in_fields = params.getlist("include")
 
         # Drop any fields that are not specified in the users opt in fields
         for field in serializer_opt_in_fields:

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -23,10 +23,10 @@ class OptInFieldsMixin:
     def fields(self):
         """
         Removes all serializer fields specified in a serializers `opt_in_fields` list that aren't specified in the
-        `opt_in_fields` query parameter.
+        `include` query parameter.
 
         As an example, if the serializer specifies that `opt_in_fields = ["computed_fields"]`
-        but `computed_fields` is not specified in the `?opt_in_fields` query parameter, `computed_fields` will be popped
+        but `computed_fields` is not specified in the `?include` query parameter, `computed_fields` will be popped
         from the list of fields.
         """
         fields = super().fields
@@ -51,7 +51,7 @@ class OptInFieldsMixin:
         params = getattr(request, "query_params", getattr(request, "GET", None))
 
         try:
-            user_opt_in_fields = params.get("opt_in_fields", None).split(",")
+            user_opt_in_fields = params.get("include", None).split(",")
         except AttributeError:
             user_opt_in_fields = []
 

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -46,11 +46,14 @@ class OptInFieldsMixin:
 
         request = self.context["request"]
 
-        # NOTE: DRF test framework builds a request object where the query
+        # NOTE: drf test framework builds a request object where the query
         # parameters are found under the GET attribute.
         params = getattr(request, "query_params", getattr(request, "GET", None))
 
-        user_opt_in_fields = params.getlist("include")
+        try:
+            user_opt_in_fields = params.get("include", None).split(",")
+        except AttributeError:
+            user_opt_in_fields = []
 
         # Drop any fields that are not specified in the users opt in fields
         for field in serializer_opt_in_fields:

--- a/nautobot/docs/additional-features/computed-fields.md
+++ b/nautobot/docs/additional-features/computed-fields.md
@@ -1,6 +1,6 @@
 # Computed Fields
 
-Computed fields are very similar in design and implementation to custom fields. See the overview of [Custom Fields](./custom-fields.md). As the name suggests, computed fields serve the need for a custom field where the value is generated using data that Nautobot stores in it's database and merging it into a Jinja2 template and associated filters.
+Computed fields are very similar in design and implementation to custom fields. See the overview of [Custom Fields](./custom-fields.md). As the name suggests, computed fields serve the need for a custom field where the value is generated using data that Nautobot stores in its database and merging it into a Jinja2 template and associated filters.
 
 As an example, within your automation system, you may want to be able to have an automatically generated field on the Device model that combines the name of the device and the uppercased site name. To do that, you would define a Jinja2 template for this field that looks like such:
 
@@ -37,23 +37,27 @@ Computed field templates can utilize the context of the object the field is bein
 
 ## Computed Field Template Filters
 
-Computed field templates can also utilize custom jinja filters that have been registered via plugins. These filters can be used by providing the name of the filter function. As an example:
+Computed field templates can also utilize custom Jinja2 filters that have been registered via plugins. These filters can be used by providing the name of the filter function. As an example:
 
 ```jinja2
 {{ obj.site.name | leet_speak }}
 ```
 
-See the documentation on [registering custom jinja filters](../plugins/development.md#including-jinja-filters) in plugins.
+See the documentation on [registering custom Jinja2 filters](../plugins/development.md#including-jinja2-filters) in plugins.
 
 
 ## Computed Fields and the REST API
 
-When retrieving an object via the REST API, computed field data is not included by default in order to prevent potentially computationally expensive rendering operations that degrade the user experience. In order to retrieve computed field data, you must use the `opt_in_fields` query parameter.
+When retrieving an object via the REST API, computed field data is not included by default in order to prevent potentially computationally expensive rendering operations that degrade the user experience. In order to retrieve computed field data, you must use the `include` query parameter.
+
 Take a look at an example URL that includes computed field data:
+
 ```no-highlight
-http://localhost:8080/api/dcim/sites?opt_in_fields=computed_fields
+http://localhost:8080/api/dcim/sites?include=computed_fields
 ```
+
 When explicitly requested as such, computed field data will be included in the `computed_fields` attribute. For example, below is the partial output of a site with one computed field defined:
+
 ```json
 {
     "id": 123,
@@ -67,4 +71,4 @@ When explicitly requested as such, computed field data will be included in the `
 ```
 
 !!! note
-    The slug field is used as the key name for items in the `computed_fields` attribute.
+    The `slug` value of each computed field is used as the key name for items in the `computed_fields` attribute.

--- a/nautobot/docs/release-notes/version-1.1.md
+++ b/nautobot/docs/release-notes/version-1.1.md
@@ -111,7 +111,7 @@ Please see the section on [migrating to Celery from RQ](../installation/services
 - [#626](https://github.com/nautobot/nautobot/pull/626) - Added prefix `NAUTOBOT_` in `override.env` example inside of `docker-entrypoint.sh`
 - [#645](https://github.com/nautobot/nautobot/issues/645) - Updated services troubleshooting docs to include "incorrect string value" fix when using Unicode emojis with MySQL as a database backend
 - [#653](https://github.com/nautobot/nautobot/issues/653) - Fixed systemd unit file for `nautobot-worker` to correctly start/stop/restart
-- [#661](https://github.com/nautobot/nautobot/issues/661) - Fixed `computed_fields` key not being included in API response for devices when using `opt_in_fields`
+- [#661](https://github.com/nautobot/nautobot/issues/661) - Fixed `computed_fields` key not being included in API response for devices when using `include` (for opt-in fields)
 - [#667](https://github.com/nautobot/nautobot/pull/667) - Fixed various outdated/incorrect places in the documentation for v1.1.0 release.
 
 ## v1.1.0b1 (2021-07-02)

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1180,3 +1180,19 @@ class ComputedFieldTest(APIViewTestCases.APIViewTestCase):
             fallback_value="error",
             content_type=site_ct,
         )
+
+        cls.site = Site.objects.create(name="Site 1", slug="site-1")
+
+    def test_computed_field_include(self):
+        """Test that explicitly including a computed field behaves as expected."""
+        self.add_permissions("dcim.view_site")
+        url = reverse("dcim-api:site-detail", kwargs={"pk": self.site.pk})
+
+        # First get the object without computed fields.
+        response = self.client.get(url, **self.header)
+        self.assertNotIn("computed_fields", response.json())
+
+        # Now get it with computed fields.
+        params = {"include": "computed_fields"}
+        response = self.client.get(url, data=params, **self.header)
+        self.assertIn("computed_fields", response.json())


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #684 
<!--
    Please include a summary of the proposed changes below.
-->

- Left the serializer `Meta` attribute named `opt_in_fields` for the time being because it tends to be more descriptive in that context.
- Added a basic unit test to assert the absence of `computed_fields` by default and presence of `computed_fields` when `?include=computed_fields` is provided
- Normalized use of word `[jJ]inja` to `Jinja2` in the computed fields docs.