### PR TITLE
Fix #547: Hide social auth

### DIFF
--- a/nautobot/core/admin.py
+++ b/nautobot/core/admin.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.admin import site as admin_site
+from social_django.models import Association, Nonce, UserSocialAuth
 from taggit.models import Tag
 
 
@@ -11,3 +12,7 @@ admin_site.index_template = "admin/nautobot_index.html"
 
 # Unregister the unused stock Tag model provided by django-taggit
 admin_site.unregister(Tag)
+
+admin_site.unregister(Association)
+admin_site.unregister(Nonce)
+admin_site.unregister(UserSocialAuth)

--- a/nautobot/core/admin.py
+++ b/nautobot/core/admin.py
@@ -13,6 +13,7 @@ admin_site.index_template = "admin/nautobot_index.html"
 # Unregister the unused stock Tag model provided by django-taggit
 admin_site.unregister(Tag)
 
+# Unregister SocialAuth from DJango admin menu
 admin_site.unregister(Association)
 admin_site.unregister(Nonce)
 admin_site.unregister(UserSocialAuth)

--- a/nautobot/core/admin.py
+++ b/nautobot/core/admin.py
@@ -13,7 +13,7 @@ admin_site.index_template = "admin/nautobot_index.html"
 # Unregister the unused stock Tag model provided by django-taggit
 admin_site.unregister(Tag)
 
-# Unregister SocialAuth from DJango admin menu
+# Unregister SocialAuth from Django admin menu
 admin_site.unregister(Association)
 admin_site.unregister(Nonce)
 admin_site.unregister(UserSocialAuth)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #547 
<!--
    Please include a summary of the proposed changes below.
-->

In the Django Admin, I've hidden the social auth by unregistering `Association`, `Nonce`, `UserSocialAuth`.

![Screenshot 2021-09-07 at 09 26 35](https://user-images.githubusercontent.com/6088317/132311435-c16fe558-5338-4220-b572-93b877aed363.png)

