### PR TITLE
Remove celery worker -B option

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     tty: true
   celery_worker:
     image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
-    entrypoint: "nautobot-server celery worker -B -l INFO"
+    entrypoint: "nautobot-server celery worker -l INFO"
     healthcheck:
       interval: 5s
       timeout: 5s


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #825 
Remove -B option from the celery worker in `development/docker-compose.yml`.

Hi @glennmatthews, how does this look?
Let me know if this needs any changes.
Thanks
<!--
    Please include a summary of the proposed changes below.
-->
