### PR TITLE
Add Commit Hash on Sync Page for Git Repositories

### DIFF
--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -106,6 +106,11 @@ def pull_git_repository_and_refresh_data(repository_pk, request, job_result_pk):
             level_choice=LogLevelChoices.LOG_INFO,
             logger=logger,
         )
+        job_result.log(
+            f'The current Git repository hash is "{repository_record.current_head}"',
+            level_choice=LogLevelChoices.LOG_INFO,
+            logger=logger,
+        )
         job_result.save()
 
 

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -86,6 +86,12 @@ def pull_git_repository_and_refresh_data(repository_pk, request, job_result_pk):
             logger=logger,
         )
 
+        job_result.log(
+            f'The current Git repository hash is "{repository_record.current_head}"',
+            level_choice=LogLevelChoices.LOG_INFO,
+            logger=logger,
+        )
+
         refresh_datasource_content("extras.gitrepository", repository_record, request, job_result, delete=False)
 
     except Exception as exc:
@@ -103,11 +109,6 @@ def pull_git_repository_and_refresh_data(repository_pk, request, job_result_pk):
                 job_result.set_status(JobResultStatusChoices.STATUS_COMPLETED)
         job_result.log(
             f"Repository synchronization completed in {job_result.duration}",
-            level_choice=LogLevelChoices.LOG_INFO,
-            logger=logger,
-        )
-        job_result.log(
-            f'The current Git repository hash is "{repository_record.current_head}"',
             level_choice=LogLevelChoices.LOG_INFO,
             logger=logger,
         )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #<ISSUE NUMBER GOES HERE>
fixes #623 
<!--
    Please include a summary of the proposed changes below.
-->
Add an information log to sync page to be able to quickly validate git hash is accurate.