### PR TITLE
Add Celery DjangoFixup explicitly

### DIFF
--- a/nautobot/core/celery.py
+++ b/nautobot/core/celery.py
@@ -4,6 +4,7 @@ import logging
 import nautobot
 
 from celery import Celery, shared_task
+from celery.fixups.django import DjangoFixup
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.module_loading import import_string
 from kombu.serialization import register
@@ -30,6 +31,11 @@ app = Celery("nautobot")
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
 app.config_from_object("django.conf:settings", namespace="CELERY")
+
+# Because of the chicken-and-egg Django settings bootstrapping issue,
+# Celery doesn't automatically install its Django-specific patches.
+# So we need to explicitly do so ourselves:
+DjangoFixup(app).install()
 
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #744 
<!--
    Please include a summary of the proposed changes below.
-->

Because of our custom loader sequence (in which `DJANGO_SETTINGS_MODULE` is not fully set before Django begins to start up), Celery's Django-specific logic was not being applied at startup time, resulting in various shared-state errors when running multiple simultaneous Celery tasks.

Besides the errors that could be encountered due to this case, another clue is that when running in the development environment (with `DEBUG = True`), the Celery worker was not warning about this setting being present, because the logic that checks for that and issues that warning was not installed. With this fix in place, the warning is now seen as expected:

```
[2021-08-02 20:30:27,980: INFO/MainProcess] Connected to redis://:**@redis:6379/0
[2021-08-02 20:30:27,993: INFO/MainProcess] mingle: searching for neighbors
[2021-08-02 20:30:29,015: INFO/MainProcess] mingle: all alone
[2021-08-02 20:30:29,037: WARNING/MainProcess] /usr/local/lib/python3.6/site-packages/celery/fixups/django.py:204: UserWarning: Using settings.DEBUG leads to a memory
            leak, never use this setting in production environments!
  leak, never use this setting in production environments!''')

[2021-08-02 20:30:29,037: INFO/MainProcess] celery@8522c2347725 ready.
```

### Testing

The original issue was reproducible as described in #744 - stopping the Celery worker, enqueuing 10 or so Jobs for execution, then starting the Celery worker so that all ten Jobs were more-or-less simultaneously picked up for execution, would result in errors such as:

```
[2021-08-02 20:27:56,645: ERROR/ForkPoolWorker-7] Task nautobot.extras.jobs.run_job[1fd322d7-c4a8-4994-b4bb-ca12c6040dd6] raised unexpected: InterfaceError('connection already closed',)
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/db/backends/base/base.py", line 237, in _cursor
    return self._prepare_cursor(self.create_cursor(name))
  File "/usr/local/lib/python3.6/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/db/backends/postgresql/base.py", line 236, in create_cursor
    cursor = self.connection.cursor()
psycopg2.InterfaceError: connection already closed
```

After this change, no such issues are seen - all ten Jobs run successfully to completion. 

I don't have any particularly bright ideas around implementing an automated regression test for this issue - suggestions are welcome.