### PR TITLE
GraphQL navbar overflowing into Graphiql

### DIFF
--- a/nautobot/core/templates/graphene/graphiql.html
+++ b/nautobot/core/templates/graphene/graphiql.html
@@ -156,6 +156,7 @@ add "&raw" to the end of the URL within a browser.
       $(".toolbar").append(queries_tab);
     }, false);
   {% endif %}
+
     function reload(id, query, variables) {
       if (variables == null){
           variables = '{}';

--- a/nautobot/core/templates/graphene/graphiql.html
+++ b/nautobot/core/templates/graphene/graphiql.html
@@ -119,39 +119,33 @@ add "&raw" to the end of the URL within a browser.
   {% if perms.extras.view_graphqlquery %}
     document.addEventListener('DOMContentLoaded', function() {
       queries_tab = `
-        <button class="toolbar-button" id="navbar_queries">
-          <div>
-            <ul class="nav">
-                <li class="dropdown">
-                    <div href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" style="color: inherit;">
-                        <span>Queries </span>
-                        <span class="caret"></span>
-                    </div>
-                    <ul class="dropdown-menu" id="graphql-queries-menu">
-                        <li class="dropdown-header">Saved Queries</li>
-                        {% for query in saved_graphiql_queries %}
-                            <li>
-                                {% if request.GET.id|slugify == query.id|slugify %}
-                                    <div class="buttons pull-right">
-                                        <a class="btn btn-xs btn-warning" onclick="save()"><i class="mdi mdi-content-save-edit"></i> Save Changes</a>
-                                    </div>
-                                    <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">
-                                        <strong>{{ query.name }}</strong>
-                                    </a>
-                                {% else %}
-                                    <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">{{ query.name }}</a>
-                                {% endif %}
-                            </li>
-                        {% endfor %}
-                        <li class="divider" role="separator"></li>
-                        <li>
-                            <a onclick="populate_model()" data-toggle="modal" data-target="#GraphQLQueries_form" title="Query Form">Save Current Query As...</a>
-                        </li>
-                    </ul>
+        <div class="btn-group" role="button">
+          <button class="toolbar-button dropdown-toggle" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">
+              <span>Queries </span>
+              <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" id="graphql-queries-menu">
+            <li class="dropdown-header">Saved Queries</li>
+              {% for query in saved_graphiql_queries %}
                 <li>
+                    {% if request.GET.id|slugify == query.id|slugify %}
+                        <div class="buttons pull-right">
+                            <a class="btn btn-xs btn-warning" onclick="save()"><i class="mdi mdi-content-save-edit"></i> Save Changes</a>
+                        </div>
+                        <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">
+                            <strong>{{ query.name }}</strong>
+                        </a>
+                    {% else %}
+                        <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">{{ query.name }}</a>
+                    {% endif %}
+                </li>
+              {% endfor %}
+              <li class="divider" role="separator"></li>
+                <li>
+                    <a onclick="populate_model()" data-toggle="modal" data-target="#GraphQLQueries_form" title="Query Form">Save Current Query As...</a>
+                </li>
             </ul>
-          </div>
-        </button>
+        </div>
       `
       $(".toolbar").append(queries_tab);
     }, false);

--- a/nautobot/core/templates/graphene/graphiql.html
+++ b/nautobot/core/templates/graphene/graphiql.html
@@ -116,6 +116,42 @@ add "&raw" to the end of the URL within a browser.
   </script>
   <script src="{% static 'graphene_django/graphiql.js' %}"></script>
   <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      queries_tab = `
+        <button class="toolbar-button" id="navbar_queries">
+          <ul class="nav">
+              <li class="dropdown">
+                  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" style="color: inherit;">
+                      <span>Queries </span>
+                      <span class="caret"></span>
+                  </a>
+                  <ul class="dropdown-menu" id="graphql-queries-menu">
+                      <li class="dropdown-header">Saved Queries</li>
+                      {% for query in saved_graphiql_queries %}
+                          <li>
+                              {% if request.GET.id|slugify == query.id|slugify %}
+                                  <div class="buttons pull-right">
+                                      <button type="button" class="btn btn-xs btn-warning" onclick="save()"><i class="mdi mdi-content-save-edit"></i> Save Changes</button>
+                                  </div>
+                                  <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">
+                                      <strong>{{ query.name }}</strong>
+                                  </a>
+                              {% else %}
+                                  <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">{{ query.name }}</a>
+                              {% endif %}
+                          </li>
+                      {% endfor %}
+                      <li class="divider" role="separator"></li>
+                      <li>
+                          <a onclick="populate_model()" data-toggle="modal" data-target="#GraphQLQueries_form" title="Query Form">Save Current Query As...</a>
+                      </li>
+                  </ul>
+              <li>
+          </ul>
+      </button>
+      `
+      $(".toolbar").append(queries_tab);
+    }, false);
 
     function reload(id, query, variables) {
       if (variables == null){

--- a/nautobot/core/templates/graphene/graphiql.html
+++ b/nautobot/core/templates/graphene/graphiql.html
@@ -119,36 +119,38 @@ add "&raw" to the end of the URL within a browser.
     document.addEventListener('DOMContentLoaded', function() {
       queries_tab = `
         <button class="toolbar-button" id="navbar_queries">
-          <ul class="nav">
-              <li class="dropdown">
-                  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" style="color: inherit;">
-                      <span>Queries </span>
-                      <span class="caret"></span>
-                  </a>
-                  <ul class="dropdown-menu" id="graphql-queries-menu">
-                      <li class="dropdown-header">Saved Queries</li>
-                      {% for query in saved_graphiql_queries %}
-                          <li>
-                              {% if request.GET.id|slugify == query.id|slugify %}
-                                  <div class="buttons pull-right">
-                                      <button type="button" class="btn btn-xs btn-warning" onclick="save()"><i class="mdi mdi-content-save-edit"></i> Save Changes</button>
-                                  </div>
-                                  <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">
-                                      <strong>{{ query.name }}</strong>
-                                  </a>
-                              {% else %}
-                                  <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">{{ query.name }}</a>
-                              {% endif %}
-                          </li>
-                      {% endfor %}
-                      <li class="divider" role="separator"></li>
-                      <li>
-                          <a onclick="populate_model()" data-toggle="modal" data-target="#GraphQLQueries_form" title="Query Form">Save Current Query As...</a>
-                      </li>
-                  </ul>
-              <li>
-          </ul>
-      </button>
+          <div>
+            <ul class="nav">
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" style="color: inherit;">
+                        <span>Queries </span>
+                        <span class="caret"></span>
+                    </a>
+                    <ul class="dropdown-menu" id="graphql-queries-menu">
+                        <li class="dropdown-header">Saved Queries</li>
+                        {% for query in saved_graphiql_queries %}
+                            <li>
+                                {% if request.GET.id|slugify == query.id|slugify %}
+                                    <div class="buttons pull-right">
+                                        <a class="btn btn-xs btn-warning" onclick="save()"><i class="mdi mdi-content-save-edit"></i> Save Changes</a>
+                                    </div>
+                                    <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">
+                                        <strong>{{ query.name }}</strong>
+                                    </a>
+                                {% else %}
+                                    <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">{{ query.name }}</a>
+                                {% endif %}
+                            </li>
+                        {% endfor %}
+                        <li class="divider" role="separator"></li>
+                        <li>
+                            <a onclick="populate_model()" data-toggle="modal" data-target="#GraphQLQueries_form" title="Query Form">Save Current Query As...</a>
+                        </li>
+                    </ul>
+                <li>
+            </ul>
+          </div>
+        </button>
       `
       $(".toolbar").append(queries_tab);
     }, false);

--- a/nautobot/core/templates/graphene/graphiql.html
+++ b/nautobot/core/templates/graphene/graphiql.html
@@ -116,16 +116,17 @@ add "&raw" to the end of the URL within a browser.
   </script>
   <script src="{% static 'graphene_django/graphiql.js' %}"></script>
   <script>
+  {% if perms.extras.view_graphqlquery %}
     document.addEventListener('DOMContentLoaded', function() {
       queries_tab = `
         <button class="toolbar-button" id="navbar_queries">
           <div>
             <ul class="nav">
                 <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" style="color: inherit;">
+                    <div href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" style="color: inherit;">
                         <span>Queries </span>
                         <span class="caret"></span>
-                    </a>
+                    </div>
                     <ul class="dropdown-menu" id="graphql-queries-menu">
                         <li class="dropdown-header">Saved Queries</li>
                         {% for query in saved_graphiql_queries %}
@@ -154,7 +155,7 @@ add "&raw" to the end of the URL within a browser.
       `
       $(".toolbar").append(queries_tab);
     }, false);
-
+  {% endif %}
     function reload(id, query, variables) {
       if (variables == null){
           variables = '{}';

--- a/nautobot/core/templates/inc/nav_menu.html
+++ b/nautobot/core/templates/inc/nav_menu.html
@@ -88,42 +88,43 @@
                     </span>
                 </div>
             </form>
+
             {% comment %}
             The following if statement means the Query tab is only rendered when the GraphiQL
             is rendered.
             {% endcomment %}
             {% if  graphiql and perms.extras.view_graphqlquery %}
-
-                <ul class="nav navbar-nav navbar-right">
-                    <li class="dropdown">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                            <span>Queries </span>
-                            <span class="caret"></span>
-                        </a>
-                        <ul class="dropdown-menu" id="graphql-queries-menu">
-                            <li class="dropdown-header">Saved Queries</li>
-                            {% for query in saved_graphiql_queries %}
+                <div id="navbar_queries">
+                    <ul class="nav navbar-nav navbar-right">
+                        <li class="dropdown">
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                                <span>Queries </span>
+                                <span class="caret"></span>
+                            </a>
+                            <ul class="dropdown-menu" id="graphql-queries-menu">
+                                <li class="dropdown-header">Saved Queries</li>
+                                {% for query in saved_graphiql_queries %}
+                                    <li>
+                                        {% if request.GET.id|slugify == query.id|slugify %}
+                                            <div class="buttons pull-right">
+                                                <button type="button" class="btn btn-xs btn-warning" onclick="save()"><i class="mdi mdi-content-save-edit"></i> Save Changes</button>
+                                            </div>
+                                            <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">
+                                                <strong>{{ query.name }}</strong>
+                                            </a>
+                                        {% else %}
+                                            <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">{{ query.name }}</a>
+                                        {% endif %}
+                                    </li>
+                                {% endfor %}
+                                <li class="divider" role="separator"></li>
                                 <li>
-                                    {% if request.GET.id|slugify == query.id|slugify %}
-                                        <div class="buttons pull-right">
-                                            <button type="button" class="btn btn-xs btn-warning" onclick="save()"><i class="mdi mdi-content-save-edit"></i> Save Changes</button>
-                                        </div>
-                                        <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">
-                                            <strong>{{ query.name }}</strong>
-                                        </a>
-                                    {% else %}
-                                        <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">{{ query.name }}</a>
-                                    {% endif %}
+                                    <a onclick="populate_model()" data-toggle="modal" data-target="#GraphQLQueries_form" title="Query Form">Save Current Query As...</a>
                                 </li>
-                            {% endfor %}
-                            <li class="divider" role="separator"></li>
-                            <li>
-                                <a onclick="populate_model()" data-toggle="modal" data-target="#GraphQLQueries_form" title="Query Form">Save Current Query As...</a>
-                            </li>
-                        </ul>
-                    <li>
-                </ul>
-
+                            </ul>
+                        <li>
+                    </ul>
+                </div>
             {% endif %}
         </div>
     </div>

--- a/nautobot/core/templates/inc/nav_menu.html
+++ b/nautobot/core/templates/inc/nav_menu.html
@@ -88,44 +88,6 @@
                     </span>
                 </div>
             </form>
-
-            {% comment %}
-            The following if statement means the Query tab is only rendered when the GraphiQL
-            is rendered.
-            {% endcomment %}
-            {% if  graphiql and perms.extras.view_graphqlquery %}
-                <div id="navbar_queries">
-                    <ul class="nav navbar-nav navbar-right">
-                        <li class="dropdown">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                                <span>Queries </span>
-                                <span class="caret"></span>
-                            </a>
-                            <ul class="dropdown-menu" id="graphql-queries-menu">
-                                <li class="dropdown-header">Saved Queries</li>
-                                {% for query in saved_graphiql_queries %}
-                                    <li>
-                                        {% if request.GET.id|slugify == query.id|slugify %}
-                                            <div class="buttons pull-right">
-                                                <button type="button" class="btn btn-xs btn-warning" onclick="save()"><i class="mdi mdi-content-save-edit"></i> Save Changes</button>
-                                            </div>
-                                            <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">
-                                                <strong>{{ query.name }}</strong>
-                                            </a>
-                                        {% else %}
-                                            <a href="#" onclick="reload('{{ query.id }}', '{{ query.query|urlencode }}', '{{ query.variables|render_json|urlencode }}')">{{ query.name }}</a>
-                                        {% endif %}
-                                    </li>
-                                {% endfor %}
-                                <li class="divider" role="separator"></li>
-                                <li>
-                                    <a onclick="populate_model()" data-toggle="modal" data-target="#GraphQLQueries_form" title="Query Form">Save Current Query As...</a>
-                                </li>
-                            </ul>
-                        <li>
-                    </ul>
-                </div>
-            {% endif %}
         </div>
     </div>
 </nav>

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -186,7 +186,6 @@ class CustomGraphQLView(GraphQLView):
         if query_slug:
             data["obj"] = GraphQLQuery.objects.get(slug=query_slug)
             data["editing"] = True
-        data["graphiql"] = True
         data["saved_graphiql_queries"] = GraphQLQuery.objects.all()
         data["form"] = GraphQLQueryForm
         return render(request, self.graphiql_template, data)

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -46,9 +46,16 @@ footer p {
     }
 }
 
-/* Hide the search bar in the navigation menu on displays less than 1250px wide */
-@media (max-width: 1249px) {
+/* Hide the search bar in the navigation menu on displays less than 1440px wide */
+@media (max-width: 1440px) {
     #navbar_search {
+        display: none;
+    }
+}
+
+/* Hide the queries tab in the navigation menu on displays less than 1249px wide */
+@media (max-width: 1249px) {
+    #navbar_queries {
         display: none;
     }
 }
@@ -74,8 +81,8 @@ footer p {
     }
 }
 
-/* Collapse the nav menu on displays less than 980px wide */
-@media (max-width: 979px) {
+/* Collapse the nav menu on displays less than 1098px wide */
+@media (max-width: 1098px) {
     #navbar {
         max-height: calc(80vh - 50px);
         overflow-y: auto;
@@ -98,7 +105,7 @@ footer p {
         border-width: 0 0 1px;
     }
     .navbar-collapse.collapse {
-        display: none!important;
+        display: none !important;
         max-height: none;
     }
     .navbar-nav {

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -46,16 +46,9 @@ footer p {
     }
 }
 
-/* Hide the search bar in the navigation menu on displays less than 1440px wide */
-@media (max-width: 1439px) {
-    #navbar_search {
-        display: none;
-    }
-}
-
-/* Hide the queries tab in the navigation menu on displays less than 1250px wide */
+/* Hide the search bar in the navigation menu on displays less than 1250px wide */
 @media (max-width: 1249px) {
-    #navbar_queries {
+    #navbar_search {
         display: none;
     }
 }
@@ -81,8 +74,8 @@ footer p {
     }
 }
 
-/* Collapse the nav menu on displays less than 1099px wide */
-@media (max-width: 1098px) {
+/* Collapse the nav menu on displays less than 980px wide */
+@media (max-width: 979px) {
     #navbar {
         max-height: calc(80vh - 50px);
         overflow-y: auto;
@@ -105,7 +98,7 @@ footer p {
         border-width: 0 0 1px;
     }
     .navbar-collapse.collapse {
-        display: none !important;
+        display: none!important;
         max-height: none;
     }
     .navbar-nav {

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -47,13 +47,13 @@ footer p {
 }
 
 /* Hide the search bar in the navigation menu on displays less than 1440px wide */
-@media (max-width: 1440px) {
+@media (max-width: 1439px) {
     #navbar_search {
         display: none;
     }
 }
 
-/* Hide the queries tab in the navigation menu on displays less than 1249px wide */
+/* Hide the queries tab in the navigation menu on displays less than 1250px wide */
 @media (max-width: 1249px) {
     #navbar_queries {
         display: none;
@@ -81,7 +81,7 @@ footer p {
     }
 }
 
-/* Collapse the nav menu on displays less than 1098px wide */
+/* Collapse the nav menu on displays less than 1099px wide */
 @media (max-width: 1098px) {
     #navbar {
         max-height: calc(80vh - 50px);


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #715 
<!--
    Please include a summary of the proposed changes below.
-->

To combat this issue, the queries tab in the navigation has now been moved to the GraphiQL interface toolbar. Javascript is being used to inject the new button into the interface.

![Screenshot 2021-08-12 at 14 48 40](https://user-images.githubusercontent.com/6088317/129208490-84f3b71a-5d28-4369-9632-699a8bf8aec4.png)

