### PR TITLE
Scheduled jobs and approval API tests

### DIFF
--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -15,6 +15,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet as ModelViewSet_
+from rest_framework.viewsets import ReadOnlyModelViewSet as ReadOnlyModelViewSet_
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.exceptions import PermissionDenied, ParseError
 from drf_yasg.openapi import Schema, TYPE_OBJECT, TYPE_ARRAY
@@ -131,11 +132,7 @@ class BulkDestroyModelMixin:
 #
 
 
-class ModelViewSet(BulkUpdateModelMixin, BulkDestroyModelMixin, ModelViewSet_):
-    """
-    Extend DRF's ModelViewSet to support bulk update and delete functions.
-    """
-
+class ModelViewSetMixin:
     brief = False
     brief_prefetch_fields = []
 
@@ -201,6 +198,12 @@ class ModelViewSet(BulkUpdateModelMixin, BulkDestroyModelMixin, ModelViewSet_):
             logger.warning(msg)
             return self.finalize_response(request, Response({"detail": msg}, status=409), *args, **kwargs)
 
+
+class ModelViewSet(BulkUpdateModelMixin, BulkDestroyModelMixin, ModelViewSetMixin, ModelViewSet_):
+    """
+    Extend DRF's ModelViewSet to support bulk update and delete functions.
+    """
+
     def _validate_objects(self, instance):
         """
         Check that the provided instance or list of instances are matched by the current queryset. This confirms that
@@ -247,6 +250,12 @@ class ModelViewSet(BulkUpdateModelMixin, BulkDestroyModelMixin, ModelViewSet_):
         logger.info(f"Deleting {model._meta.verbose_name} {instance} (PK: {instance.pk})")
 
         return super().perform_destroy(instance)
+
+
+class ReadOnlyModelViewSet(ModelViewSetMixin, ReadOnlyModelViewSet_):
+    """
+    Extend DRF's ReadOnlyModelViewSet to support queryset restriction.
+    """
 
 
 #

--- a/nautobot/extras/api/nested_serializers.py
+++ b/nautobot/extras/api/nested_serializers.py
@@ -143,7 +143,7 @@ class NestedRelationshipAssociationSerializer(WritableNestedSerializer):
 
 class NestedScheduledJobSerializer(serializers.ModelSerializer):
     name = serializers.CharField(max_length=255, required=False)
-    start_time = serializers.DateTimeField(required=False)
+    start_time = serializers.DateTimeField(format=None, required=False)
 
     class Meta:
         model = models.ScheduledJob
@@ -153,10 +153,10 @@ class NestedScheduledJobSerializer(serializers.ModelSerializer):
         data = super().validate(data)
 
         if data["interval"] != choices.JobExecutionType.TYPE_IMMEDIATELY:
-            if not data["name"]:
+            if "name" not in data:
                 raise serializers.ValidationError({"name": "Please provide a name for the job schedule."})
 
-            if not data["start_time"] or data["start_time"] < models.ScheduledJob.earliest_possible_time():
+            if "start_time" not in data or data["start_time"] < models.ScheduledJob.earliest_possible_time():
                 raise serializers.ValidationError(
                     {
                         "start_time": "Please enter a valid date and time greater than or equal to the current date and time."

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -14,11 +14,11 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.routers import APIRootView
-from rest_framework.viewsets import ReadOnlyModelViewSet, ViewSet
+from rest_framework import viewsets
 from rq import Worker
 
 from nautobot.core.api.metadata import ContentTypeMetadata, StatusFieldMetadata
-from nautobot.core.api.views import ModelViewSet
+from nautobot.core.api.views import ModelViewSet, ReadOnlyModelViewSet
 from nautobot.core.graphql import execute_saved_query
 from nautobot.extras import filters
 from nautobot.extras.choices import JobExecutionType, JobResultStatusChoices
@@ -220,7 +220,7 @@ class ConfigContextSchemaViewSet(ModelViewSet):
 #
 
 
-class JobViewSet(ViewSet):
+class JobViewSet(viewsets.ViewSet):
     permission_classes = [IsAuthenticated]
     lookup_field = "class_path"
     lookup_value_regex = "[^/]+/[^/]+/[^/]+"  # e.g. "git.repo_name/module_name/JobName"
@@ -322,7 +322,7 @@ class JobViewSet(ViewSet):
         input_serializer = serializers.JobInputSerializer(data=request.data)
         input_serializer.is_valid(raise_exception=True)
 
-        data = input_serializer.data["data"]
+        data = job_class.serialize_data(input_serializer.data["data"])
         commit = input_serializer.data["commit"]
         if commit is None:
             commit = getattr(job_class.Meta, "commit_default", True)
@@ -489,7 +489,7 @@ class ScheduledJobViewSet(ReadOnlyModelViewSet):
 #
 
 
-class ContentTypeViewSet(ReadOnlyModelViewSet):
+class ContentTypeViewSet(viewsets.ReadOnlyModelViewSet):
     """
     Read-only list of ContentTypes. Limit results to ContentTypes pertinent to Nautobot objects.
     """

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -453,10 +453,6 @@ class JobTest(APITestCase):
 
             return "Job complete"
 
-        # TODO what is this doing here
-        def test_foo(self):
-            self.log_success(obj=None, message="Test completed")
-
     def get_test_job_class(self, class_path):
         if class_path == "local/test_api/TestJob":
             return self.TestJob

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -660,23 +660,6 @@ class ScheduledJobTest(APITestCase):
             start_time=now(),
         )
 
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=["extras.scheduledjob"])
-    def test_list_objects(self):
-        count = ScheduledJob.objects.count()
-
-        response = self.client.get(reverse("extras-api:scheduledjob-list"), **self.header)
-        self.assertHttpStatus(response, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], count)
-
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=["extras.scheduledjob"])
-    def test_get_object(self):
-        job = ScheduledJob.objects.first()
-
-        url = reverse("extras-api:scheduledjob-detail", kwargs={"pk": job.pk})
-        response = self.client.get(url, **self.header)
-        self.assertHttpStatus(response, status.HTTP_200_OK)
-        self.assertEquals(response.data["name"], job.name)
-
 
 class JobApprovalTest(APITestCase):
     @classmethod


### PR DESCRIPTION
### Relates to #125

This PR adds basic test cases for the scheduling and approval API. It is also your dumping ground for cases that the API tests should cover. Ones that I can think of:

- [x] Approving an overdue scheduled job (both with and without `force`).
- [x] Scheduling a job in the past.

Please add any others you can think of!

Cheers
