### PR TITLE
Add SOCIAL_AUTH_BACKEND_PREFIX for custom auth backends

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -116,6 +116,8 @@ RELEASE_CHECK_TIMEOUT = 24 * 3600
 
 # SSO backend settings https://python-social-auth.readthedocs.io/en/latest/configuration/settings.html
 SOCIAL_AUTH_POSTGRES_JSONFIELD = False
+# Nautobot related - May be overridden if using custom social auth backend
+SOCIAL_AUTH_BACKEND_PREFIX = "social_core.backends"
 
 # Storage
 STORAGE_BACKEND = None

--- a/nautobot/core/settings_funcs.py
+++ b/nautobot/core/settings_funcs.py
@@ -1,5 +1,6 @@
 """Helper functions to detect settings after app initialization (AKA 'dynamic settings')."""
 
+from django.conf import settings
 from distutils.util import strtobool
 from functools import lru_cache
 import os
@@ -27,8 +28,9 @@ def sso_auth_enabled(auth_backends):
 
 @lru_cache(maxsize=5)
 def _sso_auth_enabled(auth_backends):
+    sso_backend_prefix = getattr(settings, "SOCIAL_AUTH_BACKEND_PREFIX", "social_core.backends")
     for backend in auth_backends:
-        if backend.startswith("social_core.backends"):
+        if backend.startswith(sso_backend_prefix):
             return True
     return False
 

--- a/nautobot/core/settings_funcs.py
+++ b/nautobot/core/settings_funcs.py
@@ -28,9 +28,8 @@ def sso_auth_enabled(auth_backends):
 
 @lru_cache(maxsize=5)
 def _sso_auth_enabled(auth_backends):
-    sso_backend_prefix = getattr(settings, "SOCIAL_AUTH_BACKEND_PREFIX", "social_core.backends")
     for backend in auth_backends:
-        if backend.startswith(sso_backend_prefix):
+        if backend.startswith(settings.SOCIAL_AUTH_BACKEND_PREFIX):
             return True
     return False
 

--- a/nautobot/core/tests/test_authentication.py
+++ b/nautobot/core/tests/test_authentication.py
@@ -12,13 +12,13 @@ from netaddr import IPNetwork
 from rest_framework.test import APIClient
 
 from nautobot.core.middleware import ExternalAuthMiddleware
+from nautobot.core.settings_funcs import sso_auth_enabled
 from nautobot.dcim.models import Site
 from nautobot.extras.models import Status
 from nautobot.ipam.models import Prefix
 from nautobot.users.models import ObjectPermission, Token
 from nautobot.utilities.testing import TestCase
 
-from nautobot.core.settings_funcs import sso_auth_enabled
 
 # Use the proper swappable User model
 User = get_user_model()
@@ -158,6 +158,41 @@ class ExternalAuthenticationTestCase(TestCase):
         self.assertSetEqual({groups[0], groups[1]}, set(new_user.groups.all()))
 
     @override_settings(
+        AUTHENTICATION_BACKENDS=TEST_AUTHENTICATION_BACKENDS,
+        REMOTE_AUTH_AUTO_CREATE_USER=True,
+        EXTERNAL_AUTH_DEFAULT_PERMISSIONS={
+            "dcim.add_site": None,
+            "dcim.change_site": None,
+        },
+    )
+    def test_external_auth_default_permissions(self):
+        """
+        Test enabling remote authentication with the default configuration.
+        """
+        headers = {
+            "HTTP_REMOTE_USER": "remoteuser2",
+        }
+
+        self.assertTrue("nautobot.core.authentication.RemoteUserBackend" in settings.AUTHENTICATION_BACKENDS)
+        self.assertTrue(settings.REMOTE_AUTH_AUTO_CREATE_USER)
+        self.assertEqual(settings.REMOTE_AUTH_HEADER, "HTTP_REMOTE_USER")
+        self.assertEqual(
+            settings.EXTERNAL_AUTH_DEFAULT_PERMISSIONS,
+            {"dcim.add_site": None, "dcim.change_site": None},
+        )
+
+        response = self.client.get(reverse("home"), follow=True, **headers)
+        self.assertEqual(response.status_code, 200)
+
+        new_user = User.objects.get(username="remoteuser2")
+        self.assertEqual(
+            uuid.UUID(self.client.session.get("_auth_user_id")),
+            new_user.pk,
+            msg="Authentication failed",
+        )
+        self.assertTrue(new_user.has_perms(["dcim.add_site", "dcim.change_site"]))
+
+    @override_settings(
         SOCIAL_AUTH_BACKEND_PREFIX="custom_auth.backend",
     )
     def test_custom_social_auth_backend_prefix_sso_enabled_true(self):
@@ -188,7 +223,7 @@ class ExternalAuthenticationTestCase(TestCase):
 
         self.assertTrue(
             sso_auth_enabled(
-                ("social_core.backends.google.GoogleOath2", "nautobot.core.authentication.ObjectPermissionBackend")
+                ("social_core.backends.google.GoogleOauth2", "nautobot.core.authentication.ObjectPermissionBackend")
             )
         )
 

--- a/nautobot/docs/configuration/authentication/sso.md
+++ b/nautobot/docs/configuration/authentication/sso.md
@@ -84,6 +84,11 @@ The default external authentication supported is [social-auth-app-django](https:
 
 ```python
 SOCIAL_AUTH_BACKEND_PREFIX = "custom_auth.backends"
+
+AUTHENTICATION_BACKENDS = [
+    "custom_auth.backends.custom.Oauth2",
+    "nautobot.core.authentication.ObjectPermissionBackend",
+]
 ```
 
 `SOCIAL_AUTH_BACKEND_PREFIX` was set to `custom_auth.backends` as we may have more than one custom backend. This will enable the SSO redirect for users when they click the login button.

--- a/nautobot/docs/configuration/authentication/sso.md
+++ b/nautobot/docs/configuration/authentication/sso.md
@@ -80,7 +80,7 @@ AUTHENTICATION_BACKENDS = [
 
 ### Custom Authentication Backends
 
-The default external authentication supported is [social-auth-app-django](https://python-social-auth.readthedocs.io/en/latest/configuration/django.html) as stated above. If you have developed your own external authentication backend, you can specify `SOCIAL_AUTH_BACKEND_PREFIX` to enable the SSO redirect when the login button is clicked. Currently, Nautobot will look for `social_core.backends` within `AUTHENTICATION_BACKENDS` to endable the redirect.Let's take a look at an example for a custom authentication backend available at `custom_auth.backends.custom.Oauth2`.
+The default external authentication supported is [social-auth-app-django](https://python-social-auth.readthedocs.io/en/latest/configuration/django.html) as stated above. If you have developed your own external authentication backend, you will need to configure `SOCIAL_AUTH_BACKEND_PREFIX` to use your backend instead and correctly enable the SSO redirect when the login button is clicked. For example, if your custom authentication backend is available at `custom_auth.backends.custom.Oauth2`, you would set things as follows:
 
 ```python
 SOCIAL_AUTH_BACKEND_PREFIX = "custom_auth.backends"

--- a/nautobot/docs/configuration/authentication/sso.md
+++ b/nautobot/docs/configuration/authentication/sso.md
@@ -54,7 +54,7 @@ Please see the SAML configuration guide below for an example of how to configure
 
 ### Authentication Backends
 
-To use external authentcation, you'll need to define `AUTHENTICATION_BACKENDS` in your `nautobot_config.py`.
+To use external authentication, you'll need to define `AUTHENTICATION_BACKENDS` in your `nautobot_config.py`.
 
 - Insert the desired external authentication backend as the first item in the list. This step is key to properly redirecting when users click the login button.
 - You must also ensure that `nautobot.core.authentication.ObjectPermissionBackend` is always the second item in the list. It is an error to exclude this backend.

--- a/nautobot/docs/configuration/authentication/sso.md
+++ b/nautobot/docs/configuration/authentication/sso.md
@@ -91,7 +91,7 @@ AUTHENTICATION_BACKENDS = [
 ]
 ```
 
-`SOCIAL_AUTH_BACKEND_PREFIX` was set to `custom_auth.backends` as we may have more than one custom backend. This will enable the SSO redirect for users when they click the login button.
+In the example above, `SOCIAL_AUTH_BACKEND_PREFIX` was set to `custom_auth.backends` within the `nautobot_config.py` for our custom authentication plugin we created (**custom_auth.backends.custom.Oauth2**). This will enable the SSO redirect for users when they click the login button.
 
 ---
 
@@ -101,19 +101,19 @@ You will need to select the correct social authentication module name for your d
 
 Some common backend module names include:
 
-| Backend                                                                                                       | Social Auth Backend Module Name                                 |
-| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| [Microsoft Azure Active Directory](https://python-social-auth.readthedocs.io/en/latest/backends/azuread.html) | `social_core.backends.azuread.AzureADOAuth2`                    |
-|                                                                                                               | `social_core.backends.azuread_b2c.AzureADB2COAuth2`             |
-|                                                                                                               | `social_core.backends.azuread_tenant.AzureADTenantOAuth2`       |
-|                                                                                                               | `social_core.backends.azuread_tenant.AzureADV2TenantOAuth2`     |
-| [Google](https://python-social-auth.readthedocs.io/en/latest/backends/google.html)                            | `social_core.backends.gae.GoogleAppEngineAuth`                  |
-|                                                                                                               | `social_core.backends.google.GoogleOAuth2`                      |
-|                                                                                                               | `social_core.backends.google.GoogleOAuth`                       |
-|                                                                                                               | `social_core.backends.google_openidconnect.GoogleOpenIdConnect` |
-| [Okta](https://python-social-auth.readthedocs.io/en/latest/backends/okta.html)                                | `social_core.backends.okta.OktaOAuth2`                          |
-|                                                                                                               | `social_core.backends.okta_openidconnect.OktaOpenIdConnect`     |
-| [SAML](https://python-social-auth.readthedocs.io/en/latest/backends/saml.html)                                | `social_core.backends.saml.SAMLAuth`                            |
+| Backend | Social Auth Backend Module Name |
+|---------|---------------------------------|
+| [Microsoft Azure Active Directory](https://python-social-auth.readthedocs.io/en/latest/backends/azuread.html) | `social_core.backends.azuread.AzureADOAuth2` |
+| | `social_core.backends.azuread_b2c.AzureADB2COAuth2` |
+| | `social_core.backends.azuread_tenant.AzureADTenantOAuth2` |
+| | `social_core.backends.azuread_tenant.AzureADV2TenantOAuth2` |
+| [Google](https://python-social-auth.readthedocs.io/en/latest/backends/google.html) | `social_core.backends.gae.GoogleAppEngineAuth` |
+| | `social_core.backends.google.GoogleOAuth2` |
+| | `social_core.backends.google.GoogleOAuth` |
+| | `social_core.backends.google_openidconnect.GoogleOpenIdConnect` |
+| [Okta](https://python-social-auth.readthedocs.io/en/latest/backends/okta.html) | `social_core.backends.okta.OktaOAuth2` |
+| | `social_core.backends.okta_openidconnect.OktaOpenIdConnect` |
+| [SAML](https://python-social-auth.readthedocs.io/en/latest/backends/saml.html) | `social_core.backends.saml.SAMLAuth` |
 
 ### User Permissions
 

--- a/nautobot/docs/configuration/authentication/sso.md
+++ b/nautobot/docs/configuration/authentication/sso.md
@@ -56,7 +56,7 @@ Please see the SAML configuration guide below for an example of how to configure
 
 To use external authentcation, you'll need to define `AUTHENTICATION_BACKENDS` in your `nautobot_config.py`.
 
-- Insert the desired external authentication backend as the first item in the list.
+- Insert the desired external authentication backend as the first item in the list. This step is key to properly redirecting when users click the login button.
 - You must also ensure that `nautobot.core.authentication.ObjectPermissionBackend` is always the second item in the list. It is an error to exclude this backend.
 
 !!! note
@@ -77,6 +77,17 @@ AUTHENTICATION_BACKENDS = [
 !!! warning
 	You should only enable one social authentication authentication backend. It is technically possible to use multiple backends but we cannot officially support more than one at this time.
 
+
+### Custom Authentication Backends
+
+The default external authentication supported is [social-auth-app-django](https://python-social-auth.readthedocs.io/en/latest/configuration/django.html) as stated above. If you have developed your own external authentication backend, you can specify `SOCIAL_AUTH_BACKEND_PREFIX` to enable the SSO redirect when the login button is clicked. Currently, Nautobot will look for `social_core.backends` within `AUTHENTICATION_BACKENDS` to endable the redirect.Let's take a look at an example for a custom authentication backend available at `custom_auth.backends.custom.Oauth2`.
+
+```python
+SOCIAL_AUTH_BACKEND_PREFIX = "custom_auth.backends"
+```
+
+`SOCIAL_AUTH_BACKEND_PREFIX` was set to `custom_auth.backends` as we may have more than one custom backend. This will enable the SSO redirect for users when they click the login button.
+
 ---
 
 ### Select your Authentication Backend
@@ -85,19 +96,19 @@ You will need to select the correct social authentication module name for your d
 
 Some common backend module names include:
 
-| Backend | Social Auth Backend Module Name |
-|---------|---------------------------------|
-| [Microsoft Azure Active Directory](https://python-social-auth.readthedocs.io/en/latest/backends/azuread.html) | `social_core.backends.azuread.AzureADOAuth2` |
-| | `social_core.backends.azuread_b2c.AzureADB2COAuth2` |
-| | `social_core.backends.azuread_tenant.AzureADTenantOAuth2` |
-| | `social_core.backends.azuread_tenant.AzureADV2TenantOAuth2` |
-| [Google](https://python-social-auth.readthedocs.io/en/latest/backends/google.html) | `social_core.backends.gae.GoogleAppEngineAuth` |
-| | `social_core.backends.google.GoogleOAuth2` |
-| | `social_core.backends.google.GoogleOAuth` |
-| | `social_core.backends.google_openidconnect.GoogleOpenIdConnect` |
-| [Okta](https://python-social-auth.readthedocs.io/en/latest/backends/okta.html) | `social_core.backends.okta.OktaOAuth2` |
-| | `social_core.backends.okta_openidconnect.OktaOpenIdConnect` |
-| [SAML](https://python-social-auth.readthedocs.io/en/latest/backends/saml.html) | `social_core.backends.saml.SAMLAuth` |
+| Backend                                                                                                       | Social Auth Backend Module Name                                 |
+| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| [Microsoft Azure Active Directory](https://python-social-auth.readthedocs.io/en/latest/backends/azuread.html) | `social_core.backends.azuread.AzureADOAuth2`                    |
+|                                                                                                               | `social_core.backends.azuread_b2c.AzureADB2COAuth2`             |
+|                                                                                                               | `social_core.backends.azuread_tenant.AzureADTenantOAuth2`       |
+|                                                                                                               | `social_core.backends.azuread_tenant.AzureADV2TenantOAuth2`     |
+| [Google](https://python-social-auth.readthedocs.io/en/latest/backends/google.html)                            | `social_core.backends.gae.GoogleAppEngineAuth`                  |
+|                                                                                                               | `social_core.backends.google.GoogleOAuth2`                      |
+|                                                                                                               | `social_core.backends.google.GoogleOAuth`                       |
+|                                                                                                               | `social_core.backends.google_openidconnect.GoogleOpenIdConnect` |
+| [Okta](https://python-social-auth.readthedocs.io/en/latest/backends/okta.html)                                | `social_core.backends.okta.OktaOAuth2`                          |
+|                                                                                                               | `social_core.backends.okta_openidconnect.OktaOpenIdConnect`     |
+| [SAML](https://python-social-auth.readthedocs.io/en/latest/backends/saml.html)                                | `social_core.backends.saml.SAMLAuth`                            |
 
 ### User Permissions
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #728
Adds Nautobot configuration to change what prefix the `sso_enabled_auth` backend looks for within `AUTHENTICATION_BACKENDS` to enable SSO redirects.

New setting: `SOCIAL_AUTH_BACKEND_PREFIX`