### PR TITLE
fixes #663 - added serialize method to the JobForm

### DIFF
--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -277,10 +277,6 @@ class JobViewSet(ViewSet):
         if not request.user.has_perm("extras.run_job"):
             raise PermissionDenied("This user does not have permission to run jobs.")
 
-        # Check that at least one RQ worker is running
-        if not Worker.count(get_connection("default")):
-            raise RQWorkerNotRunningException()
-
         job_class = self._get_job_class(class_path)
         job = job_class()
 

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -1,9 +1,7 @@
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.db.models.base import Model
 from django.db.models.fields import TextField
-from django.db.models.query import QuerySet
 from django.urls.base import reverse
 from django.core.validators import ValidationError
 from django.utils.safestring import mark_safe
@@ -748,26 +746,6 @@ class JobForm(BootstrapMixin, forms.Form):
         A boolean indicating whether the form requires user input (ignore the _commit field).
         """
         return bool(len(self.fields) > 1)
-
-    def get_serializeable_data(self):
-        """
-        This method parses `self.cleaned_data` and returns a dict which is safe to serialize
-
-        Here we convert the QuerySet of a MultiObjectVar to a list of the pk's and the model instance
-        of an ObjectVar into the pk value.
-
-        These are converted back during job execution.
-        """
-        return_data = {}
-        for field_name, value in self.cleaned_data.items():
-            if isinstance(value, QuerySet):
-                return_data[field_name] = list(value.values_list("pk", flat=True))
-            elif isinstance(value, Model):
-                return_data[field_name] = value.pk
-            else:
-                return_data[field_name] = value
-
-        return return_data
 
 
 class JobResultFilterForm(BootstrapMixin, forms.Form):

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -330,7 +330,7 @@ class BaseJob:
                     # Not all objects found
                     not_found_pk_list = value - list(queryset.values_list("pk", flat=True))
                     raise queryset.model.DoesNotExist(
-                        f"Failed to requested objects for var {field_name}: [{', '.join(not_found_pk_list)}]"
+                        f"Failed to find requested objects for var {field_name}: [{', '.join(not_found_pk_list)}]"
                     )
                 return_data[field_name] = var.field_attrs["queryset"].filter(pk__in=value)
 

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -707,7 +707,7 @@ class JobView(ContentTypePermissionRequiredMixin, View):
                 job.class_path,
                 job_content_type,
                 request.user,
-                data=form.cleaned_data,
+                data=form.get_serializeable_data(),
                 request=copy_safe_request(request),
                 commit=commit,
             )

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -707,7 +707,7 @@ class JobView(ContentTypePermissionRequiredMixin, View):
                 job.class_path,
                 job_content_type,
                 request.user,
-                data=form.get_serializeable_data(),
+                data=job_class.serialize_data(form.cleaned_data),
                 request=copy_safe_request(request),
                 commit=commit,
             )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #663 

Added a `serialize_data()` method to `Job` which handles conversion of `MultiObjectVar` and `ObjectVar` to `pk` values. Then within the job execution we use `deserialize_data()` to convert back to actual querysets and model instances, respectively.
