### PR TITLE
Fix issue with inconsistent view regarding the job_jobresult.html page

### DIFF
--- a/nautobot/extras/templates/extras/jobresult.html
+++ b/nautobot/extras/templates/extras/jobresult.html
@@ -57,10 +57,36 @@
     {% if job %}
         <p>{{ job.description }}</p>
     {% endif %}
-    <div class="row">
-        <div class="col-md-12">
+    <ul class="nav nav-tabs" role="tablist">
+        <li role="presentation" class="active">
+            <a href="#log" role="tab" data-toggle="tab" class="active">Log</a>
+        </li>
+        {% if result.data.output %}
+            <li role="presentation">
+                <a href="#output" role="tab" data-toggle="tab">Output</a>
+            </li>
+        {% endif %}
+        {% if job %}
+            <li role="presentation">
+                <a href="#source" role="tab" data-toggle="tab">Source</a>
+            </li>
+        {% endif %}
+    </ul>
+    <div class="tab-content">
+        <div role="tabpanel" class="tab-pane active" id="log">
             {% include 'extras/inc/jobresult.html' with result=result %}
         </div>
+    {% if result.data.output %}
+        <div role="tabpanel" class="tab-pane" id="output">
+            <pre>{{ result.data.output }}</pre>
+        </div>
+    {% endif %}
+    {% if job %}
+        <div role="tabpanel" class="tab-pane" id="source">
+            <p><code>{{ job.filename }}</code></p>
+            <pre>{{ job.source }}</pre>
+        </div>
+    {% endif %}
     </div>
     <div class="row">
         <div class="col-md-12">


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #864
<!--
    Please include a summary of the proposed changes below.
-->

Reproduce the same web page as `job_jobresult.html` (corresponding URI : `extras/jobs/results/<uuid>/`)
