### PR TITLE
GraphQL Multi Layer Filtering

### DIFF
--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -63,7 +63,6 @@ def generate_filter_resolver(schema_type, resolver_name, field_name):
         field_name (str): name of OneToMany field to filter
     """
     filterset_class = schema_type._meta.filterset_class
-    field_name = field_name
 
     def resolve_filter(self, *args, **kwargs):
         if filterset_class is not None:

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -54,6 +54,14 @@ def generate_null_choices_resolver(name, resolver_name):
 
 
 def generate_filter_resolver(schema_type, resolver_name, field_name):
+    """
+    Generate function to resolve OneToMany filtering.
+
+    Args:
+        schema_type (DjangoObjectType): DjangoObjectType for a given model
+        resolver_name (str): name of the resolver
+        field_name (str): name of OneToMany field to filter
+    """
     filterset_class = schema_type._meta.filterset_class
     field_name = field_name
 

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -4,7 +4,6 @@ import logging
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor
 from django.db.models.fields.reverse_related import ManyToOneRel
 
 import graphene

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -170,11 +170,12 @@ def extend_schema_type_many(schema_type, model):
         if isinstance(attr, ReverseManyToOneDescriptor):
             child_schema_type = registry["graphql_types"].get(attr.field.model._meta.label_lower)
             if child_schema_type:
+                if model._meta.model_name == "device":
+                    if field_name == "interfaces":
+                        print("oeifnfien")
                 resolver_name = f"resolve_{field_name}"
-                setattr(schema_type, field_name, graphene.List(child_schema_type, **generate_list_search_parameters(child_schema_type)))
                 setattr(schema_type, resolver_name, generate_filter_resolver(child_schema_type, resolver_name, field_name))
-    if model._meta.model_name == "device":
-                    print("oadjfoandm")
+                setattr(schema_type, field_name, graphene.List(child_schema_type, **generate_list_search_parameters(child_schema_type)))
     return schema_type
 
 

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -180,7 +180,7 @@ def extend_schema_type_filter(schema_type, model):
     for field_name in dir(model):
         attr = getattr(model, field_name)
         # Check attribute is a ManyToOne field
-        if not isinstance(attr, ReverseManyToOneDescriptor):
+        if not isinstance(attr, ReverseManyToOneDescriptor) or not getattr(model, field_name).field.many_to_one:
             continue
 
         child_schema_type = registry["graphql_types"].get(attr.field.model._meta.label_lower)

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -188,7 +188,9 @@ def extend_schema_type_filter(schema_type, model):
             resolver_name = f"resolve_{field_name}"
             search_params = generate_list_search_parameters(child_schema_type)
             # Add OneToMany field to schema_type
-            schema_type._meta.fields[field_name] = graphene.Field.mounted(graphene.List(child_schema_type, **search_params))
+            schema_type._meta.fields[field_name] = graphene.Field.mounted(
+                graphene.List(child_schema_type, **search_params)
+            )
             # Add resolve function to schema_type
             setattr(schema_type, resolver_name, generate_filter_resolver(child_schema_type, resolver_name, field_name))
 

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -33,7 +33,19 @@ from nautobot.core.graphql.schema import (
 from nautobot.dcim.choices import InterfaceTypeChoices, InterfaceModeChoices, PortTypeChoices
 from nautobot.dcim.filters import DeviceFilterSet, SiteFilterSet
 from nautobot.dcim.graphql.types import DeviceType as DeviceTypeGraphQL
-from nautobot.dcim.models import Cable, Device, DeviceRole, DeviceType, FrontPort, Interface, Manufacturer, Rack, RearPort, Region, Site
+from nautobot.dcim.models import (
+    Cable,
+    Device,
+    DeviceRole,
+    DeviceType,
+    FrontPort,
+    Interface,
+    Manufacturer,
+    Rack,
+    RearPort,
+    Region,
+    Site,
+)
 from nautobot.extras.choices import CustomFieldTypeChoices
 from nautobot.utilities.testing.utils import create_test_user
 
@@ -1056,7 +1068,6 @@ query {
                 result = self.execute_query(query)
                 self.assertIsNone(result.errors)
                 self.assertEqual(len(result.data["sites"][0]["devices"][0]["interfaces"]), nbr_expected_results)
-
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_interfaces_connected_endpoint(self):

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -964,6 +964,7 @@ query {
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_frontport_filter_second_level(self):
+        """Test custom frontport filter fields and boolean, not other concrete fields."""
 
         filters = (
             (f'name: "{self.device1_frontports[0].name}"', 1),
@@ -977,6 +978,23 @@ query {
                 result = self.execute_query(query)
                 self.assertIsNone(result.errors)
                 self.assertEqual(len(result.data["devices"][0]["frontports"]), nbr_expected_results)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_query_frontport_filter_third_level(self):
+        """Test custom frontport filter fields and boolean, not other concrete fields."""
+
+        filters = (
+            (f'name: "{self.device1_frontports[0].name}"', 1),
+            (f'device: "{self.device1.name}"', 4),
+            (f'_type: "{PortTypeChoices.TYPE_8P8C}"', 4),
+        )
+
+        for filter, nbr_expected_results in filters:
+            with self.subTest(msg=f"Checking {filter}", filter=filter, nbr_expected_results=nbr_expected_results):
+                query = "query { sites{ devices{ frontports(" + filter + "){ id }}}}"
+                result = self.execute_query(query)
+                self.assertIsNone(result.errors)
+                self.assertEqual(len(result.data["sites"][0]["devices"][0]["frontports"]), nbr_expected_results)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_interfaces_filter(self):
@@ -1003,7 +1021,7 @@ query {
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_interfaces_filter_second_level(self):
-        """Test custom interface filter fields and boolean, not other concrete fields on second level of query."""
+        """Test custom interface filter fields, not other concrete fields on second level of query."""
 
         filters = (
             (f'device_id: "{self.device1.id}"', 2),
@@ -1019,6 +1037,26 @@ query {
                 result = self.execute_query(query)
                 self.assertIsNone(result.errors)
                 self.assertEqual(len(result.data["devices"][0]["interfaces"]), nbr_expected_results)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_query_interfaces_filter_third_level(self):
+        """Test custom interface filter fields, not other concrete fields on second level of query."""
+
+        filters = (
+            (f'device_id: "{self.device1.id}"', 2),
+            ('kind: "virtual"', 2),
+            ('mac_address: "00:11:11:11:11:11"', 1),
+            ("vlan: 100", 1),
+            (f'vlan_id: "{self.vlan1.id}"', 1),
+        )
+
+        for filter, nbr_expected_results in filters:
+            with self.subTest(msg=f"Checking {filter}", filter=filter, nbr_expected_results=nbr_expected_results):
+                query = "query { sites{ devices{ interfaces(" + filter + "){ id }}}}"
+                result = self.execute_query(query)
+                self.assertIsNone(result.errors)
+                self.assertEqual(len(result.data["sites"][0]["devices"][0]["interfaces"]), nbr_expected_results)
+
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_interfaces_connected_endpoint(self):

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -30,10 +30,10 @@ from nautobot.core.graphql.schema import (
     extend_schema_type_relationships,
     extend_schema_type_null_field_choice,
 )
-from nautobot.dcim.choices import InterfaceTypeChoices, InterfaceModeChoices
+from nautobot.dcim.choices import InterfaceTypeChoices, InterfaceModeChoices, PortTypeChoices
 from nautobot.dcim.filters import DeviceFilterSet, SiteFilterSet
 from nautobot.dcim.graphql.types import DeviceType as DeviceTypeGraphQL
-from nautobot.dcim.models import Cable, Device, DeviceRole, DeviceType, Interface, Manufacturer, Rack, Region, Site
+from nautobot.dcim.models import Cable, Device, DeviceRole, DeviceType, FrontPort, Interface, Manufacturer, Rack, RearPort, Region, Site
 from nautobot.extras.choices import CustomFieldTypeChoices
 from nautobot.utilities.testing.utils import create_test_user
 
@@ -592,6 +592,40 @@ class GraphQLQueryTest(TestCase):
             comments="First Device",
         )
 
+        self.device1_rear_ports = (
+            RearPort.objects.create(device=self.device1, name="Rear Port 1", type=PortTypeChoices.TYPE_8P8C),
+            RearPort.objects.create(device=self.device1, name="Rear Port 2", type=PortTypeChoices.TYPE_8P8C),
+            RearPort.objects.create(device=self.device1, name="Rear Port 3", type=PortTypeChoices.TYPE_8P8C),
+            RearPort.objects.create(device=self.device1, name="Rear Port 4", type=PortTypeChoices.TYPE_8P8C),
+        )
+
+        self.device1_frontports = [
+            FrontPort.objects.create(
+                device=self.device1,
+                name="Front Port 1",
+                type=PortTypeChoices.TYPE_8P8C,
+                rear_port=self.device1_rear_ports[0],
+            ),
+            FrontPort.objects.create(
+                device=self.device1,
+                name="Front Port 2",
+                type=PortTypeChoices.TYPE_8P8C,
+                rear_port=self.device1_rear_ports[1],
+            ),
+            FrontPort.objects.create(
+                device=self.device1,
+                name="Front Port 3",
+                type=PortTypeChoices.TYPE_8P8C,
+                rear_port=self.device1_rear_ports[2],
+            ),
+            FrontPort.objects.create(
+                device=self.device1,
+                name="Front Port 4",
+                type=PortTypeChoices.TYPE_8P8C,
+                rear_port=self.device1_rear_ports[3],
+            ),
+        ]
+
         self.interface11 = Interface.objects.create(
             name="Int1",
             type=InterfaceTypeChoices.TYPE_VIRTUAL,
@@ -927,6 +961,22 @@ query {
                 result = self.execute_query(query)
                 self.assertIsNone(result.errors)
                 self.assertEqual(len(result.data["cables"]), nbr_expected_results)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_query_cables_filter_second_level(self):
+
+        filters = (
+            (f'name: "{self.device1_frontports[0].name}"', 1),
+            (f'device: "{self.device1.name}"', 4),
+            (f'_type: "{PortTypeChoices.TYPE_8P8C}"', 4),
+        )
+
+        for filter, nbr_expected_results in filters:
+            with self.subTest(msg=f"Checking {filter}", filter=filter, nbr_expected_results=nbr_expected_results):
+                query = "query { devices{ frontports(" + filter + "){ id }}}"
+                result = self.execute_query(query)
+                self.assertIsNone(result.errors)
+                self.assertEqual(len(result.data["devices"][0]["frontports"]), nbr_expected_results)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_interfaces_filter(self):

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -963,7 +963,7 @@ query {
                 self.assertEqual(len(result.data["cables"]), nbr_expected_results)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
-    def test_query_cables_filter_second_level(self):
+    def test_query_frontport_filter_second_level(self):
 
         filters = (
             (f'name: "{self.device1_frontports[0].name}"', 1),

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -952,6 +952,25 @@ query {
                 self.assertEqual(len(result.data["interfaces"]), nbr_expected_results)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_query_interfaces_filter_second_level(self):
+        """Test custom interface filter fields and boolean, not other concrete fields on second level of query."""
+
+        filters = (
+            (f'device_id: "{self.device1.id}"', 2),
+            ('kind: "virtual"', 2),
+            ('mac_address: "00:11:11:11:11:11"', 1),
+            ("vlan: 100", 1),
+            (f'vlan_id: "{self.vlan1.id}"', 1),
+        )
+
+        for filter, nbr_expected_results in filters:
+            with self.subTest(msg=f"Checking {filter}", filter=filter, nbr_expected_results=nbr_expected_results):
+                query = "query { devices{ interfaces(" + filter + "){ id }}}"
+                result = self.execute_query(query)
+                self.assertIsNone(result.errors)
+                self.assertEqual(len(result.data["devices"][0]["interfaces"]), nbr_expected_results)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_interfaces_connected_endpoint(self):
         """Test querying interfaces for their connected endpoints."""
 

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -976,7 +976,7 @@ query {
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_frontport_filter_second_level(self):
-        """Test custom frontport filter fields and boolean, not other concrete fields."""
+        """Test "second-level" filtering of FrontPorts within a Devices query."""
 
         filters = (
             (f'name: "{self.device1_frontports[0].name}"', 1),
@@ -993,7 +993,7 @@ query {
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_frontport_filter_third_level(self):
-        """Test custom frontport filter fields and boolean, not other concrete fields."""
+        """Test "third-level" filtering of FrontPorts within Devices within Sites."""
 
         filters = (
             (f'name: "{self.device1_frontports[0].name}"', 1),
@@ -1033,7 +1033,7 @@ query {
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_interfaces_filter_second_level(self):
-        """Test custom interface filter fields, not other concrete fields on second level of query."""
+        """Test "second-level" filtering of Interfaces within a Devices query."""
 
         filters = (
             (f'device_id: "{self.device1.id}"', 2),
@@ -1052,7 +1052,7 @@ query {
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_interfaces_filter_third_level(self):
-        """Test custom interface filter fields, not other concrete fields on second level of query."""
+        """Test "third-level" filtering of Interfaces within Devices within Sites."""
 
         filters = (
             (f'device_id: "{self.device1.id}"', 2),

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -1,10 +1,6 @@
-from nautobot.core.graphql.generators import generate_list_search_parameters
-from graphql import GraphQLError
 import graphene
-from graphene import relay
 from graphene_django import DjangoObjectType
 from graphene_django.converter import convert_django_field
-from graphene_django.filter.fields import DjangoFilterConnectionField
 
 from nautobot.circuits.graphql.types import CircuitTerminationType
 from nautobot.dcim.fields import MACAddressField

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -61,7 +61,6 @@ class DeviceType(DjangoObjectType):
     interfaces = graphene.List(InterfaceType, **generate_list_search_parameters(InterfaceType))
 
 
-
 class RackType(DjangoObjectType):
     """Graphql Type Object for Rack model."""
 

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -1,6 +1,10 @@
+from nautobot.core.graphql.generators import generate_list_search_parameters
+from graphql import GraphQLError
 import graphene
+from graphene import relay
 from graphene_django import DjangoObjectType
 from graphene_django.converter import convert_django_field
+from graphene_django.filter.fields import DjangoFilterConnectionField
 
 from nautobot.circuits.graphql.types import CircuitTerminationType
 from nautobot.dcim.fields import MACAddressField
@@ -32,24 +36,6 @@ class SiteType(DjangoObjectType):
         exclude = ["images", "_name"]
 
 
-class DeviceType(DjangoObjectType):
-    """Graphql Type Object for Device model."""
-
-    class Meta:
-        model = Device
-        filterset_class = DeviceFilterSet
-        exclude = ["_name"]
-
-
-class RackType(DjangoObjectType):
-    """Graphql Type Object for Rack model."""
-
-    class Meta:
-        model = Rack
-        filterset_class = RackFilterSet
-        exclude = ["images"]
-
-
 class InterfaceType(DjangoObjectType, PathEndpointMixin):
     """Graphql Type Object for Interface model."""
 
@@ -62,6 +48,27 @@ class InterfaceType(DjangoObjectType, PathEndpointMixin):
 
     def resolve_ip_addresses(self, args):
         return self.ip_addresses.all()
+
+
+class DeviceType(DjangoObjectType):
+    """Graphql Type Object for Device model."""
+
+    class Meta:
+        model = Device
+        filterset_class = DeviceFilterSet
+        exclude = ["_name"]
+
+    interfaces = graphene.List(InterfaceType, **generate_list_search_parameters(InterfaceType))
+
+
+
+class RackType(DjangoObjectType):
+    """Graphql Type Object for Rack model."""
+
+    class Meta:
+        model = Rack
+        filterset_class = RackFilterSet
+        exclude = ["images"]
 
 
 class ConsoleServerPortType(DjangoObjectType, PathEndpointMixin):

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -36,6 +36,24 @@ class SiteType(DjangoObjectType):
         exclude = ["images", "_name"]
 
 
+class DeviceType(DjangoObjectType):
+    """Graphql Type Object for Device model."""
+
+    class Meta:
+        model = Device
+        filterset_class = DeviceFilterSet
+        exclude = ["_name"]
+
+
+class RackType(DjangoObjectType):
+    """Graphql Type Object for Rack model."""
+
+    class Meta:
+        model = Rack
+        filterset_class = RackFilterSet
+        exclude = ["images"]
+
+
 class InterfaceType(DjangoObjectType, PathEndpointMixin):
     """Graphql Type Object for Interface model."""
 
@@ -48,26 +66,6 @@ class InterfaceType(DjangoObjectType, PathEndpointMixin):
 
     def resolve_ip_addresses(self, args):
         return self.ip_addresses.all()
-
-
-class DeviceType(DjangoObjectType):
-    """Graphql Type Object for Device model."""
-
-    class Meta:
-        model = Device
-        filterset_class = DeviceFilterSet
-        exclude = ["_name"]
-
-    interfaces = graphene.List(InterfaceType, **generate_list_search_parameters(InterfaceType))
-
-
-class RackType(DjangoObjectType):
-    """Graphql Type Object for Rack model."""
-
-    class Meta:
-        model = Rack
-        filterset_class = RackFilterSet
-        exclude = ["images"]
 
 
 class ConsoleServerPortType(DjangoObjectType, PathEndpointMixin):

--- a/nautobot/docs/user-guides/graphql.md
+++ b/nautobot/docs/user-guides/graphql.md
@@ -193,7 +193,7 @@ The results of the query look like:
 
 ### Filtering Queries
 
-These queries are great, but they are displaying the interface attributes and device names for every device in the Nautobot inventory. Currently, Nautobot allows users to filter queries at the top level of the query. In our previous examples, the top level would be the `devices` query.
+These queries are great, but they are displaying the interface attributes and device names for every device in the Nautobot inventory. Currently, Nautobot allows users to filter queries at the first and second level of the query. In our previous examples, the top level would be the `devices` query.
 
 As an example. We can query devices by their site location. This is done by adding `(site: "<site name>")` after `devices`. For example: `query { devices(site: "ams") { name }}` will display all devices in the `ams` site.
 <div>
@@ -204,7 +204,7 @@ As an example. We can query devices by their site location. This is done by addi
 </div>
 
 <br />
-GraphiQL allows you to add multiple attributes to the filter criteria. You can use the *Documentation Explorer* to assist you in finding criteria attributes to filter on. In this example, I add the `role` attribute in addition to `site`. 
+GraphiQL allows you to add multiple attributes to the filter criteria. You can use the *Documentation Explorer* to assist you in finding criteria attributes to filter on. In this example, I add the `role` attribute in addition to `site`.
 
 ```graphql
 query {
@@ -213,6 +213,7 @@ query {
   }
 }
 ```
+
 <div>
   <details>
     <summary>View GraphQL Query Results</summary>
@@ -221,13 +222,26 @@ query {
 </div>
 
 <br />
+There is also the option to use filtering on the second level of the query. On many to one relationships you can filter the results based on an attribute of the field. Any attribute that relates to a GraphQLType can be filtered.
+
+```graphql
+query {
+  devices(site: "ams", role: "edge") {
+    name
+    interface(name: "Ethernet1/1") {
+      name
+    }
+  }
+}
+```
+
 ## Using the GraphQL API in Nautobot
 
 Now that we've explored how to use the GraphiQL interface to help us create GraphQL queries, let's take our queries and call them with the REST API. This is where the real advantage is going to come in to play, because it will allow us to utilize these queries in a programmatic way.
 
 <img src="../images/graphql/10-graphql-swagger.png" alt="GraphQL: Swagger" width="400">
 
-From the [Nautobot Swagger documentation](https://demo.nautobot.com/api/docs/), we can see that the API calls to `/api/graphql` require a HTTP POST method. In the HTTP POST, the `query` field is a required. The `query` field is where we put the GraphQL query. The `variables` field is optional. It's where we define filters, if we choose to do so. 
+From the [Nautobot Swagger documentation](https://demo.nautobot.com/api/docs/), we can see that the API calls to `/api/graphql` require a HTTP POST method. In the HTTP POST, the `query` field is a required. The `query` field is where we put the GraphQL query. The `variables` field is optional. It's where we define filters, if we choose to do so.
 
 To simplify the process even more, we'll utilize the [PyNautobot SDK](https://pynautobot.readthedocs.io/en/latest/index.html).
 

--- a/nautobot/docs/user-guides/graphql.md
+++ b/nautobot/docs/user-guides/graphql.md
@@ -193,7 +193,7 @@ The results of the query look like:
 
 ### Filtering Queries
 
-These queries are great, but they are displaying the interface attributes and device names for every device in the Nautobot inventory. Currently, Nautobot allows users to filter queries at the first and second level of the query. In our previous examples, the top level would be the `devices` query.
+These queries are great, but they are displaying the interface attributes and device names for every device in the Nautobot inventory. Nautobot allows users to filter queries at any level as desired to narrow the scope of the returned data. As an example, we can filter the queried devices by their site location. This is done by adding `(site: "<site name>")` after `devices`. For example: `query { devices(site: "ams") { name }}` will display all devices in the `ams` site.
 
 As an example. We can query devices by their site location. This is done by adding `(site: "<site name>")` after `devices`. For example: `query { devices(site: "ams") { name }}` will display all devices in the `ams` site.
 <div>
@@ -204,7 +204,7 @@ As an example. We can query devices by their site location. This is done by addi
 </div>
 
 <br />
-GraphiQL allows you to add multiple attributes to the filter criteria. You can use the *Documentation Explorer* to assist you in finding criteria attributes to filter on. In this example, I add the `role` attribute in addition to `site`.
+GraphQL also allows you to filter by multiple attributes at once if desired. You can use the *Documentation Explorer* to assist you in finding criteria attributes to filter on. In this example, I add the `role` attribute in addition to `site`.
 
 ```graphql
 query {
@@ -222,14 +222,27 @@ query {
 </div>
 
 <br />
-There is also the option to use filtering on the second level of the query. On many to one relationships you can filter the results based on an attribute of the field. Any attribute that relates to a GraphQLType can be filtered.
+You can also filter at deeper levels of the query. On many to one relationships you can filter the results based on an attribute of the field. Any attribute that relates to a GraphQLType can be filtered.
 
 ```graphql
 query {
   devices(site: "ams", role: "edge") {
     name
-    interface(name: "Ethernet1/1") {
+    interfaces(name: "Ethernet1/1") {
       name
+    }
+  }
+}
+```
+
+```graphql
+query {
+  sites(name: "ams") {
+    devices(role: "edge") {
+      name
+      interfaces(name: "Ethernet1/1") {
+        name
+      }
     }
   }
 }
@@ -241,7 +254,7 @@ Now that we've explored how to use the GraphiQL interface to help us create Grap
 
 <img src="../images/graphql/10-graphql-swagger.png" alt="GraphQL: Swagger" width="400">
 
-From the [Nautobot Swagger documentation](https://demo.nautobot.com/api/docs/), we can see that the API calls to `/api/graphql` require a HTTP POST method. In the HTTP POST, the `query` field is a required. The `query` field is where we put the GraphQL query. The `variables` field is optional. It's where we define filters, if we choose to do so.
+From the [Nautobot Swagger documentation](https://demo.nautobot.com/api/docs/), we can see that the API calls to `/api/graphql` require a HTTP POST method. In the HTTP POST, the `query` field is required, as it is where we specify the GraphQL query. The `variables` field is optional; it's where we can assign values to any variables included in the query, if we choose to do so.
 
 To simplify the process even more, we'll utilize the [PyNautobot SDK](https://pynautobot.readthedocs.io/en/latest/index.html).
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #248
<!--
    Please include a summary of the proposed changes below.
-->

Added dynamic methods to add filtering on multiple layers of a query. These methods create a resolver function which can filter on another `DjangoObjectType`.

The example below shows a filter being used on the second level of the query.

Simple example:
```
query {
    devices {
      name
      interfaces(name: "e01") {
        name
      }
    }
}
```

The method works by looping over each attribute of a model to check if it has a type of `ReverseManyToOneDescriptor`. If this is the case a new resolver function will be generated which can filter on the `ManyToOne` relationship. Any attribute can be used to filter.

Todo list:

- [x] Core code
- [x] Testing
- [x] Documentation