### PR TITLE
Override X-Frame-Options specifically for the rack-elevation SVG view

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -381,7 +381,7 @@ USE_TZ = True
 WSGI_APPLICATION = "nautobot.core.wsgi.application"
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 USE_X_FORWARDED_HOST = True
-X_FRAME_OPTIONS = "SAMEORIGIN"
+X_FRAME_OPTIONS = "DENY"
 
 # Static files (CSS, JavaScript, Images)
 STATIC_ROOT = os.path.join(NAUTOBOT_ROOT, "static")

--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db.models import F
 from django.http import HttpResponseForbidden, HttpResponse
 from django.shortcuts import get_object_or_404
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from drf_yasg import openapi
 from drf_yasg.openapi import Parameter
 from drf_yasg.utils import swagger_auto_schema
@@ -198,6 +199,7 @@ class RackViewSet(StatusViewSetMixin, CustomFieldModelViewSet):
         query_serializer=serializers.RackElevationDetailFilterSerializer,
     )
     @action(detail=True)
+    @xframe_options_sameorigin
     def elevation(self, request, pk=None):
         """
         Rack elevation representing the list of rack units. Also supports rendering the elevation as an SVG.

--- a/nautobot/docs/installation/http-server.md
+++ b/nautobot/docs/installation/http-server.md
@@ -153,6 +153,9 @@ At this point, you should be able to connect to the HTTPS service at the server 
 !!! info
     Please keep in mind that the configurations provided here are bare minimums required to get Nautobot up and running. You may want to make adjustments to better suit your production environment.
 
+!!! warning
+    Certain components of Nautobot (such as the display of rack elevation diagrams) rely on the use of embedded objects. Ensure that your HTTP server configuration does not override the `X-Frame-Options` response header set by Nautobot.
+
 ## Troubleshooting
 
 ### Unable to Connect

--- a/nautobot/docs/installation/http-server.md
+++ b/nautobot/docs/installation/http-server.md
@@ -153,9 +153,6 @@ At this point, you should be able to connect to the HTTPS service at the server 
 !!! info
     Please keep in mind that the configurations provided here are bare minimums required to get Nautobot up and running. You may want to make adjustments to better suit your production environment.
 
-!!! warning
-    Certain components of Nautobot (such as the display of rack elevation diagrams) rely on the use of embedded objects. Ensure that your HTTP server configuration does not override the `X-Frame-Options` response header set by Nautobot.
-
 ## Troubleshooting
 
 ### Unable to Connect

--- a/nautobot/docs/installation/selinux-troubleshooting.md
+++ b/nautobot/docs/installation/selinux-troubleshooting.md
@@ -183,6 +183,6 @@ Content-Length: 18698
 Connection: keep-alive
 X-Content-Type-Options: nosniff
 Referrer-Policy: same-origin
-X-Frame-Options: SAMEORIGIN
+X-Frame-Options: DENY
 Vary: Cookie, Origin
 ```


### PR DESCRIPTION
### Fixes: #939 

Instead of setting `X_FRAME_OPTIONS = "SAMEORIGIN"` globally, which Django complains about as a generalized security risk, change the global default back to the recommended setting of `"DENY"` and use a Django view decorator to specifically set `"SAMEORIGIN"` for the one view (rack-elevation SVG rendering) where it's needed.