### PR TITLE
Adding Logging Examples

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -70,12 +70,12 @@ if not TESTING:
         "handlers": {
             "normal_console": {
                 "level": "INFO",
-                "class": "rq.utils.ColorizingStreamHandler",
+                "class": "logging.StreamHandler",
                 "formatter": "normal",
             },
             "verbose_console": {
                 "level": "DEBUG",
-                "class": "rq.utils.ColorizingStreamHandler",
+                "class": "logging.StreamHandler",
                 "formatter": "verbose",
             },
         },

--- a/docker/nautobot_config.append.py
+++ b/docker/nautobot_config.append.py
@@ -15,7 +15,7 @@ LOGGING = {
     "handlers": {
         "normal_console": {
             "level": "DEBUG",
-            "class": "rq.utils.ColorizingStreamHandler",
+            "class": "logging.StreamHandler",
             "formatter": "normal",
         },
     },

--- a/examples/logging/README.md
+++ b/examples/logging/README.md
@@ -1,0 +1,1 @@
+This folder contains some examples of how logging can be configured.

--- a/examples/logging/advanced_requests.md
+++ b/examples/logging/advanced_requests.md
@@ -47,7 +47,10 @@ LOGGING = {
             "level": LOG_LEVEL,
             "propagate": False,
         },
-        "django": {"handlers": ["normal_console"], "level": "INFO"},
+        "django": {
+            "handlers": ["normal_console"],
+            "level": "INFO"
+        },
         "nautobot": {
             "handlers": ["normal_console"],
             "level": LOG_LEVEL,
@@ -60,16 +63,10 @@ LOGGING = {
 
 ```no-highlight
 20:50:57.972 INFO    django.server:  "GET /health/ HTTP/1.1" 200 11743
-20:50:57.972 INFO    django.server:  "GET /health/ HTTP/1.1" 200 11743
-20:50:58.769 INFO    django.server:  "GET /login/?next=/ HTTP/1.1" 200 18336
 20:50:58.769 INFO    django.server:  "GET /login/?next=/ HTTP/1.1" 200 18336
 20:51:04.710 INFO    django.server:  "GET /health/ HTTP/1.1" 200 11741
-20:51:04.710 INFO    django.server:  "GET /health/ HTTP/1.1" 200 11741
-20:51:05.836 INFO    nautobot.auth.login:  User admin successfully authenticated
 20:51:05.836 INFO    nautobot.auth.login:  User admin successfully authenticated
 20:51:07.340 INFO    django.server:  "POST /login/ HTTP/1.1" 302 0
-20:51:07.340 INFO    django.server:  "POST /login/ HTTP/1.1" 302 0
-20:51:10.182 INFO    django.server:  "GET / HTTP/1.1" 200 118573
 20:51:10.182 INFO    django.server:  "GET / HTTP/1.1" 200 118573
 21:02:25.928 WARNING django.request: user=admin Not Found: /api/ipam/ip-addresses/63b38cc7-979d-52c4-b26f-e44dd5f390ca/
 21:02:25.945 WARNING django.server: "GET /api/ipam/ip-addresses/63b38cc7-979d-52c4-b26f-e44dd5f390ca/ HTTP/1.1" 404 15611

--- a/examples/logging/advanced_requests.md
+++ b/examples/logging/advanced_requests.md
@@ -1,0 +1,65 @@
+By default django logs [4xx and 5xx requests](https://docs.djangoproject.com/en/3.2/topics/logging/#django-request) 
+but is missing details such as the request user name.  This can be helpful in debugging. This example 
+shows how the request user can be added to the logs.
+
+```python
+def add_username(record):
+    record.username = record.request.user.username
+    return True
+
+
+LOG_LEVEL = "DEBUG" if DEBUG else "INFO"
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "normal": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s: %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+        "request": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s: user=%(username)s %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+        "verbose": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s(): %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+    },
+    "handlers": {
+        "normal_console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "normal",
+        },
+        "requests": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "request",
+            "filters": ["add_username"],
+        },
+    },
+    "filters": {
+        "add_username": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": add_username,
+        }
+    },
+    "loggers": {
+        "django.request": {
+            "handlers": ["requests"],
+            "level": LOG_LEVEL,
+            "propagate": False,
+        },
+        "django": {"handlers": ["normal_console"], "level": LOG_LEVEL},
+        "nautobot": {
+            "handlers": ["normal_console"],
+            "level": LOG_LEVEL,
+        },
+        "rq.worker": {
+            "handlers": ["normal_console"],
+            "level": LOG_LEVEL,
+        },
+    },
+}
+```

--- a/examples/logging/advanced_requests.md
+++ b/examples/logging/advanced_requests.md
@@ -21,10 +21,6 @@ LOGGING = {
             "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s: user=%(username)s %(message)s",
             "datefmt": "%H:%M:%S",
         },
-        "verbose": {
-            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s(): %(message)s",
-            "datefmt": "%H:%M:%S",
-        },
     },
     "handlers": {
         "normal_console": {
@@ -51,15 +47,30 @@ LOGGING = {
             "level": LOG_LEVEL,
             "propagate": False,
         },
-        "django": {"handlers": ["normal_console"], "level": LOG_LEVEL},
+        "django": {"handlers": ["normal_console"], "level": "INFO"},
         "nautobot": {
-            "handlers": ["normal_console"],
-            "level": LOG_LEVEL,
-        },
-        "rq.worker": {
             "handlers": ["normal_console"],
             "level": LOG_LEVEL,
         },
     },
 }
+```
+
+## Example Logs
+
+```no-highlight
+20:50:57.972 INFO    django.server:  "GET /health/ HTTP/1.1" 200 11743
+20:50:57.972 INFO    django.server:  "GET /health/ HTTP/1.1" 200 11743
+20:50:58.769 INFO    django.server:  "GET /login/?next=/ HTTP/1.1" 200 18336
+20:50:58.769 INFO    django.server:  "GET /login/?next=/ HTTP/1.1" 200 18336
+20:51:04.710 INFO    django.server:  "GET /health/ HTTP/1.1" 200 11741
+20:51:04.710 INFO    django.server:  "GET /health/ HTTP/1.1" 200 11741
+20:51:05.836 INFO    nautobot.auth.login:  User admin successfully authenticated
+20:51:05.836 INFO    nautobot.auth.login:  User admin successfully authenticated
+20:51:07.340 INFO    django.server:  "POST /login/ HTTP/1.1" 302 0
+20:51:07.340 INFO    django.server:  "POST /login/ HTTP/1.1" 302 0
+20:51:10.182 INFO    django.server:  "GET / HTTP/1.1" 200 118573
+20:51:10.182 INFO    django.server:  "GET / HTTP/1.1" 200 118573
+21:02:25.928 WARNING django.request: user=admin Not Found: /api/ipam/ip-addresses/63b38cc7-979d-52c4-b26f-e44dd5f390ca/
+21:02:25.945 WARNING django.server: "GET /api/ipam/ip-addresses/63b38cc7-979d-52c4-b26f-e44dd5f390ca/ HTTP/1.1" 404 15611
 ```

--- a/examples/logging/all_logs.md
+++ b/examples/logging/all_logs.md
@@ -21,7 +21,10 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["normal_console"], "level": LOG_LEVEL},
+        "django": {
+            "handlers": ["normal_console"],
+            "level": "INFO"
+        },
         "nautobot": {
             "handlers": ["normal_console"],
             "level": LOG_LEVEL,

--- a/examples/logging/all_logs.md
+++ b/examples/logging/all_logs.md
@@ -1,0 +1,46 @@
+This example captures all logs sent to the python logger.  This is helpful if you don't know the logger name
+for the loggers config or if you simply want to make sure you collect ALL logs.  But be warned, ALL logs might
+be a lot of logs:
+
+```python
+LOG_LEVEL = "DEBUG" if DEBUG else "INFO"
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "normal": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s:  %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+        "verbose": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s():  %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+    },
+    "handlers": {
+        "normal_console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "normal",
+        },
+    },
+    "loggers": {
+        "django": {"handlers": ["normal_console"], "level": LOG_LEVEL},
+        "nautobot": {
+            "handlers": ["normal_console"],
+            "level": LOG_LEVEL,
+        },
+        "rq.worker": {
+            "handlers": ["normal_console"],
+            "level": LOG_LEVEL,
+        },
+    },
+    "root": {
+        "handlers": ["console", "newrelic"] if NEWRELIC_ENABLED else ["console"],
+        "level": LOG_LEVEL,
+    },
+}
+```
+
+The important addition is the `LOGGING["root"]` entry here.  You can skip the `LOGGING["loggers"]` section
+entirely if you wish.

--- a/examples/logging/all_logs.md
+++ b/examples/logging/all_logs.md
@@ -12,10 +12,6 @@ LOGGING = {
             "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s:  %(message)s",
             "datefmt": "%H:%M:%S",
         },
-        "verbose": {
-            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s():  %(message)s",
-            "datefmt": "%H:%M:%S",
-        },
     },
     "handlers": {
         "normal_console": {
@@ -30,13 +26,9 @@ LOGGING = {
             "handlers": ["normal_console"],
             "level": LOG_LEVEL,
         },
-        "rq.worker": {
-            "handlers": ["normal_console"],
-            "level": LOG_LEVEL,
-        },
     },
     "root": {
-        "handlers": ["console", "newrelic"] if NEWRELIC_ENABLED else ["console"],
+        "handlers": "normal_console",
         "level": LOG_LEVEL,
     },
 }
@@ -44,3 +36,16 @@ LOGGING = {
 
 The important addition is the `LOGGING["root"]` entry here.  You can skip the `LOGGING["loggers"]` section
 entirely if you wish.
+
+## Example Logs
+
+```no-highlight
+20:38:28.967 INFO    django.server: "GET / HTTP/1.1" 200 29409
+20:38:29.174 INFO    django.server: "GET /static/debug_toolbar/js/toolbar.js HTTP/1.1" 304 0
+20:38:29.194 INFO    django.server: "GET /static/debug_toolbar/css/toolbar.css HTTP/1.1" 304 0
+20:38:29.677 INFO    django.server: "GET /static/debug_toolbar/css/print.css HTTP/1.1" 304 0
+20:38:29.775 INFO    django.server: "GET /static/debug_toolbar/js/utils.js HTTP/1.1" 304 0
+20:38:33.433 INFO    django.server: "GET /login/?next=/ HTTP/1.1" 200 18335
+20:38:41.121 INFO    nautobot.auth.login: User admin successfully authenticated
+20:38:42.053 INFO    django.server: "POST /login/ HTTP/1.1" 302 0
+```

--- a/examples/logging/basic_file.md
+++ b/examples/logging/basic_file.md
@@ -26,7 +26,10 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["normal_console"], "level": "INFO"},
+        "django": {
+            "handlers": ["normal_console"],
+            "level": "INFO"
+        },
         "nautobot": {
             "handlers": ["normal_console"],
             "level": LOG_LEVEL,

--- a/examples/logging/basic_file.md
+++ b/examples/logging/basic_file.md
@@ -12,10 +12,6 @@ LOGGING = {
             "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s:  %(message)s",
             "datefmt": "%H:%M:%S",
         },
-        "verbose": {
-            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s(): %(message)s",
-            "datefmt": "%H:%M:%S",
-        },
     },
     "handlers": {
         "nautobot_log": {
@@ -30,15 +26,26 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["normal_console"], "level": LOG_LEVEL},
+        "django": {"handlers": ["normal_console"], "level": "INFO"},
         "nautobot": {
-            "handlers": ["normal_console"],
-            "level": LOG_LEVEL,
-        },
-        "rq.worker": {
             "handlers": ["normal_console"],
             "level": LOG_LEVEL,
         },
     },
 }
+```
+
+## Example Logs
+
+```no-highlight
+20:38:28.967 INFO    django.server: "GET / HTTP/1.1" 200 29409
+20:38:29.174 INFO    django.server: "GET /static/debug_toolbar/js/toolbar.js HTTP/1.1" 304 0
+20:38:29.194 INFO    django.server: "GET /static/debug_toolbar/css/toolbar.css HTTP/1.1" 304 0
+20:38:29.677 INFO    django.server: "GET /static/debug_toolbar/css/print.css HTTP/1.1" 304 0
+20:38:29.775 INFO    django.server: "GET /static/debug_toolbar/js/utils.js HTTP/1.1" 304 0
+20:38:33.433 INFO    django.server: "GET /login/?next=/ HTTP/1.1" 200 18335
+20:38:40.878 DEBUG   nautobot.auth.login: Login form validation was successful
+20:38:41.121 INFO    nautobot.auth.login: User admin successfully authenticated
+20:38:41.121 DEBUG   nautobot.auth.login: Redirecting user to /
+20:38:42.053 INFO    django.server: "POST /login/ HTTP/1.1" 302 0
 ```

--- a/examples/logging/basic_file.md
+++ b/examples/logging/basic_file.md
@@ -1,0 +1,44 @@
+This example sends logging to files in `/var/log/nautobot`, please note this directory should exist and 
+be writeable by the nautobot user.  Files are rotated daily for 5 days at midnight UTC.
+
+```python
+LOG_DIR = "/var/log/nautobot"
+LOG_LEVEL = "DEBUG" if DEBUG else "INFO"
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "normal": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s:  %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+        "verbose": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s(): %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+    },
+    "handlers": {
+        "nautobot_log": {
+            "level": "DEBUG",
+            "class": "logging.handlers.TimedRotatingFileHandler",
+            "filename": f"{LOG_DIR}/nautobot.log",
+            "when": "midnight",
+            "utc": True,
+            "interval": 1,
+            "backupCount": 5,
+            "formatter": "normal",
+        },
+    },
+    "loggers": {
+        "django": {"handlers": ["normal_console"], "level": LOG_LEVEL},
+        "nautobot": {
+            "handlers": ["normal_console"],
+            "level": LOG_LEVEL,
+        },
+        "rq.worker": {
+            "handlers": ["normal_console"],
+            "level": LOG_LEVEL,
+        },
+    },
+}
+```

--- a/examples/logging/basic_stdout.md
+++ b/examples/logging/basic_stdout.md
@@ -1,0 +1,38 @@
+This example provides adequate logging for basic deployments where the logs to stdout are caputured by
+some external process such as docker or kubernetes:
+
+```python
+LOG_LEVEL = "DEBUG" if DEBUG else "INFO"
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "normal": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s: %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+        "verbose": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s(): %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+    },
+    "handlers": {
+        "normal_console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "normal",
+        },
+    },
+    "loggers": {
+        "django": {"handlers": ["normal_console"], "level": LOG_LEVEL},
+        "nautobot": {
+            "handlers": ["normal_console"],
+            "level": LOG_LEVEL,
+        },
+        "rq.worker": {
+            "handlers": ["normal_console"],
+            "level": LOG_LEVEL,
+        },
+    },
+}
+```

--- a/examples/logging/basic_stdout.md
+++ b/examples/logging/basic_stdout.md
@@ -20,7 +20,10 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["normal_console"], "level": "INFO"},
+        "django": {
+            "handlers": ["normal_console"],
+            "level": "INFO"
+        },
         "nautobot": {
             "handlers": ["normal_console"],
             "level": LOG_LEVEL,

--- a/examples/logging/basic_stdout.md
+++ b/examples/logging/basic_stdout.md
@@ -1,5 +1,5 @@
-This example provides adequate logging for basic deployments where the logs to stdout are caputured by
-some external process such as docker or kubernetes:
+This example provides adequate logging for basic deployments where the logs to stdout are captured by
+some external process such as Docker or Kubernetes:
 
 ```python
 LOG_LEVEL = "DEBUG" if DEBUG else "INFO"

--- a/examples/logging/basic_stdout.md
+++ b/examples/logging/basic_stdout.md
@@ -11,10 +11,6 @@ LOGGING = {
             "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s: %(message)s",
             "datefmt": "%H:%M:%S",
         },
-        "verbose": {
-            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s(): %(message)s",
-            "datefmt": "%H:%M:%S",
-        },
     },
     "handlers": {
         "normal_console": {
@@ -24,15 +20,25 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["normal_console"], "level": LOG_LEVEL},
+        "django": {"handlers": ["normal_console"], "level": "INFO"},
         "nautobot": {
-            "handlers": ["normal_console"],
-            "level": LOG_LEVEL,
-        },
-        "rq.worker": {
             "handlers": ["normal_console"],
             "level": LOG_LEVEL,
         },
     },
 }
+```
+## Example Logs
+
+```no-highlight
+20:38:28.967 INFO    django.server: "GET / HTTP/1.1" 200 29409
+20:38:29.174 INFO    django.server: "GET /static/debug_toolbar/js/toolbar.js HTTP/1.1" 304 0
+20:38:29.194 INFO    django.server: "GET /static/debug_toolbar/css/toolbar.css HTTP/1.1" 304 0
+20:38:29.677 INFO    django.server: "GET /static/debug_toolbar/css/print.css HTTP/1.1" 304 0
+20:38:29.775 INFO    django.server: "GET /static/debug_toolbar/js/utils.js HTTP/1.1" 304 0
+20:38:33.433 INFO    django.server: "GET /login/?next=/ HTTP/1.1" 200 18335
+20:38:40.878 DEBUG   nautobot.auth.login: Login form validation was successful
+20:38:41.121 INFO    nautobot.auth.login: User admin successfully authenticated
+20:38:41.121 DEBUG   nautobot.auth.login: Redirecting user to /
+20:38:42.053 INFO    django.server: "POST /login/ HTTP/1.1" 302 0
 ```

--- a/examples/logging/local_debug.md
+++ b/examples/logging/local_debug.md
@@ -19,12 +19,12 @@ LOGGING = {
     "handlers": {
         "normal_console": {
             "level": "INFO",
-            "class": "rq.utils.ColorizingStreamHandler",
+            "class": "logging.StreamHandler",
             "formatter": "normal",
         },
         "verbose_console": {
             "level": "DEBUG",
-            "class": "rq.utils.ColorizingStreamHandler",
+            "class": "logging.StreamHandler",
             "formatter": "verbose",
         },
     },
@@ -34,10 +34,34 @@ LOGGING = {
             "handlers": ["verbose_console" if DEBUG else "normal_console"],
             "level": LOG_LEVEL,
         },
-        "rq.worker": {
-            "handlers": ["verbose_console" if DEBUG else "normal_console"],
-            "level": LOG_LEVEL,
-        },
     },
 }
+```
+
+## Example Logs
+
+```no-highlight
+  "GET / HTTP/1.1" 200 29109
+20:23:04.320 INFO    django.server :
+  "GET /static/debug_toolbar/css/toolbar.css HTTP/1.1" 200 11461
+20:23:04.326 INFO    django.server :
+  "GET /static/debug_toolbar/js/toolbar.js HTTP/1.1" 200 10452
+20:23:04.957 INFO    django.server :
+  "GET /static/debug_toolbar/css/print.css HTTP/1.1" 200 43
+20:23:05.013 INFO    django.server :
+  "GET /static/debug_toolbar/js/utils.js HTTP/1.1" 200 2988
+20:23:06.901 INFO    django.server :
+  "GET /login/?next=/ HTTP/1.1" 200 18334
+20:23:10.246 DEBUG   nautobot.auth.login  views.py                                  post() :
+  Login form validation was successful
+20:23:10.335 INFO    nautobot.auth.login  views.py                                  post() :
+  User admin successfully authenticated
+20:23:10.335 DEBUG   nautobot.auth.login  views.py                      redirect_to_next() :
+  Redirecting user to /
+20:23:10.801 INFO    django.server :
+  "POST /login/ HTTP/1.1" 302 0
+20:23:11.254 DEBUG   nautobot.releases    releases.py                 get_latest_release() :
+  Skipping release check; RELEASE_CHECK_URL not defined
+20:23:12.806 INFO    django.server :
+  "GET / HTTP/1.1" 200 118574
 ```

--- a/examples/logging/local_debug.md
+++ b/examples/logging/local_debug.md
@@ -1,4 +1,4 @@
-This logging configuration is great for running Nautbot locally in docker with `DEBUG=True`.  It is 
+This logging configuration is great for running Nautobot locally in Docker with `DEBUG=True`.  It is 
 impractical to use in production due to the multi-line output:
 
 ```python

--- a/examples/logging/local_debug.md
+++ b/examples/logging/local_debug.md
@@ -1,0 +1,43 @@
+This logging configuration is great for running Nautbot locally in docker with `DEBUG=True`.  It is 
+impractical to use in production due to the multi-line output:
+
+```python
+LOG_LEVEL = "DEBUG" if DEBUG else "INFO"
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "normal": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s :\n  %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+        "verbose": {
+            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s() :\n  %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+    },
+    "handlers": {
+        "normal_console": {
+            "level": "INFO",
+            "class": "rq.utils.ColorizingStreamHandler",
+            "formatter": "normal",
+        },
+        "verbose_console": {
+            "level": "DEBUG",
+            "class": "rq.utils.ColorizingStreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "loggers": {
+        "django": {"handlers": ["normal_console"], "level": "INFO"},
+        "nautobot": {
+            "handlers": ["verbose_console" if DEBUG else "normal_console"],
+            "level": LOG_LEVEL,
+        },
+        "rq.worker": {
+            "handlers": ["verbose_console" if DEBUG else "normal_console"],
+            "level": LOG_LEVEL,
+        },
+    },
+}
+```

--- a/examples/logging/local_debug.md
+++ b/examples/logging/local_debug.md
@@ -29,7 +29,10 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["normal_console"], "level": "INFO"},
+        "django": {
+            "handlers": ["normal_console"],
+            "level": "INFO"
+        },
         "nautobot": {
             "handlers": ["verbose_console" if DEBUG else "normal_console"],
             "level": LOG_LEVEL,

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -446,8 +446,8 @@ LOGGING = {
     },
     'handlers': {
         'file': {'level': 'INFO', 'class': 'logging.FileHandler', 'filename': '/var/log/nautobot.log', 'formatter': 'normal'},
-        'normal_console': {'level': 'INFO', 'class': 'rq.utils.ColorizingStreamHandler', 'formatter': 'normal'},
-        'verbose_console': {'level': 'DEBUG', 'class': 'rq.utils.ColorizingStreamHandler', 'formatter': 'verbose'},
+        'normal_console': {'level': 'INFO', 'class': 'logging.StreamHandler', 'formatter': 'normal'},
+        'verbose_console': {'level': 'DEBUG', 'class': 'logging.StreamHandler', 'formatter': 'verbose'},
     },
     'loggers': {
         'django': {'handlers': ['file', 'normal_console'], 'level': 'INFO'},

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -457,6 +457,8 @@ LOGGING = {
 }
 ```
 
+Additional examples are available in [`/examples/logging`](https://github.com/nautobot/nautobot/tree/develop/examples/logging).
+
 ### Available Loggers
 
 * `django.*` - Generic Django operations (HTTP requests/responses, etc.)

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -428,7 +428,7 @@ Default: `{}` (Empty dictionary)
 
 By default, all messages of INFO severity or higher will be logged to the console. Additionally, if [`DEBUG`](#debug) is False and email access has been configured, ERROR and CRITICAL messages will be emailed to the users defined in [`ADMINS`](#admins).
 
-The Django framework on which Nautobot runs allows for the customization of logging format and destination. Please consult the [Django logging documentation](https://docs.djangoproject.com/en/stable/topics/logging/) for more information on configuring this setting. Below is an example which will write all INFO and higher messages to a local file and log DEBUG and higher messages from Nautobot itself and from the RQ worker process to the console with added verbosity and colorization:
+The Django framework on which Nautobot runs allows for the customization of logging format and destination. Please consult the [Django logging documentation](https://docs.djangoproject.com/en/stable/topics/logging/) for more information on configuring this setting. Below is an example which will write all INFO and higher messages to a local file and log DEBUG and higher messages from Nautobot itself with higher verbosity:
 
 ```python
 LOGGING = {
@@ -452,7 +452,6 @@ LOGGING = {
     'loggers': {
         'django': {'handlers': ['file', 'normal_console'], 'level': 'INFO'},
         'nautobot': {'handlers': ['file', 'verbose_console'], 'level': 'DEBUG'},
-        'rq.worker': {'handlers': ['file', 'verbose_console'], 'level': 'DEBUG'},
     },
 }
 ```

--- a/tasks.py
+++ b/tasks.py
@@ -283,7 +283,7 @@ def vscode(context):
     """Launch Visual Studio Code with the appropriate Environment variables to run in a container."""
     command = "code nautobot.code-workspace"
 
-    context.run(command)
+    context.run(command, env={"PYTHON_VER": context.nautobot.python_ver})
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds some examples for configuring logging.  To include an example for #755 might be accomplished.  I also found the `invoke vscode` task was not setting the env vars correctly for using the vscode dev containers feature.