### PR TITLE
Permit definition of Relationships between a model and its own type

### DIFF
--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -228,7 +228,7 @@ class GraphQLExtendSchemaRelationship(TestCase):
         rack_ct = ContentType.objects.get_for_model(Rack)
         vlan_ct = ContentType.objects.get_for_model(VLAN)
 
-        self.m2m_1 = Relationship.objects.create(
+        self.m2m_1 = Relationship(
             name="Vlan to Rack",
             slug="vlan-rack",
             source_type=rack_ct,
@@ -237,24 +237,27 @@ class GraphQLExtendSchemaRelationship(TestCase):
             destination_label="My Racks",
             type="many-to-many",
         )
+        self.m2m_1.validated_save()
 
-        self.m2m_2 = Relationship.objects.create(
+        self.m2m_2 = Relationship(
             name="Another Vlan to Rack",
             slug="vlan-rack-2",
             source_type=rack_ct,
             destination_type=vlan_ct,
             type="many-to-many",
         )
+        self.m2m_2.validated_save()
 
-        self.o2m_1 = Relationship.objects.create(
+        self.o2m_1 = Relationship(
             name="generic site to vlan",
             slug="site-vlan",
             source_type=site_ct,
             destination_type=vlan_ct,
             type="one-to-many",
         )
+        self.o2m_1.validated_save()
 
-        self.o2o_1 = Relationship.objects.create(
+        self.o2o_1 = Relationship(
             name="Primary Rack per Site",
             slug="primary-rack-site",
             source_type=rack_ct,
@@ -263,6 +266,7 @@ class GraphQLExtendSchemaRelationship(TestCase):
             destination_label="Primary Rack",
             type="one-to-one",
         )
+        self.o2o_1.validated_save()
 
         self.sites = [
             Site.objects.create(name="Site A", slug="site-a"),

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -118,7 +118,7 @@ class SiteTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         )
 
         cls.relationships = (
-            Relationship.objects.create(
+            Relationship(
                 name="Region related sites",
                 slug="region-related-sites",
                 type=RelationshipTypeChoices.TYPE_ONE_TO_MANY,
@@ -128,11 +128,13 @@ class SiteTestCase(ViewTestCases.PrimaryObjectViewTestCase):
                 destination_label="Related region",
             ),
         )
+        for relationship in cls.relationships:
+            relationship.validated_save()
 
         for site in sites:
-            RelationshipAssociation.objects.create(
-                relationship=cls.relationships[0], source=site, destination=regions[1]
-            )
+            RelationshipAssociation(
+                relationship=cls.relationships[0], source=regions[1], destination=site
+            ).validated_save()
 
         tags = cls.create_tags("Alpha", "Bravo", "Charlie")
 
@@ -318,7 +320,7 @@ class RackTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         )
 
         cls.relationships = (
-            Relationship.objects.create(
+            Relationship(
                 name="Backup Sites",
                 slug="backup-sites",
                 type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
@@ -328,9 +330,13 @@ class RackTestCase(ViewTestCases.PrimaryObjectViewTestCase):
                 destination_label="Racks using this site as a backup",
             ),
         )
+        for relationship in cls.relationships:
+            relationship.validated_save()
 
         for rack in racks:
-            RelationshipAssociation.objects.create(relationship=cls.relationships[0], source=rack, destination=sites[1])
+            RelationshipAssociation(
+                relationship=cls.relationships[0], source=rack, destination=sites[1]
+            ).validated_save()
 
         tags = cls.create_tags("Alpha", "Bravo", "Charlie")
 
@@ -1059,7 +1065,7 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         )
 
         cls.relationships = (
-            Relationship.objects.create(
+            Relationship(
                 name="BGP Router-ID",
                 slug="router-id",
                 type=RelationshipTypeChoices.TYPE_ONE_TO_ONE,
@@ -1069,6 +1075,8 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
                 destination_label="Device using this as BGP router-ID",
             ),
         )
+        for relationship in cls.relationships:
+            relationship.validated_save()
 
         ipaddresses = (
             IPAddress.objects.create(address="1.1.1.1/32"),
@@ -1077,9 +1085,9 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         )
 
         for device, ipaddress in zip(devices, ipaddresses):
-            RelationshipAssociation.objects.create(
+            RelationshipAssociation(
                 relationship=cls.relationships[0], source=device, destination=ipaddress
-            )
+            ).validated_save()
 
         tags = cls.create_tags("Alpha", "Bravo", "Charlie")
 

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -336,9 +336,6 @@ class Relationship(BaseModel, ChangeLoggedModel):
 
     def clean(self):
 
-        if self.source_type == self.destination_type:
-            raise ValidationError("Not supported to have the same Objet type for Source and Destination.")
-
         # Check if source and destination filters are valid
         for side in ["source", "destination"]:
             if not getattr(self, f"{side}_filter"):

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -451,13 +451,16 @@ class RelationshipAssociationTable(BaseTable):
     pk = ToggleColumn()
     actions = ButtonsColumn(RelationshipAssociation, buttons=("delete",))
 
-    source = tables.Column(linkify=True)
+    source_type = tables.Column()
+    source = tables.Column(linkify=True, orderable=False)
 
-    destination = tables.Column(linkify=True)
+    destination_type = tables.Column()
+    destination = tables.Column(linkify=True, orderable=False)
 
     class Meta(BaseTable.Meta):
         model = RelationshipAssociation
-        fields = ("relationship", "source", "destination", "actions")
+        fields = ("pk", "relationship", "source_type", "source", "destination_type", "destination", "actions")
+        default_columns = ("pk", "relationship", "source", "destination", "actions")
 
 
 class GraphQLQueryTable(BaseTable):

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1019,27 +1019,27 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase):
         site_type = ContentType.objects.get_for_model(Site)
         device_type = ContentType.objects.get_for_model(Device)
 
-        Relationship.objects.create(
+        Relationship(
             name="Related Sites",
             slug="related-sites",
             type="many-to-many",
             source_type=site_type,
             destination_type=site_type,
-        )
-        Relationship.objects.create(
+        ).validated_save()
+        Relationship(
             name="Unrelated Sites",
             slug="unrelated-sites",
             type="many-to-many",
             source_type=site_type,
             destination_type=site_type,
-        )
-        Relationship.objects.create(
+        ).validated_save()
+        Relationship(
             name="Devices found elsewhere",
             slug="devices-elsewhere",
             type="many-to-many",
             source_type=site_type,
             destination_type=device_type,
-        )
+        ).validated_save()
 
 
 class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
@@ -1052,13 +1052,14 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
         site_type = ContentType.objects.get_for_model(Site)
         device_type = ContentType.objects.get_for_model(Device)
 
-        cls.relationship = Relationship.objects.create(
+        cls.relationship = Relationship(
             name="Devices found elsewhere",
             slug="elsewhere-devices",
             type="many-to-many",
             source_type=site_type,
             destination_type=device_type,
         )
+        cls.relationship.validated_save()
         cls.sites = (
             Site.objects.create(name="Empty Site", slug="empty"),
             Site.objects.create(name="Occupied Site", slug="occupied"),
@@ -1073,27 +1074,27 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
             Device.objects.create(name="Device 3", device_type=devicetype, device_role=devicerole, site=cls.sites[1]),
         )
 
-        RelationshipAssociation.objects.create(
+        RelationshipAssociation(
             relationship=cls.relationship,
             source_type=site_type,
             source_id=cls.sites[0].pk,
             destination_type=device_type,
             destination_id=cls.devices[0].pk,
-        )
-        RelationshipAssociation.objects.create(
+        ).validated_save()
+        RelationshipAssociation(
             relationship=cls.relationship,
             source_type=site_type,
             source_id=cls.sites[0].pk,
             destination_type=device_type,
             destination_id=cls.devices[1].pk,
-        )
-        RelationshipAssociation.objects.create(
+        ).validated_save()
+        RelationshipAssociation(
             relationship=cls.relationship,
             source_type=site_type,
             source_id=cls.sites[0].pk,
             destination_type=device_type,
             destination_id=cls.devices[2].pk,
-        )
+        ).validated_save()
 
         cls.create_data = [
             {

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -313,27 +313,27 @@ class RelationshipTestCase(TestCase):
         interface_type = ContentType.objects.get_for_model(Interface)
         vlan_type = ContentType.objects.get_for_model(VLAN)
 
-        Relationship.objects.create(
+        Relationship(
             name="Device VLANs",
             slug="device-vlans",
             type="many-to-many",
             source_type=device_type,
             destination_type=vlan_type,
-        )
-        Relationship.objects.create(
+        ).validated_save()
+        Relationship(
             name="Primary VLAN",
             slug="primary-vlan",
             type="one-to-many",
             source_type=vlan_type,
             destination_type=device_type,
-        )
-        Relationship.objects.create(
+        ).validated_save()
+        Relationship(
             name="Primary Interface",
             slug="primary-interface",
             type="one-to-one",
             source_type=device_type,
             destination_type=interface_type,
-        )
+        ).validated_save()
 
     def test_id(self):
         params = {"id": self.queryset.values_list("pk", flat=True)[:2]}
@@ -366,14 +366,14 @@ class RelationshipAssociationTestCase(TestCase):
         cls.vlan_type = ContentType.objects.get_for_model(VLAN)
 
         cls.relationships = (
-            Relationship.objects.create(
+            Relationship(
                 name="Device VLANs",
                 slug="device-vlans",
                 type="many-to-many",
                 source_type=cls.device_type,
                 destination_type=cls.vlan_type,
             ),
-            Relationship.objects.create(
+            Relationship(
                 name="Primary VLAN",
                 slug="primary-vlan",
                 type="one-to-many",
@@ -381,6 +381,8 @@ class RelationshipAssociationTestCase(TestCase):
                 destination_type=cls.device_type,
             ),
         )
+        for relationship in cls.relationships:
+            relationship.validated_save()
 
         manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
         devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="Device Type 1", slug="device-type-1")
@@ -395,34 +397,34 @@ class RelationshipAssociationTestCase(TestCase):
             VLAN.objects.create(vid=2, name="VLAN 2"),
         )
 
-        RelationshipAssociation.objects.create(
+        RelationshipAssociation(
             relationship=cls.relationships[0],
             source_type=cls.device_type,
             source_id=cls.devices[0].pk,
             destination_type=cls.vlan_type,
             destination_id=cls.vlans[0].pk,
-        )
-        RelationshipAssociation.objects.create(
+        ).validated_save()
+        RelationshipAssociation(
             relationship=cls.relationships[0],
             source_type=cls.device_type,
             source_id=cls.devices[1].pk,
             destination_type=cls.vlan_type,
             destination_id=cls.vlans[1].pk,
-        )
-        RelationshipAssociation.objects.create(
+        ).validated_save()
+        RelationshipAssociation(
             relationship=cls.relationships[1],
             source_type=cls.vlan_type,
             source_id=cls.vlans[0].pk,
             destination_type=cls.device_type,
             destination_id=cls.devices[0].pk,
-        )
-        RelationshipAssociation.objects.create(
+        ).validated_save()
+        RelationshipAssociation(
             relationship=cls.relationships[1],
             source_type=cls.vlan_type,
             source_id=cls.vlans[1].pk,
             destination_type=cls.device_type,
             destination_id=cls.devices[1].pk,
-        )
+        ).validated_save()
 
     def test_id(self):
         params = {"id": self.queryset.values_list("pk", flat=True)[:2]}

--- a/nautobot/extras/tests/test_forms.py
+++ b/nautobot/extras/tests/test_forms.py
@@ -45,20 +45,22 @@ class RelationshipModelFormTestCase(TestCase):
         cls.vlangroup_1 = ipam_models.VLANGroup.objects.create(name="VLAN Group 1", slug="vlan-group-1", site=cls.site)
         cls.vlangroup_2 = ipam_models.VLANGroup.objects.create(name="VLAN Group 2", slug="vlan-group-2", site=cls.site)
 
-        cls.relationship_1 = Relationship.objects.create(
+        cls.relationship_1 = Relationship(
             name="BGP Router-ID",
             slug="bgp-router-id",
             source_type=ContentType.objects.get_for_model(dcim_models.Device),
             destination_type=ContentType.objects.get_for_model(ipam_models.IPAddress),
             type=RelationshipTypeChoices.TYPE_ONE_TO_ONE,
         )
-        cls.relationship_2 = Relationship.objects.create(
+        cls.relationship_1.validated_save()
+        cls.relationship_2 = Relationship(
             name="Device VLAN Groups",
             slug="device-vlan-groups",
             source_type=ContentType.objects.get_for_model(dcim_models.Device),
             destination_type=ContentType.objects.get_for_model(ipam_models.VLANGroup),
             type=RelationshipTypeChoices.TYPE_ONE_TO_MANY,
         )
+        cls.relationship_2.validated_save()
 
         cls.device_form_base_data = {
             "name": "New Device",
@@ -154,13 +156,13 @@ class RelationshipModelFormTestCase(TestCase):
         A new record CANNOT create ONE_TO_ONE relations where its "destination" is already associated.
         """
         # Existing ONE_TO_ONE relation
-        RelationshipAssociation.objects.create(
+        RelationshipAssociation(
             relationship=self.relationship_1,
             source_type=self.relationship_1.source_type,
             source_id=self.device_1.pk,
             destination_type=self.relationship_1.destination_type,
             destination_id=self.ipaddress_1.pk,
-        )
+        ).validated_save()
 
         # Can't associate New Device with IP Address 1 (already associated to Device 1)
         form = DeviceForm(
@@ -189,13 +191,13 @@ class RelationshipModelFormTestCase(TestCase):
         A new record CANNOT create ONE_TO_MANY relations where any of its "destinations" are already associated.
         """
         # Existing ONE_TO_MANY relation
-        RelationshipAssociation.objects.create(
+        RelationshipAssociation(
             relationship=self.relationship_2,
             source_type=self.relationship_2.source_type,
             source_id=self.device_1.pk,
             destination_type=self.relationship_2.destination_type,
             destination_id=self.vlangroup_1.pk,
-        )
+        ).validated_save()
 
         # Can't associate New Device with VLAN Group 1 (already associated to Device 1)
         form = DeviceForm(
@@ -215,21 +217,21 @@ class RelationshipModelFormTestCase(TestCase):
         An existing record with an existing ONE_TO_ONE or ONE_TO_MANY association can change its destination(s).
         """
         # Existing ONE_TO_ONE relation
-        RelationshipAssociation.objects.create(
+        RelationshipAssociation(
             relationship=self.relationship_1,
             source_type=self.relationship_1.source_type,
             source_id=self.device_1.pk,
             destination_type=self.relationship_1.destination_type,
             destination_id=self.ipaddress_1.pk,
-        )
+        ).validated_save()
         # Existing ONE_TO_MANY relation
-        RelationshipAssociation.objects.create(
+        RelationshipAssociation(
             relationship=self.relationship_2,
             source_type=self.relationship_2.source_type,
             source_id=self.device_1.pk,
             destination_type=self.relationship_2.destination_type,
             destination_id=self.vlangroup_1.pk,
-        )
+        ).validated_save()
 
         form = DeviceForm(
             instance=self.device_1,
@@ -264,13 +266,13 @@ class RelationshipModelFormTestCase(TestCase):
         An existing record with an existing ONE_TO_ONE association can change its source.
         """
         # Existing ONE_TO_ONE relation
-        RelationshipAssociation.objects.create(
+        RelationshipAssociation(
             relationship=self.relationship_1,
             source_type=self.relationship_1.source_type,
             source_id=self.device_1.pk,
             destination_type=self.relationship_1.destination_type,
             destination_id=self.ipaddress_1.pk,
-        )
+        ).validated_save()
 
         form = IPAddressForm(
             instance=self.ipaddress_1,
@@ -295,13 +297,13 @@ class RelationshipModelFormTestCase(TestCase):
         An existing record with an existing ONE_TO_MANY association can change its source.
         """
         # Existing ONE_TO_MANY relation
-        RelationshipAssociation.objects.create(
+        RelationshipAssociation(
             relationship=self.relationship_2,
             source_type=self.relationship_2.source_type,
             source_id=self.device_1.pk,
             destination_type=self.relationship_2.destination_type,
             destination_id=self.vlangroup_1.pk,
-        )
+        ).validated_save()
 
         form = VLANGroupForm(
             instance=self.vlangroup_1,

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -19,51 +19,12 @@ class RelationshipBaseTest(TestCase):
         self.rack_ct = ContentType.objects.get_for_model(Rack)
         self.vlan_ct = ContentType.objects.get_for_model(VLAN)
 
-        self.m2m_1 = Relationship(
-            name="Vlan to Rack",
-            slug="vlan-rack",
-            source_type=self.rack_ct,
-            source_label="My Vlans",
-            source_filter={"site": "mysite"},
-            destination_type=self.vlan_ct,
-            destination_label="My Racks",
-            type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
-        )
-        self.m2m_1.save()
-
-        self.m2m_2 = Relationship(
-            name="Another Vlan to Rack",
-            slug="vlan-rack-2",
-            source_type=self.rack_ct,
-            destination_type=self.vlan_ct,
-            type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
-        )
-        self.m2m_2.save()
-
-        self.o2m_1 = Relationship(
-            name="generic site to vlan",
-            slug="site-vlan",
-            source_type=self.site_ct,
-            destination_type=self.vlan_ct,
-            type=RelationshipTypeChoices.TYPE_ONE_TO_MANY,
-        )
-        self.o2m_1.save()
-
-        self.o2o_1 = Relationship(
-            name="Primary Rack per Site",
-            slug="primary-rack-site",
-            source_type=self.rack_ct,
-            source_hidden=True,
-            destination_type=self.site_ct,
-            destination_label="Primary Rack",
-            type=RelationshipTypeChoices.TYPE_ONE_TO_ONE,
-        )
-        self.o2o_1.save()
-
         self.sites = [
             Site.objects.create(name="Site A", slug="site-a"),
             Site.objects.create(name="Site B", slug="site-b"),
             Site.objects.create(name="Site C", slug="site-c"),
+            Site.objects.create(name="Site D", slug="site-d"),
+            Site.objects.create(name="Site E", slug="site-e"),
         ]
 
         self.racks = [
@@ -77,6 +38,59 @@ class RelationshipBaseTest(TestCase):
             VLAN.objects.create(name="VLAN B", vid=100, site=self.sites[1]),
             VLAN.objects.create(name="VLAN C", vid=100, site=self.sites[2]),
         ]
+
+        self.m2m_1 = Relationship(
+            name="Vlan to Rack",
+            slug="vlan-rack",
+            source_type=self.rack_ct,
+            source_label="My Vlans",
+            source_filter={"site": ["site-a"]},
+            destination_type=self.vlan_ct,
+            destination_label="My Racks",
+            type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
+        )
+        self.m2m_1.validated_save()
+
+        self.m2m_2 = Relationship(
+            name="Another Vlan to Rack",
+            slug="vlan-rack-2",
+            source_type=self.rack_ct,
+            destination_type=self.vlan_ct,
+            type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
+        )
+        self.m2m_2.validated_save()
+
+        self.o2m_1 = Relationship(
+            name="generic site to vlan",
+            slug="site-vlan",
+            source_type=self.site_ct,
+            destination_type=self.vlan_ct,
+            type=RelationshipTypeChoices.TYPE_ONE_TO_MANY,
+        )
+        self.o2m_1.validated_save()
+
+        self.o2o_1 = Relationship(
+            name="Primary Rack per Site",
+            slug="primary-rack-site",
+            source_type=self.rack_ct,
+            source_hidden=True,
+            destination_type=self.site_ct,
+            destination_label="Primary Rack",
+            type=RelationshipTypeChoices.TYPE_ONE_TO_ONE,
+        )
+        self.o2o_1.validated_save()
+
+        # Relationship between objects of the same type
+        self.o2o_2 = Relationship(
+            name="Alphabetical Sites",
+            slug="alphabetical-sites",
+            source_type=self.site_ct,
+            source_label="Alphabetically Prior",
+            destination_type=self.site_ct,
+            destination_label="Alphabetically Subsequent",
+            type=RelationshipTypeChoices.TYPE_ONE_TO_ONE,
+        )
+        self.o2o_2.validated_save()
 
 
 class RelationshipTest(RelationshipBaseTest):
@@ -142,18 +156,6 @@ class RelationshipTest(RelationshipBaseTest):
         }
         self.assertEqual(handler.exception.message_dict, expected_errors)
 
-    def test_clean_same_object(self):
-        m2m = Relationship(
-            name="Another Vlan to Rack",
-            slug="vlan-rack-2",
-            source_type=self.rack_ct,
-            destination_type=self.rack_ct,
-            type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
-        )
-
-        with self.assertRaises(ValidationError):
-            m2m.clean()
-
     def test_clean_valid(self):
         m2m = Relationship(
             name="Another Vlan to Rack",
@@ -190,6 +192,8 @@ class RelationshipTest(RelationshipBaseTest):
         self.assertTrue(self.m2m_1.has_many("destination"))
         self.assertFalse(self.o2o_1.has_many("source"))
         self.assertFalse(self.o2o_1.has_many("destination"))
+        self.assertFalse(self.o2o_2.has_many("source"))
+        self.assertFalse(self.o2o_2.has_many("destination"))
 
     def test_to_form_field_m2m(self):
 
@@ -203,7 +207,7 @@ class RelationshipTest(RelationshipBaseTest):
         self.assertFalse(field.required)
         self.assertIsInstance(field, DynamicModelMultipleChoiceField)
         self.assertEqual(field.label, "My Racks")
-        self.assertEqual(field.query_params, {"site": "mysite"})
+        self.assertEqual(field.query_params, {"site": ["site-a"]})
 
     def test_to_form_field_o2m(self):
 
@@ -216,6 +220,17 @@ class RelationshipTest(RelationshipBaseTest):
         self.assertFalse(field.required)
         self.assertIsInstance(field, DynamicModelChoiceField)
         self.assertEqual(field.label, "site")
+
+    def test_to_form_field_o2o(self):
+        field = self.o2o_1.to_form_field("source")
+        self.assertFalse(field.required)
+        self.assertIsInstance(field, DynamicModelChoiceField)
+        self.assertEqual(field.label, "site")
+
+        field = self.o2o_1.to_form_field("destination")
+        self.assertFalse(field.required)
+        self.assertIsInstance(field, DynamicModelChoiceField)
+        self.assertEqual(field.label, "Primary Rack")
 
 
 class RelationshipAssociationTest(RelationshipBaseTest):
@@ -238,12 +253,10 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         """Validate that one-to-one relationships can't have more than one relationship association per side."""
 
         cra = RelationshipAssociation(relationship=self.o2o_1, source=self.racks[0], destination=self.sites[0])
-        cra.clean()
-        cra.save()
+        cra.validated_save()
 
         cra = RelationshipAssociation(relationship=self.o2o_1, source=self.racks[1], destination=self.sites[1])
-        cra.clean()
-        cra.save()
+        cra.validated_save()
 
         with self.assertRaises(ValidationError) as handler:
             cra = RelationshipAssociation(relationship=self.o2o_1, source=self.racks[0], destination=self.sites[2])
@@ -266,16 +279,13 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         """Validate that one-to-many relationships can't have more than one relationship association per source."""
 
         cra = RelationshipAssociation(relationship=self.o2m_1, source=self.sites[0], destination=self.vlans[0])
-        cra.clean()
-        cra.save()
+        cra.validated_save()
 
         cra = RelationshipAssociation(relationship=self.o2m_1, source=self.sites[0], destination=self.vlans[1])
-        cra.clean()
-        cra.save()
+        cra.validated_save()
 
         cra = RelationshipAssociation(relationship=self.o2m_1, source=self.sites[1], destination=self.vlans[2])
-        cra.clean()
-        cra.save()
+        cra.validated_save()
 
         with self.assertRaises(ValidationError) as handler:
             cra = RelationshipAssociation(relationship=self.o2m_1, source=self.sites[2], destination=self.vlans[0])
@@ -287,27 +297,51 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         }
         self.assertEqual(handler.exception.message_dict, expected_errors)
 
+        # Shouldn't be possible to create another copy of the same RelationshipAssociation
+        with self.assertRaises(ValidationError) as handler:
+            cra = RelationshipAssociation(relationship=self.o2m_1, source=self.sites[0], destination=self.vlans[0])
+            cra.validated_save()
+        expected_errors = {
+            "__all__": [
+                "Relationship association with this Relationship, Source type, Source id, Destination type "
+                "and Destination id already exists."
+            ],
+            "destination": [
+                "Unable to create more than one generic site to vlan association to VLAN A (100) (destination)",
+            ],
+        }
+        self.assertEqual(handler.exception.message_dict, expected_errors)
+
     def test_clean_check_quantity_m2m(self):
         """Validate that many-to-many relationship can have many relationship associations."""
         cra = RelationshipAssociation(relationship=self.m2m_1, source=self.racks[0], destination=self.vlans[0])
-        cra.clean()
-        cra.save()
+        cra.validated_save()
 
         cra = RelationshipAssociation(relationship=self.m2m_1, source=self.racks[0], destination=self.vlans[1])
-        cra.clean()
-        cra.save()
+        cra.validated_save()
 
         cra = RelationshipAssociation(relationship=self.m2m_1, source=self.racks[1], destination=self.vlans[2])
-        cra.clean()
-        cra.save()
+        cra.validated_save()
 
         cra = RelationshipAssociation(relationship=self.m2m_1, source=self.racks[2], destination=self.vlans[0])
-        cra.clean()
+        cra.validated_save()
+
+        # Shouldn't be possible to create another copy of the same RelationshipAssociation
+        with self.assertRaises(ValidationError) as handler:
+            cra = RelationshipAssociation(relationship=self.m2m_1, source=self.racks[0], destination=self.vlans[0])
+            cra.validated_save()
+        expected_errors = {
+            "__all__": [
+                "Relationship association with this Relationship, Source type, Source id, Destination type "
+                "and Destination id already exists."
+            ],
+        }
+        self.assertEqual(handler.exception.message_dict, expected_errors)
 
     def test_get_peer(self):
         """Validate that the get_peer() method works correctly."""
         cra = RelationshipAssociation(relationship=self.m2m_1, source=self.racks[0], destination=self.vlans[0])
-        cra.save()
+        cra.validated_save()
 
         self.assertEqual(cra.get_peer(self.racks[0]), self.vlans[0])
         self.assertEqual(cra.get_peer(self.vlans[0]), self.racks[0])
@@ -315,22 +349,40 @@ class RelationshipAssociationTest(RelationshipBaseTest):
 
     def test_delete_cascade(self):
         """Verify that a RelationshipAssociation is deleted if either of the associated records is deleted."""
-        RelationshipAssociation.objects.create(relationship=self.m2m_1, source=self.racks[0], destination=self.vlans[0])
-        RelationshipAssociation.objects.create(relationship=self.m2m_1, source=self.racks[0], destination=self.vlans[1])
-        RelationshipAssociation.objects.create(relationship=self.m2m_1, source=self.racks[1], destination=self.vlans[0])
+        associations = [
+            RelationshipAssociation(relationship=self.m2m_1, source=self.racks[0], destination=self.vlans[0]),
+            RelationshipAssociation(relationship=self.m2m_1, source=self.racks[0], destination=self.vlans[1]),
+            RelationshipAssociation(relationship=self.m2m_1, source=self.racks[1], destination=self.vlans[0]),
+            # Create an association loop just to make sure it works correctly on deletion
+            RelationshipAssociation(relationship=self.o2o_2, source=self.sites[2], destination=self.sites[3]),
+            RelationshipAssociation(relationship=self.o2o_2, source=self.sites[3], destination=self.sites[2]),
+            # Create a self-referential association as well
+            RelationshipAssociation(relationship=self.o2o_2, source=self.sites[4], destination=self.sites[4]),
+        ]
+        for association in associations:
+            association.validated_save()
 
-        self.assertEqual(3, RelationshipAssociation.objects.count())
+        self.assertEqual(6, RelationshipAssociation.objects.count())
 
         # Test automatic deletion of RelationshipAssociations when their 'source' object is deleted
         self.racks[0].delete()
 
         # Both relations involving racks[0] should have been deleted
-        # The relation between racks[1] and vlans[0] should remain
-        self.assertEqual(1, RelationshipAssociation.objects.count())
+        # The relation between racks[1] and vlans[0] should remain, as should the site relations
+        self.assertEqual(4, RelationshipAssociation.objects.count())
 
         # Test automatic deletion of RelationshipAssociations when their 'destination' object is deleted
         self.vlans[0].delete()
 
+        # Site relation remains
+        self.assertEqual(3, RelationshipAssociation.objects.count())
+
+        # Test automatic deletion of RelationshipAssociations when there's a loop of source/destination references
+        self.sites[3].delete()
+        self.assertEqual(1, RelationshipAssociation.objects.count())
+
+        # Test automatic deletion of RelationshipAssociations when the same object is both source and destination
+        self.sites[4].delete()
         self.assertEqual(0, RelationshipAssociation.objects.count())
 
     def test_generic_relation(self):

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -654,27 +654,27 @@ class RelationshipTestCase(
         interface_type = ContentType.objects.get_for_model(Interface)
         vlan_type = ContentType.objects.get_for_model(VLAN)
 
-        Relationship.objects.create(
+        Relationship(
             name="Device VLANs",
             slug="device-vlans",
             type="many-to-many",
             source_type=device_type,
             destination_type=vlan_type,
-        )
-        Relationship.objects.create(
+        ).validated_save()
+        Relationship(
             name="Primary VLAN",
             slug="primary-vlan",
             type="one-to-many",
             source_type=vlan_type,
             destination_type=device_type,
-        )
-        Relationship.objects.create(
+        ).validated_save()
+        Relationship(
             name="Primary Interface",
             slug="primary-interface",
             type="one-to-one",
             source_type=device_type,
             destination_type=interface_type,
-        )
+        ).validated_save()
 
         cls.form_data = {
             "name": "VLAN-to-Interface",
@@ -705,13 +705,14 @@ class RelationshipAssociationTestCase(
         device_type = ContentType.objects.get_for_model(Device)
         vlan_type = ContentType.objects.get_for_model(VLAN)
 
-        relationship = Relationship.objects.create(
+        relationship = Relationship(
             name="Device VLANs",
             slug="device-vlans",
             type="many-to-many",
             source_type=device_type,
             destination_type=vlan_type,
         )
+        relationship.validated_save()
         manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
         devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="Device Type 1", slug="device-type-1")
         devicerole = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
@@ -727,27 +728,27 @@ class RelationshipAssociationTestCase(
             VLAN.objects.create(vid=3, name="VLAN 3"),
         )
 
-        RelationshipAssociation.objects.create(
+        RelationshipAssociation(
             relationship=relationship,
             source_type=device_type,
             source_id=devices[0].pk,
             destination_type=vlan_type,
             destination_id=vlans[0].pk,
-        )
-        RelationshipAssociation.objects.create(
+        ).validated_save()
+        RelationshipAssociation(
             relationship=relationship,
             source_type=device_type,
             source_id=devices[1].pk,
             destination_type=vlan_type,
             destination_id=vlans[1].pk,
-        )
-        RelationshipAssociation.objects.create(
+        ).validated_save()
+        RelationshipAssociation(
             relationship=relationship,
             source_type=device_type,
             source_id=devices[2].pk,
             destination_type=vlan_type,
             destination_id=vlans[2].pk,
-        )
+        ).validated_save()
 
 
 class ComputedFieldTestCase(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #157 
<!--
    Please include a summary of the proposed changes below.
-->

This appears to turn out to be a really simple fix - I removed the `Relationship.clean()` logic that was explicitly blocking creation of Relationships with the same `source_type` and `destination_type`, and as far as I can determine, it all just works. The remainder of these diffs are as follows:

- In all test cases using `Relationship` and `RelationshipAssociation` objects, instantiate the objects and call `validated_save()` rather than calling `.objects.create()`. Making this change uncovered and allowed me to fix a couple of cases where we were not actually creating valid records.
- In the RelationshipAssociation table view, we can't actually order by `source` or `destination` as those are GenericForeignKeys, so I've added `orderable=False` to those two columns.
- Also in the RelationshipAssociation table view, I added optional columns for the `source_type` and `destination_type`, because 1) these are columns that the filter allows us to filter on, so they should be displayed and 2) these columns *are* orderable.
- In `test_relationships.py`, I've added a self-referential relationship definition and added a couple of test steps, especially one that validates that cascading deletion of RelationshipAssociations still works when deleting a model that has a relationship to itself.

![image](https://user-images.githubusercontent.com/5603551/130516277-80049e79-cac6-4252-851d-791b394bf410.png)

(Here "Destination Sites" and "Source Sites" are the two sides of a many-to-many relationship between Site and Site, and "Alphabetically After" and "Alphabetically Before" are the two sides of a one-to-one relationship between Site and Site.)

![image](https://user-images.githubusercontent.com/5603551/130516397-ca8205f5-9ccd-43f3-99e9-97257de1ee6e.png)
