### PR TITLE
Scheduling and approvals documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,7 +77,7 @@ nav:
         - Git Repositories: 'models/extras/gitrepository.md'
         - Health Check: 'additional-features/healthcheck.md'
         - Jobs: 'additional-features/jobs.md'
-        - Job Scheduling and Approvals: 'additional-features/job_scheduling_and_approvals.md'
+        - Job Scheduling and Approvals: 'additional-features/job-scheduling-and-approvals.md'
         - NAPALM: 'additional-features/napalm.md'
         - Prometheus Metrics: 'additional-features/prometheus-metrics.md'
         - Relationships: 'models/extras/relationship.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
         - Git Repositories: 'models/extras/gitrepository.md'
         - Health Check: 'additional-features/healthcheck.md'
         - Jobs: 'additional-features/jobs.md'
+        - Job Scheduling and Approvals: 'additional-features/job_scheduling_and_approvals.md'
         - NAPALM: 'additional-features/napalm.md'
         - Prometheus Metrics: 'additional-features/prometheus-metrics.md'
         - Relationships: 'models/extras/relationship.md'

--- a/nautobot/docs/additional-features/job-scheduling-and-approvals.md
+++ b/nautobot/docs/additional-features/job-scheduling-and-approvals.md
@@ -10,15 +10,15 @@ Jobs can be scheduled through the UI or the API.
 
 ### Scheduling via the UI
 
-The Job Scheduling views can be accessed via the navigation at `Extensibility > Jobs`, selecting a Job as appropriate.
+The Job Scheduling views can be accessed via the navigation at `Extensibility > Jobs > Jobs`, selecting a Job as appropriate.
 
 The UI allows you to select a scheduling type. Further fields will be displayed as appropriate for that schedule type.
 
-If the job requires no approval, it will then be added to the queue of scheduled jobs or run immediately. Otherwise, the job will be added to the approval quere where it can be approved by other users.
+If the job requires no approval, it will then be added to the queue of scheduled jobs or run immediately. Otherwise, the job will be added to the approval queue where it can be approved by other users.
 
 ### Scheduling via the API
 
-Jobs can also be scheduled via the REST API. The endpoint used for this is the regular job endpoint, filling the `schedule` parameter will act just as scheduling in the UI.
+Jobs can also be scheduled via the REST API. The endpoint used for this is the regular job endpoint; specifying the optional `schedule` parameter will act just as scheduling in the UI.
 
 ```no-highlight
 curl -X POST \
@@ -38,13 +38,13 @@ Jobs can be approved via the UI and API by any user that has the rights to run a
 !!! note
     Jobs that are past their scheduled run date can still be approved, but the approver will be asked to confirm the operation.
 
-## Approval via the UI
+### Approval via the UI
 
-The queue of jobs that need approval can be found under `Extensibility > Job Approval Queue`. There, any job that needs approval before it gets run is listed. To approve a job, select it and click the button to approve. Please note that you will be  asked for confirmation if a job is being approved that is past its scheduled datetime.
+The queue of jobs that need approval can be found under `Extensibility > Job Approval Queue`. This view lists all currently requested jobs that need approval before they are run. To approve a job, select it and click the button to approve. Please note that you will be  asked for confirmation if a job is being approved that is past its scheduled date and time.
 
 If the approver is unsure what a job would do, a dry run can also be started via that same view.
 
-## Approval via the API
+### Approval via the API
 
 Approvals can also be given via the REST API. The endpoints to approve, deny, and dry run a scheduled job are found on the scheduled job endpoint under `approve`, `deny`, and `dry-run`, respectively.
 

--- a/nautobot/docs/additional-features/job_scheduling_and_approvals.md
+++ b/nautobot/docs/additional-features/job_scheduling_and_approvals.md
@@ -42,9 +42,11 @@ Jobs can be approved via the UI and API by any user that has the rights to run a
 
 The queue of jobs that need approval can be found under `Extensibility > Job Approval Queue`. There, any job that needs approval before it gets run is listed. To approve a job, select it and click the button to approve. Please note that you will be  asked for confirmation if a job is being approved that is past its scheduled datetime.
 
+If the approver is unsure what a job would do, a dry run can also be started via that same view.
+
 ## Approval via the API
 
-Approvals can also be given via the REST API. The endpoints to approve, deny, and dry run a scheduled job are found on the scheduleb job endpoint under `approve`, `deny`, and `dry-run`, respectively.
+Approvals can also be given via the REST API. The endpoints to approve, deny, and dry run a scheduled job are found on the scheduled job endpoint under `approve`, `deny`, and `dry-run`, respectively.
 
 ```no-highlight
 curl -X POST \

--- a/nautobot/docs/additional-features/job_scheduling_and_approvals.md
+++ b/nautobot/docs/additional-features/job_scheduling_and_approvals.md
@@ -1,0 +1,57 @@
+# Job Scheduling and Approvals
+
+Oftentimes jobs will need to be run at a later date or periodically, or require approval from someone before they can be started. To this end, Nautobot offers facilities for scheduling and approving jobs.
+
+## Job Scheduling
+
+Jobs can be scheduled to be run immediately, at some point in the future, or at an interval.
+
+Jobs can be scheduled through the UI or the API.
+
+### Scheduling via the UI
+
+The Job Scheduling views can be accessed via the navigation at `Extensibility > Jobs`, selecting a Job as appropriate.
+
+The UI allows you to select a scheduling type. Further fields will be displayed as appropriate for that schedule type.
+
+If the job requires no approval, it will then be added to the queue of scheduled jobs or run immediately. Otherwise, the job will be added to the approval quere where it can be approved by other users.
+
+### Scheduling via the API
+
+Jobs can also be scheduled via the REST API. The endpoint used for this is the regular job endpoint, filling the `schedule` parameter will act just as scheduling in the UI.
+
+```no-highlight
+curl -X POST \
+-H "Authorization: Token $TOKEN" \
+-H "Content-Type: application/json" \
+-H "Accept: application/json; indent=4" \
+http://nautobot/api/extras/jobs/local/example/MyJobWithNoVars/run/ \
+--data '{"schedule": {"name": "test", "interval": "future", "start_time": "2030-01-01T01:00:00.000Z"}}'
+```
+
+## Job Approvals
+
+Jobs that have `approval_required` set to `True` on their `Meta` object require another user to approve a scheduled job.
+
+Jobs can be approved via the UI and API by any user that has the rights to run a job.
+
+!!! note
+    Jobs that are past their scheduled run date can still be approved, but the approver will be asked to confirm the operation.
+
+## Approval via the UI
+
+The queue of jobs that need approval can be found under `Extensibility > Job Approval Queue`. There, any job that needs approval before it gets run is listed. To approve a job, select it and click the button to approve. Please note that you will be  asked for confirmation if a job is being approved that is past its scheduled datetime.
+
+## Approval via the API
+
+Approvals can also be given via the REST API. The endpoints to approve, deny, and dry run a scheduled job are found on the scheduleb job endpoint under `approve`, `deny`, and `dry-run`, respectively.
+
+```no-highlight
+curl -X POST \
+-H "Authorization: Token $TOKEN" \
+-H "Content-Type: application/json" \
+-H "Accept: application/json; indent=4" \
+http://nautobot/api/extras/scheduled-jobs/$JOB_ID/approve?force=true
+```
+
+The approval endpoint additionally provides a `force` query parameter that needs to be set if a job is past its scheduled datetime. This mimics the confirmation dialog in the UI.

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -82,7 +82,7 @@ A human-friendly description of what this job does.
 
 #### `approval_required`
 
-A boolean that will mark this job as requiring approval from another user to be run. For more details on approvals, [please refer to the section on scheduling and approvals](./job_scheduling_and_approvals.md).
+A boolean that will mark this job as requiring approval from another user to be run. For more details on approvals, [please refer to the section on scheduling and approvals](./job-scheduling-and-approvals.md).
 
 #### `commit_default`
 
@@ -357,7 +357,7 @@ Once a job has been run, the latest [`JobResult`](../models/extras/jobresult.md)
 
 ### Via the API
 
-To run a job via the REST API, issue a POST request to the job's endpoint, with the option of specifying any required user input data and/or the `commit` flag, as well as optional scheduling information as described in [the section on scheduling and approvals](./job_scheduling_and_approvals.md).
+To run a job via the REST API, issue a POST request to the job's endpoint, with the option of specifying any required user input data and/or the `commit` flag, as well as optional scheduling information as described in [the section on scheduling and approvals](./job-scheduling-and-approvals.md).
 
 ```no-highlight
 curl -X POST \

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -98,6 +98,10 @@ A list of strings (field names) representing the order your form fields should a
 
 A boolean that designates whether the job is able to make changes to data in the database. The value defaults to `False` but when set to `True`, any data modifications executed from the job's code will be automatically aborted at the end of the job. The job input form is also modified to remove the `commit` checkbox as it is irrelevant for read-only jobs. When a job is marked as read-only, log messages that are normally automatically emitted about the DB transaction state are not included because no changes to data are allowed. Note that user input may still be optionally collected with read-only jobs via job variables, as described below.
 
+#### `approval_required`
+
+A boolean that will mark this job as requiring approval from another user to be run. For more details on approvals, [please refer to the section on scheduling and approvals](./job_scheduling_and_approvals.md).
+
 ### Variables
 
 Variables allow your job to accept user input via the Nautobot UI, but they are optional; if your job does not require any user input, there is no need to define any variables. Conversely, if you are making use of user input in your job, you *must* also implement the `run()` method, as it is the only entry point to your job that has visibility into the variable values provided by the user.
@@ -353,7 +357,7 @@ Once a job has been run, the latest [`JobResult`](../models/extras/jobresult.md)
 
 ### Via the API
 
-To run a job via the REST API, issue a POST request to the job's endpoint, with the option of specifying any required user input data and/or the `commit` flag.
+To run a job via the REST API, issue a POST request to the job's endpoint, with the option of specifying any required user input data and/or the `commit` flag, as well as optional scheduling information as described in [the section on scheduling and approvals](./job_scheduling_and_approvals.md).
 
 ```no-highlight
 curl -X POST \

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -80,6 +80,10 @@ This is the human-friendly name of your job, as will be displayed in the Nautobo
 
 A human-friendly description of what this job does.
 
+#### `approval_required`
+
+A boolean that will mark this job as requiring approval from another user to be run. For more details on approvals, [please refer to the section on scheduling and approvals](./job_scheduling_and_approvals.md).
+
 #### `commit_default`
 
 The checkbox to commit database changes when executing a job is checked by default in the Nautobot UI. You can set `commit_default` to `False` under the `Meta` class if you want this option to instead be unchecked by default.
@@ -97,10 +101,6 @@ A list of strings (field names) representing the order your form fields should a
 #### `read_only`
 
 A boolean that designates whether the job is able to make changes to data in the database. The value defaults to `False` but when set to `True`, any data modifications executed from the job's code will be automatically aborted at the end of the job. The job input form is also modified to remove the `commit` checkbox as it is irrelevant for read-only jobs. When a job is marked as read-only, log messages that are normally automatically emitted about the DB transaction state are not included because no changes to data are allowed. Note that user input may still be optionally collected with read-only jobs via job variables, as described below.
-
-#### `approval_required`
-
-A boolean that will mark this job as requiring approval from another user to be run. For more details on approvals, [please refer to the section on scheduling and approvals](./job_scheduling_and_approvals.md).
 
 ### Variables
 

--- a/nautobot/docs/installation/upgrading.md
+++ b/nautobot/docs/installation/upgrading.md
@@ -8,7 +8,7 @@ additional work, certain releases may introduce breaking or backward-incompatibl
 release notes under the release in which the change went into effect.
 
 !!! note
-    As of Nautobot v1.2.0, Nautobot supports deferring (“scheduling”) Jobs. To facilitate this, a new serivce called `celery-beat-worker` was introduced. Please review the [service installation documentation](./services.md) to find out how to set it up.
+    As of Nautobot v1.2.0, Nautobot supports deferring (“scheduling”) Jobs. To facilitate this, a new service called `celery-beat-worker` is now required. Please review the [service installation documentation](./services.md) to find out how to set it up.
 
 ## Update Prerequisites to Required Versions
 

--- a/nautobot/docs/installation/upgrading.md
+++ b/nautobot/docs/installation/upgrading.md
@@ -7,6 +7,9 @@ have been published since your current version was released. Although the upgrad
 additional work, certain releases may introduce breaking or backward-incompatible changes. These are called out in the
 release notes under the release in which the change went into effect.
 
+!!! note
+    As of Nautobot v1.2.0, Nautobot supports deferring (“scheduling”) Jobs. To facilitate this, a new serivce called `celery-beat-worker` was introduced. Please review the [service installation documentation](./services.md) to find out how to set it up.
+
 ## Update Prerequisites to Required Versions
 
 Nautobot v1.0.0 and later requires the following:


### PR DESCRIPTION
### Relates to #374 

This PR adds documentation on how to schedule and approve jobs via the UI and API. It’s somewhat concise (too concise?), but it should be comprehensive.

Please let me know if I missed anything and/or you’d like any section expanded or changed.

Cheers
