### PR TITLE
Fix incorrect startup behavior in "final" Docker image

### DIFF
--- a/development/docker-compose.build.yml
+++ b/development/docker-compose.build.yml
@@ -10,3 +10,5 @@ services:
       - 8443:8443
   worker:
     image: "networktocode/nautobot-py${PYTHON_VER}:local"
+  celery_worker:
+    image: "networktocode/nautobot-py${PYTHON_VER}:local"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #785 
<!--
    Please include a summary of the proposed changes below.
-->

This was a **fun** one to chase down! 

`nautobot-server` uses a custom `MetaPathFinder` and `Loader` when loading the Nautobot configuration file so as to do some special processing of the configuration, including (most importantly for this issue) the injection of `PLUGINS` into `INSTALLED_APPS`.

In the baseline code, this custom finder/loader is appended to the end of `sys.meta_path`, meaning that it is only used if the built-in Python importers are unable to find and load the Nautobot config file on its own.

A key thing to know about Python's built-in importer logic is that it always prepends the current working directory to `sys.path`, meaning that Python modules in the current working directory can be loaded by the built-in importer logic.

Perhaps you can see where this is leading...

In the `dev` Docker image, the `WORKDIR` is `/source`, so `/opt/nautobot/nautobot_config.py` is *not* in `sys.path`, and is not discoverable by the built-in Python importers, so our custom finder/loader gets called as a fallback of last resort and successfully finds and loads `nautobot_config.py` and updates Django's `settings.INSTALLED_APPS` to include the configured `PLUGINS`.

In the `final` Docker image, by contrast, `WORKDIR` is `/opt/nautobot`, so `/opt/nautobot/nautobot_config.py` *is* available in `sys.path` and so it gets loaded by the built-in Python importers, meaning that our custom finder/loader does *not* get called and so the `PLUGINS` do *not* get added to `INSTALLED_APPS`, resulting in the error described in #785.

A "simple" fix would be to change the `WORKDIR` (and hence `sys.path`) in the `final` image, but this would be suboptimal because there would still be a latent issue where running `nautobot-server` from the directory containing `nautobot_config.py` would still trigger this issue.

The "better" fix is to *prepend* rather than *append* our custom finder/loader to `sys.meta_path` so that it gets used as a first resort rather than a last resort, meaning that `nautobot_config.py` will be loaded by the custom loader *regardless* of `sys.path`, and that's what I've done here.

Additionally, I noticed that `development/docker-compose.build.yml` wasn't overriding the `image` setting for the `celery_worker` container, meaning that even when `nautobot` and `worker` (RQ) were using the `final` image, `celery_worker` was still using the `dev` image. I've fixed that here.