### PR TITLE
Updates Powerfeed Utilization Data

### DIFF
--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -376,7 +376,9 @@ class PowerPort(CableTermination, PathEndpoint, ComponentModel):
             "maximum": self.maximum_draw or 0,
             "outlet_count": PowerOutlet.objects.filter(power_port=self).count(),
             "legs": [],
-            "utilization_data": UtilizationData(numerator=self.allocated_draw or 0, denominator=self.maximum_draw or 0),
+            "utilization_data": UtilizationData(
+                numerator=self.allocated_draw or 0, denominator=self.connected_endpoint.available_power or 0
+            ),
         }
 
 

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -381,9 +381,7 @@ class PowerPort(CableTermination, PathEndpoint, ComponentModel):
             "maximum": self.maximum_draw or 0,
             "outlet_count": PowerOutlet.objects.filter(power_port=self).count(),
             "legs": [],
-            "utilization_data": UtilizationData(
-                numerator=self.allocated_draw or 0, denominator=denominator
-            ),
+            "utilization_data": UtilizationData(numerator=self.allocated_draw or 0, denominator=denominator),
         }
 
 

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -23,7 +23,7 @@ from nautobot.utilities.fields import NaturalOrderingField
 from nautobot.utilities.mptt import TreeManager
 from nautobot.utilities.ordering import naturalize_interface
 from nautobot.utilities.query_functions import CollateAsChar
-from nautobot.utilities.utils import serialize_object
+from nautobot.utilities.utils import UtilizationData, serialize_object
 
 
 __all__ = (
@@ -376,6 +376,7 @@ class PowerPort(CableTermination, PathEndpoint, ComponentModel):
             "maximum": self.maximum_draw or 0,
             "outlet_count": PowerOutlet.objects.filter(power_port=self).count(),
             "legs": [],
+            "utilization_data": UtilizationData(numerator=self.allocated_draw or 0, denominator=self.maximum_draw or 0)
         }
 
 

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -370,6 +370,11 @@ class PowerPort(CableTermination, PathEndpoint, ComponentModel):
 
             return ret
 
+        if self.connected_endpoint and hasattr(self.connected_endpoint, "availalble_power"):
+            denominator = self.connected_endpoint.available_power or 0
+        else:
+            denominator = 0
+
         # Default to administratively defined values
         return {
             "allocated": self.allocated_draw or 0,
@@ -377,7 +382,7 @@ class PowerPort(CableTermination, PathEndpoint, ComponentModel):
             "outlet_count": PowerOutlet.objects.filter(power_port=self).count(),
             "legs": [],
             "utilization_data": UtilizationData(
-                numerator=self.allocated_draw or 0, denominator=self.connected_endpoint.available_power or 0
+                numerator=self.allocated_draw or 0, denominator=denominator
             ),
         }
 

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -370,7 +370,7 @@ class PowerPort(CableTermination, PathEndpoint, ComponentModel):
 
             return ret
 
-        if self.connected_endpoint and hasattr(self.connected_endpoint, "availalble_power"):
+        if self.connected_endpoint and hasattr(self.connected_endpoint, "available_power"):
             denominator = self.connected_endpoint.available_power or 0
         else:
             denominator = 0

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -376,7 +376,7 @@ class PowerPort(CableTermination, PathEndpoint, ComponentModel):
             "maximum": self.maximum_draw or 0,
             "outlet_count": PowerOutlet.objects.filter(power_port=self).count(),
             "legs": [],
-            "utilization_data": UtilizationData(numerator=self.allocated_draw or 0, denominator=self.maximum_draw or 0)
+            "utilization_data": UtilizationData(numerator=self.allocated_draw or 0, denominator=self.maximum_draw or 0),
         }
 
 

--- a/nautobot/dcim/templates/dcim/rack.html
+++ b/nautobot/dcim/templates/dcim/rack.html
@@ -247,7 +247,7 @@
                             </td>
                             {% with power_port=powerfeed.connected_endpoint %}
                                 {% if power_port %}
-                                    <td>{% utilization_graph power_port.get_power_draw %}</td>
+                                    <td>{% utilization_graph power_port.get_power_draw.utilization_data %}</td>
                                 {% else %}
                                     <td class="text-muted">N/A</td>
                                 {% endif %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #723 
<!--
    Please include a summary of the proposed changes below.
-->

Adds UtilizationData to the return of `get_power_draw(self)`.

As part of an internal conversation it was recommended to return the denominator of `available_power`. That does not appear to be part of the object. So went with `maximum_draw` instead for the denominator value.