### PR TITLE
Require a username when running a database-affecting Job from the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.swp
 /site/
 /venv/
-/dist/
+**/dist/
 /*.sh
 local_requirements.txt
 !upgrade.sh

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -357,7 +357,12 @@ Once a job has been run, the latest [`JobResult`](../models/extras/jobresult.md)
 
 ### Via the API
 
-To run a job via the REST API, issue a POST request to the job's endpoint, with the option of specifying any required user input data and/or the `commit` flag.
+To run a job via the REST API, issue a POST request to the job's endpoint `/api/extras/jobs/<class_path>/run/`. You can optionally provide JSON data to set the `commit` flag and/or specify any required user input `data`.
+
+!!! note
+    [See above](#jobs-and-class_path) for information on constructing the `class_path` for any given Job.
+
+For example, to run a job with no user inputs and without committing any anything to the database:
 
 ```no-highlight
 curl -X POST \
@@ -367,17 +372,16 @@ curl -X POST \
 http://nautobot/api/extras/jobs/local/example/MyJobWithNoVars/run/
 ```
 
+Or to run a job that expects user inputs, and commit changes to the database:
+
 ```no-highlight
 curl -X POST \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; indent=4" \
 http://nautobot/api/extras/jobs/local/example/MyJobWithVars/run/ \
---data '{"data": {"foo": "somevalue", "bar": 123}, "commit": true}'
+--data '{"data": {"string_variable": "somevalue", "integer_variable": 123}, "commit": true}'
 ```
-
-!!! note
-    In this example, `local/example/MyJobWithVars` is the job's `class_path` - [see above](#jobs-and-class_path) for information on constructing the `class_path` for any given Job.
 
 When providing input data, it is possible to specify complex values contained in `ObjectVar`s, `MultiObjectVar`s, and `IPAddressVar`s.
 
@@ -390,7 +394,7 @@ When providing input data, it is possible to specify complex values contained in
 Jobs that do not require user input can be run from the CLI by invoking the management command:
 
 ```no-highlight
-nautobot-server runjob [--username <username>] [--commit] <grouping_name>/<module>/<JobName>
+nautobot-server runjob [--username <username>] [--commit] <class_path>
 ```
 
 !!! note
@@ -404,8 +408,10 @@ nautobot-server runjob --username myusername local/example/MyJobWithNoVars
 
 Provision of user input (`data` values) via the CLI is not supported at this time.
 
-!!! note
-    `nautobot-server` commands, like other direct interactions with the Django ORM, are not gated by the usual Nautobot user authentication flow. It is possible to specify any valid `--username` argument to the `nautobot-server runjob` command in order to impersonate any given user as the requester of a job. Use this power wisely and be cautious who you allow to access it.
+!!! warning
+    The `--username <username>` parameter can be used to specify the user that will be identified as the requester of the job. It is optional if the job will not be modifying the database, but is mandatory if you are running with `--commit`, as the specified user will own any resulting database changes.
+
+    Note that `nautobot-server` commands, like all management commands and other direct interactions with the Django database, are not gated by the usual Nautobot user authentication flow. It is possible to specify any existing `--username` with the `nautobot-server runjob` command in order to impersonate any defined user in Nautobot. Use this power wisely and be cautious who you allow to access it.
 
 ## Example Jobs
 

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -390,7 +390,7 @@ When providing input data, it is possible to specify complex values contained in
 Jobs that do not require user input can be run from the CLI by invoking the management command:
 
 ```no-highlight
-nautobot-server runjob <grouping_name>/<module>/<JobName> [--commit]
+nautobot-server runjob [--username <username>] [--commit] <grouping_name>/<module>/<JobName>
 ```
 
 !!! note
@@ -399,10 +399,13 @@ nautobot-server runjob <grouping_name>/<module>/<JobName> [--commit]
 Using the same example shown in the API:
 
 ```no-highlight
-nautobot-server runjob local/example/MyJobWithNoVars
+nautobot-server runjob --username myusername local/example/MyJobWithNoVars
 ```
 
-Provision of user inputs via the CLI is not supported at this time.
+Provision of user input (`data` values) via the CLI is not supported at this time.
+
+!!! note
+    `nautobot-server` commands, like other direct interactions with the Django ORM, are not gated by the usual Nautobot user authentication flow. It is possible to specify any valid `--username` argument to the `nautobot-server runjob` command in order to impersonate any given user as the requester of a job. Use this power wisely and be cautious who you allow to access it.
 
 ## Example Jobs
 

--- a/nautobot/docs/administration/nautobot-server.md
+++ b/nautobot/docs/administration/nautobot-server.md
@@ -357,11 +357,16 @@ Done.
 Run a job (script, report) to validate or update data in Nautobot.
 
 `--commit`<br>
-Commit changes to DB (defaults to dry-run if unset).
+Commit changes to DB (defaults to dry-run if unset). `--username` is mandatory if using this argument.
+
+`--username <username>`<br>
+User account to impersonate as the requester of this job.
 
 ```no-highlight
-$ nautobot-server runjob local/example/MyJobWithVars --commit
+$ nautobot-server runjob --commit --username someuser local/example/MyJobWithNoVars
 ```
+
+Note that there is presently no option to provide input parameters (`data`) for jobs via the CLI.
 
 Please see the [guide on Jobs](../additional-features/jobs.md) for more information on working with and running jobs.
 

--- a/nautobot/docs/release-notes/version-1.1.md
+++ b/nautobot/docs/release-notes/version-1.1.md
@@ -90,6 +90,10 @@ The example `uwsgi.ini` provided in earlier versions of the Nautobot documentati
 - [#623](https://github.com/nautobot/nautobot/issues/623) - Git repository sync logs now include the commit hash that was synchronized to.
 - [#861](https://github.com/nautobot/nautobot/issues/861) - Bulk editing of devices can now update their site, rack, and rack-group assignments.
 
+### Fixed
+
+- [#944](https://github.com/nautobot/nautobot/issues/944) - Jobs that commit changes to the database could not be invoked successfully from the `nautobot-server runjob` command.
+
 ## v1.1.3 (2021-09-13)
 
 ### Added
@@ -128,7 +132,7 @@ The example `uwsgi.ini` provided in earlier versions of the Nautobot documentati
 ### Security
 
 - [#893](https://github.com/nautobot/nautobot/pull/893) - Bump Pillow dependency version from 8.2.0 to 8.2.3 to address numerous critical CVE advisories
--
+
 ## v1.1.2 (2021-08-10)
 
 ### Added

--- a/nautobot/extras/management/commands/runjob.py
+++ b/nautobot/extras/management/commands/runjob.py
@@ -1,12 +1,16 @@
 import time
+import uuid
 
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand, CommandError
+from django.test.client import RequestFactory
 from django.utils import timezone
 
 from nautobot.extras.choices import JobResultStatusChoices
 from nautobot.extras.models import JobResult
 from nautobot.extras.jobs import get_job, run_job
+from nautobot.utilities.utils import copy_safe_request
 
 
 class Command(BaseCommand):
@@ -17,7 +21,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "--commit",
             action="store_true",
-            help="Commit changes to DB (defaults to dry-run if unset)",
+            help="Commit changes to DB (defaults to dry-run if unset). --username is mandatory if using this argument",
+        )
+        parser.add_argument(
+            "-u",
+            "--username",
+            help="User account to impersonate as the requester of this job",
         )
 
     def handle(self, *args, **options):
@@ -26,6 +35,23 @@ class Command(BaseCommand):
         job_class = get_job(options["job"])
         if not job_class:
             raise CommandError('Job "%s" not found' % options["job"])
+
+        user = None
+        request = None
+        if options["commit"] and not options["username"]:
+            # Job execution with commit=True uses change_logging(), which requires a user as the author of any changes
+            raise CommandError("--username is mandatory when running with --commit as True")
+
+        if options["username"]:
+            User = get_user_model()
+            try:
+                user = User.objects.get(username=options["username"])
+            except User.DoesNotExist as exc:
+                raise CommandError("No such username") from exc
+
+            request = RequestFactory().request(SERVER_NAME="nautobot_server_runjob")
+            request.id = uuid.uuid4()
+            request.user = user
 
         job_content_type = ContentType.objects.get(app_label="extras", model="job")
 
@@ -36,9 +62,9 @@ class Command(BaseCommand):
             run_job,
             job_class.class_path,
             job_content_type,
-            None,
+            user,
             data={},  # TODO: parsing CLI args into a data dictionary is not currently implemented
-            request=None,
+            request=copy_safe_request(request) if request else None,
             commit=options["commit"],
         )
 

--- a/nautobot/extras/management/commands/runjob.py
+++ b/nautobot/extras/management/commands/runjob.py
@@ -40,14 +40,14 @@ class Command(BaseCommand):
         request = None
         if options["commit"] and not options["username"]:
             # Job execution with commit=True uses change_logging(), which requires a user as the author of any changes
-            raise CommandError("--username is mandatory when running with --commit as True")
+            raise CommandError("--username is mandatory when --commit is used")
 
         if options["username"]:
             User = get_user_model()
             try:
                 user = User.objects.get(username=options["username"])
             except User.DoesNotExist as exc:
-                raise CommandError("No such username") from exc
+                raise CommandError("No such user") from exc
 
             request = RequestFactory().request(SERVER_NAME="nautobot_server_runjob")
             request.id = uuid.uuid4()

--- a/nautobot/extras/tests/dummy_jobs/test_modify_db.py
+++ b/nautobot/extras/tests/dummy_jobs/test_modify_db.py
@@ -1,0 +1,17 @@
+from nautobot.extras.jobs import Job
+from nautobot.extras.models import Status
+
+
+class TestModifyDB(Job):
+    """
+    Job that modifies the database.
+    """
+
+    def test_modify_db(self):
+        """
+        Job function.
+        """
+        Status.objects.create(
+            name="Test Status",
+            slug="test-status",
+        )

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -1,16 +1,21 @@
 import json
+from io import StringIO
 import os
 import uuid
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 
 from nautobot.dcim.models import DeviceRole, Site
 from nautobot.extras.choices import JobResultStatusChoices
 from nautobot.extras.jobs import get_job, run_job
-from nautobot.extras.models import FileAttachment, FileProxy, JobResult
-from nautobot.utilities.testing import TestCase
+from nautobot.extras.models import FileAttachment, FileProxy, JobResult, Status
+from nautobot.utilities.testing import CeleryTestCase, TestCase
 
 
 class JobTest(TestCase):
@@ -346,3 +351,73 @@ class JobFileUploadTest(TestCase):
 
             # Assert that FileProxy was cleaned up
             self.assertEqual(FileProxy.objects.count(), 0)
+
+
+class RunJobManagementCommandTest(CeleryTestCase):
+    """Test cases for the `nautobot-server runjob` management command."""
+
+    def run_command(self, *args):
+        out = StringIO()
+        err = StringIO()
+        call_command(
+            "runjob",
+            *args,
+            stdout=out,
+            stderr=err,
+        )
+
+        return (out.getvalue(), err.getvalue())
+
+    def test_runjob_nochange_successful(self):
+        """Basic success-path test for Jobs that don't modify the Nautobot database."""
+        with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+            out, err = self.run_command("local/test_pass/TestPass")
+            self.assertIn("Running local/test_pass/TestPass...", out)
+            self.assertIn("test_pass: 1 success, 1 info, 0 warning, 0 failure", out)
+            self.assertIn("info: Database changes have been reverted automatically.", out)
+            self.assertIn("local/test_pass/TestPass: SUCCESS", out)
+            self.assertEqual("", err)
+
+    def test_runjob_db_change_no_commit(self):
+        """A job that changes the DB, when run with commit=False, doesn't modify the database."""
+        with self.assertRaises(ObjectDoesNotExist):
+            Status.objects.get(slug="test-status")
+
+        with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+            out, err = self.run_command("local/test_modify_db/TestModifyDB")
+            self.assertIn("Running local/test_modify_db/TestModifyDB...", out)
+            self.assertIn("test_modify_db: 0 success, 1 info, 0 warning, 0 failure", out)
+            self.assertIn("info: Database changes have been reverted automatically.", out)
+            self.assertIn("local/test_modify_db/TestModifyDB: SUCCESS", out)
+            self.assertEqual("", err)
+
+        with self.assertRaises(ObjectDoesNotExist):
+            Status.objects.get(slug="test-status")
+
+    def test_runjob_db_change_commit_no_username(self):
+        """A job that changes the DB, when run with commit=True but no username, is rejected."""
+        with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+            with self.assertRaises(CommandError):
+                self.run_command("--commit", "local/test_modify_db/TestModifyDB")
+
+    def test_runjob_db_change_commit_wrong_username(self):
+        """A job that changes the DB, when run with commit=True and a nonexistent username, is rejected."""
+        with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+            with self.assertRaises(CommandError):
+                self.run_command("--commit", "--username", "nosuchuser", "local/test_modify_db/TestModifyDB")
+
+    def test_runjob_db_change_commit_and_username(self):
+        """A job that chagnes the DB, when run with commit=True and a username, successfully updates the DB."""
+        with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+            get_user_model().objects.create(username="dummy_user")
+
+            out, err = self.run_command("--commit", "--username", "dummy_user", "local/test_modify_db/TestModifyDB")
+            self.assertIn("Running local/test_modify_db/TestModifyDB...", out)
+            self.assertIn("test_modify_db: 0 success, 0 info, 0 warning, 0 failure", out)
+            self.assertIn("local/test_modify_db/TestModifyDB: SUCCESS", out)
+            self.assertEqual("", err)
+
+        status = Status.objects.get(slug="test-status")
+        self.assertEqual(status.name, "Test Status")
+
+        status.delete()

--- a/tasks.py
+++ b/tasks.py
@@ -272,11 +272,14 @@ def restart(context, service=None):
     docker_compose(context, "restart", service=service)
 
 
-@task
-def stop(context):
+@task(help={"service": "If specified, only affect this service."})
+def stop(context, service=None):
     """Stop Nautobot and its dependencies."""
     print("Stopping Nautobot...")
-    docker_compose(context, "down")
+    if not service:
+        docker_compose(context, "down")
+    else:
+        docker_compose(context, "stop", service=service)
 
 
 @task


### PR DESCRIPTION
### Fixes: #944 

When a Job is run with `--commit`, it automatically executes in a `change_logging()` context. This context hard-requires that an appropriate request context (with an associated User account) exists. The `nautobot-server runjob` command was not providing any such request or User, causing jobs to error out when run with --commit as soon as they attempted to make any database changes (triggering change-logging to run).

Solution:
- Add an additional parameter, `--username <username>` to the `nautobot-server runjob` command, as we don't have any way to map the calling (OS) user account automatically to a Django User.
- When `--commit` is included in a `runjob` command, make `--username <username>` a mandatory additional parameter. (This is not a backwards-incompatible change, as `runjob --commit <job>` would always error out previously due to #944; now it will fail with a CommandError and explanatory message instead of throwing an uncaught AttributeError)
- When `runjob --username <username> <job>` (with or without `--commit`) is called, construct the request context making use of this user and pass it into the `enqueue_job` function as appropriate.
- Update documentation
- Add unit testing.

```
# nautobot-server runjob --commit plugins/dummy_plugin.jobs/DummyJob
CommandError: --username is mandatory when running with --commit as True
```

```
# nautobot-server runjob --help
usage: nautobot-server runjob [-h] [--commit] [-u USERNAME] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
                              [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
                              job

Run a job (script, report) to validate or update data in Nautobot

positional arguments:
  job                   Job to run

optional arguments:
  -h, --help            show this help message and exit
  --commit              Commit changes to DB (defaults to dry-run if unset). --username is mandatory if using this
                        argument
  -u USERNAME, --username USERNAME
                        User account to impersonate as the requester of this job
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g. "myproject.settings.main". If this isn't provided,
                        the DJANGO_SETTINGS_MODULE environment variable will be used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g. "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.
  --force-color         Force colorization of the command output.
  --skip-checks         Skip system checks.
```