### PR TITLE
Avoid Status.DoesNotExist during loaddata

### DIFF
--- a/nautobot/dcim/models/cables.py
+++ b/nautobot/dcim/models/cables.py
@@ -118,8 +118,11 @@ class Cable(PrimaryModel, StatusModel):
         # A copy of the PK to be used by __str__ in case the object is deleted
         self._pk = self.pk
 
-        # Cache the original status so we can check later if it's been changed
-        self._orig_status = self.status
+        if self.present_in_database:
+            # Cache the original status so we can check later if it's been changed
+            self._orig_status = self.status
+        else:
+            self._orig_status = None
 
     @classmethod
     def from_db(cls, db, field_names, values):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #555
<!--
    Please include a summary of the proposed changes below.
-->

During `nautobot-server loaddata`, the attempt in `Cable.__init__` to cache any pre-existing `Status` for the cable was throwing an exception because the Status models hadn't been written to the database yet. Since `Cable._orig_status` is only used in the `update_connected_endpoints` signal handler for `post_save`, and *only* in the case where `created == False`, we can safely skip setting `_orig_status` in the case where the Cable is being newly created and doesn't pre-exist in the database.

That's my working theory anyway - this change definitely allows `invoke loaddata` to run without errors now, but our unit test coverage for this signal path appears pretty close to zero, so please hold me accountable here. :-)
