### PR TITLE
JobResult list view to show job Meta.name where available instead of class_path

### DIFF
--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -826,6 +826,18 @@ class JobResult(BaseModel, CustomFieldModel):
 
         return None
 
+    @property
+    def related_name(self):
+        """
+        Similar to self.name, but if there's an appropriate `related_object`, use its name instead.
+        """
+        related_object = self.related_object
+        if not related_object:
+            return self.name
+        if hasattr(related_object, "name"):
+            return related_object.name
+        return str(related_object)
+
     def get_absolute_url(self):
         return reverse("extras:jobresult", kwargs={"pk": self.pk})
 

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -60,6 +60,16 @@ GITREPOSITORY_BUTTONS = """
 <button data-url="{% url 'extras:gitrepository_sync' slug=record.slug %}" type="submit" class="btn btn-primary btn-xs sync-repository" title="Sync" {% if not perms.extras.change_gitrepository %}disabled="disabled"{% endif %}><i class="mdi mdi-source-branch-sync" aria-hidden="true"></i></button>
 """
 
+JOB_RESULT_JOB = """
+{% if record.related_object and record.related_object.Meta and record.related_object.Meta.name %}
+{{ record.related_object.Meta.name }}
+{% elif record.related_object %}
+{{ record.related_object }}
+{% else %}
+{{ record.name }}
+{% endif %}
+"""
+
 OBJECTCHANGE_OBJECT = """
 {% if record.changed_object and record.changed_object.get_absolute_url %}
     <a href="{{ record.changed_object.get_absolute_url }}">{{ record.object_repr }}</a>
@@ -259,8 +269,8 @@ def job_creator_link(value, record):
 class JobResultTable(BaseTable):
     pk = ToggleColumn()
     obj_type = tables.Column(verbose_name="Object Type", accessor="obj_type.name")
+    job = tables.TemplateColumn(template_code=JOB_RESULT_JOB, linkify=job_creator_link)
     name = tables.Column(linkify=job_creator_link)
-    job_id = tables.Column(linkify=job_creator_link, verbose_name="Job ID")
     created = tables.DateTimeColumn(linkify=True, format=settings.SHORT_DATETIME_FORMAT)
     status = tables.TemplateColumn(
         template_code="{% include 'extras/inc/job_label.html' with result=record %}",
@@ -283,15 +293,15 @@ class JobResultTable(BaseTable):
             "pk",
             "created",
             "obj_type",
+            "job",
             "name",
-            "job_id",
             "duration",
             "completed",
             "user",
             "status",
             "data",
         )
-        default_columns = ("pk", "created", "name", "user", "status", "data")
+        default_columns = ("pk", "created", "job", "user", "status", "data")
 
 
 class ObjectChangeTable(BaseTable):

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -61,7 +61,7 @@ GITREPOSITORY_BUTTONS = """
 """
 
 JOB_RESULT_JOB = """
-{% if record.related_object and record.related_object.Meta and record.related_object.Meta.name %}
+{% if record.related_object.Meta.name %}
 {{ record.related_object.Meta.name }}
 {% elif record.related_object %}
 {{ record.related_object }}

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -60,16 +60,6 @@ GITREPOSITORY_BUTTONS = """
 <button data-url="{% url 'extras:gitrepository_sync' slug=record.slug %}" type="submit" class="btn btn-primary btn-xs sync-repository" title="Sync" {% if not perms.extras.change_gitrepository %}disabled="disabled"{% endif %}><i class="mdi mdi-source-branch-sync" aria-hidden="true"></i></button>
 """
 
-JOB_RESULT_JOB = """
-{% if record.related_object.Meta.name %}
-{{ record.related_object.Meta.name }}
-{% elif record.related_object %}
-{{ record.related_object }}
-{% else %}
-{{ record.name }}
-{% endif %}
-"""
-
 OBJECTCHANGE_OBJECT = """
 {% if record.changed_object and record.changed_object.get_absolute_url %}
     <a href="{{ record.changed_object.get_absolute_url }}">{{ record.object_repr }}</a>
@@ -269,8 +259,8 @@ def job_creator_link(value, record):
 class JobResultTable(BaseTable):
     pk = ToggleColumn()
     obj_type = tables.Column(verbose_name="Object Type", accessor="obj_type.name")
-    job = tables.TemplateColumn(template_code=JOB_RESULT_JOB, linkify=job_creator_link)
-    name = tables.Column(linkify=job_creator_link)
+    related_object = tables.Column(verbose_name="Related Object", linkify=job_creator_link, accessor="related_name")
+    name = tables.Column()
     created = tables.DateTimeColumn(linkify=True, format=settings.SHORT_DATETIME_FORMAT)
     status = tables.TemplateColumn(
         template_code="{% include 'extras/inc/job_label.html' with result=record %}",
@@ -292,16 +282,16 @@ class JobResultTable(BaseTable):
         fields = (
             "pk",
             "created",
-            "obj_type",
-            "job",
             "name",
+            "obj_type",
+            "related_object",
             "duration",
             "completed",
             "user",
             "status",
             "data",
         )
-        default_columns = ("pk", "created", "job", "user", "status", "data")
+        default_columns = ("pk", "created", "related_object", "user", "status", "data")
 
 
 class ObjectChangeTable(BaseTable):

--- a/nautobot/extras/templates/extras/inc/panel_jobhistory.html
+++ b/nautobot/extras/templates/extras/inc/panel_jobhistory.html
@@ -2,14 +2,7 @@
     {% for result in job_results %}
         <div class="list-group-item">
             <a href="{% url 'extras:jobresult' pk=result.pk %}">
-                {{ result.obj_type.name }} -
-                {% if result.related_object.Meta.name %}
-                    {{ result.related_object.Meta.name }}
-                {% elif result.related_object %}
-                    {{ result.related_object }}
-                {% else %}
-                    {{ result.name }}
-                {% endif %}
+                {{ result.obj_type.name }} - {{ result.related_name }}
             </a>
             <span class="pull-right" title="{{ result.created }}">{% include 'extras/inc/job_label.html' %}</span>
             <br>

--- a/nautobot/extras/templates/extras/inc/panel_jobhistory.html
+++ b/nautobot/extras/templates/extras/inc/panel_jobhistory.html
@@ -1,7 +1,16 @@
 {% if job_results and perms.extras.view_jobresult %}
     {% for result in job_results %}
         <div class="list-group-item">
-            <a href="{% url 'extras:jobresult' pk=result.pk %}">{{ result.obj_type.name }} - {{ result.name }}</a>
+            <a href="{% url 'extras:jobresult' pk=result.pk %}">
+                {{ result.obj_type.name }} -
+                {% if result.related_object.Meta.name %}
+                    {{ result.related_object.Meta.name }}
+                {% elif result.related_object %}
+                    {{ result.related_object }}
+                {% else %}
+                    {{ result.name }}
+                {% endif %}
+            </a>
             <span class="pull-right" title="{{ result.created }}">{% include 'extras/inc/job_label.html' %}</span>
             <br>
             <small>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #472 
<!--
    Please include a summary of the proposed changes below.
-->

In the JobResult list view, default to a column showing the associated Job's `Meta.name` string (where available) rather than the `class_path`. (Will fall back to `class_path` if the associated Job has been deleted or is otherwise unavailable to introspect). This makes it consistent with the JobResult detail view, which was already displaying the `Meta.name` if available.

![image](https://user-images.githubusercontent.com/5603551/128239426-7cfc7390-06ed-49fe-a9a3-9b5b1e4646e9.png)

I also removed the `job_id` UUID column from the table as being pretty much unnecessary.