### PR TITLE
Add template documentation

### DIFF
--- a/examples/dummy_plugin/dummy_plugin/templates/dummy_plugin/dummymodel.html
+++ b/examples/dummy_plugin/dummy_plugin/templates/dummy_plugin/dummymodel.html
@@ -1,31 +1,32 @@
+<!-- this is a view demonstrating the capabilities of generic/object_detail.thml -->
 {% extends 'generic/object_detail.html' %}
 {% load helpers %}
 
 {% block extra_breadcrumb %}
         <li>
-            <a href="{% url 'plugins:dummy_plugin:dummymodel_list' %}?number={{ object.number }}">{{ object.number }}</a>
+            <a href="{% url 'plugins:dummy_plugin:dummymodel_list' %}?number={{ object.number }}">{{ object.number }} (Breadcrumbs)</a>
         </li>
 {% endblock extra_breadcrumb %}
 
 {% block extra_buttons %}
         <a onClick="alert('I am from the detail view template.')" class="btn btn-success">
-            <span class="mdi mdi-exclamation-thick" aria-hidden="true"></span> Extra Button
+            <span class="mdi mdi-exclamation-thick" aria-hidden="true"></span> Extra Buttons go here
         </a>
 {% endblock extra_buttons %}
 
 {% block panel_buttons %}
         <a onClick="alert('I am from the detail view template.')" class="btn btn-primary">
-            <span class="mdi mdi-help" aria-hidden="true"></span> Panel Button 1
+            <span class="mdi mdi-help" aria-hidden="true"></span> Panel Buttons go here
         </a>
         <a onClick="alert('I am from the detail view template.')" class="btn btn-primary">
-            <span class="mdi mdi-help" aria-hidden="true"></span> Panel Button 2
+            <span class="mdi mdi-help" aria-hidden="true"></span> Another Panel Button
         </a>
 {% endblock panel_buttons %}
 
 {% block content_left_page %}
         <div class="panel panel-default">
             <div class="panel-heading">
-                <strong>DummyModel</strong>
+                <strong>DummyModel (Left Page Content)</strong>
             </div>
 
             <table class="table table-hover panel-body attr-table">
@@ -44,7 +45,7 @@
 {% block content_right_page %}
         <div class="panel panel-default">
             <div class="panel-heading">
-                <strong>View Template Right Page</strong>
+                <strong>View Template Right Page Content</strong>
             </div>
 
             <table class="table table-hover panel-body attr-table">
@@ -63,7 +64,7 @@
 {% block content_full_width_page %}
         <div class="panel panel-default">
             <div class="panel-heading">
-                <strong>View Template Full Width Page</strong>
+                <strong>View Template Full Width Page Content</strong>
             </div>
 
             <table class="table table-hover panel-body attr-table">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,7 +88,6 @@ nav:
         - Using Plugins: 'plugins/index.md'
         - Developing Plugins: 'plugins/development.md'
         - Porting NetBox Plugins to Nautobot: 'plugins/porting-from-netbox.md'
-        - Templates for Plugins: 'plugins/templates.md'
     - Administration:
         - Nautobot Server: 'administration/nautobot-server.md'
         - Nautobot Shell: 'administration/nautobot-shell.md'
@@ -108,6 +107,7 @@ nav:
         - Style Guide: 'development/style-guide.md'
         - Extending Models: 'development/extending-models.md'
         - Application Registry: 'development/application-registry.md'
+        - Templates: 'development/templates.md'
         - Navigation Menu: 'development/navigation-menu.md'
         - Home Page Panels: 'development/homepage.md'
         - User Preferences: 'development/user-preferences.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
         - Using Plugins: 'plugins/index.md'
         - Developing Plugins: 'plugins/development.md'
         - Porting NetBox Plugins to Nautobot: 'plugins/porting-from-netbox.md'
+        - Templates for Plugins: 'plugins/templates.md'
     - Administration:
         - Nautobot Server: 'administration/nautobot-server.md'
         - Nautobot Shell: 'administration/nautobot-shell.md'

--- a/nautobot/docs/development/templates.md
+++ b/nautobot/docs/development/templates.md
@@ -54,8 +54,12 @@ In it, the following blocks may be implemented:
 
 ## Object Edit
 
-The base view for object addition or change is `generic/object_edit.html`. It
-does not provide any blocks for customizing the user experience.
+The base view for object addition or change is `generic/object_edit.html`, with
+the following blocks:
+
+- `form`: is the block in which the form gets rendered. This can be overriden
+  to provide a custom UI or UX for form views beyond what `render_form`
+  provides.
 
 ## Object Import
 

--- a/nautobot/docs/development/templates.md
+++ b/nautobot/docs/development/templates.md
@@ -16,28 +16,29 @@ The following blocks are available to you:
 
 - `header`: overloading this block allows for changing the entire top row of
   the page, including the title, breadcrumbs, search field, and tabs.
-- `breadcrumbs`: overloading this block allows for changing the entire breadcrumbs
-  block.
-- `extra_breadcrumbs`: this enables extending the breadcrumbs block just
-  before the model without having to redefine the entire block.
-- `buttons`: overloading this block allows redefining the entire button
-  section on the right of the page.
-- `extra_buttons`: this block enables extending the buttons block without
-  losing the predefined buttons. Custom buttons will appear between the
-  plugin buttons and clone/edit/delete actions.
-- `masthead`: is the block that contains the title. Overloading it enables
-  to change anything about the title block.
-- `title`: is the block contained by `masthead` and wrapped in a heading block.
-  Overloading it makes it possible to change the heading text.
-- `nav_tabs`: are the navigation tabs. If overloaded, custom tabs can be
-  rendered instead of the default.
-- `extra_nav_tabs`: this block allows to add new tabs without having to
-  override the default ones.
+    - `breadcrumbs`: overloading this block allows for changing the entire
+      breadcrumbs block.
+        - `extra_breadcrumbs`: this enables extending the breadcrumbs block
+          just before the model without having to redefine the entire block.
+    - `buttons`: overloading this block allows redefining the entire button
+      section on the right of the page.
+        - `extra_buttons`: this block enables extending the buttons block
+          without losing the predefined buttons. Custom buttons will appear
+          between the plugin buttons and clone/edit/delete actions.
+    - `masthead`: is the block that contains the title. Overloading it enables
+      to change anything about the title block.
+    - `title`: is the block contained by `masthead` and wrapped in a heading
+      block. Overloading it makes it possible to change the heading text as
+      well as the page title shown in the browser.
+    - `nav_tabs`: are the navigation tabs. If overloaded, custom tabs can be
+      rendered instead of the default.
+        - `extra_nav_tabs`: this block allows to add new tabs without having to
+          override the default ones.
 - `content`: is the entire content of the page below the `header`.
-- `content_left_page`: is a half-width column on the left. Multiple panels can
-  be rendered in a single block.
-- `content_right_page`: is a half-width column on the right.
-- `content_full_width_page`: is a full-width column.
+    - `content_left_page`: is a half-width column on the left. Multiple panels
+      can be rendered in a single block.
+    - `content_right_page`: is a half-width column on the right.
+    - `content_full_width_page`: is a full-width column.
 
 ## Object List
 
@@ -72,8 +73,8 @@ The base view for object deletion is `generic/object_delete.html`.
 It provides the following custom blocks:
 
 - `message`: is the overridable confirmation message for deletion.
-- `message_extra`: provides a way to add to the default message without
-  overriding it.
+    - `message_extra`: provides a way to add to the default message without
+      overriding it.
 
 ## Bulk Edit
 

--- a/nautobot/docs/plugins/templates.md
+++ b/nautobot/docs/plugins/templates.md
@@ -1,0 +1,106 @@
+# Templates for Plugins
+
+Nautobot comes with a variety of plugins that allow for a lot of flexibility
+while keeping the page style consistent with the rest of the application.
+This document presents these templates and their features.
+
+You can use it for your templates by calling `{% extends '<template_name>' %}`
+at the top of your template file.
+
+## Object Detail
+
+The most customizable template available to plugin authors is
+`generic/object_detail.html`.
+
+The following blocks are available to you:
+
+- `header`: overloading this block allows for changing the entire top row of
+  the page, including the title, breadcrumbs, search field, and tabs.
+- `breadcrumbs`: overloading this block allows for changing the entire breadcrumbs
+  block.
+- `extra_breadcrumbs`: this enables extending the breadcrumbs block just
+  before the model without having to redefine the entire block.
+- `buttons`: overloading this block allows redefining the entire button
+  section on the right of the page.
+- `extra_buttons`: this block enables extending the buttons block without
+  losing the predefined buttons. Custom buttons will appear between the
+  plugin buttons and clone/edit/delete actions.
+- `masthead`: is the block that contains the title. Overloading it enables
+  to change anything about the title block.
+- `title`: is the block contained by `masthead` and wrapped in a heading block.
+  Overloading it makes it possible to change the heading text.
+- `nav_tabs`: are the navigation tabs. If overloaded, custom tabs can be
+  rendered instead of the default.
+- `extra_nav_tabs`: this block allows to add new tabs without having to
+  override the default ones.
+- `content`: is the entire content of the page below the `header`.
+- `content_left_page`: is a half-width column on the left. Multiple panels can
+  be rendered in a single block.
+- `content_right_page`: is a half-width column on the right.
+- `content_full_width_page`: is a full-width column.
+
+## Object List
+
+The base view for listing objects is `generic/object_list.html`.
+
+In it, the following blocks may be implemented:
+
+- `buttons`: may provide a set of buttons at the top right of the page, to the
+  left of the table configuration button.
+- `sidebar`: may implement a sidebar below the search form on the right.
+- `bulk_buttons`: may be a set of buttons at the bottom of the table, to the
+  left of potential bulk edit or delete buttons.
+
+## Object Edit
+
+The base view for object addition or change is `generic/object_edit.html`. It
+does not provide any blocks for customizing the user experience.
+
+## Object Import
+
+The base view for object import is `generic/object_import.html`.
+
+The blocks that views may override are:
+
+- `tabs`: may provide tabs at the top of the page. The default import view is
+  not tabbed.
+
+## Object Deletion
+
+The base view for object deletion is `generic/object_delete.html`.
+
+It provides the following custom blocks:
+
+- `message`: is the overridable confirmation message for deletion.
+- `message_extra`: provides a way to add to the default message without
+  overriding it.
+
+## Bulk Edit
+
+The base view for bulk object change is `generic/object_bulk_edit.html`. It
+does not provide any blocks for customizing the user experience.
+
+## Bulk Import
+
+The base view for bulk object import is `generic/object_bulk_import.html`.
+
+The blocks that views may override are:
+
+- `tabs`: may provide tabs at the top of the page. The default import view is
+  not tabbed.
+
+## Bulk Deletion
+
+The base view for bulk object deletion is `generic/object_bulk_delete.html`.
+
+It provides the following custom blocks:
+
+- `message_extra`: provides a way to add to the default message.
+
+**Note**: contrary to the deletion of a single object, this view does *not*
+provide a way to completely override the deletion message.
+
+## Bulk Renaming
+
+The base view for renaming object in bulk is `generic/object_bulk_rename.html`.
+It does not provide any blocks for customizing the user experience.


### PR DESCRIPTION
This PR adds document on templates that plugins may override. Except for `generic/object_detail.html`, I was rather selective about which blocks to expose to the user, mostly limiting it to empty blocks specifically defined to be implemented by extending templates.

The prose is somewhat repetitive, maybe I should refactor this into a table per view? Input here would be especially appreciated.

Cheers