### PR TITLE
Check for Celery worker, not RQ worker, when deciding whether REST API for Git/Job can proceed

### DIFF
--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -586,7 +586,7 @@ class JobTest(APITestCase):
     def test_run_job_object_var_lookup(self):
         """Job run requests can reference objects by their attributes."""
         self.add_permissions("extras.run_job")
-        device_role = DeviceRole.objects.create(name="role", slug="role")
+        DeviceRole.objects.create(name="role", slug="role")
         job_data = {
             "var1": "FooBar",
             "var2": 123,

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -100,7 +100,7 @@ def generate_signature(request_body, secret):
     return hmac_prep.hexdigest()
 
 
-def get_worker_count(request):
+def get_worker_count(request=None):
     """
     Return a count of the active Celery workers.
     """
@@ -118,6 +118,7 @@ def get_worker_count(request):
     celery_count = len(active) if active is not None else 0
 
     if rq_count and not celery_count:
-        messages.warning(request, "RQ workers are deprecated. Please migrate your workers to Celery.")
+        if request:
+            messages.warning(request, "RQ workers are deprecated. Please migrate your workers to Celery.")
 
     return celery_count

--- a/nautobot/utilities/exceptions.py
+++ b/nautobot/utilities/exceptions.py
@@ -10,12 +10,23 @@ class AbortTransaction(Exception):
     pass
 
 
+# TODO remove this in 2.0
 class RQWorkerNotRunningException(APIException):
     """
-    Indicates the temporary inability to enqueue a new task (e.g. custom script execution) because no RQ worker
-    processes are currently running.
+    Indicates the temporary inability to enqueue a legacy RQ task  because no RQ worker processes are currently running.
     """
 
     status_code = status.HTTP_503_SERVICE_UNAVAILABLE
     default_detail = "Unable to process request: RQ worker process not running."
     default_code = "rq_worker_not_running"
+
+
+class CeleryWorkerNotRunningException(APIException):
+    """
+    Indicates the temporary inability to enqueue a new Celery task (e.g. custom script execution) because
+    no Celery worker processes are currently running.
+    """
+
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = "Unable to process request: Celery worker process not running."
+    default_code = "celery_worker_not_running"

--- a/tasks.py
+++ b/tasks.py
@@ -272,11 +272,14 @@ def restart(context, service=None):
     docker_compose(context, "restart", service=service)
 
 
-@task
-def stop(context):
+@task(help={"service": "If specified, only affect this service."})
+def stop(context, service=None):
     """Stop Nautobot and its dependencies."""
     print("Stopping Nautobot...")
-    docker_compose(context, "down")
+    if not service:
+        docker_compose(context, "down")
+    else:
+        docker_compose(context, "stop", service=service)
 
 
 @task


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #955 
<!--
    Please include a summary of the proposed changes below.
-->

- Fix the logic in the git-repository/sync REST API that was still checking for the RQ worker so that it now correctly checks for the Celery worker.
- Add missing logic in the job/run REST API to do a similar check
- Fix logic in API tests that was still checking for the RQ worker when deciding whether to skip tests so that it now correctly checks for the Celery worker
- One test case was failing after the above changes. Investigating this uncovered #958, which appears non-trivial to fix. For the moment I've disabled this test case with a TODO comment referencing the opened issue.