### PR TITLE
Scheduling and Approvals UI tests

### DIFF
--- a/nautobot/extras/tests/dummy_jobs/test_required_args.py
+++ b/nautobot/extras/tests/dummy_jobs/test_required_args.py
@@ -1,0 +1,5 @@
+from nautobot.extras.jobs import Job, StringVar
+
+
+class TestRequired(Job):
+    var = StringVar(required=True)

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import urllib.parse
 import uuid
 
@@ -6,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
 from nautobot.dcim.models import ConsolePort, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
-from nautobot.extras.choices import CustomFieldTypeChoices, ObjectChangeActionChoices
+from nautobot.extras.choices import CustomFieldTypeChoices, JobExecutionType, ObjectChangeActionChoices
 from nautobot.extras.constants import *
 from nautobot.extras.models import (
     ConfigContext,
@@ -16,9 +17,11 @@ from nautobot.extras.models import (
     ExportTemplate,
     GitRepository,
     GraphQLQuery,
+    JobResult,
     ObjectChange,
     Relationship,
     RelationshipAssociation,
+    ScheduledJob,
     Status,
     Tag,
     Webhook,
@@ -908,3 +911,104 @@ class WebhookTestCase(
             "http_method": "POST",
             "http_content_type": "application/json",
         }
+
+
+class ScheduledJobTestCase(
+    ViewTestCases.ListObjectsViewTestCase,
+):
+    model = ScheduledJob
+
+    @classmethod
+    def setUpTestData(cls):
+        user = User.objects.create(username="user1", is_active=True)
+        ScheduledJob.objects.create(
+            name="test1",
+            task="nautobot.extras.jobs.scheduled_job_handler",
+            job_class="-",
+            interval=JobExecutionType.TYPE_IMMEDIATELY,
+            user=user,
+            start_time=datetime.now(),
+        )
+        ScheduledJob.objects.create(
+            name="test2",
+            task="nautobot.extras.jobs.scheduled_job_handler",
+            job_class="-",
+            interval=JobExecutionType.TYPE_IMMEDIATELY,
+            user=user,
+            start_time=datetime.now(),
+        )
+        ScheduledJob.objects.create(
+            name="test3",
+            task="nautobot.extras.jobs.scheduled_job_handler",
+            job_class="-",
+            interval=JobExecutionType.TYPE_IMMEDIATELY,
+            user=user,
+            start_time=datetime.now(),
+        )
+
+
+class ApprovalQueueTestCase(
+    ViewTestCases.ListObjectsViewTestCase,
+):
+    model = ScheduledJob
+
+    def _get_url(self, action, instance=None):
+        if action != "list":
+            raise ValueError("This override is only valid for list test cases")
+        return reverse("extras:scheduledjob_approval_queue_list")
+
+    @classmethod
+    def setUpTestData(cls):
+        user = User.objects.create(username="user1", is_active=True)
+        ScheduledJob.objects.create(
+            name="test1",
+            task="nautobot.extras.jobs.scheduled_job_handler",
+            job_class="-",
+            interval=JobExecutionType.TYPE_IMMEDIATELY,
+            user=user,
+            approval_required=True,
+            start_time=datetime.now(),
+        )
+        ScheduledJob.objects.create(
+            name="test2",
+            task="nautobot.extras.jobs.scheduled_job_handler",
+            job_class="-",
+            interval=JobExecutionType.TYPE_IMMEDIATELY,
+            user=user,
+            approval_required=True,
+            start_time=datetime.now(),
+        )
+        ScheduledJob.objects.create(
+            name="test3",
+            task="nautobot.extras.jobs.scheduled_job_handler",
+            job_class="-",
+            interval=JobExecutionType.TYPE_IMMEDIATELY,
+            user=user,
+            approval_required=True,
+            start_time=datetime.now(),
+        )
+
+
+class JobResultTestCase(
+    ViewTestCases.ListObjectsViewTestCase,
+):
+    model = JobResult
+
+    @classmethod
+    def setUpTestData(cls):
+        obj_type = ContentType.objects.get(app_label="extras", model="job")
+        JobResult.objects.create(
+            name="test1",
+            job_id=uuid.uuid4(),
+            obj_type=obj_type,
+        )
+        JobResult.objects.create(
+            name="test2",
+            job_id=uuid.uuid4(),
+            obj_type=obj_type,
+        )
+        JobResult.objects.create(
+            name="test3",
+            job_id=uuid.uuid4(),
+            obj_type=obj_type,
+        )

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -929,17 +929,18 @@ class TestJobMixin(SimpleTestCase):
     class TestJob(Job):
         pass
 
+    @staticmethod
     def get_test_job_class(self, class_path):
         if class_path.startswith("local/test_view"):
-            return self.TestJob
+            return TestJobMixin.TestJob
         raise Http404
 
     @classmethod
     def setUpClass(cls):
         # Monkey-patch the viewsets' _get_job methods to return our test class above
         cls.original_method = JobView._get_job
-        JobView._get_job = self.get_test_job_class
-        ScheduledJobView._get_job = self.get_test_job_class
+        JobView._get_job = TestJobMixin.get_test_job_class
+        ScheduledJobView._get_job = TestJobMixin.get_test_job_class
 
     @classmethod
     def tearDownClass(cls):

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -6,6 +6,7 @@ import uuid
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.http import Http404
 from django.test import override_settings, SimpleTestCase
 from django.urls import reverse
 from django.utils import timezone

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -1133,13 +1133,15 @@ class JobTestCase(
         self.assertEqual(errors, ["_schedule_type: This field is required."])
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"], JOBS_ROOT=DUMMY_JOBS)
-    def test_run_now_no_worker(self):
+    @mock.patch("nautobot.extras.views.get_worker_count")
+    def test_run_now_no_worker(self, patched):
         self.add_permissions("extras.run_job")
 
         data = {
             "_schedule_type": "immediately",
         }
 
+        patched.return_value = 0
         response = self.client.post(reverse("extras:job", kwargs={"class_path": "local/test_pass/TestPass"}), data)
 
         self.assertHttpStatus(response, 200)

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -1097,13 +1097,13 @@ class JobTestCase(
     def test_list_without_permission(self):
         self.assertHttpStatus(self.client.get(reverse("extras:job_list")), 403)
 
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"], JOBS_ROOT=DUMMY_JOBS)
     def test_list(self):
         response = self.client.get(reverse("extras:job_list"))
         self.assertHttpStatus(response, 200)
 
         response_body = extract_page_body(response.content.decode(response.charset))
-        self.assertIn("DummyJob", response_body)
+        self.assertIn("TestPass", response_body)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=[], JOBS_ROOT=DUMMY_JOBS)
     def test_get_without_permission(self):

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -934,12 +934,18 @@ class TestJobMixin(SimpleTestCase):
             return self.TestJob
         raise Http404
 
-    def setUp(self):
-        super().setUp()
-
+    @classmethod
+    def setUpClass(cls):
         # Monkey-patch the viewsets' _get_job methods to return our test class above
+        cls.original_method = JobView._get_job
         JobView._get_job = self.get_test_job_class
         ScheduledJobView._get_job = self.get_test_job_class
+
+    @classmethod
+    def tearDownClass(cls):
+        # Undo monkey-patch
+        JobView._get_job = cls.original_method
+        ScheduledJobView._get_job = cls.original_method
 
 
 class ScheduledJobTestCase(

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -937,6 +937,7 @@ class TestJobMixin(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # Monkey-patch the viewsets' _get_job methods to return our test class above
         cls.original_method = JobView._get_job
         JobView._get_job = TestJobMixin.get_test_job_class
@@ -944,6 +945,7 @@ class TestJobMixin(SimpleTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        super().tearDownClass()
         # Undo monkey-patch
         JobView._get_job = cls.original_method
         ScheduledJobView._get_job = cls.original_method

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -20,7 +20,7 @@ from nautobot.core.celery import app
 from nautobot.core.views import generic
 from nautobot.dcim.models import Device
 from nautobot.dcim.tables import DeviceTable
-from nautobot.extras import utils as extras_utils
+from nautobot.extras.utils import get_worker_count
 from nautobot.utilities.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.utilities.utils import (
     copy_safe_request,
@@ -504,7 +504,7 @@ class GitRepositorySyncView(View):
         repository = get_object_or_404(GitRepository.objects.all(), slug=slug)
 
         # Allow execution only if a worker process is running.
-        if not extras_utils.get_worker_count(request):
+        if not get_worker_count(request):
             messages.error(request, "Unable to run job: Celery worker process not running.")
         else:
             enqueue_pull_git_repository_and_refresh_data(repository, request)
@@ -691,7 +691,7 @@ class JobView(ContentTypePermissionRequiredMixin, View):
         schedule_form = forms.JobScheduleForm(request.POST)
 
         # Allow execution only if a worker process is running.
-        if not extras_utils.get_worker_count(request):
+        if not get_worker_count(request):
             messages.error(request, "Unable to run job: Celery worker process not running.")
         elif job_form.is_valid() and schedule_form.is_valid():
             # Run the job. A new JobResult is created.

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -28,7 +28,7 @@ from nautobot.utilities.utils import (
     shallow_compare_dict,
 )
 from nautobot.utilities.tables import ButtonsColumn
-from nautobot.utilities.views import ContentTypePermissionRequiredMixin, ObjectPermissionRequiredMixin
+from nautobot.utilities.views import ContentTypePermissionRequiredMixin
 from nautobot.virtualization.models import VirtualMachine
 from nautobot.virtualization.tables import VirtualMachineTable
 from . import filters, forms, tables
@@ -990,12 +990,12 @@ class JobResultBulkDeleteView(generic.BulkDeleteView):
     table = tables.JobResultTable
 
 
-class JobResultView(ObjectPermissionRequiredMixin, View):
+class JobResultView(generic.ObjectView):
     """
     Display a JobResult and its data.
     """
 
-    queryset = JobResult.objects
+    queryset = JobResult.objects.all()
 
     def get_required_permission(self):
         return "extras.view_jobresult"

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -20,7 +20,7 @@ from nautobot.core.celery import app
 from nautobot.core.views import generic
 from nautobot.dcim.models import Device
 from nautobot.dcim.tables import DeviceTable
-from nautobot.extras.utils import get_worker_count
+from nautobot.extras import utils as extras_utils
 from nautobot.utilities.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.utilities.utils import (
     copy_safe_request,
@@ -504,7 +504,7 @@ class GitRepositorySyncView(View):
         repository = get_object_or_404(GitRepository.objects.all(), slug=slug)
 
         # Allow execution only if a worker process is running.
-        if not get_worker_count(request):
+        if not extras_utils.get_worker_count(request):
             messages.error(request, "Unable to run job: Celery worker process not running.")
         else:
             enqueue_pull_git_repository_and_refresh_data(repository, request)
@@ -691,7 +691,7 @@ class JobView(ContentTypePermissionRequiredMixin, View):
         schedule_form = forms.JobScheduleForm(request.POST)
 
         # Allow execution only if a worker process is running.
-        if not get_worker_count(request):
+        if not extras_utils.get_worker_count(request):
             messages.error(request, "Unable to run job: Celery worker process not running.")
         elif job_form.is_valid() and schedule_form.is_valid():
             # Run the job. A new JobResult is created.


### PR DESCRIPTION
### Relates to #125 

This PR adds view/UI test cases for scheduling & approvals (and is thus basically a sequel to #879).

As of now, all job views are untested. We still have to figure out how to approach this: should all job views be tested in the context of this PR?

Cheers