### PR TITLE
Avoid NoReverseMatch exception during app startup if navigation has a bad link

### DIFF
--- a/nautobot/core/apps/__init__.py
+++ b/nautobot/core/apps/__init__.py
@@ -2,7 +2,6 @@ import logging
 
 from abc import ABC, abstractproperty
 from django.apps import AppConfig
-from django.urls import reverse
 from operator import getitem
 from collections import OrderedDict
 
@@ -232,8 +231,6 @@ class NavMenuItem(NavMenuBase, PermissionsMixin):
     def __init__(self, link, name, permissions=None, buttons=(), weight=1000):
         """Ensure item properties."""
         super().__init__(permissions)
-        # Reverse lookup sanity check
-        reverse(link)
         self.link = link
         self.name = name
         self.weight = weight
@@ -282,8 +279,6 @@ class NavMenuButton(NavMenuBase, PermissionsMixin):
     ):
         """Ensure button properties."""
         super().__init__(permissions)
-        # Reverse lookup sanity check
-        reverse(link)
         self.link = link
         self.title = title
         self.icon_class = icon_class

--- a/nautobot/core/templates/inc/nav_menu.html
+++ b/nautobot/core/templates/inc/nav_menu.html
@@ -33,11 +33,40 @@
                                                         <div class="buttons pull-right">
                                                             {% for button_title, button_details in item_details.buttons.items %}
                                                                 {% if request.user|has_perms:button_details.permissions %}
-                                                                    <a href="{% url button_details.link %}" data-button-weight="{{ button_details.weight }}" class="btn btn-xs btn-{{ button_details.button_class }}" title="{{ button_title }}"><i class="mdi {{ button_details.icon_class }}"></i></a>
+                                                                    {% comment %}
+                                                                        Use 'url xxx as variable' so that an invalid
+                                                                        link doesn't throw a NoReverseMatch exception.
+                                                                    {% endcomment %}
+                                                                    {% url button_details.link as button_url %}
+                                                                    {% if button_url %}
+                                                                        <a href="{{ button_url }}"
+                                                                           data-button-weight="{{ button_details.weight }}"
+                                                                           class="btn btn-xs btn-{{ button_details.button_class }}"
+                                                                           title="{{ button_title }}">
+                                                                            <i class="mdi {{ button_details.icon_class }}"></i>
+                                                                        </a>
+                                                                    {% else %}
+                                                                        <a class="btn btn-xs btn-danger"
+                                                                           title="ERROR: Invalid link!">
+                                                                            <i class="mdi mdi-alert"></i>
+                                                                        </a>
+                                                                    {% endif %}
                                                                 {% endif %}
                                                             {% endfor %}
                                                         </div>
-                                                        <a href="{% url item_link %}" data-item-weight="{{ item_details.weight }}">{{ item_details.name }}</a>
+                                                        {% comment %}
+                                                            Use 'url xxx as variable' so that an invalid
+                                                            link doesn't throw a NoReverseMatch exception.
+                                                        {% endcomment %}
+                                                        {% url item_link as item_url %}
+                                                        {% if item_url %}
+                                                            <a href="{{ item_url }}"
+                                                               data-item-weight="{{ item_details.weight }}">
+                                                                {{ item_details.name }}
+                                                            </a>
+                                                        {% else %}
+                                                            <a>ERROR: Invalid link!</a>
+                                                        {% endif %}
                                                     </li>
                                                 {% endif %}
                                             {% endfor %}

--- a/nautobot/extras/tests/integration/test_configcontextschema.py
+++ b/nautobot/extras/tests/integration/test_configcontextschema.py
@@ -31,7 +31,7 @@ class ConfigContextSchemaTestCase(SplinterTestCase):
         # Navigate to ConfigContextSchema list view
         self.browser.visit(self.live_server_url)
         self.browser.links.find_by_partial_text("Extensibility").click()
-        self.browser.links.find_by_text("Config Context Schemas").click()
+        self.browser.links.find_by_partial_text("Config Context Schemas").click()
 
         # Click add add button
         self.browser.find_by_xpath("/html/body/div/div[1]/a").click()
@@ -58,7 +58,7 @@ class ConfigContextSchemaTestCase(SplinterTestCase):
         # Navigate to ConfigContextSchema list view
         self.browser.visit(self.live_server_url)
         self.browser.links.find_by_partial_text("Extensibility").click()
-        self.browser.links.find_by_text("Config Context Schemas").click()
+        self.browser.links.find_by_partial_text("Config Context Schemas").click()
 
         # Click add add button
         self.browser.find_by_xpath("/html/body/div/div[1]/a").click()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #N/A
<!--
    Please include a summary of the proposed changes below.
-->

> I developed this fix while investigating #785 - while it doesn't actually address that issue (see #788 for that) I think it's still useful.

If a `navigation.py` (core app or plugin-defined) defines nav menu items with an invalid link name (one that cannot be successfully `reverse()`d), as implemented Nautobot startup will fail with a `NoReverseMatch` exception:

```
Traceback (most recent call last):
  File "/usr/local/bin/nautobot-server", line 5, in <module>
    main()
  File "/source/nautobot/core/cli.py", line 62, in main
    initializer=_configure_settings,  # Called after defaults
  File "/source/nautobot/core/runner/runner.py", line 266, in run_app
    management.execute_from_command_line([runner_name, command] + command_args)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 377, in execute
    django.setup()
  File "/usr/local/lib/python3.6/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python3.6/site-packages/django/apps/registry.py", line 122, in populate
    app_config.ready()
  File "/source/nautobot/extras/plugins/__init__.py", line 101, in ready
    register_plugin_menu_items(self.verbose_name, menu_items)
  File "/source/nautobot/extras/plugins/__init__.py", line 358, in register_plugin_menu_items
    weight=new_menu_button_weight,
  File "/source/nautobot/core/apps/__init__.py", line 286, in __init__
    reverse(link)
  File "/usr/local/lib/python3.6/site-packages/django/urls/base.py", line 87, in reverse
    return iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs))
  File "/usr/local/lib/python3.6/site-packages/django/urls/resolvers.py", line 685, in _reverse_with_prefix
    raise NoReverseMatch(msg)
django.urls.exceptions.NoReverseMatch: Reverse for 'dummymodel_add_foo' not found. 'dummymodel_add_foo' is not a valid view function or pattern name.
```

Additionally it's not ideal for us to be calling `reverse()` during initial AppConfig loading at all, as there may be some timing or sequencing issues wherein an app is ready before all urlpatterns have been fully registered (this was my working theory on investigating #785 that led to this fix).

The solution delivered here is to remove the init-time `reverse()` check, and additionally handle bad URLs in the rendering of the nav-menu template, rather than failing the entire template rendering and throwing an exception to the user. If a bad URL is registered in the nav menu, the UI will now show this:

![Screen Shot 2021-08-05 at 3 26 55 PM](https://user-images.githubusercontent.com/5603551/128565146-7fc1e6bd-c411-44e9-9c37-6a793acf47c1.png)

![Screen Shot 2021-08-05 at 3 27 06 PM](https://user-images.githubusercontent.com/5603551/128565153-b41b3358-0aea-4436-bd1d-04d7f27a5f5e.png)
