### PR TITLE
Fix GraphQLQuery run API endpoint

### DIFF
--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -456,27 +456,6 @@ Arguments:
 
 Returned is a GraphQL object which holds the same data as returned from GraphiQL. Use `execute_query().to_dict()` to get the data back inside of a dictionary.
 
-Usage in a view:
-
-``` python
-from nautobot.core.graphql import execute_saved_query
-
-
-class GraphQLModelView(ModelViewSet):
-    queryset = GraphQLModelQuery.objects.all()
-
-    @action(detail=True, methods=["post"])
-    def run(self, request, pk):
-        try:
-            result = execute_saved_query(pk, variable=request.data, request=request).to_dict()
-            return Response(result)
-        except GraphQLError as error:
-            return Response(
-                {"errors": [GraphQLView.format_error(error)]},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-```
-
 ## REST API Endpoints
 
 Plugins can declare custom endpoints on Nautobot's REST API to retrieve or manipulate models or other data. These behave very similarly to views, except that instead of rendering arbitrary content using a template, data is returned in JSON format using a serializer. Nautobot uses the [Django REST Framework](https://www.django-rest-framework.org/), which makes writing API serializers and views very simple.

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -738,7 +738,7 @@ class RelationshipAssociationSerializer(serializers.ModelSerializer):
 
 class GraphQLQuerySerializer(ValidatedModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name="extras-api:graphqlquery-detail")
-    variables = serializers.DictField(allow_null=True, default={})
+    variables = serializers.DictField(required=False, allow_null=True, default={})
 
     class Meta:
         model = GraphQLQuery
@@ -750,6 +750,14 @@ class GraphQLQuerySerializer(ValidatedModelSerializer):
             "query",
             "variables",
         )
+
+
+class GraphQLQueryInputSerializer(serializers.Serializer):
+    variables = serializers.DictField(allow_null=True, default={})
+
+
+class GraphQLQueryOutputSerializer(serializers.Serializer):
+    data = serializers.DictField(default={})
 
 
 # Computed Fields

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -434,11 +434,16 @@ class GraphQLQueryViewSet(ModelViewSet):
     serializer_class = serializers.GraphQLQuerySerializer
     filterset_class = filters.GraphQLQueryFilterSet
 
-    @swagger_auto_schema(method="post", request_body=serializers.GraphQLQuerySerializer)
+    @swagger_auto_schema(
+        method="post",
+        request_body=serializers.GraphQLQueryInputSerializer,
+        responses={"200": serializers.GraphQLQueryOutputSerializer},
+    )
     @action(detail=True, methods=["post"])
     def run(self, request, pk):
         try:
-            result = execute_saved_query(pk, variables=request.data, request=request).to_dict()
+            query = get_object_or_404(self.queryset, pk=pk)
+            result = execute_saved_query(query.slug, variables=request.data.get("variables"), request=request).to_dict()
             return Response(result)
         except GraphQLError as error:
             return Response(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #727 
<!--
    Please include a summary of the proposed changes below.
-->

The REST API endpoint for running saved GraphQL queries was incorrectly passing the model UUID into `execute_saved_query()` but that function expects a slug, not a UUID. Fixing that allows queries to be executed successfully.

![image](https://user-images.githubusercontent.com/5603551/126804730-492e976a-93e9-41e0-bacc-3483ab1072d8.png)


Additionally, fixed up the Swagger docs for the inputs and outputs of this API endpoint:

![image](https://user-images.githubusercontent.com/5603551/126804604-1143aabd-2240-4ed8-99d0-200f7ef2b5ff.png)

![image](https://user-images.githubusercontent.com/5603551/126804639-6d558fcc-8552-4bf8-8a03-fe0f9d580028.png)
