### PR TITLE
Add overdue job prompt to approval

### DIFF
--- a/nautobot/extras/templates/extras/job_approval_confirmation.html
+++ b/nautobot/extras/templates/extras/job_approval_confirmation.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load helpers %}
 
-{% block title %}{{ job }} - Confirm Approval{% endblock %}
+{% block title %}{{ scheduled_job }} - Confirm Approval{% endblock %}
 
 {% block content %}
     <div class="row">
@@ -9,7 +9,7 @@
             <div class="panel panel-danger">
                 <div class="panel-heading"><strong>Confirm Approval</strong></div>
                 <div class="panel-body">
-                    <p><strong>Warning:</strong> You are approving a job that is past its scheduled date. It will run immediately after approval.</p>
+                    <p><strong>Warning:</strong> You are approving a job that is past its scheduled date ({{ scheduled_job.start_time }}). It will run immediately after approval.</p>
                     {% block message_extra %}{% endblock %}
                 </div>
             </div>

--- a/nautobot/extras/templates/extras/job_approval_confirmation.html
+++ b/nautobot/extras/templates/extras/job_approval_confirmation.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% load helpers %}
+
+{% block title %}{{ job }} - Confirm Approval{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-danger">
+                <div class="panel-heading"><strong>Confirm Approval</strong></div>
+                <div class="panel-body">
+                    <p><strong>Warning:</strong> You are approving a job that is past its scheduled date. It will run immediately after approval.</p>
+                    {% block message_extra %}{% endblock %}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-6 col-md-offset-3">
+            <form action="" method="post" class="form">
+                {% csrf_token %}
+                <div class="text-center">
+                    <button type="submit" name="_force_approve" class="btn btn-danger">Confirm</button>
+                    <a href="{{ return_url }}" class="btn btn-default">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -825,7 +825,12 @@ class JobApprovalRequestView(ContentTypePermissionRequiredMixin, View):
 
         post_data = request.POST
 
-        if "_dry_run" in post_data:
+        deny = "_deny" in post_data
+        approve = "_approve" in post_data
+        force_approve = "_force_approve" in post_data
+        dry_run = "_dry_run" in post_data
+
+        if dry_run:
             # Immediately enqueue the job with commit=False and send the user to the normal JobResult view
             job_content_type = ContentType.objects.get(app_label="extras", model="job")
             job_result = JobResult.enqueue_job(
@@ -840,8 +845,7 @@ class JobApprovalRequestView(ContentTypePermissionRequiredMixin, View):
             )
 
             return redirect("extras:job_jobresult", pk=job_result.pk)
-
-        elif "_deny" in post_data:
+        elif deny:
             # Delete the scheduled_job instance
             scheduled_job.delete()
             if request.user == scheduled_job.user:
@@ -851,12 +855,14 @@ class JobApprovalRequestView(ContentTypePermissionRequiredMixin, View):
 
             return redirect("extras:scheduledjob_approval_queue_list")
 
-        elif "_approve" in post_data:
+        elif approve or force_approve:
             # Mark the scheduled_job as approved, allowing the schedular to schedule the job execution task
             if request.user == scheduled_job.user:
                 # The requestor *cannot* approve their own job
                 messages.error(request, "You cannot approve your own job request!")
             else:
+                if scheduled_job.one_off and scheduled_job.start_time < timezone.now() and not force_approve:
+                    return render(request, "extras/job_approval_confirmation.html", {"scheduled_job": scheduled_job})
                 scheduled_job.approved_by_user = request.user
                 scheduled_job.approved_at = timezone.now()
                 scheduled_job.save()


### PR DESCRIPTION
### Relates to #125

This PR adds a confirmation view to the job approval if the job is a once-off and past its scheduled time.

<img width="857" alt="Bildschirmfoto 2021-09-01 um 10 56 51" src="https://user-images.githubusercontent.com/7725188/131643551-2fd7f4a4-5171-41d2-b06c-2ae2b6868646.png">

The text should be informative enough, I hope?

Cheers
