### PR TITLE
Pin exact version of gitpython to avoid breakage

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -652,7 +652,7 @@ smmap = ">=3.0.1,<5"
 
 [[package]]
 name = "gitpython"
-version = "3.1.20"
+version = "3.1.18"
 description = "Python Git Library"
 category = "main"
 optional = false
@@ -660,7 +660,7 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
-typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.10\""}
+typing-extensions = {version = ">=3.7.4.0", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "graphene"
@@ -1543,7 +1543,7 @@ mysql = ["mysqlclient"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "b758a613069a121ec5bb5babe876fd4e1274879ee3b07db483340537344cd9e4"
+content-hash = "56d9a10a87981d11dde804500ab21cc7daf54ba6e8b8bbb6000f54a0b1141d46"
 
 [metadata.files]
 amqp = [
@@ -1849,8 +1849,8 @@ gitdb = [
     {file = "gitdb-4.0.7.tar.gz", hash = "sha256:96bf5c08b157a666fec41129e6d327235284cca4c81e92109260f353ba138005"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.20-py3-none-any.whl", hash = "sha256:b1e1c269deab1b08ce65403cf14e10d2ef1f6c89e33ea7c5e5bb0222ea593b8a"},
-    {file = "GitPython-3.1.20.tar.gz", hash = "sha256:df0e072a200703a65387b0cfdf0466e3bab729c0458cf6b7349d0e9877636519"},
+    {file = "GitPython-3.1.18-py3-none-any.whl", hash = "sha256:fce760879cd2aebd2991b3542876dc5c4a909b30c9d69dfc488e504a8db37ee8"},
+    {file = "GitPython-3.1.18.tar.gz", hash = "sha256:b838a895977b45ab6f0cc926a9045c8d1c44e2b653c1fcc39fe91f42c6e8f05b"},
 ]
 graphene = [
     {file = "graphene-2.1.9-py2.py3-none-any.whl", hash = "sha256:3d446eb1237c551052bc31155cf1a3a607053e4f58c9172b83a1b597beaa0868"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ djangorestframework = "~3.12.4"
 # Swagger schema generation for the REST API
 drf-yasg = {extras = ["validation"], version = "~1.20.0"}
 # Git integrations for Python
-GitPython = "~3.1.15"
+GitPython = "3.1.18"
 # GraphQL support
 graphene-django = "~2.15.0"
 # Package version detection in older versions of Python


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #N/A
<!--
    Please include a summary of the proposed changes below.
-->

When I merged latest `develop` into `next` in b95f6b4da3af0619ef1d1bd11ed0a8dacead1dac, I had to regenerate `poetry.lock` to resolve some merge conflicts. In the process, Poetry updated from GitPython 3.1.18 to 3.1.20, which is a *yanked* release and should not be used (because it's not compatible with Python 3.7.1, causing [failures in our CI](https://app.travis-ci.com/github/nautobot/nautobot/jobs/537913820)).

Unfortunately Poetry does not yet [support](https://github.com/python-poetry/poetry/issues/2453) ignoring of yanked releases, so for the time being we just need to pin GitPython exactly to the latest known-good release.