### PR TITLE
Fix #718: Computed field template overflow

### DIFF
--- a/nautobot/extras/templates/extras/computedfield.html
+++ b/nautobot/extras/templates/extras/computedfield.html
@@ -95,7 +95,7 @@
             <div class="panel-heading">
                 <strong>Template</strong>
             </div>
-            <span><pre style="margin: 15px;">{{ object.template }}</pre></span>
+            <pre style="margin: 15px;">{{ object.template }}</pre>
         </div>
     </div>
 </div>

--- a/nautobot/extras/templates/extras/computedfield.html
+++ b/nautobot/extras/templates/extras/computedfield.html
@@ -95,7 +95,9 @@
             <div class="panel-heading">
                 <strong>Template</strong>
             </div>
-            <pre style="margin: 15px;">{{ object.template }}</pre>
+            <div class="panel-body">
+                <pre>{{ object.template }}</pre>
+            </div>
         </div>
     </div>
 </div>

--- a/nautobot/extras/templates/extras/computedfield.html
+++ b/nautobot/extras/templates/extras/computedfield.html
@@ -77,10 +77,6 @@
                     <td><span>{{ object.description|placeholder }}</span></td>
                 </tr>
                 <tr>
-                    <td>Template</td>
-                    <td><pre>{{ object.template }}</pre></td>
-                </tr>
-                <tr>
                     <td>Fallback Value</td>
                     <td><span>{{ object.fallback_value }}</span></td>
                 </tr>
@@ -92,5 +88,17 @@
         </div>
     </div>
 </div>
+
+<div class="row">
+	<div class="col-md-12">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <strong>Template</strong>
+            </div>
+            <span><pre style="margin: 15px;">{{ object.template }}</pre></span>
+        </div>
+    </div>
+</div>
+
 
 {% endblock %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #718 
<!--
    Please include a summary of the proposed changes below.
-->

Created full width panel with scrollable `pre`. When next gets merged back into main or develop, will need to modify this section of code to use the generic tag `context_full_width` (#737)