### PR TITLE
Switch to cron schedules

### DIFF
--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -1132,11 +1132,11 @@ class ScheduledJob(BaseModel):
 
     def to_cron(self):
         t = self.start_time
-        if self.interval == TYPE_HOURLY:
+        if self.interval == JobExecutionType.TYPE_HOURLY:
             return schedules.crontab(minute=t.minute)
-        elif self.interval == TYPE_DAILY:
+        elif self.interval == JobExecutionType.TYPE_DAILY:
             return schedules.crontab(minute=t.minute, hour=t.hour)
-        elif self.interval == TYPE_WEEKLY:
+        elif self.interval == JobExecutionType.TYPE_WEEKLY:
             return schedules.crontab(minute=t.minute, hour=t.hour, day_of_week=t.weekday())
 
 

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -1138,6 +1138,7 @@ class ScheduledJob(BaseModel):
             return schedules.crontab(minute=t.minute, hour=t.hour)
         elif self.interval == JobExecutionType.TYPE_WEEKLY:
             return schedules.crontab(minute=t.minute, hour=t.hour, day_of_week=t.weekday())
+        raise ValueError(f"I do not know to convert {self.interval} to a Cronjob!")
 
 
 signals.pre_delete.connect(ScheduledJobs.changed, sender=ScheduledJob)

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -1131,12 +1131,13 @@ class ScheduledJob(BaseModel):
         return timezone.now() + timedelta(seconds=15)
 
     def to_cron(self):
+        t = self.start_time
         if self.interval == TYPE_HOURLY:
-            return schedules.crontab(minute=0)
+            return schedules.crontab(minute=t.minute)
         elif self.interval == TYPE_DAILY:
-            return schedules.crontab(minute=0, hour=0)
+            return schedules.crontab(minute=t.minute, hour=t.hour)
         elif self.interval == TYPE_WEEKLY:
-            return schedules.crontab(minute=0, hour=0, day_of_week="mon")
+            return schedules.crontab(minute=t.minute, hour=t.hour, day_of_week=t.weekday())
 
 
 signals.pre_delete.connect(ScheduledJobs.changed, sender=ScheduledJob)


### PR DESCRIPTION
### Relates to #125

This PR makes the job scheduling system switch to Cron schedules. This will help facilitate more expressive ways of scheduling jobs in the future, as well as reduce the amount of error-prone scheduling math that we have to do ourselves, since Crontabs are geared towards recurring tasks like we are envisioning.

Cheers
