### PR TITLE
Fix #852 and #853, add regression test coverage

### DIFF
--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -95,7 +95,7 @@ class ObjectView(ObjectPermissionRequiredMixin, View):
                 continue
 
             try:
-                return reverse(route, kwargs={"pk": getattr(instance, field)})
+                return reverse(route, kwargs={field: getattr(instance, field)})
             except NoReverseMatch:
                 continue
 

--- a/nautobot/utilities/templatetags/buttons.py
+++ b/nautobot/utilities/templatetags/buttons.py
@@ -48,16 +48,16 @@ def edit_button(instance, use_pk=False, key="slug"):
 
     Args:
         instance: Model record.
-        use_pk: If True, use the primary key instead of the slug. (Deprecated, use "key" instead)
-        key: The attribute in model used in reverse lookup.
+        use_pk: If True, use the primary key instead of any specified "key" field. (Deprecated, use `key="pk"` instead)
+        key: The attribute on the model to use for reverse URL lookup.
     """
     viewname = _get_viewname(instance, "edit")
 
     # Assign kwargs
-    if use_pk:
-        kwargs = {"pk": instance.pk}
-    else:
+    if hasattr(instance, key) and not use_pk:
         kwargs = {key: getattr(instance, key)}
+    else:
+        kwargs = {"pk": instance.pk}
 
     url = reverse(viewname, kwargs=kwargs)
 
@@ -73,16 +73,16 @@ def delete_button(instance, use_pk=False, key="slug"):
 
     Args:
         instance: Model record.
-        use_pk: If True, use the primary key instead of the slug. (Deprecated, use "key" instead)
-        key: The attribute in model used in reverse lookup.
+        use_pk: If True, use the primary key instead of any specified "key" field. (Deprecated, use `key="pk"` instead)
+        key: The attribute on the model to use for reverse URL lookup.
     """
     viewname = _get_viewname(instance, "delete")
 
     # Assign kwargs
-    if use_pk:
-        kwargs = {"pk": instance.pk}
-    else:
+    if hasattr(instance, key) and not use_pk:
         kwargs = {key: getattr(instance, key)}
+    else:
+        kwargs = {"pk": instance.pk}
 
     url = reverse(viewname, kwargs=kwargs)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #852 
### Fixes: #853 
<!--
    Please include a summary of the proposed changes below.
-->

- In determining whether to render a "Change Log" tab some bad code was introduced by #737, in which we were always looking for a reverse URL pattern based on the "pk", even when the field we were supposed to use was the "slug". This resulted in Change Log tabs being omitted from views where they should be present (#852). I've fixed this and added a check to the `test_get_object_anonymous` generic test case to check for the presence of this tab.
- On models that don't have a `slug` field, due to changes made in #735, we were by default using the `slug` field to look up the URL patterns for the "edit" and "delete" buttons, resulting in a page rendering error (#853). This wasn't caught by our existing view test automation because all of the "get" test cases were running with only "view" permission on the model being tested, so the add/edit/delete buttons were never being rendered. I changed the `test_get_object_with_constrained_permission` test case so that it includes write permissions on the model, and verified that this updated test catches the original issue. I've updated the button templatetags code so that it restores the pre-#735 behavior of falling through to using the PK if the specified model doesn't have a `slug` field.
