### PR TITLE
Fix #731 - enforce 'format' in config context schemas

### DIFF
--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -18,6 +18,7 @@ from graphene_django.settings import graphene_settings
 from graphql import get_default_backend
 from graphql.error import GraphQLSyntaxError
 from graphql.language.ast import OperationDefinition
+from jsonschema import draft7_format_checker
 from jsonschema.exceptions import SchemaError, ValidationError as JSONSchemaValidationError
 from jsonschema.validators import Draft7Validator
 from rest_framework.utils.encoders import JSONEncoder
@@ -457,7 +458,7 @@ class ConfigContextSchemaValidationMixin:
         # If schema is None, then no schema has been specified on the instance and thus no validation should occur.
         if schema:
             try:
-                Draft7Validator(schema.data_schema).validate(data)
+                Draft7Validator(schema.data_schema, format_checker=draft7_format_checker).validate(data)
             except JSONSchemaValidationError as e:
                 raise ValidationError({data_field: [f"Validation using the JSON Schema {schema} failed.", e.message]})
 

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -482,7 +482,7 @@ class ConfigContextSchemaTestCase(TestCase):
     """
 
     def setUp(self):
-        context_data = {"a": 123, "b": 456, "c": 777}
+        context_data = {"a": 123, "b": "456", "c": "10.7.7.7"}
 
         # Schemas
         self.schema_validation_pass = ConfigContextSchema.objects.create(
@@ -491,13 +491,33 @@ class ConfigContextSchemaTestCase(TestCase):
             data_schema={
                 "type": "object",
                 "additionalProperties": False,
-                "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}, "c": {"type": "integer"}},
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "string"},
+                    "c": {"type": "string", "format": "ipv4"},
+                },
             },
         )
-        self.schema_validation_fail = ConfigContextSchema.objects.create(
-            name="schema-fail",
-            slug="schema-fail",
-            data_schema={"type": "object", "additionalProperties": False, "properties": {"foo": {"type": "string"}}},
+        self.schemas_validation_fail = (
+            ConfigContextSchema.objects.create(
+                name="schema fail (wrong properties)",
+                slug="schema-fail-wrong-properties",
+                data_schema={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {"foo": {"type": "string"}},
+                },
+            ),
+            ConfigContextSchema.objects.create(
+                name="schema fail (wrong type)",
+                slug="schema-fail-wrong-type",
+                data_schema={"type": "object", "properties": {"b": {"type": "integer"}}},
+            ),
+            ConfigContextSchema.objects.create(
+                name="schema fail (wrong format)",
+                slug="schema-fail-wrong-format",
+                data_schema={"type": "object", "properties": {"b": {"type": "string", "format": "ipv4"}}},
+            ),
         )
 
         # ConfigContext
@@ -546,10 +566,11 @@ class ConfigContextSchemaTestCase(TestCase):
         And the config context context data is NOT valid for the schema
         Assert calling clean on the config context object DOES raise a ValidationError
         """
-        self.config_context.schema = self.schema_validation_fail
+        for schema in self.schemas_validation_fail:
+            self.config_context.schema = schema
 
-        with self.assertRaises(ValidationError):
-            self.config_context.full_clean()
+            with self.assertRaises(ValidationError):
+                self.config_context.full_clean()
 
     def test_existing_config_context_with_no_schema_applied(self):
         """
@@ -583,10 +604,11 @@ class ConfigContextSchemaTestCase(TestCase):
         And the device local_context_data is NOT valid for the schema
         Assert calling clean on the device object DOES raise a ValidationError
         """
-        self.device.local_context_schema = self.schema_validation_fail
+        for schema in self.schemas_validation_fail:
+            self.device.local_context_schema = schema
 
-        with self.assertRaises(ValidationError):
-            self.device.full_clean()
+            with self.assertRaises(ValidationError):
+                self.device.full_clean()
 
     def test_existing_device_with_no_schema_applied(self):
         """
@@ -620,10 +642,11 @@ class ConfigContextSchemaTestCase(TestCase):
         And the virtual machine local_context_data is NOT valid for the schema
         Assert calling clean on the virtual machine object DOES raise a ValidationError
         """
-        self.virtual_machine.local_context_schema = self.schema_validation_fail
+        for schema in self.schemas_validation_fail:
+            self.virtual_machine.local_context_schema = schema
 
-        with self.assertRaises(ValidationError):
-            self.virtual_machine.full_clean()
+            with self.assertRaises(ValidationError):
+                self.virtual_machine.full_clean()
 
     def test_existing_virtual_machine_with_no_schema_applied(self):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #731 
<!--
    Please include a summary of the proposed changes below.
-->

Add an explicit `format_checker` to our JSONSchema validation call so that schemas that include `format` properties (such as `"format": "ipv4"`) are properly enforced. Update model test cases to check for this.