### PR TITLE
Expanding the prometheus metrics docs

### DIFF
--- a/nautobot/docs/additional-features/prometheus-metrics.md
+++ b/nautobot/docs/additional-features/prometheus-metrics.md
@@ -6,12 +6,12 @@ Nautobot supports optionally exposing native Prometheus metrics from the applica
 
 Metrics are not exposed by default. Metric exposition can be toggled with the `METRICS_ENABLED` configuration setting which exposes metrics at the `/metrics` HTTP endpoint, e.g. `https://nautobot.local/metrics`. 
 
-In addition to the `METRICS_ENABLED` setting, database and caching metrics can also be enabled by changing the database engine and caching backend:
+In addition to the `METRICS_ENABLED` setting, database and/or caching metrics can also be enabled by changing the database engine and/or caching backends from `django.db.backends` / `django_redis.cache` to `django_promethus.db.backends` / `django_promethus.cache.backends.redis`:
 
 ```python
 DATABASES = {
     "default": {
-        # Other setttings...
+        # Other settings...
         "ENGINE": "django_prometheus.db.backends.postgresql",  # use "django_prometheus.db.backends.mysql" with MySQL
     }
 }
@@ -19,7 +19,7 @@ DATABASES = {
 # Other settings...
 CACHES = {
     "default": {
-        # Other setttings...
+        # Other settings...
         "BACKEND": "django_prometheus.cache.backends.redis.RedisCache",
     }
 }

--- a/nautobot/docs/additional-features/prometheus-metrics.md
+++ b/nautobot/docs/additional-features/prometheus-metrics.md
@@ -2,7 +2,30 @@
 
 Nautobot supports optionally exposing native Prometheus metrics from the application. [Prometheus](https://prometheus.io/) is a popular time series metric platform used for monitoring.
 
-Nautobot exposes metrics at the `/metrics` HTTP endpoint, e.g. `https://nautobot.local/metrics`. Metric exposition can be toggled with the `METRICS_ENABLED` configuration setting. Metrics are not exposed by default.
+## Configuration
+
+Metrics are not exposed by default. Metric exposition can be toggled with the `METRICS_ENABLED` configuration setting which exposes metrics at the `/metrics` HTTP endpoint, e.g. `https://nautobot.local/metrics`. 
+
+In addition to the `METRICS_ENABLED` database and caching metrics can also be enabled by changing the database engine and caching backend:
+
+```python
+DATABASES = {
+    "default": {
+        # Other setttings...
+        "ENGINE": "django_prometheus.db.backends.postgresql",  # use "django_prometheus.db.backends.mysql" with MySQL
+    }
+}
+
+# Other settings...
+CACHES = {
+    "default": {
+        # Other setttings...
+        "BACKEND": "django_prometheus.cache.backends.redis.RedisCache",
+    }
+}
+```
+
+For more information see the [django-prometheus](https://github.com/korfuri/django-prometheus) docs.
 
 ## Metric Types
 
@@ -27,3 +50,6 @@ When deploying Nautobot in a multiprocess manner (e.g. running multiple uWSGI wo
 
 !!! warning
     If having accurate long-term metrics in a multiprocess environment is crucial to your deployment, it's recommended you use the `uwsgi` library instead of `gunicorn`. The issue lies in the way `gunicorn` tracks worker processes (vs `uwsgi`) which helps manage the metrics files created by the above configurations. If you're using Nautobot with gunicorn in a containerized enviroment following the one-process-per-container methodology, then you will likely not need to change to `uwsgi`. More details can be found in  [issue #3779](https://github.com/netbox-community/netbox/issues/3779#issuecomment-590547562).
+
+!!! note
+    Metrics from the celery worker are not available from Nautobot at this time.  However, additional tools such as [flower](https://flower.readthedocs.io/en/latest/) can be used to monitor the celery workers until these metrics are exposed through Nautobot.

--- a/nautobot/docs/additional-features/prometheus-metrics.md
+++ b/nautobot/docs/additional-features/prometheus-metrics.md
@@ -6,7 +6,7 @@ Nautobot supports optionally exposing native Prometheus metrics from the applica
 
 Metrics are not exposed by default. Metric exposition can be toggled with the `METRICS_ENABLED` configuration setting which exposes metrics at the `/metrics` HTTP endpoint, e.g. `https://nautobot.local/metrics`. 
 
-In addition to the `METRICS_ENABLED` database and caching metrics can also be enabled by changing the database engine and caching backend:
+In addition to the `METRICS_ENABLED` setting, database and caching metrics can also be enabled by changing the database engine and caching backend:
 
 ```python
 DATABASES = {


### PR DESCRIPTION
This PR provides some additional optional configuration around the Prometheus metrics.  These settings provide slightly more insight into the DB and Caching.  I also added a note to cover celery metrics for now.