### PR TITLE
Fix incorrect tenancy display in related prefixes table

### DIFF
--- a/nautobot/circuits/tables.py
+++ b/nautobot/circuits/tables.py
@@ -2,7 +2,7 @@ import django_tables2 as tables
 from django_tables2.utils import Accessor
 
 from nautobot.extras.tables import StatusTableMixin
-from nautobot.tenancy.tables import COL_TENANT
+from nautobot.tenancy.tables import TenantColumn
 from nautobot.utilities.tables import (
     BaseTable,
     ButtonsColumn,
@@ -72,7 +72,7 @@ class CircuitTable(StatusTableMixin, BaseTable):
     pk = ToggleColumn()
     cid = tables.LinkColumn(verbose_name="ID")
     provider = tables.LinkColumn(viewname="circuits:provider", args=[Accessor("provider__slug")])
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     a_side = tables.Column(verbose_name="A Side")
     z_side = tables.Column(verbose_name="Z Side")
     tags = TagColumn(url_name="circuits:circuit_list")

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -18,7 +18,7 @@ from nautobot.dcim.models import (
 )
 from nautobot.dcim.utils import cable_status_color_css
 from nautobot.extras.tables import StatusTableMixin
-from nautobot.tenancy.tables import COL_TENANT
+from nautobot.tenancy.tables import TenantColumn
 from nautobot.utilities.tables import (
     BaseTable,
     BooleanColumn,
@@ -170,7 +170,7 @@ class PlatformTable(BaseTable):
 class DeviceTable(StatusTableMixin, BaseTable):
     pk = ToggleColumn()
     name = tables.TemplateColumn(order_by=("_name",), template_code=DEVICE_LINK)
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     site = tables.Column(linkify=True)
     rack = tables.Column(linkify=True)
     device_role = ColoredLabelColumn(verbose_name="Role")
@@ -230,7 +230,7 @@ class DeviceTable(StatusTableMixin, BaseTable):
 class DeviceImportTable(BaseTable):
     name = tables.TemplateColumn(template_code=DEVICE_LINK)
     status = ColoredLabelColumn()
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     site = tables.Column(linkify=True)
     rack = tables.Column(linkify=True)
     device_role = tables.Column(verbose_name="Role")

--- a/nautobot/dcim/tables/racks.py
+++ b/nautobot/dcim/tables/racks.py
@@ -3,7 +3,7 @@ from django_tables2.utils import Accessor
 
 from nautobot.dcim.models import Rack, RackGroup, RackReservation, RackRole
 from nautobot.extras.tables import StatusTableMixin
-from nautobot.tenancy.tables import COL_TENANT
+from nautobot.tenancy.tables import TenantColumn
 from nautobot.utilities.tables import (
     BaseTable,
     ButtonsColumn,
@@ -77,7 +77,7 @@ class RackTable(StatusTableMixin, BaseTable):
     name = tables.Column(order_by=("_name",), linkify=True)
     group = tables.Column(linkify=True)
     site = tables.Column(linkify=True)
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     role = ColoredLabelColumn()
     u_height = tables.TemplateColumn(template_code="{{ record.u_height }}U", verbose_name="Height")
 
@@ -168,7 +168,7 @@ class RackReservationTable(BaseTable):
     pk = ToggleColumn()
     reservation = tables.Column(accessor="pk", linkify=True)
     site = tables.Column(accessor=Accessor("rack__site"), linkify=True)
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     rack = tables.Column(linkify=True)
     unit_list = tables.Column(orderable=False, verbose_name="Units")
     tags = TagColumn(url_name="dcim:rackreservation_list")

--- a/nautobot/dcim/tables/sites.py
+++ b/nautobot/dcim/tables/sites.py
@@ -2,7 +2,7 @@ import django_tables2 as tables
 
 from nautobot.dcim.models import Region, Site
 from nautobot.extras.tables import StatusTableMixin
-from nautobot.tenancy.tables import COL_TENANT
+from nautobot.tenancy.tables import TenantColumn
 from nautobot.utilities.tables import (
     BaseTable,
     ButtonsColumn,
@@ -43,7 +43,7 @@ class SiteTable(StatusTableMixin, BaseTable):
     pk = ToggleColumn()
     name = tables.LinkColumn(order_by=("_name",))
     region = tables.Column(linkify=True)
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     tags = TagColumn(url_name="dcim:site_list")
 
     class Meta(BaseTable.Meta):

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -4,7 +4,7 @@ from django_tables2.utils import Accessor
 
 from nautobot.dcim.models import Interface
 from nautobot.extras.tables import StatusTableMixin
-from nautobot.tenancy.tables import COL_TENANT
+from nautobot.tenancy.tables import TenantColumn
 from nautobot.utilities.tables import (
     BaseTable,
     BooleanColumn,
@@ -127,19 +127,6 @@ VLAN_MEMBER_TAGGED = """
 {% endif %}
 """
 
-TENANT_LINK = """
-{% if record.tenant %}
-    <a href="{% url 'tenancy:tenant' slug=record.tenant.slug %}" title="{{ record.tenant.description }}">{{ record.tenant }}</a>
-{% elif record.vrf.tenant %}
-    <a href="{% url 'tenancy:tenant' slug=record.vrf.tenant.slug %}" title="{{ record.vrf.tenant.description }}">{{ record.vrf.tenant }}</a>*
-{% elif object.tenant %}
-    <a href="{% url 'tenancy:tenant' slug=object.tenant.slug %}" title="{{ object.tenant.description }}">{{ object.tenant }}</a>
-{% else %}
-    &mdash;
-{% endif %}
-"""
-
-
 #
 # VRFs
 #
@@ -149,7 +136,7 @@ class VRFTable(BaseTable):
     pk = ToggleColumn()
     name = tables.LinkColumn()
     rd = tables.Column(verbose_name="RD")
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     enforce_unique = BooleanColumn(verbose_name="Unique")
     import_targets = tables.TemplateColumn(template_code=VRF_TARGETS, orderable=False)
     export_targets = tables.TemplateColumn(template_code=VRF_TARGETS, orderable=False)
@@ -179,7 +166,7 @@ class VRFTable(BaseTable):
 class RouteTargetTable(BaseTable):
     pk = ToggleColumn()
     name = tables.LinkColumn()
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     tags = TagColumn(url_name="ipam:vrf_list")
 
     class Meta(BaseTable.Meta):
@@ -233,7 +220,7 @@ class RIRTable(BaseTable):
 class AggregateTable(BaseTable):
     pk = ToggleColumn()
     prefix = tables.LinkColumn(verbose_name="Aggregate", order_by=("network", "prefix_length"))
-    tenant = tables.TemplateColumn(template_code=TENANT_LINK)
+    tenant = TenantColumn()
     date_added = tables.DateColumn(format="Y-m-d", verbose_name="Added")
 
     class Meta(BaseTable.Meta):
@@ -319,7 +306,7 @@ class PrefixTable(StatusTableMixin, BaseTable):
         template_code=PREFIX_LINK, attrs={"td": {"class": "text-nowrap"}}, order_by=("network", "prefix_length")
     )
     vrf = tables.TemplateColumn(template_code=VRF_LINK, verbose_name="VRF")
-    tenant = tables.TemplateColumn(template_code=TENANT_LINK)
+    tenant = TenantColumn()
     site = tables.Column(linkify=True)
     vlan = tables.Column(linkify=True, verbose_name="VLAN")
     role = tables.TemplateColumn(template_code=PREFIX_ROLE_LINK)
@@ -358,7 +345,7 @@ class PrefixTable(StatusTableMixin, BaseTable):
 
 class PrefixDetailTable(PrefixTable):
     utilization = tables.TemplateColumn(template_code=UTILIZATION_GRAPH, orderable=False)
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     tags = TagColumn(url_name="ipam:prefix_list")
 
     class Meta(PrefixTable.Meta):
@@ -404,7 +391,7 @@ class IPAddressTable(StatusTableMixin, BaseTable):
     )
     vrf = tables.TemplateColumn(template_code=VRF_LINK, verbose_name="VRF")
     role = ChoiceFieldColumn()
-    tenant = tables.TemplateColumn(template_code=TENANT_LINK)
+    tenant = TenantColumn()
     assigned_object = tables.Column(linkify=True, orderable=False, verbose_name="Interface")
     assigned_object_parent = tables.Column(
         accessor="assigned_object__parent",
@@ -434,7 +421,7 @@ class IPAddressTable(StatusTableMixin, BaseTable):
 
 class IPAddressDetailTable(IPAddressTable):
     nat_inside = tables.Column(linkify=True, orderable=False, verbose_name="NAT (Inside)")
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     assigned = BooleanColumn(accessor="assigned_object_id", verbose_name="Assigned")
     tags = TagColumn(url_name="ipam:ipaddress_list")
 
@@ -491,7 +478,7 @@ class InterfaceIPAddressTable(StatusTableMixin, BaseTable):
 
     address = tables.LinkColumn(verbose_name="IP Address")
     vrf = tables.TemplateColumn(template_code=VRF_LINK, verbose_name="VRF")
-    tenant = tables.TemplateColumn(template_code=TENANT_LINK)
+    tenant = TenantColumn()
 
     class Meta(BaseTable.Meta):
         model = IPAddress
@@ -526,7 +513,7 @@ class VLANTable(StatusTableMixin, BaseTable):
     vid = tables.TemplateColumn(template_code=VLAN_LINK, verbose_name="ID")
     site = tables.LinkColumn(viewname="dcim:site", args=[Accessor("site__slug")])
     group = tables.LinkColumn(viewname="ipam:vlangroup", args=[Accessor("group__pk")])
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     role = tables.TemplateColumn(template_code=VLAN_ROLE_LINK)
 
     class Meta(BaseTable.Meta):
@@ -549,7 +536,7 @@ class VLANTable(StatusTableMixin, BaseTable):
 
 class VLANDetailTable(VLANTable):
     prefixes = tables.TemplateColumn(template_code=VLAN_PREFIXES, orderable=False, verbose_name="Prefixes")
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     tags = TagColumn(url_name="ipam:vlan_list")
 
     class Meta(VLANTable.Meta):
@@ -616,7 +603,7 @@ class InterfaceVLANTable(StatusTableMixin, BaseTable):
     tagged = BooleanColumn()
     site = tables.Column(linkify=True)
     group = tables.Column(accessor=Accessor("group__name"), verbose_name="Group")
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
     role = tables.TemplateColumn(template_code=VLAN_ROLE_LINK)
 
     class Meta(BaseTable.Meta):

--- a/nautobot/tenancy/tables.py
+++ b/nautobot/tenancy/tables.py
@@ -41,7 +41,7 @@ class TenantColumn(tables.TemplateColumn):
         super().__init__(template_code=self.template_code, *args, **kwargs)
 
     def value(self, value):
-        return str(value)
+        return str(value) if value else None
 
 
 #

--- a/nautobot/tenancy/tables.py
+++ b/nautobot/tenancy/tables.py
@@ -16,13 +16,32 @@ MPTT_LINK = """
 <a href="{{ record.get_absolute_url }}">{{ record.name }}</a>
 """
 
-COL_TENANT = """
-{% if record.tenant %}
-    <a href="{% url 'tenancy:tenant' slug=record.tenant.slug %}" title="{{ record.tenant.description }}">{{ record.tenant }}</a>
-{% else %}
-    &mdash;
-{% endif %}
-"""
+
+#
+# Table columns
+#
+
+
+class TenantColumn(tables.TemplateColumn):
+    """
+    Column for linking to a record's associated Tenant, or failing that, it's associated VRF's tenant.
+    """
+
+    template_code = """
+    {% if record.tenant %}
+        <a href="{{ record.tenant.get_absolute_url }}" title="{{ record.tenant.description }}">{{ record.tenant }}</a>
+    {% elif record.vrf.tenant %}
+        <a href="{{ record.vrf.tenant.get_absolute_url }}" title="{{ record.vrf.tenant.description }}">{{ record.vrf.tenant }}</a>*
+    {% else %}
+        &mdash;
+    {% endif %}
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(template_code=self.template_code, *args, **kwargs)
+
+    def value(self, value):
+        return str(value)
 
 
 #

--- a/nautobot/virtualization/tables.py
+++ b/nautobot/virtualization/tables.py
@@ -2,7 +2,7 @@ import django_tables2 as tables
 
 from nautobot.dcim.tables.devices import BaseInterfaceTable
 from nautobot.extras.tables import StatusTableMixin
-from nautobot.tenancy.tables import COL_TENANT
+from nautobot.tenancy.tables import TenantColumn
 from nautobot.utilities.tables import (
     BaseTable,
     ButtonsColumn,
@@ -125,7 +125,7 @@ class VirtualMachineTable(StatusTableMixin, BaseTable):
     name = tables.LinkColumn()
     cluster = tables.Column(linkify=True)
     role = ColoredLabelColumn()
-    tenant = tables.TemplateColumn(template_code=COL_TENANT)
+    tenant = TenantColumn()
 
     class Meta(BaseTable.Meta):
         model = VirtualMachine


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #779 
<!--
    Please include a summary of the proposed changes below.
-->

#779 describes a bug that we inadvertently introduced in #696 by cherry-picking several fixes from NetBox. In NetBox, the introduced bug (https://github.com/netbox-community/netbox/issues/6108) was initially fixed in version 2.10.9 by removing the introduced incorrect logic (https://github.com/netbox-community/netbox/commit/03b3f5937f49324db0639c73d5242cd0e9c2a548), but a more complete fix was introduced by refactoring in version 2.11.x to provide a more general pattern for tenant reference columns (https://github.com/netbox-community/netbox/commit/20a85c1ef264ecfffcbe8602ab103baed5a7cf5b), which was then slightly refined in https://github.com/netbox-community/netbox/commit/0a1531ce8a5597333f2ac87fcc795c83a052fd47.

This PR therefore includes Nautobot-adapted versions of https://github.com/netbox-community/netbox/commit/20a85c1ef264ecfffcbe8602ab103baed5a7cf5b and https://github.com/netbox-community/netbox/commit/0a1531ce8a5597333f2ac87fcc795c83a052fd47, both originally authored by @jeremystretch.

Before the fix - note that the "No Tenant" prefix in the right table incorrectly shows itself as belonging to the same tenant as the selected tenant:

![image](https://user-images.githubusercontent.com/5603551/129098443-f32b2439-9099-41bb-9bfc-baf22c3d677d.png)

After the fix - related prefix in the right table is correctly shown as having no tenant:

![image](https://user-images.githubusercontent.com/5603551/129098574-6a574306-bf9b-444e-8bfe-491c5366b398.png)
