### PR TITLE
Add object variable lookup

### DIFF
--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -366,6 +366,14 @@ The URL contains the `class_path` element that is composed of 3 elements, from t
 - `example` - path to the job definition file; in this example, a locally installed `example.py` file. For a plugin-provided job, this might be something like `my_plugin_name.jobs.my_job_filename`.
 - `MyJobWithVars` - name of the class inheriting from `nautobot.extras.jobs.Job` contained in the above file.
 
+Additionally, it is possible to specify complex values contained in `ObjectVar`s, `MultiObjectVar`s, and `IPAddressVar`s.
+
+`ObjectVar`s can be queried by either using their primary key directly as the value, or as a dictionary containing a more complicated query that gets passed into the Django ORM as keyword arguments.
+
+`MultiObjectVar`s can be queried using a list of primary keys.
+
+`IPAddressVar`s can be provided as strings in CIDR notation.
+
 ### Via the CLI
 
 Jobs that do not require user input can be run from the CLI by invoking the management command:

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -366,13 +366,11 @@ The URL contains the `class_path` element that is composed of 3 elements, from t
 - `example` - path to the job definition file; in this example, a locally installed `example.py` file. For a plugin-provided job, this might be something like `my_plugin_name.jobs.my_job_filename`.
 - `MyJobWithVars` - name of the class inheriting from `nautobot.extras.jobs.Job` contained in the above file.
 
-Additionally, it is possible to specify complex values contained in `ObjectVar`s, `MultiObjectVar`s, and `IPAddressVar`s.
+When providing input data, it is possible to specify complex values contained in `ObjectVar`s, `MultiObjectVar`s, and `IPAddressVar`s.
 
-`ObjectVar`s can be queried by either using their primary key directly as the value, or as a dictionary containing a more complicated query that gets passed into the Django ORM as keyword arguments.
-
-`MultiObjectVar`s can be queried using a list of primary keys.
-
-`IPAddressVar`s can be provided as strings in CIDR notation.
+* `ObjectVar`s can be specified by either using their primary key directly as the value, or as a dictionary containing a more complicated query that gets passed into the Django ORM as keyword arguments.
+* `MultiObjectVar`s can be specified as a list of primary keys.
+* `IPAddressVar`s can be provided as strings in CIDR notation.
 
 ### Via the CLI
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -364,7 +364,10 @@ class BaseJob:
                 return_data[field_name] = var.field_attrs["queryset"].filter(pk__in=value)
 
             elif isinstance(var, ObjectVar):
-                return_data[field_name] = var.field_attrs["queryset"].get(pk=value)
+                if type(value) is dict:
+                    return_data[field_name] = var.field_attrs["queryset"].get(**value)
+                else:
+                    return_data[field_name] = var.field_attrs["queryset"].get(pk=value)
             elif isinstance(var, FileVar):
                 return_data[field_name] = cls.load_file(value)
             # IPAddressVar is a netaddr.IPAddress object

--- a/nautobot/extras/tests/dummy_jobs/test_object_vars.py
+++ b/nautobot/extras/tests/dummy_jobs/test_object_vars.py
@@ -1,0 +1,36 @@
+import json
+
+from nautobot.dcim.models import DeviceRole
+from nautobot.extras.jobs import *
+
+
+name = "Object Vars"
+
+
+class TestObjectVars(Job):
+    class Meta:
+        description = "Validate Objects"
+
+    role = ObjectVar(model=DeviceRole)
+    roles = MultiObjectVar(model=DeviceRole)
+
+    def run(self, data, commit):
+        role = data["role"]
+        roles = data["roles"]
+
+        # Log the data as JSON so we can pull it back out for testing.
+        self.log_info(
+            obj=json.dumps(
+                {
+                    "role": str(role.pk),
+                    "roles": [str(r) for r in roles.values_list("pk", flat=True)],
+                }
+            )
+        )
+
+        self.log_warning(f"Role: {role}")
+        self.log_warning(f"Roles: {roles}")
+
+        self.log_success(message="Job didn't crash!")
+
+        return "Nice Roles, bro."

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -42,7 +42,7 @@ from nautobot.extras.models import (
     Tag,
     Webhook,
 )
-from nautobot.extras.jobs import Job, BooleanVar, IntegerVar, StringVar
+from nautobot.extras.jobs import Job, BooleanVar, IntegerVar, StringVar, ObjectVar
 from nautobot.utilities.testing import APITestCase, APIViewTestCases
 from nautobot.utilities.testing.utils import disable_warnings
 
@@ -426,6 +426,7 @@ class JobTest(APITestCase):
         var1 = StringVar()
         var2 = IntegerVar()
         var3 = BooleanVar()
+        var4 = ObjectVar(model=DeviceRole)
 
         def run(self, data, commit=True):
             self.log_info(message=data["var1"])
@@ -537,6 +538,27 @@ class JobTest(APITestCase):
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data["result"]["status"]["value"], "pending")
+
+    @skipIf(not rq_worker_running, "RQ worker not running")
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"], JOBS_ROOT=THIS_DIRECTORY)
+    def test_run_job_object_var_lookup(self):
+        self.add_permissions("extras.run_job")
+        d = DeviceRole.objects.create(name="role", slug="role")
+        job_data = {"var4": {"name": "role"}}
+
+        data = {
+            "data": job_data,
+            "commit": True,
+        }
+
+        url = reverse("extras-api:job-run", kwargs={"class_path": "local/test_api/TestJob"})
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        url = reverse("extras-api:jobresult-detail", kwargs={"pk": response.data["result"]["id"]})
+        response = self.client.get(url, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertEqual(response.data["data"]["vars"]["var4"], d.pk)
 
 
 class JobResultTest(APITestCase):


### PR DESCRIPTION
### Fixes: #652

This PR fixes #652 by making it possible to query for `ObjectVar`s using a dict of field-value pairs. As it stands in this PR it is unsafe, because it allows the suer to pass arbitrary query dicts. We should probably disallow some kinds of queries (or, even better, only allow certain ones), but I’d suggest we make that change part of #828 or a follow-up PR.

Cheers