### PR TITLE
Plugin banner feature

### DIFF
--- a/examples/dummy_plugin/dummy_plugin/banner.py
+++ b/examples/dummy_plugin/dummy_plugin/banner.py
@@ -1,0 +1,50 @@
+"""Example of using a plugin to inject a custom banner across various pages."""
+
+from typing import Optional
+
+from django.utils.html import format_html
+
+from nautobot.extras.choices import BannerClassChoices
+from nautobot.extras.plugins import PluginBanner
+
+
+def banner(context, *args, **kwargs) -> Optional[PluginBanner]:
+    """
+    Construct a custom PluginBanner, if appropriate.
+
+    - If not authenticated, no banner is displayed.
+    - On all authenticated UI views, the banner includes a greeting to the logged-in user.
+    - On object table views, the banner also reports on the model being listed in the table.
+    - On object detail views, the banner also reports on the object being viewed, and whether it's the changelog view.
+    """
+    if not context.request.user.is_authenticated:
+        # No banner if the user isn't logged in
+        return None
+
+    # Banner content greeting the user
+    content = format_html(
+        "<div>Dummy Plugin says “Hello, <strong>{}</strong>!” 👋</div>",
+        context.request.user,
+    )
+
+    if "object" in context:
+        # Object detail view
+        content += format_html(
+            "<div>You are viewing {} {}</div>",
+            context["object"]._meta.verbose_name,
+            context["object"],
+        )
+        if "/changelog/" in context.request.path:
+            # Object changelog view
+            content += format_html("<div>Specifically, its changelog.</div>")
+        return PluginBanner(content=content, banner_class=BannerClassChoices.CLASS_SUCCESS)
+    elif "table" in context:
+        # Table view
+        content += format_html(
+            "<div>You are viewing a table of {}</div>",
+            context["table"].Meta.model._meta.verbose_name_plural,
+        )
+        return PluginBanner(content=content, banner_class=BannerClassChoices.CLASS_SUCCESS)
+
+    # Default banner rendering
+    return PluginBanner(content=content, banner_class=BannerClassChoices.CLASS_INFO)

--- a/nautobot/core/templates/base.html
+++ b/nautobot/core/templates/base.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load helpers %}
+{% load plugins %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -51,6 +52,7 @@
                 <p>Nautobot is currently in maintenance mode. Functionality may be limited.</p>
             </div>
         {% endif %}
+        {% plugin_banners %}
         {% for message in messages %}
             <div class="alert alert-{{ message.tags }} alert-dismissable" role="alert">
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -424,7 +424,7 @@ This makes our view accessible at the URL `/plugins/animal-sounds/random/`. (Rem
 
 ### Banners
 
-A plugin can provide a function that renders a custom banner on any number of Nautobot views by defining a function `banner()` inside of `banner.py`. This function currently receives a single argument, `context`, which is the [Django request context](https://docs.djangoproject.com/en/3.2/ref/templates/api/#using-requestcontext) in which the current page is being rendered. The function can return `None` if no banner is needed for a given page view, or can return a `PluginBanner` object describing the banner contents. Here's a simple example `banner.py`:
+A plugin can provide a function that renders a custom banner on any number of Nautobot views by defining a function `banner()` inside of `banner.py`. This function currently receives a single argument, `context`, which is the [Django request context](https://docs.djangoproject.com/en/stable/ref/templates/api/#using-requestcontext) in which the current page is being rendered. The function can return `None` if no banner is needed for a given page view, or can return a `PluginBanner` object describing the banner contents. Here's a simple example `banner.py`:
 
 ```python
 # banner.py
@@ -450,13 +450,13 @@ def banner(context, *args, **kwargs):
 
 Plugins can modify the existing navigation bar layout by defining `menu_items` inside of `navigation.py`. Using the key and weight system, a developer can integrate the plugin amongst existing menu tabs, groups, items and buttons and/or create entirely new menus as desired.
 
-More documentation and examples can be found [here](../development/navigation-menu.md).
+More documentation and examples can be found in the [Navigation Menu](../development/navigation-menu.md) guide.
 
 ### Home Page Content
 
 Plugins can add content to the Nautobot home page by defining `layout` inside of `homepage.py`. Using the key and weight system, a developer can integrate the plugin content amongst existing panels, groups, and items and/or create entirely new panels as desired.
 
-More documentation and examples can be found [here](../development/homepage.md).
+More documentation and examples can be found in the guide on [Home Page Panels](../development/homepage.md).
 
 ## Integrating with GraphQL
 

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -5,14 +5,18 @@ This documentation covers the development of custom plugins for Nautobot. Plugin
 Plugins can do a lot, including:
 
 * Create Django models to store data in the database
+* Inject additional content into the Nautobot UI:
+
+    * Add content and navigation links to existing object views
+    * Provide new "views" (pages) in the user interface
+    * Add a banner to any Nautobot view(s)
+    * Add menus and menu items to the Nautobot navigation menu bar
+    * Add panels and items to the Nautobot home page
+
 * Add custom validation logic to apply to existing data models
-* Provide their own "pages" (views) in the web user interface
 * Provide [Jobs](../additional-features/jobs.md)
-* Inject template content and navigation links
 * Establish their own GraphQL types and REST API endpoints
 * Add custom request/response middleware
-* Add content to the Nautobot navigation menu bar
-* Add content to the Nautobot home page
 
 Keep in mind that each piece of functionality is entirely optional. For example, if your plugin merely adds a piece of middleware or an API endpoint for existing data, there's no need to define any new models.
 
@@ -34,6 +38,7 @@ plugin_name/
       - serializers.py      # REST API Model serializers
       - urls.py             # REST API URL patterns
       - views.py            # REST API view sets
+    - banner.py             # Banners
     - custom_validators.py  # Custom Validators
     - datasources.py        # Loading Data from a Git Repository
     - graphql/
@@ -142,6 +147,7 @@ The configurable attributes for a `PluginConfig` are listed below in alphabetica
 | ---- | ----------- |
 | `author` | Name of plugin's author |
 | `author_email` | Author's public email address |
+| `banner_function` | The dotted path to a function that can render a custom banner (default: `banner.banner`) |
 | `base_url` | (Optional) Base path to use for plugin URLs. If not specified, the project's `name` will be used. |
 | `caching_config` | Plugin-specific cache configuration |
 | `custom_validators` | The dotted path to the list of custom validator classes (default: `custom_validators.custom_validators`) |
@@ -286,6 +292,51 @@ This will display the plugin and its model in the admin UI. Staff users can crea
 
 ## Web UI Views
 
+### Extending Core Templates
+
+Plugins can inject custom content into certain areas of the detail views of applicable models. This is accomplished by subclassing `PluginTemplateExtension`, designating a particular Nautobot model, and defining the desired methods to render custom content. Four methods are available:
+
+* `left_page()` - Inject content on the left side of the page
+* `right_page()` - Inject content on the right side of the page
+* `full_width_page()` - Inject content across the entire bottom of the page
+* `buttons()` - Add buttons to the top of the page
+
+Additionally, a `render()` method is available for convenience. This method accepts the name of a template to render, and any additional context data you want to pass. Its use is optional, however.
+
+When a PluginTemplateExtension is instantiated, context data is assigned to `self.context`. Available data include:
+
+* `object` - The object being viewed
+* `request` - The current request
+* `settings` - Global Nautobot settings
+* `config` - Plugin-specific configuration parameters
+
+For example, accessing `{{ request.user }}` within a template will return the current user.
+
+Declared subclasses should be gathered into a list or tuple for integration with Nautobot. By default, Nautobot looks for an iterable named `template_extensions` within a `template_content.py` file. (This can be overridden by setting `template_extensions` to a custom value on the plugin's `PluginConfig`.) An example is below.
+
+```python
+# template_content.py
+from nautobot.extras.plugins import PluginTemplateExtension
+
+from .models import Animal
+
+
+class SiteAnimalCount(PluginTemplateExtension):
+    """Template extension to display animal count on the right side of the page."""
+
+    model = 'dcim.site'
+
+    def right_page(self):
+        return self.render('nautobot_animal_sounds/inc/animal_count.html', extra_context={
+            'animal_count': Animal.objects.count(),
+        })
+
+
+template_extensions = [SiteAnimalCount]
+```
+
+### Adding New Views
+
 If your plugin needs its own page or pages in the Nautobot web UI, you'll need to define views. A view is a particular page tied to a URL within Nautobot, which renders content using a template. Views are typically defined in `views.py`, and URL patterns in `urls.py`. As an example, let's write a view which displays a random animal and the sound it makes. First, create the view in `views.py`:
 
 ```python
@@ -308,7 +359,7 @@ class RandomAnimalView(View):
 
 This view retrieves a random animal from the database and and passes it as a context variable when rendering a template named `animal.html`, which doesn't exist yet. To create this template, first create a directory named `templates/nautobot_animal_sounds/` within the plugin source directory. (We use the plugin's name as a subdirectory to guard against naming collisions with other plugins.) Then, create a template named `animal.html` as described below.
 
-### Extending the Base Template
+#### Extending the Base Template
 
 Nautobot provides a base template to ensure a consistent user experience, which plugins can extend with their own content. This template includes four content blocks:
 
@@ -347,6 +398,8 @@ The first line of the template instructs Django to extend the Nautobot base temp
 !!! note
     Django renders templates with its own custom [template language](https://docs.djangoproject.com/en/stable/topics/templates/#the-django-template-language). This template language is very similar to Jinja2, however there are some important differences to keep in mind.
 
+#### Registering URL Patterns
+
 Finally, to make the view accessible to users, we need to register a URL for it. We do this in `urls.py` by defining a `urlpatterns` variable containing a list of paths.
 
 ```python
@@ -368,6 +421,42 @@ A URL pattern has three components:
 * `name` - A short name used to identify the URL path internally
 
 This makes our view accessible at the URL `/plugins/animal-sounds/random/`. (Remember, our `AnimalSoundsConfig` class sets our plugin's base URL to `animal-sounds`.) Viewing this URL should show the base Nautobot template with our custom content inside it.
+
+### Banners
+
+A plugin can provide a function that renders a custom banner on any number of Nautobot views by defining a function `banner()` inside of `banner.py`. This function currently receives a single argument, `context`, which is the [Django request context](https://docs.djangoproject.com/en/3.2/ref/templates/api/#using-requestcontext) in which the current page is being rendered. The function can return `None` if no banner is needed for a given page view, or can return a `PluginBanner` object describing the banner contents. Here's a simple example `banner.py`:
+
+```python
+# banner.py
+from django.utils.html import format_html
+
+from nautobot.extras.choices import BannerClassChoices
+from nautobot.extras.plugins import PluginBanner
+
+def banner(context, *args, **kwargs):
+    """Greet the user, if logged in."""
+    # Request parameters can be accessed via context.request
+    if not context.request.user.is_authenticated:
+        # No banner if the user isn't logged in
+        return None
+    else:
+        return PluginBanner(
+            content=format_html("Hello, <strong>{}</strong>! 👋", context.request.user),
+            banner_class=BannerClassChoices.CLASS_SUCCESS,
+        )
+```
+
+### Navigation Menu Items
+
+Plugins can modify the existing navigation bar layout by defining `menu_items` inside of `navigation.py`. Using the key and weight system, a developer can integrate the plugin amongst existing menu tabs, groups, items and buttons and/or create entirely new menus as desired.
+
+More documentation and examples can be found [here](../development/navigation-menu.md).
+
+### Home Page Content
+
+Plugins can add content to the Nautobot home page by defining `layout` inside of `homepage.py`. Using the key and weight system, a developer can integrate the plugin content amongst existing panels, groups, and items and/or create entirely new panels as desired.
+
+More documentation and examples can be found [here](../development/homepage.md).
 
 ## Integrating with GraphQL
 
@@ -517,61 +606,6 @@ With these three components in place, we can request `/api/plugins/animal-sounds
 
 !!! warning
     This example is provided as a minimal reference implementation only. It does not address authentication, performance, or the myriad of other concerns that plugin authors should have.
-
-## Navigation Menu Items
-
-Plugins can modify the existing navigation bar layout by defining `menu_items` inside of `navigation.py`. Using the key and weight system, a developer can integrate the plugin amongst existing menu tabs, groups, items and buttons and/or create entirely new menus as desired.
-
-More documentation and examples can be found [here](../development/navigation-menu.md)
-
-## Home Page Content
-
-Plugins can add content to the Nautobot home page by defining `layout` inside of `homepage.py`. Using the key and weight system, a developer can integrate the plugin content amongst existing panels, groups, and items and/or create entirely new panels as desired.
-
-More documentation and examples can be found [here](../development/homepage.md)
-
-## Extending Core Templates
-
-Plugins can inject custom content into certain areas of the detail views of applicable models. This is accomplished by subclassing `PluginTemplateExtension`, designating a particular Nautobot model, and defining the desired methods to render custom content. Four methods are available:
-
-* `left_page()` - Inject content on the left side of the page
-* `right_page()` - Inject content on the right side of the page
-* `full_width_page()` - Inject content across the entire bottom of the page
-* `buttons()` - Add buttons to the top of the page
-
-Additionally, a `render()` method is available for convenience. This method accepts the name of a template to render, and any additional context data you want to pass. Its use is optional, however.
-
-When a PluginTemplateExtension is instantiated, context data is assigned to `self.context`. Available data include:
-
-* `object` - The object being viewed
-* `request` - The current request
-* `settings` - Global Nautobot settings
-* `config` - Plugin-specific configuration parameters
-
-For example, accessing `{{ request.user }}` within a template will return the current user.
-
-Declared subclasses should be gathered into a list or tuple for integration with Nautobot. By default, Nautobot looks for an iterable named `template_extensions` within a `template_content.py` file. (This can be overridden by setting `template_extensions` to a custom value on the plugin's `PluginConfig`.) An example is below.
-
-```python
-# template_content.py
-from nautobot.extras.plugins import PluginTemplateExtension
-
-from .models import Animal
-
-
-class SiteAnimalCount(PluginTemplateExtension):
-    """Template extension to display animal count on the right side of the page."""
-
-    model = 'dcim.site'
-
-    def right_page(self):
-        return self.render('nautobot_animal_sounds/inc/animal_count.html', extra_context={
-            'animal_count': Animal.objects.count(),
-        })
-
-
-template_extensions = [SiteAnimalCount]
-```
 
 ## Including Jinja2 Filters
 

--- a/nautobot/extras/choices.py
+++ b/nautobot/extras/choices.py
@@ -2,6 +2,27 @@ from nautobot.utilities.choices import ChoiceSet
 
 
 #
+# Banners (currently plugin-specific)
+#
+
+
+class BannerClassChoices(ChoiceSet):
+    """Styling choices for custom banners."""
+
+    CLASS_SUCCESS = "success"
+    CLASS_INFO = "info"
+    CLASS_WARNING = "warning"
+    CLASS_DANGER = "danger"
+
+    CHOICES = (
+        (CLASS_SUCCESS, "Success"),
+        (CLASS_INFO, "Info"),
+        (CLASS_WARNING, "Warning"),
+        (CLASS_DANGER, "Danger"),
+    )
+
+
+#
 # CustomFields
 #
 

--- a/nautobot/extras/templates/extras/templatetags/plugin_banners.html
+++ b/nautobot/extras/templates/extras/templatetags/plugin_banners.html
@@ -1,0 +1,6 @@
+{% load helpers %}
+{% for banner in banners %}
+    <div class="plugin-banner alert alert-{{ banner.banner_class }} text-center" role="alert">
+        {{ banner.content | safe }}
+    </div>
+{% endfor %}

--- a/nautobot/extras/templatetags/plugins.py
+++ b/nautobot/extras/templatetags/plugins.py
@@ -1,11 +1,16 @@
+import logging
+
 from django import template as template_
 from django.conf import settings
 from django.utils.safestring import mark_safe
 
-from nautobot.extras.plugins import PluginTemplateExtension
+from nautobot.extras.plugins import PluginBanner, PluginTemplateExtension
 from nautobot.extras.registry import registry
 
 register = template_.Library()
+
+
+logger = logging.getLogger("nautobot.plugins")
 
 
 def _get_registered_content(obj, method, template_context):
@@ -73,3 +78,24 @@ def plugin_full_width_page(context, obj):
     Render all full width page content registered by plugins
     """
     return _get_registered_content(obj, "full_width_page", context)
+
+
+@register.inclusion_tag("extras/templatetags/plugin_banners.html", takes_context=True)
+def plugin_banners(context):
+    """
+    Render all banners registered by plugins.
+    """
+    banners = []
+    for banner_function in registry["plugin_banners"]:
+        banner = banner_function(context)
+        if banner:
+            if isinstance(banner, PluginBanner):
+                banners.append(banner)
+            else:
+                logger.error(
+                    "Plugin banner function %s should return a PluginBanner, but instead returned %s",
+                    banner_function,
+                    banner,
+                )
+
+    return {"banners": banners}

--- a/nautobot/extras/tests/integration/test_configcontextschema.py
+++ b/nautobot/extras/tests/integration/test_configcontextschema.py
@@ -33,8 +33,9 @@ class ConfigContextSchemaTestCase(SplinterTestCase):
         self.browser.links.find_by_partial_text("Extensibility").click()
         self.browser.links.find_by_text("Config Context Schemas").click()
 
-        # Click add add button
-        self.browser.find_by_xpath("/html/body/div/div[1]/a").click()
+        # Click add button
+        # Need to be a bit clever in our search here to avoid accidentally hitting "IP Addresses -> Add" in the nav
+        self.browser.find_by_xpath("//div[contains(@class, 'wrapper')]//a[contains(., 'Add')]").click()
 
         # Fill out form
         self.browser.fill("name", "Integration Schema 1")
@@ -60,8 +61,9 @@ class ConfigContextSchemaTestCase(SplinterTestCase):
         self.browser.links.find_by_partial_text("Extensibility").click()
         self.browser.links.find_by_text("Config Context Schemas").click()
 
-        # Click add add button
-        self.browser.find_by_xpath("/html/body/div/div[1]/a").click()
+        # Click add button
+        # Need to be a bit clever in our search here to avoid accidentally hitting "IP Addresses -> Add" in the nav
+        self.browser.find_by_xpath("//div[contains(@class, 'wrapper')]//a[contains(., 'Add')]").click()
 
         # Fill out form
         self.browser.fill("name", "Integration Schema 2")

--- a/nautobot/extras/tests/integration/test_plugin_banner.py
+++ b/nautobot/extras/tests/integration/test_plugin_banner.py
@@ -1,0 +1,35 @@
+from unittest import skipIf
+
+from django.conf import settings
+
+from nautobot.utilities.testing.integration import SeleniumTestCase
+
+
+@skipIf("dummy_plugin" not in settings.PLUGINS, "dummy_plugin not in settings.PLUGINS")
+class PluginBannerTestCase(SeleniumTestCase):
+    """Integration test for rendering of plugin-injected banner content."""
+
+    fixtures = ["user-data.json"]
+
+    def test_banner_not_rendered(self):
+        """As implemented, plugin banner does not render if the user is not logged in.
+
+        More generally this tests the case where the registered banner() function returns None is handled correctly.
+        """
+        self.load_page(self.live_server_url)
+
+        banners_html = self.selenium.find_elements_by_class_name("plugin-banner")
+        self.assertEqual(0, len(banners_html))
+
+    def test_banner_rendered(self):
+        """Plugin banner renders correctly if the user is logged in."""
+        self.login(self.user.username, self.password)
+
+        self.load_page(self.live_server_url)
+
+        try:
+            banners_html = self.selenium.find_elements_by_class_name("plugin-banner")
+            self.assertEqual(1, len(banners_html))
+            self.assertIn(f"Hello, <strong>{self.user.username}</strong>", banners_html[0].get_property("innerHTML"))
+        finally:
+            self.logout()

--- a/nautobot/extras/tests/test_plugins.py
+++ b/nautobot/extras/tests/test_plugins.py
@@ -47,7 +47,15 @@ class PluginTest(TestCase):
         url = reverse("admin:dummy_plugin_dummymodel_add")
         self.assertEqual(url, "/admin/dummy_plugin/dummymodel/add/")
 
-    def test_template_extensions(self):
+    def test_banner_registration(self):
+        """
+        Check that plugin Banner is registered.
+        """
+        from dummy_plugin.banner import banner
+
+        self.assertIn(banner, registry["plugin_banners"])
+
+    def test_template_extensions_registration(self):
         """
         Check that plugin TemplateExtensions are registered.
         """
@@ -75,7 +83,7 @@ class PluginTest(TestCase):
 
         self.assertEqual(leet_speak, rendering_engine.env.filters[leet_speak.__name__])
 
-    def test_graphql_types(self):
+    def test_graphql_types_registration(self):
         """
         Check that plugin GraphQL Types are registered.
         """
@@ -125,7 +133,7 @@ class PluginTest(TestCase):
             jobs_dict["plugins"]["dummy_plugin.jobs"]["jobs"]["DummyJob"],
         )
 
-    def test_git_datasource_contents(self):
+    def test_git_datasource_contents_registration(self):
         """
         Check that plugin DatasourceContents are registered.
         """

--- a/nautobot/utilities/testing/integration.py
+++ b/nautobot/utilities/testing/integration.py
@@ -40,7 +40,7 @@ class NautobotRemote(webdriver.Remote):
         return self.find_element_by_xpath(f'//button[text()="{button_text}"]')
 
     def find_elements_by_class_name(self, name):
-        return self.find_elements_by_xpath(f"//*[@class='{name}']")
+        return self.find_elements_by_xpath(f"//*[contains(@class, '{name}')]")
 
 
 FIREFOX_PROFILE_PREFERENCES = {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #534 
<!--
    Please include a summary of the proposed changes below.
-->

Add the ability for plugins to provide a callback function in `plugin_name/banners.py -> banner()`. This callback function is invoked as a part of a new template tag included in `base.html` (i.e, every Nautobot UI view) and receives the Django context as an input parameter, allowing it to introspect both the request itself (user, query_params, URL, etc) and the template rendering context. It can then return a `PluginBanner` instance (describing the desired banner) or None (if a banner doesn't apply to this page)

Example dummy-plugin banner implementation is included, which renders differently based on the requesting user and the template context:

![image](https://user-images.githubusercontent.com/5603551/127708993-a79851ee-216e-458f-9265-ebc20b36c8c3.png)

![image](https://user-images.githubusercontent.com/5603551/127708949-7904531d-351c-42ba-b737-4d01724eb330.png)

![image](https://user-images.githubusercontent.com/5603551/127708965-fd07fe46-2325-4b76-a4c2-4e78a914d561.png)

Additionally:
- Added documentation in `plugins/development.md` about how to use this feature. As we now have a *bunch* of ways for a plugin to modify the UI, I rearranged the content of this file a bit to group all of the UI-related features into a common subsection.
- Added unit and integration tests
- The injection of this new banner into the test environment via the dummy_plugin broke an overly-specific XPath in the config-context-schema integration test, so I had to update that accordingly.