### PR TITLE
Adding docs and checks for MAINTENANCE_MODE

### DIFF
--- a/nautobot/core/checks.py
+++ b/nautobot/core/checks.py
@@ -28,6 +28,12 @@ E004 = Error(
     obj=settings,
 )
 
+E005 = Error(
+    "MAINTENANCE_MODE has been set but SESSION_ENGINE is still using the database.  Nautobot can not enter Maintenance mode.",
+    id="nautobot.core.E005",
+    obj=settings,
+)
+
 W005 = Warning(
     "STORAGE_CONFIG has been set but STORAGE_BACKEND is not defined. STORAGE_CONFIG will be ignored.",
     id="nautobot.core.W005",
@@ -95,3 +101,10 @@ def check_minimum_rq_queues(app_configs, **kwargs):
                 )
             )
     return errors
+
+
+@register(Tags.compatibility)
+def check_maintenance_mode(app_configs, **kwargs):
+    if settings.MAINTENANCE_MODE and settings.SESSION_ENGINE == "django.contrib.sessions.backends.db":
+        return [E005]
+    return []

--- a/nautobot/core/tests/test_checks.py
+++ b/nautobot/core/tests/test_checks.py
@@ -42,3 +42,11 @@ class CheckCoreSettingsTest(TestCase):
     def test_check_storage_config_and_backend(self):
         """Warn if STORAGE_CONFIG and STORAGE_BACKEND aren't mutually set."""
         self.assertEqual(checks.check_storage_config_and_backend(None), [checks.W005])
+
+    @override_settings(
+        MAINTENANCE_MODE=True,
+        SESSION_ENGINE="django.contrib.sessions.backends.db",
+    )
+    def test_check_maintenance_mode(self):
+        """Error if MAINTENANCE_MODE is set and yet SESSION_ENGINE is still storing sessions in the db."""
+        self.assertEqual(checks.check_maintenance_mode(None), [checks.E005])

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -692,6 +692,7 @@ Default: `'django.contrib.sessions.backends.db'`
 
 Controls where Nautobot stores session data.
 
+To use cache-based sessions, set this to `'django.contrib.sessions.backends.cache'`.
 To use file-based sessions, set this to `'django.contrib.sessions.backends.file'`.
 
 See the official Django documentation on [Configuring the session](https://docs.djangoproject.com/en/stable/topics/http/sessions/#configuring-sessions) engine for more details.

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -479,6 +479,9 @@ Environment Variable: `NAUTOBOT_MAINTENANCE_MODE`
 
 Setting this to `True` will display a "maintenance mode" banner at the top of every page. Additionally, Nautobot will no longer update a user's "last active" time upon login. This is to allow new logins when the database is in a read-only state. Recording of login times will resume when maintenance mode is disabled.
 
+!!! note
+    The default [`SESSION_ENGINE`](#session_engine) configuration will store sessions in the database, this obviously will not work when `MAINTENANCE_MODE` is `True` and the database is in a read-only state for maintenance.  Consider setting `SESSION_ENGINE` to `django.contrib.sessions.backends.cache` when enabling `MAINTENANCE_MODE`.
+
 ---
 
 ## MAX_PAGE_SIZE


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #506
<!--
    Please include a summary of the proposed changes below.
-->

This PR adds a note to the MAINTENANCE_MODE documentation describing why SESSION_ENGINE should not be configured to store sessions in the DB while MAINTENANCE_MODE is active.  It also adds a check to `nautobot-server check` to catch this misconfiguration.