### PR TITLE
Don't use same db_table as previously created by health_check.db

### DIFF
--- a/nautobot/extras/migrations/0012_healthchecktestmodel.py
+++ b/nautobot/extras/migrations/0012_healthchecktestmodel.py
@@ -22,8 +22,5 @@ class Migration(migrations.Migration):
                 ),
                 ("title", models.CharField(max_length=128)),
             ],
-            options={
-                "db_table": "health_check_db_testmodel",
-            },
         ),
     ]

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -991,6 +991,3 @@ class GraphQLQuery(BaseModel, ChangeLoggedModel):
 
 class HealthCheckTestModel(BaseModel):
     title = models.CharField(max_length=128)
-
-    class Meta:
-        db_table = "health_check_db_testmodel"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #830
<!--
    Please include a summary of the proposed changes below.
-->

Fix an issue introduced by #819 - since the `health_check_db_testmodel` table is created in Nautobot 1.1.x installations by the `health_check.db` app (which was removed in #819), trying to have a migration that creates a new table with the same name caused a `django.db.utils.ProgrammingError: relation "health_check_db_testmodel" already exists` error when upgrading to this latest code. It's safer to just create our own table rather than trying to take ownership of an existing table, I believe (but would definitely appreciate a check here as to whether there's a better way to address this??).