### PR TITLE
Adding docs and logic to skip initialization in docker

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,14 +8,16 @@ set -e
 DB_WAIT_TIMEOUT=${DB_WAIT_TIMEOUT-3}
 MAX_DB_WAIT_TIME=${MAX_DB_WAIT_TIME-30}
 CUR_DB_WAIT_TIME=0
-while ! nautobot-server post_upgrade --no-invalidate-all 2>&1 && [ "${CUR_DB_WAIT_TIME}" -lt "${MAX_DB_WAIT_TIME}" ]; do
-  echo "⏳ Waiting on DB... (${CUR_DB_WAIT_TIME}s / ${MAX_DB_WAIT_TIME}s)"
-  sleep "${DB_WAIT_TIMEOUT}"
-  CUR_DB_WAIT_TIME=$(( CUR_DB_WAIT_TIME + DB_WAIT_TIMEOUT ))
-done
-if [ "${CUR_DB_WAIT_TIME}" -ge "${MAX_DB_WAIT_TIME}" ]; then
-  echo "❌ Waited ${MAX_DB_WAIT_TIME}s or more for the DB to become ready."
-  exit 1
+if [ ! "$NAUTOBOT_DOCKER_SKIP_INIT" ]; then
+  while ! nautobot-server post_upgrade --no-invalidate-all 2>&1 && [ "${CUR_DB_WAIT_TIME}" -lt "${MAX_DB_WAIT_TIME}" ]; do
+    echo "⏳ Waiting on DB... (${CUR_DB_WAIT_TIME}s / ${MAX_DB_WAIT_TIME}s)"
+    sleep "${DB_WAIT_TIMEOUT}"
+    CUR_DB_WAIT_TIME=$(( CUR_DB_WAIT_TIME + DB_WAIT_TIMEOUT ))
+  done
+  if [ "${CUR_DB_WAIT_TIME}" -ge "${MAX_DB_WAIT_TIME}" ]; then
+    echo "❌ Waited ${MAX_DB_WAIT_TIME}s or more for the DB to become ready."
+    exit 1
+  fi
 fi
 
 # Run a quick healthcheck and bail if something fails, --deploy will warn on potential issues for production

--- a/nautobot/docs/additional-features/healthcheck.md
+++ b/nautobot/docs/additional-features/healthcheck.md
@@ -2,7 +2,7 @@
 
 Nautobot includes a health check endpoint `/health` which utilizes the [django-health-check](https://github.com/KristianOellegaard/django-health-check) project.  This endpoint is designed for use by an optional load balancer placed in front of Nautobot to determine the health of the Nautobot server.  By default the healthcheck enables checks for the following:
 
-* Database Backend
+* Database Backend (checks read and write access to the database)
 * Caching Backend
 * Storage Backend
 

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -482,6 +482,12 @@ Setting this to `True` will display a "maintenance mode" banner at the top of ev
 !!! note
     The default [`SESSION_ENGINE`](#session_engine) configuration will store sessions in the database, this obviously will not work when `MAINTENANCE_MODE` is `True` and the database is in a read-only state for maintenance.  Consider setting `SESSION_ENGINE` to `django.contrib.sessions.backends.cache` when enabling `MAINTENANCE_MODE`.
 
+!!! note
+    The docker container attempts to run migrations on startup, if the database is in a read-only state the docker container will fail to start.  Setting [`NAUTOBOT_DOCKER_SKIP_INIT`](/docker/#nautobot_docker_skip_init) to `true` will prevent the migrations from occurring.
+
+!!! note
+    The Nautobot [health check](../additional-features/healthcheck.md) will fail if the database is in read-only mode.
+
 ---
 
 ## MAX_PAGE_SIZE

--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -61,6 +61,58 @@ services:
       - /local/path/to/custom/nautobot_config.py:/opt/nautobot/nautobot_config.py:ro
 ```
 
+### Docker only configuration
+
+The entry point for the docker container has some additional features that can be configured via additional environment variables, these are all optional variables:
+
+#### `NAUTOBOT_CREATE_SUPERUSER`
+
+Default: unset
+
+Enables creation of a super user specified by [`NAUTOBOT_SUPERUSER_NAME`](#nautobot_superuser_name), [`NAUTOBOT_SUPERUSER_EMAIL`]((#nautobot_superuser_email)), [`NAUTOBOT_SUPERUSER_PASSWORD`](#nautobot_superuser_password), and [`NAUTOBOT_SUPERUSER_API_TOKEN`](#nautobot_superuser_api_token).
+
+---
+
+#### `NAUTOBOT_DOCKER_SKIP_INIT`
+
+Default: unset
+
+When starting, the container attempts to connect to the database and run database migrations and upgrade steps necessary when upgrading versions.  In normal operation this is harmless to run on every startup and validates the database is operating correctly.  However, in certain circumstances such as database maintenance when the database is in a read-only mode it may make sense to start Nautobot but skip these steps.  Setting this variable to `true` will start Nautobot without running these initial steps.
+
+---
+
+#### `NAUTOBOT_SUPERUSER_API_TOKEN`
+
+Default: unset
+
+If [`NAUTOBOT_CREATE_SUPERUSER`](#nautobot_superuser_name) is true `NAUTOBOT_SUPERUSER_API_TOKEN` specifies the api token of the super user to be created alternatively the `/run/secrets/superuser_api_token` file contents are read for the token.  Either the variable or the file is required if `NAUTOBOT_CREATE_SUPERUSER` is true.
+
+---
+
+#### `NAUTOBOT_SUPERUSER_EMAIL`
+
+Default: `admin@example.com`
+
+If [`NAUTOBOT_CREATE_SUPERUSER`](#nautobot_superuser_name) is true `NAUTOBOT_SUPERUSER_EMAIL` specifies the email address of the super user to be created.
+
+---
+
+#### `NAUTOBOT_SUPERUSER_NAME`
+
+Default: `admin`
+
+If [`NAUTOBOT_CREATE_SUPERUSER`](#nautobot_superuser_name) is true `NAUTOBOT_SUPERUSER_NAME` specifies the username of the super user to be created.
+
+---
+
+#### `NAUTOBOT_SUPERUSER_PASSWORD`
+
+Default: unset
+
+If [`NAUTOBOT_CREATE_SUPERUSER`](#nautobot_superuser_name) is true `NAUTOBOT_SUPERUSER_PASSWORD` specifies the password of the super user to be created alternatively the `/run/secrets/superuser_password` file contents are read for the password.  Either the variable or the file is required if `NAUTOBOT_CREATE_SUPERUSER` is true.
+
+---
+
 ### uWSGI
 
 The docker container uses [uWSGI](https://uwsgi-docs.readthedocs.io/) to serve Nautobot.  A default configuration is [provided](/docker/uwsgi.ini), and can be overridden by injecting a new `uwsgi.ini` file at `/opt/nautobot/uwsgi.ini`.  There are a couple of environment variables provided to override some uWSGI defaults:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #791 
<!--
    Please include a summary of the proposed changes below.
-->

This PR allows users to skip the initialization process (`nautobot-server post_upgrade`) in the docker container if they wish.  This is useful if using `MAINTENANCE_MODE` with a read-only database.  I also added some additional documentation around the already existing docker env vars used to create a superuser account `NAUTOBOT_SUPERUSER_*`.  When testing with a read-only DB the healthcheck will fail I think this is ok for now, we might want to have a read-only custom check for the healthcheck but for now, I added a note about this in the docs as well.
