### PR TITLE
Add CELERY_TASK_SOFT_TIMEOUT setting, and a few transaction.on_commit() wrappers

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -526,8 +526,11 @@ RQ_QUEUES = {
 # Instruct celery to report the started status of a job, instead of just `pending`, `finished`, or `failed`
 CELERY_TASK_TRACK_STARTED = True
 
-# Global task time limit (seconds)
-CELERY_TASK_TIME_LIMIT = int(os.getenv("NAUTOBOT_CELERY_TASK_TIME_LIMIT", 30 * 60))
+# Global task time limits (seconds)
+# Exceeding the soft limit will result in a SoftTimeLimitExceeded exception,
+# while exceeding the hard limit will result in a SIGKILL.
+CELERY_TASK_SOFT_TIME_LIMIT = int(os.getenv("NAUTOBOT_CELERY_TASK_SOFT_TIME_LIMIT", 5 * 60))
+CELERY_TASK_TIME_LIMIT = int(os.getenv("NAUTOBOT_CELERY_TASK_TIME_LIMIT", 10 * 60))
 
 # The Redis connection defined in the CACHES config above for the broker and results backend
 CELERY_BROKER_URL = CACHES["default"]["LOCATION"]

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -107,7 +107,7 @@ The Redis connection string to use for caching.
 
 ## CELERY_TASK_SOFT_TIME_LIMIT
 
-Default: 300
+Default: `300` (5 minutes)
 
 Environment Variable: `NAUTOBOT_CELERY_TASK_SOFT_TIME_LIMIT`
 
@@ -117,7 +117,7 @@ The global Celery task soft timeout (in seconds). Any background task that excee
 
 ## CELERY_TASK_TIME_LIMIT
 
-Default: `600`
+Default: `600` (10 minutes)
 
 Environment Variable: `NAUTOBOT_CELERY_TASK_TIME_LIMIT`
 

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -105,13 +105,23 @@ The Redis connection string to use for caching.
 
 ---
 
+## CELERY_TASK_SOFT_TIME_LIMIT
+
+Default: 300
+
+Environment Variable: `NAUTOBOT_CELERY_TASK_SOFT_TIME_LIMIT`
+
+The global Celery task soft timeout (in seconds). Any background task that exceeds this duration will receive a `SoftTimeLimitExceeded` exception and is responsible for handling this exception and performing any necessary cleanup or final operations before ending. See also `CELERY_TASK_TIME_LIMIT` below.
+
+---
+
 ## CELERY_TASK_TIME_LIMIT
 
-Default: `1800`
+Default: `600`
 
 Environment Variable: `NAUTOBOT_CELERY_TASK_TIME_LIMIT`
 
-The global Celery task timeout (in seconds)
+The global Celery task hard timeout (in seconds). Any background task that exceeds this duration will be forcibly killed with a `SIGKILL` signal.
 
 ---
 

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from datetime import datetime, date
 
 from django import forms
+from django.db import transaction
 from django.contrib.contenttypes.models import ContentType
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import RegexValidator, ValidationError
@@ -494,7 +495,9 @@ class CustomFieldChoice(BaseModel):
         super().save(*args, **kwargs)
 
         if self.value != database_object.value:
-            update_custom_field_choice_data.delay(self.field.pk, database_object.value, self.value)
+            transaction.on_commit(
+                lambda: update_custom_field_choice_data.delay(self.field.pk, database_object.value, self.value)
+            )
 
     def delete(self, *args, **kwargs):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #697 
<!--
    Please include a summary of the proposed changes below.
-->

Adding a `CELERY_TASK_SOFT_TIME_LIMIT` configuration value less than the hard limit `CELERY_TASK_TIME_LIMIT` actually gets us most of the way there, especially as far as error-handling for long-running Jobs is concerned - the resulting `SoftTimeLimitExceeded` exception is caught and logged and the JobResult as a whole is marked as Errored:

![image](https://user-images.githubusercontent.com/5603551/125710816-06bb1e3d-805a-436f-a933-3559ea7e8087.png)


In testing an artificially short SOFT_TIME_LIMIT with some of the other background tasks, I noticed intermittent failures of several resulting from the Celery worker picking up and executing these tasks before the objects they were supposed to reference had actually been fully committed to the database. In plugins where we've seen similar issues in the past, `transaction.on_commit()` has been the solution, so I added this wrapper where needed and it seems to have resolved those issues.

I lowered the default hard time limit for background tasks from 30 minutes to 10 minutes, and set the default soft time limit to 5 minutes, which matches the default for RQ tasks in Nautobot 1.0.x.