### PR TITLE
Add delete action to scheduled jobs

### DIFF
--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -685,6 +685,7 @@ class ScheduledJobTestCase(
     ViewTestCases.GetObjectViewTestCase,
     ViewTestCases.ListObjectsViewTestCase,
     ViewTestCases.DeleteObjectViewTestCase,
+    ViewTestCases.BulkDeleteObjectsViewTestCase,
 ):
     model = ScheduledJob
 

--- a/nautobot/extras/urls.py
+++ b/nautobot/extras/urls.py
@@ -321,6 +321,11 @@ urlpatterns = [
     path("jobs/scheduled-jobs/<uuid:pk>/", views.ScheduledJobView.as_view(), name="scheduledjob"),
     path("jobs/scheduled-jobs/<uuid:pk>/delete/", views.ScheduledJobDeleteView.as_view(), name="scheduledjob_delete"),
     path(
+        "jobs/scheduled-jobs/delete/",
+        views.ScheduledJobBulkDeleteView.as_view(),
+        name="scheduledjob_bulk_delete",
+    ),
+    path(
         "jobs/scheduled-jobs/approval-queue/",
         views.ScheduledJobApprovalQueueListView.as_view(),
         name="scheduledjob_approval_queue_list",

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -933,6 +933,7 @@ class ScheduledJobListView(generic.ObjectListView):
 class ScheduledJobBulkDeleteView(generic.BulkDeleteView):
     queryset = ScheduledJob.objects.all()
     table = tables.ScheduledJobTable
+    filterset = filters.ScheduledJobFilterSet
 
 
 class ScheduledJobApprovalQueueListView(generic.ObjectListView):

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -927,7 +927,12 @@ class ScheduledJobListView(generic.ObjectListView):
     table = tables.ScheduledJobTable
     filterset = filters.ScheduledJobFilterSet
     filterset_form = forms.ScheduledJobFilterForm
-    action_buttons = ()
+    action_buttons = ("delete",)
+
+
+class ScheduledJobBulkDeleteView(generic.BulkDeleteView):
+    queryset = ScheduledJob.objects.all()
+    table = tables.ScheduledJobTable
 
 
 class ScheduledJobApprovalQueueListView(generic.ObjectListView):


### PR DESCRIPTION
### Fixes: #937 

This PR fixes #937 by adding a bulk deletion option for scheduled jobs. I decided to only add that option for now, since editing isn’t really something we do for scheduled jobs.

Cheers
