### PR TITLE
Catch other exceptions in ComputedField rendering

### DIFF
--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -10,7 +10,6 @@ from django.core.validators import RegexValidator, ValidationError
 from django.db import models
 from django.urls import reverse
 from django.utils.safestring import mark_safe
-from jinja2 import TemplateError
 
 from nautobot.extras.choices import *
 from nautobot.extras.models import ChangeLoggedModel
@@ -81,8 +80,8 @@ class ComputedField(BaseModel, ChangeLoggedModel):
     def render(self, context):
         try:
             return render_jinja2(self.template, context)
-        except TemplateError as e:
-            logger.warning("Failed to render computed field %s: %s", self.slug, e)
+        except Exception as exc:
+            logger.warning("Failed to render computed field %s: %s", self.slug, exc)
             return self.fallback_value
 
 

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -773,6 +773,7 @@ class CustomFieldModelTest(TestCase):
             fallback_value="An error occurred while rendering this template.",
             weight=100,
         )
+        # Field whose template will raise a TemplateError
         self.bad_computed_field = ComputedField.objects.create(
             content_type=ContentType.objects.get_for_model(Site),
             slug="bad_computed_field",
@@ -780,6 +781,15 @@ class CustomFieldModelTest(TestCase):
             template="{{ something_that_throws_an_err | not_a_real_filter }} bad data",
             fallback_value="This template has errored",
             weight=100,
+        )
+        # Field whose template will raise a TypeError
+        self.worse_computed_field = ComputedField.objects.create(
+            content_type=ContentType.objects.get_for_model(Site),
+            slug="worse_computed_field",
+            label="Worse Computed Field",
+            template="{{ obj.images | list }}",
+            fallback_value="Another template error",
+            weight=200,
         )
         self.non_site_computed_field = ComputedField.objects.create(
             content_type=ContentType.objects.get_for_model(Device),
@@ -857,6 +867,7 @@ class CustomFieldModelTest(TestCase):
         expected_renderings = {
             "computed_field_one": f"{self.site1.name} is the name of this site.",
             "bad_computed_field": self.bad_computed_field.fallback_value,
+            "worse_computed_field": self.worse_computed_field.fallback_value,
         }
         self.assertDictEqual(self.site1.get_computed_fields(), expected_renderings)
 
@@ -864,6 +875,7 @@ class CustomFieldModelTest(TestCase):
         expected_renderings = {
             "Computed Field One": f"{self.site1.name} is the name of this site.",
             "Bad Computed Field": self.bad_computed_field.fallback_value,
+            "Worse Computed Field": self.worse_computed_field.fallback_value,
         }
         self.assertDictEqual(self.site1.get_computed_fields(label_as_key=True), expected_renderings)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #699 
<!--
    Please include a summary of the proposed changes below.
-->

There are ways that a ComputedField can be constructed such that it raise exceptions other than a Jinja2 `TemplateError` when rendered - make sure we catch those too.