### PR TITLE
Fix graphql restart on relationship change

### DIFF
--- a/nautobot/circuits/graphql/types.py
+++ b/nautobot/circuits/graphql/types.py
@@ -1,11 +1,10 @@
-from graphene_django import DjangoObjectType
-
+from nautobot.core.graphql.base import NautobotObjectType
 from nautobot.circuits.models import CircuitTermination
 from nautobot.circuits.filters import CircuitTerminationFilterSet
 from nautobot.dcim.graphql.mixins import PathEndpointMixin
 
 
-class CircuitTerminationType(DjangoObjectType, PathEndpointMixin):
+class CircuitTerminationType(NautobotObjectType, PathEndpointMixin):
     """Graphql Type Object for CircuitTermination model."""
 
     class Meta:

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -379,7 +379,7 @@ class GraphQLDRFAPIView(APIView):
 
     def __init__(self, schema=None, executor=None, middleware=None, root_value=None, backend=None):
         if not schema:
-            from nautobot.core.graphql.schema_init import schema
+            from nautobot.core.graphql.schema_init import get_schema
 
         if backend is None:
             backend = get_default_backend()
@@ -387,7 +387,7 @@ class GraphQLDRFAPIView(APIView):
         if middleware is None:
             middleware = graphene_settings.MIDDLEWARE
 
-        self.graphql_schema = self.graphql_schema or schema
+        self.graphql_schema = self.graphql_schema or get_schema()
 
         if middleware is not None:
             if isinstance(middleware, MiddlewareManager):

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -379,7 +379,7 @@ class GraphQLDRFAPIView(APIView):
 
     def __init__(self, schema=None, executor=None, middleware=None, root_value=None, backend=None):
         if not schema:
-            schema = graphene_settings.SCHEMA
+            from nautobot.core.graphql.schema_init import schema
 
         if backend is None:
             backend = get_default_backend()

--- a/nautobot/core/graphql/__init__.py
+++ b/nautobot/core/graphql/__init__.py
@@ -43,7 +43,8 @@ def execute_query(query, variables=None, request=None, user=None):
         request = RequestFactory().post("/graphql/")
         request.user = user
     backend = get_default_backend()
-    schema = graphene_settings.SCHEMA
+    from .schema_init import schema
+
     document = backend.document_from_string(schema, query)
     if variables:
         return document.execute(context_value=request, variable_values=variables)
@@ -63,10 +64,8 @@ def execute_saved_query(saved_query_slug, **kwargs):
     Returns:
         GraphQL Object: Result for query
     """
-    from .schema_init import schema
-
     query = GraphQLQuery.objects.get(slug=saved_query_slug)
-    return execute_query(query=query.query, schema=schema, **kwargs)
+    return execute_query(query=query.query, **kwargs)
 
 
 # See also:

--- a/nautobot/core/graphql/__init__.py
+++ b/nautobot/core/graphql/__init__.py
@@ -63,8 +63,10 @@ def execute_saved_query(saved_query_slug, **kwargs):
     Returns:
         GraphQL Object: Result for query
     """
+    from .schema_init import schema
+
     query = GraphQLQuery.objects.get(slug=saved_query_slug)
-    return execute_query(query=query.query, **kwargs)
+    return execute_query(query=query.query, schema=schema, **kwargs)
 
 
 # See also:

--- a/nautobot/core/graphql/__init__.py
+++ b/nautobot/core/graphql/__init__.py
@@ -43,9 +43,9 @@ def execute_query(query, variables=None, request=None, user=None):
         request = RequestFactory().post("/graphql/")
         request.user = user
     backend = get_default_backend()
-    from .schema_init import schema
+    from .schema_init import get_schema
 
-    document = backend.document_from_string(schema, query)
+    document = backend.document_from_string(get_schema(), query)
     if variables:
         return document.execute(context_value=request, variable_values=variables)
     else:

--- a/nautobot/core/graphql/base.py
+++ b/nautobot/core/graphql/base.py
@@ -1,0 +1,10 @@
+from graphene_django import DjangoObjectType
+
+
+class NautobotObjectType(DjangoObjectType):
+    def __init_subclass__(cls, **kwargs):
+        cls._cached_meta = cls.Meta
+        super().__init_subclass__(**kwargs)
+
+    class Meta:
+        abstract = True

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -211,6 +211,12 @@ def extend_schema_type_custom_field(schema_type, model):
     if settings.GRAPHQL_CUSTOM_FIELD_PREFIX and isinstance(settings.GRAPHQL_CUSTOM_FIELD_PREFIX, str):
         prefix = f"{settings.GRAPHQL_CUSTOM_FIELD_PREFIX}_"
 
+    # clear old custom fields; TODO: safe?
+    for field in dir(schema_type):
+        if field.startswith(f"resolve_{prefix}"):
+            delattr(schema_type, field)
+            del schema_type._meta.fields[field.replace("resolve_", "")]
+
     for field in cfs:
         field_name = f"{prefix}{str_to_var_name(field.name)}"
         resolver_name = f"resolve_{field_name}"
@@ -252,6 +258,12 @@ def extend_schema_type_computed_field(schema_type, model):
     prefix = ""
     if settings.GRAPHQL_COMPUTED_FIELD_PREFIX and isinstance(settings.GRAPHQL_COMPUTED_FIELD_PREFIX, str):
         prefix = f"{settings.GRAPHQL_COMPUTED_FIELD_PREFIX}_"
+
+    # clear old custom fields; TODO: safe?
+    for field in dir(schema_type):
+        if field.startswith(f"resolve_{prefix}"):
+            delattr(schema_type, field)
+            del schema_type._meta.fields[field.replace("resolve_", "")]
 
     for field in cfs:
         field_name = f"{prefix}{str_to_var_name(field.slug)}"
@@ -337,6 +349,12 @@ def extend_schema_type_relationships(schema_type, model):
     prefix = ""
     if settings.GRAPHQL_RELATIONSHIP_PREFIX and isinstance(settings.GRAPHQL_RELATIONSHIP_PREFIX, str):
         prefix = f"{settings.GRAPHQL_RELATIONSHIP_PREFIX}_"
+
+    # clear old custom fields; TODO: safe?
+    for field in dir(schema_type):
+        if field.startswith(f"resolve_{prefix}"):
+            delattr(schema_type, field)
+            del schema_type._meta.fields[field.replace("resolve_", "")]
 
     for side, relationships in relationships_by_side.items():
         for relationship in relationships:

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -362,6 +362,8 @@ def extend_schema_type_relationships(reg, schema_type, model):
     return schema_type
 
 
+# this generates a dynamic copy of the static classes. this is needed to
+# avoid manipulating the classes we define statically directly
 def make_class(cls):
     return type(f"{cls.__name__}Copy", (cls,), {"Meta": cls._cached_meta})
 

--- a/nautobot/core/graphql/schema_init.py
+++ b/nautobot/core/graphql/schema_init.py
@@ -4,11 +4,10 @@ from graphene_django.types import ObjectType
 from .schema import generate_query_mixin
 
 
-DynamicGraphQL = generate_query_mixin()
+def generate_schema():
+    DynamicGraphQL = generate_query_mixin()
 
+    class Query(ObjectType, DynamicGraphQL):
+        """Contains the entire GraphQL Schema definition for Nautobot."""
 
-class Query(ObjectType, DynamicGraphQL):
-    """Contains the entire GraphQL Schema definition for Nautobot."""
-
-
-schema = graphene.Schema(query=Query, auto_camelcase=False)
+    return graphene.Schema(query=Query, auto_camelcase=False)

--- a/nautobot/core/graphql/schema_init.py
+++ b/nautobot/core/graphql/schema_init.py
@@ -1,13 +1,23 @@
 import graphene
 from graphene_django.types import ObjectType
+from django.db.models import signals
 
 from .schema import generate_query_mixin
+from nautobot.extras.models import CustomField, Relationship
 
 
-def generate_schema():
+def generate_schema(*args, **kwargs):
     DynamicGraphQL = generate_query_mixin()
 
     class Query(ObjectType, DynamicGraphQL):
         """Contains the entire GraphQL Schema definition for Nautobot."""
 
     return graphene.Schema(query=Query, auto_camelcase=False)
+
+
+schema = generate_schema()
+
+signals.post_save.connect(generate_schema, sender=Relationship)
+signals.post_delete.connect(generate_schema, sender=Relationship)
+signals.post_save.connect(generate_schema, sender=CustomField)
+signals.post_delete.connect(generate_schema, sender=CustomField)

--- a/nautobot/core/graphql/schema_init.py
+++ b/nautobot/core/graphql/schema_init.py
@@ -5,17 +5,24 @@ from django.db.models import signals
 from .schema import generate_query_mixin
 from nautobot.extras.models import CustomField, Relationship
 
+schema = None
 
+
+# manipulating the global is less than pretty, but since we have to manipulate
+# the state of the app from signals that might just be what we have to do
 def generate_schema(*args, **kwargs):
+    global schema
     DynamicGraphQL = generate_query_mixin()
 
     class Query(ObjectType, DynamicGraphQL):
         """Contains the entire GraphQL Schema definition for Nautobot."""
 
-    return graphene.Schema(query=Query, auto_camelcase=False)
+    schema = graphene.Schema(query=Query, auto_camelcase=False)
 
 
-schema = generate_schema()
+# generate the initial schema
+generate_schema()
+
 
 signals.post_save.connect(generate_schema, sender=Relationship)
 signals.post_delete.connect(generate_schema, sender=Relationship)

--- a/nautobot/core/graphql/schema_init.py
+++ b/nautobot/core/graphql/schema_init.py
@@ -1,27 +1,65 @@
+import hashlib
+import json
+
+from django.db.models import signals
 import graphene
 from graphene_django.types import ObjectType
-from django.db.models import signals
+import redis
 
 from .schema import generate_query_mixin
+from nautobot.core.settings_funcs import parse_redis_connection
 from nautobot.extras.models import CustomField, Relationship
+
 
 schema = None
 
 
-# manipulating the global is less than pretty, but since we have to manipulate
+def schema_hash(schema):
+    return hashlib.md5(json.dumps(schema.introspect(), sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def redis_hash_changed():
+    hsh = schema_hash(schema)
+    r = redis.from_url(parse_redis_connection(0))
+
+    return r.get("nautobot_graphql_schema_hash") == hsh
+
+
+def redis_set():
+    hsh = schema_hash(schema)
+    r = redis.from_url(parse_redis_connection(0))
+
+    r.set("nautobot_graphql_schema_hash", hsh)
+
+
+# manipulating the global is less than pretty, but it’s the only way to enable
 # the state of the app from signals that might just be what we have to do
 def generate_schema(*args, **kwargs):
-    global schema
     DynamicGraphQL = generate_query_mixin()
 
-    class Query(ObjectType, DynamicGraphQL):
-        """Contains the entire GraphQL Schema definition for Nautobot."""
+    global schema
+    Query = type("Query", (ObjectType, DynamicGraphQL), {})
 
     schema = graphene.Schema(query=Query, auto_camelcase=False)
+
+    # how to deal with the race condition that since generation a new
+    # relationship was generated? fixpoint logic used here, might not
+    # terminate
+    if redis_hash_changed():
+        generate_schema()
+    else:
+        redis_set()
 
 
 # generate the initial schema
 generate_schema()
+
+
+def get_schema():
+    if redis_hash_changed():
+        generate_schema()
+
+    return schema
 
 
 signals.post_save.connect(generate_schema, sender=Relationship)

--- a/nautobot/core/graphql/types.py
+++ b/nautobot/core/graphql/types.py
@@ -1,9 +1,9 @@
 from django.contrib.contenttypes.models import ContentType
 
-from graphene_django import DjangoObjectType
+from .base import NautobotObjectType
 
 
-class ContentTypeType(DjangoObjectType):
+class ContentTypeType(NautobotObjectType):
     """
     Graphene-Django object type for ContentType records.
 

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -435,7 +435,6 @@ CORS_ALLOWED_ORIGINS = []
 #
 
 GRAPHENE = {
-    "SCHEMA": "nautobot.core.graphql.schema_init.schema",
     "DJANGO_CHOICE_FIELD_ENUM_V3_NAMING": True,  # any field with a name of type will break in Graphene otherwise.
 }
 GRAPHQL_CUSTOM_FIELD_PREFIX = "cf"

--- a/nautobot/core/settings_funcs.py
+++ b/nautobot/core/settings_funcs.py
@@ -82,6 +82,6 @@ def parse_redis_connection(redis_database):
     # password because the Redis Python client already does this.
     redis_creds = ""
     if redis_username or redis_password:
-        redis_creds = f"{redis_username}:{redis_password}@"
+        redis_creds = f"{redis_username or 'default'}:{redis_password}@"
 
     return f"{redis_scheme}://{redis_creds}{redis_host}:{redis_port}/{redis_database}"

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -71,9 +71,9 @@ User = get_user_model()
 class GraphQLTestCase(TestCase):
     @classmethod
     def setUp(self):
-        from nautobot.core.graphql.schema_init import schema
+        from nautobot.core.graphql.schema_init import get_schema
 
-        self.schema = schema
+        self.schema = get_schema()
         self.user = create_test_user("graphql_testuser")
         GraphQLQuery.objects.create(name="GQL 1", slug="gql-1", query="{ query: sites {name} }")
         GraphQLQuery.objects.create(
@@ -569,9 +569,9 @@ class GraphQLQueryTest(TestCase):
         self.request.user = self.user
 
         self.backend = get_default_backend()
-        from nautobot.core.graphql.schema_init import schema
+        from nautobot.core.graphql.schema_init import get_schema
 
-        self.schema = schema
+        self.schema = get_schema()
 
         # Populate Data
         manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -17,8 +17,9 @@ from graphene_django.views import GraphQLView
 
 from nautobot.core.constants import SEARCH_MAX_RESULTS, SEARCH_TYPES
 from nautobot.core.forms import SearchForm
+from nautobot.core.graphql.schema_init import generate_schema
 from nautobot.core.releases import get_latest_release
-from nautobot.extras.models import GraphQLQuery
+from nautobot.extras.models import GraphQLQuery, Relationship
 from nautobot.extras.registry import registry
 from nautobot.extras.forms import GraphQLQueryForm
 
@@ -181,6 +182,9 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
 
 
 class CustomGraphQLView(GraphQLView):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, schema=generate_schema())
+
     def render_graphiql(self, request, **data):
         query_slug = request.GET.get("slug")
         if query_slug:

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -182,9 +182,9 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
 
 class CustomGraphQLView(GraphQLView):
     def __init__(self, *args, **kwargs):
-        from nautobot.core.graphql.schema_init import schema
+        from nautobot.core.graphql.schema_init import get_schema
 
-        super().__init__(*args, **kwargs, schema=schema)
+        super().__init__(*args, **kwargs, schema=get_schema())
 
     def render_graphiql(self, request, **data):
         query_slug = request.GET.get("slug")

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -17,7 +17,6 @@ from graphene_django.views import GraphQLView
 
 from nautobot.core.constants import SEARCH_MAX_RESULTS, SEARCH_TYPES
 from nautobot.core.forms import SearchForm
-from nautobot.core.graphql.schema_init import generate_schema
 from nautobot.core.releases import get_latest_release
 from nautobot.extras.models import GraphQLQuery, Relationship
 from nautobot.extras.registry import registry
@@ -183,7 +182,9 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
 
 class CustomGraphQLView(GraphQLView):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs, schema=generate_schema())
+        from nautobot.core.graphql.schema_init import schema
+
+        super().__init__(*args, **kwargs, schema=schema)
 
     def render_graphiql(self, request, **data):
         query_slug = request.GET.get("slug")

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -1,8 +1,8 @@
 import graphene
-from graphene_django import DjangoObjectType
 from graphene_django.converter import convert_django_field
 
 from nautobot.circuits.graphql.types import CircuitTerminationType
+from nautobot.core.graphql.base import NautobotObjectType
 from nautobot.dcim.fields import MACAddressField
 from nautobot.dcim.graphql.mixins import PathEndpointMixin
 from nautobot.dcim.models import Cable, CablePath, ConsoleServerPort, Device, Interface, Rack, Site
@@ -23,7 +23,7 @@ def convert_field_to_string(field, registry=None):
     return graphene.String()
 
 
-class SiteType(DjangoObjectType):
+class SiteType(NautobotObjectType):
     """Graphql Type Object for Site model."""
 
     class Meta:
@@ -32,7 +32,7 @@ class SiteType(DjangoObjectType):
         exclude = ["images", "_name"]
 
 
-class DeviceType(DjangoObjectType):
+class DeviceType(NautobotObjectType):
     """Graphql Type Object for Device model."""
 
     class Meta:
@@ -41,7 +41,7 @@ class DeviceType(DjangoObjectType):
         exclude = ["_name"]
 
 
-class RackType(DjangoObjectType):
+class RackType(NautobotObjectType):
     """Graphql Type Object for Rack model."""
 
     class Meta:
@@ -50,7 +50,7 @@ class RackType(DjangoObjectType):
         exclude = ["images"]
 
 
-class InterfaceType(DjangoObjectType, PathEndpointMixin):
+class InterfaceType(NautobotObjectType, PathEndpointMixin):
     """Graphql Type Object for Interface model."""
 
     class Meta:
@@ -64,7 +64,7 @@ class InterfaceType(DjangoObjectType, PathEndpointMixin):
         return self.ip_addresses.all()
 
 
-class ConsoleServerPortType(DjangoObjectType, PathEndpointMixin):
+class ConsoleServerPortType(NautobotObjectType, PathEndpointMixin):
     """Graphql Type Object for ConsoleServerPort model."""
 
     class Meta:
@@ -72,7 +72,7 @@ class ConsoleServerPortType(DjangoObjectType, PathEndpointMixin):
         filterset_class = ConsoleServerPortFilterSet
 
 
-class CableType(DjangoObjectType):
+class CableType(NautobotObjectType):
     """Graphql Type Object for Cable model."""
 
     class Meta:
@@ -96,7 +96,7 @@ class CableType(DjangoObjectType):
         return None
 
 
-class CablePathType(DjangoObjectType):
+class CablePathType(NautobotObjectType):
     """GraphQL type object for CablePath model."""
 
     class Meta:

--- a/nautobot/extras/graphql/types.py
+++ b/nautobot/extras/graphql/types.py
@@ -1,14 +1,14 @@
 import graphene
-from graphene_django import DjangoObjectType
 from graphene_django.converter import convert_django_field
 
 from taggit.managers import TaggableManager
 
+from nautobot.core.graphql.base import NautobotObjectType
 from nautobot.extras.models import Status, Tag
 from nautobot.extras.filters import StatusFilterSet, TagFilterSet
 
 
-class TagType(DjangoObjectType):
+class TagType(NautobotObjectType):
     """Graphql Type Object for Tag model."""
 
     class Meta:
@@ -22,7 +22,7 @@ def convert_field_to_list_tags(field, registry=None):
     return graphene.List(TagType)
 
 
-class StatusType(DjangoObjectType):
+class StatusType(NautobotObjectType):
     """Graphql Type object for `Status` model."""
 
     class Meta:

--- a/nautobot/ipam/graphql/types.py
+++ b/nautobot/ipam/graphql/types.py
@@ -1,7 +1,7 @@
 import graphene
-from graphene_django import DjangoObjectType
 from graphene_django.converter import convert_django_field, convert_field_to_string
 
+from nautobot.core.graphql.base import NautobotObjectType
 from nautobot.dcim.graphql.types import InterfaceType
 from nautobot.ipam import models, filters, fields
 from nautobot.extras.graphql.types import TagType  # noqa: F401
@@ -12,7 +12,7 @@ from nautobot.virtualization.graphql.types import VMInterfaceType
 convert_django_field.register(fields.VarbinaryIPField)(convert_field_to_string)
 
 
-class AggregateType(DjangoObjectType):
+class AggregateType(NautobotObjectType):
     """Graphql Type Object for Aggregate model."""
 
     prefix = graphene.String()
@@ -37,7 +37,7 @@ class AssignedObjectType(graphene.Union):
         return None
 
 
-class IPAddressType(DjangoObjectType):
+class IPAddressType(NautobotObjectType):
     """Graphql Type Object for IPAddress model."""
 
     address = graphene.String()
@@ -60,7 +60,7 @@ class IPAddressType(DjangoObjectType):
         return None
 
 
-class PrefixType(DjangoObjectType):
+class PrefixType(NautobotObjectType):
     """Graphql Type Object for Prefix model."""
 
     prefix = graphene.String()

--- a/nautobot/virtualization/graphql/types.py
+++ b/nautobot/virtualization/graphql/types.py
@@ -1,11 +1,11 @@
 import graphene
-from graphene_django import DjangoObjectType
 
+from nautobot.core.graphql.base import NautobotObjectType
 from nautobot.virtualization.models import VirtualMachine, VMInterface
 from nautobot.virtualization.filters import VirtualMachineFilterSet, VMInterfaceFilterSet
 
 
-class VirtualMachineType(DjangoObjectType):
+class VirtualMachineType(NautobotObjectType):
     """GraphQL type object for VirtualMachine model."""
 
     class Meta:
@@ -13,7 +13,7 @@ class VirtualMachineType(DjangoObjectType):
         filterset_class = VirtualMachineFilterSet
 
 
-class VMInterfaceType(DjangoObjectType):
+class VMInterfaceType(NautobotObjectType):
     """GraphQL type object for VMInterface model."""
 
     class Meta:


### PR DESCRIPTION
### Fixes: #446

This PR fixes the need to restart to pick up new relationships, custom fields, and computed fields. The problem was twofold:

1. The schema was generated on startup and did not change. Now the schema gets generated on initialization of the view class. We could optimize this by making it a global that gets changed based on signals instead if efficiency requires this (that’s a little hard to test locally, though).
2. Even then, this only made the schema pick up new fields. Old ones were not deleted, since they were made properties of the object type class on generation. As such, the generators now have to clean up all the old fields before generating the new ones. This is facilitated by the fact that we generate prefixes for these classes. Selecting by prefix is not 100% safe (technically one could generte a name clash), but it should be safe enough. I’ve noted this as TODO, though, since I’d like some input before moving forward with this.

Cheers