### PR TITLE
Add mysql option to dev environment

### DIFF
--- a/development/dev.env
+++ b/development/dev.env
@@ -1,11 +1,13 @@
 NAUTOBOT_ALLOWED_HOSTS=*
 NAUTOBOT_CHANGELOG_RETENTION=0
 NAUTOBOT_CONFIG=/opt/nautobot/nautobot_config.py
+# If using MySQL, set NAUTOBOT_DB_HOST=mysql
 NAUTOBOT_DB_HOST=postgres
 NAUTOBOT_DB_NAME=nautobot
 NAUTOBOT_DB_PASSWORD=decinablesprewad
 NAUTOBOT_DB_USER=nautobot
 NAUTOBOT_DB_TIMEOUT=300
+# If using MySQL, set NAUTOBOT_DB_ENGINE=django.db.backends.mysql
 NAUTOBOT_DB_ENGINE=django.db.backends.postgresql
 NAUTOBOT_MAX_PAGE_SIZE=0
 NAUTOBOT_NAPALM_TIMEOUT=5
@@ -16,13 +18,19 @@ NAUTOBOT_REDIS_PORT=6379
 # NAUTOBOT_REDIS_SSL=True
 NAUTOBOT_SECRET_KEY=012345678901234567890123456789012345678901234567890123456789
 
-# Needed for Postgres should match the values for Nautobot above
+# Needed for MySQL, must match the values for Nautobot above
+MYSQL_ROOT_PASSWORD=decinablesprewad
+MYSQL_DATABASE=nautobot
+MYSQL_PASSWORD=decinablesprewad
+MYSQL_USER=nautobot
+
+# Needed for Postgres, must match the values for Nautobot above
 PGPASSWORD=decinablesprewad
 POSTGRES_DB=nautobot
 POSTGRES_PASSWORD=decinablesprewad
 POSTGRES_USER=nautobot
 
-# Needed for Redis should match the values for Nautobot above
+# Needed for Redis, must match the values for Nautobot above
 REDIS_PASSWORD=decinablesprewad
 
 # Needed for Selenium integration tests

--- a/development/docker-compose.mysql.yml
+++ b/development/docker-compose.mysql.yml
@@ -1,0 +1,14 @@
+---
+version: "3.4"
+services:
+  nautobot:
+    depends_on:
+      - mysql
+  mysql:
+    image: mysql:8
+    env_file:
+      - dev.env
+    volumes:
+      - mysqldata_nautobot:/var/lib/mysql
+volumes:
+  mysqldata_nautobot:

--- a/development/docker-compose.postgres.yml
+++ b/development/docker-compose.postgres.yml
@@ -1,0 +1,14 @@
+---
+version: "3.4"
+services:
+  nautobot:
+    depends_on:
+      - postgres
+  postgres:
+    image: postgres:13
+    env_file:
+      - dev.env
+    volumes:
+      - pgdata_nautobot:/var/lib/postgresql/data
+volumes:
+  pgdata_nautobot:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - postgres
       - redis
       - selenium
     env_file:
@@ -62,12 +61,6 @@ services:
     env_file:
       - ./dev.env
     tty: true
-  postgres:
-    image: postgres:13
-    env_file:
-      - dev.env
-    volumes:
-      - pgdata_nautobot:/var/lib/postgresql/data
   redis:
     image: redis:6-alpine
     command:
@@ -81,5 +74,3 @@ services:
     ports:
         - "4444:4444"
     shm_size: 2g
-volumes:
-  pgdata_nautobot:

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -30,6 +30,10 @@ DATABASES = {
     }
 }
 
+# Ensure proper Unicode handling for MySQL
+if DATABASES["default"]["ENGINE"] == "django.db.backends.mysql":
+    DATABASES["default"]["OPTIONS"] = {"charset": "utf8mb4"}
+
 #
 # Debug
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ ENV PATH="${PATH}:/root/.poetry/bin"
 # Install development OS dependencies
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y openssl && \
+    apt-get install --no-install-recommends -y openssl build-essential default-libmysqlclient-dev && \
     apt-get autoremove -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
@@ -67,7 +67,7 @@ WORKDIR /source
 # Local source code is mounted as volume into container. This approach does not require
 # to rebuild a container when source code change occurs.
 # -------------------------------------------------------------------------------------
-RUN poetry install --no-root --no-ansi
+RUN poetry install --no-root --no-ansi --extras mysql
 
 # Generate required dirs and self signed ssl certificates
 RUN mkdir /opt/nautobot /prom_cache && openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj \
@@ -90,7 +90,7 @@ COPY nautobot /source/nautobot
 
 # Build the whl for use in the final container and install for the dev container
 RUN poetry build && \
-    poetry install --no-ansi
+    poetry install --no-ansi --extras mysql
 
 ################################ Stage: cleaninstall
 # Build an image with required dependencies to pull the installation from

--- a/invoke.yml.example
+++ b/invoke.yml.example
@@ -6,6 +6,7 @@ nautobot:
   compose_dir: "/full/path/to/nautobot/development"
   compose_files:
     - "docker-compose.yml"
+    - "docker-compose.postgres.yml"
     - "docker-compose.dev.yml"
     - "docker-compose.override.yml"
   docker_image_names_main:

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -29,9 +29,12 @@ DATABASES = {
         "ENGINE": os.getenv(
             "NAUTOBOT_DB_ENGINE", "django.db.backends.postgresql"
         ),  # Database driver ("mysql" or "postgresql")
-        # "OPTIONS": {"charset": "utf8mb4"},  # For MySQL unicode emoji support, uncomment this line
     }
 }
+
+# Ensure proper Unicode handling for MySQL
+if DATABASES["default"]["ENGINE"] == "django.db.backends.mysql":
+    DATABASES["default"]["OPTIONS"] = {"charset": "utf8mb4"}
 
 # Nautobot uses RQ for task scheduling. These are the following defaults.
 # For detailed configuration see: https://github.com/rq/django-rq#installation

--- a/tasks.py
+++ b/tasks.py
@@ -49,6 +49,7 @@ namespace.configure(
             "compose_dir": os.path.join(os.path.dirname(__file__), "development/"),
             "compose_files": [
                 "docker-compose.yml",
+                "docker-compose.postgres.yml",
                 "docker-compose.dev.yml",
             ],
             # Image names to use when building from "main" branch


### PR DESCRIPTION
Add option for the docker-compose development workflow to use MySQL as an alternative to PostgreSQL.
