### PR TITLE
Added webhook suppot for plugins.

### DIFF
--- a/examples/dummy_plugin/dummy_plugin/models.py
+++ b/examples/dummy_plugin/dummy_plugin/models.py
@@ -7,7 +7,7 @@ from nautobot.extras.models import ObjectChange
 from nautobot.utilities.utils import serialize_object
 
 
-@extras_features("graphql")
+@extras_features("graphql", "webhooks")
 class DummyModel(BaseModel):
     name = models.CharField(max_length=20, help_text="The name of this Dummy.")
     number = models.IntegerField(default=100, help_text="The number of this Dummy.")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #11 
<!--
    Please include a summary of the proposed changes below.
-->

Using the extras_features decorator I was able to create a webhook for the dummy_plugin.
When I removed the plugin from Nautobot, i can still see the webhook with the Object Type set to dummymodel. Not sure what the expected result should be for this?

We could set change the model so content_types is a foregin key field where we can set on_delete which would hopefully delete the record if one of the content_types get removed.

Testing has been added to `extras/tests/test_plugins.py`