### PR TITLE
Properly serialize IPAddress job variable fields to JSON.

### DIFF
--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -370,7 +370,7 @@ class BaseJob:
             # IPAddressVar is a netaddr.IPAddress object
             elif isinstance(var, IPAddressVar):
                 return_data[field_name] = netaddr.IPAddress(value)
-            # IPAddressWithMaskVar, IPNetworkVar are a netaddr.IPNetwork objects
+            # IPAddressWithMaskVar, IPNetworkVar are netaddr.IPNetwork objects
             elif isinstance(var, (IPAddressWithMaskVar, IPNetworkVar)):
                 return_data[field_name] = netaddr.IPNetwork(value)
             else:

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -367,6 +367,12 @@ class BaseJob:
                 return_data[field_name] = var.field_attrs["queryset"].get(pk=value)
             elif isinstance(var, FileVar):
                 return_data[field_name] = cls.load_file(value)
+            # IPAddressVar is a netaddr.IPAddress object
+            elif isinstance(var, IPAddressVar):
+                return_data[field_name] = netaddr.IPAddress(value)
+            # IPAddressWithMaskVar, IPNetworkVar are a netaddr.IPNetwork objects
+            elif isinstance(var, (IPAddressWithMaskVar, IPNetworkVar)):
+                return_data[field_name] = netaddr.IPNetwork(value)
             else:
                 return_data[field_name] = value
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -22,6 +22,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.functional import classproperty
+import netaddr
 import yaml
 
 
@@ -321,6 +322,9 @@ class BaseJob:
             # FileVar (Save each FileVar as a FileProxy)
             elif isinstance(value, InMemoryUploadedFile):
                 return_data[field_name] = BaseJob.save_file(value)
+            # IPAddressVar, IPAddressWithMaskVar, IPNetworkVar
+            elif isinstance(value, netaddr.ip.BaseIP):
+                return_data[field_name] = str(value)
             # Everything else...
             else:
                 return_data[field_name] = value
@@ -343,7 +347,12 @@ class BaseJob:
         return_data = {}
 
         for field_name, value in data.items():
-            var = vars[field_name]
+            # If a field isn't a var, skip it (e.g. `_commit`).
+            try:
+                var = vars[field_name]
+            except KeyError:
+                continue
+
             if isinstance(var, MultiObjectVar):
                 queryset = var.field_attrs["queryset"].filter(pk__in=value)
                 if queryset.count() < len(value):

--- a/nautobot/extras/tests/dummy_jobs/test_ipaddress_vars.py
+++ b/nautobot/extras/tests/dummy_jobs/test_ipaddress_vars.py
@@ -17,7 +17,7 @@ class TestIPAddresses(Job):
         description="IPv4 with mask",
     )
     ipv4_network = IPAddressWithMaskVar(
-        description="IPv4 with mask",
+        description="IPv4 network",
     )
     ipv6_address = IPAddressVar(
         description="IPv6 Address",
@@ -26,7 +26,7 @@ class TestIPAddresses(Job):
         description="IPv6 with mask",
     )
     ipv6_network = IPAddressWithMaskVar(
-        description="IPv6 with mask",
+        description="IPv6 network",
     )
 
     def run(self, data, commit):

--- a/nautobot/extras/tests/dummy_jobs/test_ipaddress_vars.py
+++ b/nautobot/extras/tests/dummy_jobs/test_ipaddress_vars.py
@@ -1,0 +1,52 @@
+import json
+
+from nautobot.extras.jobs import *
+
+
+name = "IP Addresses"
+
+
+class TestIPAddresses(Job):
+    class Meta:
+        description = "Validate IP Addresses"
+
+    ipv4_address = IPAddressVar(
+        description="IPv4 Address",
+    )
+    ipv4_with_mask = IPAddressWithMaskVar(
+        description="IPv4 with mask",
+    )
+    ipv4_network = IPAddressWithMaskVar(
+        description="IPv4 with mask",
+    )
+    ipv6_address = IPAddressVar(
+        description="IPv6 Address",
+    )
+    ipv6_with_mask = IPAddressWithMaskVar(
+        description="IPv6 with mask",
+    )
+    ipv6_network = IPAddressWithMaskVar(
+        description="IPv6 with mask",
+    )
+
+    def run(self, data, commit):
+        ipv4_address = data["ipv4_address"]
+        ipv4_with_mask = data["ipv4_with_mask"]
+        ipv4_network = data["ipv4_network"]
+        ipv6_address = data["ipv6_address"]
+        ipv6_with_mask = data["ipv6_with_mask"]
+        ipv6_network = data["ipv6_network"]
+
+        # Log the data as JSON so we can pull it back out for testing.
+        self.log_info(obj=json.dumps({k: str(v) for k, v in data.items()}))
+
+        self.log_warning(f"IPv4: {ipv4_address}")
+        self.log_warning(f"IPv4: {ipv4_with_mask}")
+        self.log_warning(f"IPv4: {ipv4_network}")
+        self.log_warning(f"IPv6: {ipv6_address}")
+        self.log_warning(f"IPv6: {ipv6_with_mask}")
+        self.log_warning(f"IPv6: {ipv6_network}")
+
+        self.log_success(message="Job didn't crash!")
+
+        return "Nice IPs, bro."


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #746 
<!--
    Please include a summary of the proposed changes below.
-->
- Vars of type `IPAddressVar`, `IPAddressWithMaskVar`, `IPNetworkVar` are now serialized to strings
- Minor bug fix when using `Job.deserialize_data()` in testing, that would raise a `KeyError` on form fields not found in the job vars (such as `_commit`)