### PR TITLE
Add webhooks to custom_fields

### DIFF
--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -11,7 +11,7 @@ from django.utils.safestring import mark_safe
 
 from nautobot.extras.choices import *
 from nautobot.extras.tasks import delete_custom_field_data, update_custom_field_choice_data
-from nautobot.extras.utils import FeatureQuery
+from nautobot.extras.utils import FeatureQuery, extras_features
 from nautobot.core.models import BaseModel
 from nautobot.utilities.fields import JSONArrayField
 from nautobot.utilities.forms import (
@@ -91,6 +91,7 @@ class CustomFieldManager(models.Manager.from_queryset(RestrictedQuerySet)):
         return self.get_queryset().filter(content_types=content_type)
 
 
+@extras_features("webhooks")
 class CustomField(BaseModel):
     content_types = models.ManyToManyField(
         to=ContentType,

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -363,6 +363,7 @@ class CustomField(BaseModel):
         delete_custom_field_data.delay(self.name, content_types)
 
 
+@extras_features("webhooks")
 class CustomFieldChoice(BaseModel):
     """
     The custom field choice is used to store the possible set of values for a selection type custom field


### PR DESCRIPTION
### Fixes: #519 

`CustomField` and `CustomFieldChoice` models can now attach a webhook to register like other models.

![image](https://user-images.githubusercontent.com/15998111/129728494-baeb3a2f-91b6-4391-831f-b2fc7458f215.png)
