### PR TITLE
Fixes saved GraphQL queries containing double quotes

### DIFF
--- a/nautobot/extras/templates/extras/graphqlquery.html
+++ b/nautobot/extras/templates/extras/graphqlquery.html
@@ -113,7 +113,7 @@
             headers: {"X-CSRFTOKEN": "{{ csrf_token }}"},
             dataType: "json",
             data: {
-                "query": `{{ object.query }}`,
+                "query": `{{ object.query | escapejs }}`,
                 "variables": variables,
             },
             success: function(data) {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #703 
<!--
    Please include a summary of the proposed changes below.
-->
We can use either `safe` or `escapejs` that is built into Django to fix this issue. I'm not 100% if either of these are the best solution as we're allowing users to potentially bypass and execute code. I think the `escapejs` is the safest option out of the two.

I'm not entirely sure how to test this other than maybe looking for the query string within the content without escaped characters, but I can use help if it's not something like that.

Let me know if this is appropriate or if there is a better way to solve this issue. More details can be found in the issue.
