### PR TITLE
Remove any wildcard import, clean up unused imports, turn on flake8 F401/F403/F405

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,15 +2,15 @@
 ignore =
     # E203 whitespace before ':' (per Black, this is actually correct in some cases)
     E203,
-    # F401 module imported but unused (TODO: fix and re-enable this one)
-    F401,
-    # F403 'from module import *' used (TODO: fix and re-enable this one)
-    F403,
-    # F405 name may be undefined or defined from star imports (TODO: fix and re-enable this one)
-    F405,
     # E501 line greater than 80 characters in length (we use a 120-character line length, enforced by Black)
     E501,
     # W503 line break before binary operator (per Black, this is actually correct in some cases)
     W503,
     # W504 line break after binary operator (per Black, this is actually correct in some cases)
     W504
+
+per-file-ignores =
+    nautobot/dcim/tables/__init__.py:F401,F403,F405
+    nautobot/dcim/models/__init__.py:F401,F403,F405
+    nautobot/utilities/forms/__init__.py:F401,F403,F405
+    nautobot/utilities/testing/__init__.py:F401,F403,F405

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-from nautobot.core.settings import *
+from nautobot.core.settings import *  # noqa: F403
 from nautobot.core.settings_funcs import is_truthy, parse_redis_connection
 
 
@@ -43,10 +43,10 @@ DEBUG = is_truthy(os.getenv("NAUTOBOT_DEBUG", True))
 # Django Debug Toolbar
 DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG and not TESTING}
 
-if "debug_toolbar" not in INSTALLED_APPS:
-    INSTALLED_APPS.append("debug_toolbar")
-if "debug_toolbar.middleware.DebugToolbarMiddleware" not in MIDDLEWARE:
-    MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
+if "debug_toolbar" not in INSTALLED_APPS:  # noqa: F405
+    INSTALLED_APPS.append("debug_toolbar")  # noqa: F405
+if "debug_toolbar.middleware.DebugToolbarMiddleware" not in MIDDLEWARE:  # noqa: F405
+    MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")  # noqa: F405
 
 #
 # Logging

--- a/nautobot/circuits/api/serializers.py
+++ b/nautobot/circuits/api/serializers.py
@@ -17,8 +17,11 @@ from nautobot.extras.api.serializers import (
     TaggedObjectSerializer,
 )
 from nautobot.tenancy.api.nested_serializers import NestedTenantSerializer
-from .nested_serializers import *
+from .nested_serializers import NestedCircuitSerializer, NestedCircuitTypeSerializer, NestedProviderSerializer
 
+# This import is separated from the above import, as the variable(s) are not actually used anywhere in this file,
+# but still required for brief fields functionality to work
+from .nested_serializers import NestedCircuitTerminationSerializer  # noqa: F401
 
 #
 # Providers

--- a/nautobot/circuits/filters.py
+++ b/nautobot/circuits/filters.py
@@ -15,7 +15,6 @@ from nautobot.utilities.filters import (
     TagFilter,
     TreeNodeMultipleChoiceFilter,
 )
-from .choices import *
 from .models import Circuit, CircuitTermination, CircuitType, Provider
 
 __all__ = (

--- a/nautobot/circuits/models.py
+++ b/nautobot/circuits/models.py
@@ -8,7 +8,7 @@ from nautobot.extras.utils import extras_features
 from nautobot.core.fields import AutoSlugField
 from nautobot.core.models.generics import BaseModel, OrganizationalModel, PrimaryModel
 from nautobot.utilities.utils import serialize_object
-from .choices import *
+from .choices import CircuitTerminationSideChoices
 from .querysets import CircuitQuerySet
 
 

--- a/nautobot/circuits/tests/test_api.py
+++ b/nautobot/circuits/tests/test_api.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 
-from nautobot.circuits.choices import *
+from nautobot.circuits.choices import CircuitTerminationSideChoices
 from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, Provider
 from nautobot.dcim.models import Site
 from nautobot.extras.models import Status

--- a/nautobot/circuits/tests/test_filters.py
+++ b/nautobot/circuits/tests/test_filters.py
@@ -1,7 +1,11 @@
 from django.test import TestCase
 
-from nautobot.circuits.choices import *
-from nautobot.circuits.filters import *
+from nautobot.circuits.filters import (
+    CircuitFilterSet,
+    CircuitTerminationFilterSet,
+    CircuitTypeFilterSet,
+    ProviderFilterSet,
+)
 from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, Provider
 from nautobot.dcim.models import Cable, Device, DeviceRole, DeviceType, Interface, Manufacturer, Region, Site
 from nautobot.extras.models import Status

--- a/nautobot/circuits/tests/test_views.py
+++ b/nautobot/circuits/tests/test_views.py
@@ -1,6 +1,5 @@
 import datetime
 
-from nautobot.circuits.choices import *
 from nautobot.circuits.models import Circuit, CircuitType, Provider
 from nautobot.extras.models import Status
 from nautobot.utilities.testing import ViewTestCases

--- a/nautobot/core/__init__.py
+++ b/nautobot/core/__init__.py
@@ -1,4 +1,4 @@
-from nautobot.core import checks
+from nautobot.core import checks  # noqa: F401
 
 # This will make sure the celery app is always imported when
 # Django starts so that shared_task will use this app.

--- a/nautobot/core/admin.py
+++ b/nautobot/core/admin.py
@@ -1,4 +1,4 @@
-from django.conf import settings
+from django.conf import settings  # noqa: F401
 from django.contrib.admin import site as admin_site
 from social_django.models import Association, Nonce, UserSocialAuth
 from taggit.models import Tag

--- a/nautobot/core/api/fields.py
+++ b/nautobot/core/api/fields.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 
 from django.core.exceptions import ObjectDoesNotExist
-import pytz
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.relations import PrimaryKeyRelatedField, RelatedField

--- a/nautobot/core/celery/__init__.py
+++ b/nautobot/core/celery/__init__.py
@@ -1,8 +1,6 @@
 import json
 import logging
 
-import nautobot
-
 from celery import Celery, shared_task
 from celery.fixups.django import DjangoFixup
 from django.core.serializers.json import DjangoJSONEncoder

--- a/nautobot/core/cli.py
+++ b/nautobot/core/cli.py
@@ -4,7 +4,6 @@ Utilities and primitives for the `nautobot-server` CLI command.
 
 from pathlib import Path
 import os
-import warnings
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.utils import get_random_secret_key

--- a/nautobot/core/graphql/__init__.py
+++ b/nautobot/core/graphql/__init__.py
@@ -2,7 +2,6 @@ from django.db.models import JSONField, BigIntegerField
 from django.db.models.fields import BinaryField
 from django.test.client import RequestFactory
 
-from nautobot.extras.context_managers import web_request_context
 from nautobot.extras.models import GraphQLQuery
 
 import graphene

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import django_filters.fields
 import graphene
 from graphql import GraphQLError
 from graphene_django import DjangoObjectType

--- a/nautobot/core/middleware.py
+++ b/nautobot/core/middleware.py
@@ -1,9 +1,7 @@
-import logging
 import uuid
 
 from django.conf import settings
 from django.contrib.auth.middleware import RemoteUserMiddleware as RemoteUserMiddleware_
-from django.core.exceptions import ImproperlyConfigured
 from django.db import ProgrammingError
 from django.http import Http404
 from django.utils.deprecation import MiddlewareMixin

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -4,7 +4,7 @@ import platform
 from django.contrib.messages import constants as messages
 
 from nautobot import __version__
-from nautobot.core.settings_funcs import is_truthy, parse_redis_connection
+from nautobot.core.settings_funcs import parse_redis_connection
 
 #
 # Environment setup

--- a/nautobot/core/tests/integration/test_plugin_home.py
+++ b/nautobot/core/tests/integration/test_plugin_home.py
@@ -8,7 +8,6 @@ from nautobot.tenancy.models import Tenant
 from nautobot.utilities.testing.integration import SeleniumTestCase
 
 from dummy_plugin.models import DummyModel
-from dummy_plugin.homepage import get_dummy_data
 
 
 @skipIf(

--- a/nautobot/core/tests/integration/test_plugin_navbar.py
+++ b/nautobot/core/tests/integration/test_plugin_navbar.py
@@ -1,7 +1,6 @@
 from unittest import skipIf
 
 from django.conf import settings
-from django.test.utils import override_settings
 
 from nautobot.utilities.testing.integration import SeleniumTestCase
 from nautobot.utilities.choices import ButtonActionColorChoices, ButtonActionIconChoices

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -6,7 +6,7 @@
 import os
 
 from nautobot.core.settings import *  # noqa: F401,F403
-from nautobot.core.settings_funcs import is_truthy, parse_redis_connection
+from nautobot.core.settings_funcs import parse_redis_connection
 
 
 ALLOWED_HOSTS = ["*"]

--- a/nautobot/core/tests/test_authentication.py
+++ b/nautobot/core/tests/test_authentication.py
@@ -1,4 +1,3 @@
-from unittest import mock
 import uuid
 
 from django.conf import settings
@@ -11,7 +10,6 @@ from django.urls import reverse
 from netaddr import IPNetwork
 from rest_framework.test import APIClient
 
-from nautobot.core.middleware import ExternalAuthMiddleware
 from nautobot.dcim.models import Site
 from nautobot.extras.models import Status
 from nautobot.ipam.models import Prefix

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -3,7 +3,6 @@ import platform
 import sys
 
 from django.conf import settings
-from django.db.models import F
 from django.http import HttpResponseServerError
 from django.shortcuts import render
 from django.template import loader, RequestContext, Template

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -12,8 +12,27 @@ from nautobot.core.api import (
     ValidatedModelSerializer,
     WritableNestedSerializer,
 )
-from nautobot.dcim.choices import *
-from nautobot.dcim.constants import *
+
+from nautobot.dcim.choices import (
+    RackTypeChoices,
+    RackWidthChoices,
+    RackDimensionUnitChoices,
+    RackElevationDetailRenderChoices,
+    SubdeviceRoleChoices,
+    DeviceFaceChoices,
+    ConsolePortTypeChoices,
+    PowerPortTypeChoices,
+    PowerOutletTypeChoices,
+    PowerOutletFeedLegChoices,
+    InterfaceTypeChoices,
+    InterfaceModeChoices,
+    PortTypeChoices,
+    CableLengthUnitChoices,
+    PowerFeedTypeChoices,
+    PowerFeedSupplyChoices,
+    PowerFeedPhaseChoices,
+)
+from nautobot.dcim.constants import RACK_ELEVATION_LEGEND_WIDTH_DEFAULT, CABLE_TERMINATION_MODELS
 from nautobot.dcim.models import (
     Cable,
     CablePath,
@@ -64,7 +83,45 @@ from nautobot.tenancy.api.nested_serializers import NestedTenantSerializer
 from nautobot.users.api.nested_serializers import NestedUserSerializer
 from nautobot.utilities.api import get_serializer_for_model
 from nautobot.virtualization.api.nested_serializers import NestedClusterSerializer
-from .nested_serializers import *
+from .nested_serializers import (
+    NestedCableSerializer,
+    NestedDeviceBaySerializer,
+    NestedDeviceRoleSerializer,
+    NestedDeviceSerializer,
+    NestedDeviceTypeSerializer,
+    NestedInterfaceSerializer,
+    NestedManufacturerSerializer,
+    NestedPlatformSerializer,
+    NestedPowerPanelSerializer,
+    NestedPowerPortSerializer,
+    NestedPowerPortTemplateSerializer,
+    NestedRackGroupSerializer,
+    NestedRackRoleSerializer,
+    NestedRackSerializer,
+    NestedRearPortTemplateSerializer,
+    NestedRegionSerializer,
+    NestedSiteSerializer,
+    NestedVirtualChassisSerializer,
+)
+
+# This import is separated from the above import, as the variable(s) are not actually used anywhere in this file,
+# but still required for brief fields functionality to work
+from .nested_serializers import (  # noqa: F401
+    NestedConsolePortSerializer,
+    NestedConsolePortTemplateSerializer,
+    NestedConsoleServerPortSerializer,
+    NestedConsoleServerPortTemplateSerializer,
+    NestedDeviceBayTemplateSerializer,
+    NestedFrontPortSerializer,
+    NestedFrontPortTemplateSerializer,
+    NestedInterfaceTemplateSerializer,
+    NestedInventoryItemSerializer,
+    NestedPowerFeedSerializer,
+    NestedPowerOutletSerializer,
+    NestedPowerOutletTemplateSerializer,
+    NestedRackReservationSerializer,
+    NestedRearPortSerializer,
+)
 
 
 class CableTerminationSerializer(serializers.ModelSerializer):

--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -18,7 +18,6 @@ from rest_framework.viewsets import GenericViewSet, ViewSet
 from nautobot.circuits.models import Circuit
 from nautobot.core.api.views import ModelViewSet
 from nautobot.core.api.exceptions import ServiceUnavailable
-from nautobot.core.api.metadata import ContentTypeMetadata
 from nautobot.dcim import filters
 from nautobot.dcim.models import (
     Cable,

--- a/nautobot/dcim/filters.py
+++ b/nautobot/dcim/filters.py
@@ -1,5 +1,6 @@
 import django_filters
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 
 from nautobot.extras.filters import (
     CustomFieldModelFilterSet,
@@ -14,14 +15,21 @@ from nautobot.utilities.filters import (
     BaseFilterSet,
     MultiValueCharFilter,
     MultiValueMACAddressFilter,
-    MultiValueNumberFilter,
     NameSlugSearchFilterSet,
     TagFilter,
     TreeNodeMultipleChoiceFilter,
 )
 from nautobot.virtualization.models import Cluster
-from .choices import *
-from .constants import *
+from .choices import (
+    RackTypeChoices,
+    RackWidthChoices,
+    ConsolePortTypeChoices,
+    PowerPortTypeChoices,
+    PowerOutletTypeChoices,
+    InterfaceTypeChoices,
+    CableTypeChoices,
+)
+from .constants import VIRTUAL_IFACE_TYPES, WIRELESS_IFACE_TYPES, NONCONNECTABLE_IFACE_TYPES
 from .models import (
     Cable,
     ConsolePort,

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -5,8 +5,8 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.forms.array import SimpleArrayField
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Q
 from django.utils.safestring import mark_safe
-import netaddr
 from netaddr import EUI
 from netaddr.core import AddrFormatError
 from timezone_field import TimeZoneFormField
@@ -27,8 +27,8 @@ from nautobot.extras.forms import (
     StatusModelCSVFormMixin,
     StatusFilterFormMixin,
 )
-from nautobot.extras.models import ConfigContextSchema, Tag
-from nautobot.ipam.constants import BGP_ASN_MAX, BGP_ASN_MIN, IPV4_BYTE_LENGTH, IPV6_BYTE_LENGTH
+from nautobot.extras.models import Tag
+from nautobot.ipam.constants import BGP_ASN_MAX, BGP_ASN_MIN
 from nautobot.ipam.models import IPAddress, VLAN
 from nautobot.tenancy.forms import TenancyFilterForm, TenancyForm
 from nautobot.tenancy.models import Tenant, TenantGroup
@@ -47,7 +47,6 @@ from nautobot.utilities.forms import (
     DynamicModelMultipleChoiceField,
     ExpandableNameField,
     form_from_model,
-    JSONField,
     NumericArrayField,
     SelectWithPK,
     SmallTextarea,
@@ -58,8 +57,33 @@ from nautobot.utilities.forms import (
     BOOLEAN_WITH_BLANK_CHOICES,
 )
 from nautobot.virtualization.models import Cluster, ClusterGroup
-from .choices import *
-from .constants import *
+from .choices import (
+    RackTypeChoices,
+    RackWidthChoices,
+    RackDimensionUnitChoices,
+    SubdeviceRoleChoices,
+    DeviceFaceChoices,
+    ConsolePortTypeChoices,
+    PowerPortTypeChoices,
+    PowerOutletTypeChoices,
+    PowerOutletFeedLegChoices,
+    InterfaceTypeChoices,
+    InterfaceModeChoices,
+    PortTypeChoices,
+    CableTypeChoices,
+    CableLengthUnitChoices,
+    PowerFeedTypeChoices,
+    PowerFeedSupplyChoices,
+    PowerFeedPhaseChoices,
+)
+from .constants import (
+    REARPORT_POSITIONS_MIN,
+    REARPORT_POSITIONS_MAX,
+    INTERFACE_MTU_MIN,
+    INTERFACE_MTU_MAX,
+    CABLE_TERMINATION_MODELS,
+)
+
 from .models import (
     Cable,
     DeviceBay,

--- a/nautobot/dcim/lookups.py
+++ b/nautobot/dcim/lookups.py
@@ -1,5 +1,5 @@
 from django.db import NotSupportedError
-from django.db.models.lookups import Lookup, Contains
+from django.db.models.lookups import Lookup
 
 from nautobot.dcim.utils import object_to_path_node
 

--- a/nautobot/dcim/models/cables.py
+++ b/nautobot/dcim/models/cables.py
@@ -8,8 +8,9 @@ from django.db.models import Sum
 from django.urls import reverse
 from django.utils.functional import classproperty
 
-from nautobot.dcim.choices import *
-from nautobot.dcim.constants import *
+from nautobot.dcim.choices import CableTypeChoices, CableLengthUnitChoices
+from nautobot.dcim.constants import NONCONNECTABLE_IFACE_TYPES, CABLE_TERMINATION_MODELS, COMPATIBLE_TERMINATION_TYPES
+
 from nautobot.dcim.fields import JSONPathField
 from nautobot.dcim.utils import (
     decompile_path_node,

--- a/nautobot/dcim/models/device_component_templates.py
+++ b/nautobot/dcim/models/device_component_templates.py
@@ -2,8 +2,18 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
-from nautobot.dcim.choices import *
-from nautobot.dcim.constants import *
+from nautobot.dcim.choices import (
+    SubdeviceRoleChoices,
+    ConsolePortTypeChoices,
+    PowerPortTypeChoices,
+    PowerOutletTypeChoices,
+    PowerOutletFeedLegChoices,
+    InterfaceTypeChoices,
+    PortTypeChoices,
+)
+
+from nautobot.dcim.constants import REARPORT_POSITIONS_MIN, REARPORT_POSITIONS_MAX
+
 from nautobot.extras.models import CustomFieldModel, ObjectChange, RelationshipModel
 from nautobot.extras.utils import extras_features
 from nautobot.core.models import BaseModel

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -8,8 +8,25 @@ from django.urls import reverse
 from mptt.models import MPTTModel, TreeForeignKey
 from taggit.managers import TaggableManager
 
-from nautobot.dcim.choices import *
-from nautobot.dcim.constants import *
+
+from nautobot.dcim.choices import (
+    ConsolePortTypeChoices,
+    PowerPortTypeChoices,
+    PowerOutletTypeChoices,
+    PowerOutletFeedLegChoices,
+    InterfaceTypeChoices,
+    InterfaceModeChoices,
+    PortTypeChoices,
+    PowerFeedPhaseChoices,
+)
+from nautobot.dcim.constants import (
+    REARPORT_POSITIONS_MIN,
+    REARPORT_POSITIONS_MAX,
+    VIRTUAL_IFACE_TYPES,
+    WIRELESS_IFACE_TYPES,
+    NONCONNECTABLE_IFACE_TYPES,
+)
+
 from nautobot.dcim.fields import MACAddressCharField
 from nautobot.extras.models import (
     CustomFieldModel,

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -7,12 +7,12 @@ from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from django.db.models import F, ProtectedError
+from django.db.models import F, ProtectedError, Q
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
-from nautobot.dcim.choices import *
-from nautobot.dcim.constants import *
+from nautobot.dcim.choices import SubdeviceRoleChoices, DeviceFaceChoices
+
 from nautobot.extras.models import ConfigContextModel, StatusModel
 from nautobot.extras.querysets import ConfigContextModelQuerySet
 from nautobot.extras.utils import extras_features
@@ -20,7 +20,16 @@ from nautobot.core.fields import AutoSlugField
 from nautobot.core.models.generics import OrganizationalModel, PrimaryModel
 from nautobot.utilities.choices import ColorChoices
 from nautobot.utilities.fields import ColorField, NaturalOrderingField
-from .device_components import *
+from .device_components import (
+    ConsolePort,
+    ConsoleServerPort,
+    DeviceBay,
+    FrontPort,
+    Interface,
+    PowerOutlet,
+    PowerPort,
+    RearPort,
+)
 
 
 __all__ = (

--- a/nautobot/dcim/models/power.py
+++ b/nautobot/dcim/models/power.py
@@ -3,8 +3,13 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.urls import reverse
 
-from nautobot.dcim.choices import *
-from nautobot.dcim.constants import *
+from nautobot.dcim.choices import PowerFeedTypeChoices, PowerFeedSupplyChoices, PowerFeedPhaseChoices
+from nautobot.dcim.constants import (
+    POWERFEED_VOLTAGE_DEFAULT,
+    POWERFEED_AMPERAGE_DEFAULT,
+    POWERFEED_MAX_UTILIZATION_DEFAULT,
+)
+
 from nautobot.extras.models import StatusModel
 from nautobot.extras.utils import extras_features
 from nautobot.core.models.generics import PrimaryModel

--- a/nautobot/dcim/models/racks.py
+++ b/nautobot/dcim/models/racks.py
@@ -6,12 +6,13 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from django.db.models import Count, Sum
+from django.db.models import Count, Sum, Q
 from django.urls import reverse
 from mptt.models import MPTTModel, TreeForeignKey
 
-from nautobot.dcim.choices import *
-from nautobot.dcim.constants import *
+from nautobot.dcim.choices import RackTypeChoices, RackWidthChoices, RackDimensionUnitChoices, DeviceFaceChoices
+from nautobot.dcim.constants import RACK_U_HEIGHT_DEFAULT, RACK_ELEVATION_LEGEND_WIDTH_DEFAULT
+
 from nautobot.dcim.elevations import RackElevationSVG
 from nautobot.extras.models import ObjectChange, StatusModel
 from nautobot.extras.utils import extras_features

--- a/nautobot/dcim/models/sites.py
+++ b/nautobot/dcim/models/sites.py
@@ -1,11 +1,10 @@
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
+from django.db.models import Q
 from django.urls import reverse
 from mptt.models import MPTTModel, TreeForeignKey
 from timezone_field import TimeZoneField
 
-from nautobot.dcim.choices import *
-from nautobot.dcim.constants import *
 from nautobot.dcim.fields import ASNField
 from nautobot.extras.models import ObjectChange, StatusModel
 from nautobot.extras.utils import extras_features

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -2,8 +2,14 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 
-from nautobot.dcim.choices import *
-from nautobot.dcim.constants import *
+from nautobot.dcim.choices import (
+    SubdeviceRoleChoices,
+    InterfaceTypeChoices,
+    InterfaceModeChoices,
+    PortTypeChoices,
+    PowerFeedTypeChoices,
+)
+
 from nautobot.dcim.models import (
     Cable,
     ConsolePort,

--- a/nautobot/dcim/tests/test_cablepaths.py
+++ b/nautobot/dcim/tests/test_cablepaths.py
@@ -2,8 +2,26 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from nautobot.circuits.models import *
-from nautobot.dcim.models import *
+from nautobot.circuits.models import Provider, CircuitType, Circuit, CircuitTermination
+from nautobot.dcim.models import (
+    Site,
+    Manufacturer,
+    DeviceType,
+    DeviceRole,
+    Device,
+    PowerPanel,
+    Cable,
+    CablePath,
+    Interface,
+    ConsolePort,
+    ConsoleServerPort,
+    PowerPort,
+    PowerOutlet,
+    PowerFeed,
+    RearPort,
+    FrontPort,
+)
+
 from nautobot.dcim.utils import object_to_path_node
 from nautobot.extras.models import Status
 

--- a/nautobot/dcim/tests/test_filters.py
+++ b/nautobot/dcim/tests/test_filters.py
@@ -1,8 +1,57 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from nautobot.dcim.choices import *
-from nautobot.dcim.filters import *
+from nautobot.dcim.choices import (
+    RackTypeChoices,
+    RackWidthChoices,
+    RackDimensionUnitChoices,
+    SubdeviceRoleChoices,
+    DeviceFaceChoices,
+    PowerOutletFeedLegChoices,
+    InterfaceTypeChoices,
+    InterfaceModeChoices,
+    PortTypeChoices,
+    CableTypeChoices,
+    CableLengthUnitChoices,
+    PowerFeedTypeChoices,
+    PowerFeedSupplyChoices,
+    PowerFeedPhaseChoices,
+)
+from nautobot.dcim.filters import (
+    RegionFilterSet,
+    SiteFilterSet,
+    RackGroupFilterSet,
+    RackRoleFilterSet,
+    RackFilterSet,
+    RackReservationFilterSet,
+    ManufacturerFilterSet,
+    DeviceTypeFilterSet,
+    ConsolePortTemplateFilterSet,
+    ConsoleServerPortTemplateFilterSet,
+    PowerPortTemplateFilterSet,
+    PowerOutletTemplateFilterSet,
+    InterfaceTemplateFilterSet,
+    FrontPortTemplateFilterSet,
+    RearPortTemplateFilterSet,
+    DeviceBayTemplateFilterSet,
+    DeviceRoleFilterSet,
+    PlatformFilterSet,
+    DeviceFilterSet,
+    ConsolePortFilterSet,
+    ConsoleServerPortFilterSet,
+    PowerPortFilterSet,
+    PowerOutletFilterSet,
+    InterfaceFilterSet,
+    FrontPortFilterSet,
+    RearPortFilterSet,
+    DeviceBayFilterSet,
+    InventoryItemFilterSet,
+    VirtualChassisFilterSet,
+    CableFilterSet,
+    PowerPanelFilterSet,
+    PowerFeedFilterSet,
+)
+
 from nautobot.dcim.models import (
     Cable,
     ConsolePort,

--- a/nautobot/dcim/tests/test_forms.py
+++ b/nautobot/dcim/tests/test_forms.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 
-from nautobot.dcim.forms import *
-from nautobot.dcim.models import *
+from nautobot.dcim.forms import DeviceForm, InterfaceCreateForm
+from nautobot.dcim.choices import DeviceFaceChoices, InterfaceTypeChoices
+
+from nautobot.dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Platform, Rack, Site
 from nautobot.extras.models import Status
 from nautobot.virtualization.models import Cluster, ClusterGroup, ClusterType
 

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -1,9 +1,35 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from nautobot.circuits.models import *
-from nautobot.dcim.choices import *
-from nautobot.dcim.models import *
+from nautobot.circuits.models import Provider, CircuitType, Circuit, CircuitTermination
+from nautobot.dcim.choices import DeviceFaceChoices, PowerOutletFeedLegChoices, InterfaceTypeChoices, PortTypeChoices
+from nautobot.dcim.models import (
+    Cable,
+    ConsolePort,
+    ConsolePortTemplate,
+    ConsoleServerPort,
+    ConsoleServerPortTemplate,
+    Device,
+    DeviceBay,
+    DeviceBayTemplate,
+    DeviceRole,
+    DeviceType,
+    FrontPort,
+    FrontPortTemplate,
+    Interface,
+    InterfaceTemplate,
+    Manufacturer,
+    PowerPort,
+    PowerPortTemplate,
+    PowerOutlet,
+    PowerOutletTemplate,
+    PowerPanel,
+    Rack,
+    RackGroup,
+    RearPort,
+    RearPortTemplate,
+    Site,
+)
 from nautobot.extras.models import Status
 from nautobot.tenancy.models import Tenant
 

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -11,9 +11,60 @@ from netaddr import EUI
 
 from nautobot.circuits.choices import CircuitTerminationSideChoices
 from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, Provider
-from nautobot.dcim.choices import *
-from nautobot.dcim.constants import *
-from nautobot.dcim.models import *
+from nautobot.dcim.choices import (
+    RackTypeChoices,
+    RackWidthChoices,
+    RackDimensionUnitChoices,
+    SubdeviceRoleChoices,
+    DeviceFaceChoices,
+    ConsolePortTypeChoices,
+    PowerPortTypeChoices,
+    PowerOutletTypeChoices,
+    PowerOutletFeedLegChoices,
+    InterfaceTypeChoices,
+    InterfaceModeChoices,
+    PortTypeChoices,
+    CableTypeChoices,
+    CableLengthUnitChoices,
+    PowerFeedTypeChoices,
+    PowerFeedSupplyChoices,
+    PowerFeedPhaseChoices,
+)
+
+from nautobot.dcim.models import (
+    Cable,
+    ConsolePort,
+    ConsolePortTemplate,
+    ConsoleServerPort,
+    ConsoleServerPortTemplate,
+    Device,
+    DeviceBay,
+    DeviceBayTemplate,
+    DeviceRole,
+    DeviceType,
+    FrontPort,
+    FrontPortTemplate,
+    Interface,
+    InterfaceTemplate,
+    Manufacturer,
+    InventoryItem,
+    Platform,
+    PowerFeed,
+    PowerPort,
+    PowerPortTemplate,
+    PowerOutlet,
+    PowerOutletTemplate,
+    PowerPanel,
+    Rack,
+    RackGroup,
+    RackReservation,
+    RackRole,
+    RearPort,
+    RearPortTemplate,
+    Region,
+    Site,
+    VirtualChassis,
+)
 from nautobot.extras.choices import CustomFieldTypeChoices, RelationshipTypeChoices
 from nautobot.extras.models import (
     ConfigContextSchema,

--- a/nautobot/extras/admin.py
+++ b/nautobot/extras/admin.py
@@ -3,8 +3,6 @@ from django import forms
 from django.contrib import admin, messages
 from django.db import transaction
 from django.db.models import ProtectedError
-from django.http import HttpResponseRedirect
-from django.urls import reverse
 
 from nautobot.utilities.forms import LaxURLField
 from .models import CustomField, CustomFieldChoice, CustomLink, ExportTemplate, FileProxy, JobResult, Webhook

--- a/nautobot/extras/api/customfields.py
+++ b/nautobot/extras/api/customfields.py
@@ -3,9 +3,7 @@ from rest_framework.serializers import SerializerMethodField
 from rest_framework.fields import CreateOnlyDefault, Field
 
 from nautobot.core.api import ValidatedModelSerializer
-from nautobot.extras.api.nested_serializers import NestedCustomFieldSerializer
-from nautobot.extras.choices import *
-from nautobot.extras.models import CustomField, CustomFieldChoice
+from nautobot.extras.models import CustomField
 
 
 #

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -1,9 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from drf_yasg.utils import swagger_serializer_method
-from graphene_django.settings import graphene_settings
-from graphql import get_default_backend
-from graphql.error import GraphQLSyntaxError
 from rest_framework import serializers
 
 from nautobot.core.api import (
@@ -22,7 +19,12 @@ from nautobot.dcim.api.nested_serializers import (
     NestedSiteSerializer,
 )
 from nautobot.dcim.models import Device, DeviceRole, DeviceType, Platform, Rack, Region, Site
-from nautobot.extras.choices import *
+from nautobot.extras.choices import (
+    CustomFieldTypeChoices,
+    CustomFieldFilterLogicChoices,
+    ObjectChangeActionChoices,
+    JobResultStatusChoices,
+)
 from nautobot.extras.datasources import get_datasource_content_choices
 from nautobot.extras.models import (
     ComputedField,
@@ -60,8 +62,28 @@ from nautobot.virtualization.api.nested_serializers import (
 from nautobot.virtualization.models import Cluster, ClusterGroup
 from .customfields import CustomFieldModelSerializer
 from .fields import MultipleChoiceJSONField
-from .nested_serializers import *
+from .nested_serializers import (
+    NestedConfigContextSchemaSerializer,
+    NestedCustomFieldSerializer,
+    NestedJobResultSerializer,
+    NestedRelationshipSerializer,
+    NestedScheduledJobSerializer,
+    NestedTagSerializer,
+)
 
+# This import is separated from the above import, as the variable(s) are not actually used anywhere in this file,
+# but still required for brief fields functionality to work
+from .nested_serializers import (  # noqa: F401
+    NestedConfigContextSerializer,
+    NestedCustomLinkSerializer,
+    NestedExportTemplateSerializer,
+    NestedGitRepositorySerializer,
+    NestedGraphQLQuerySerializer,
+    NestedImageAttachmentSerializer,
+    NestedRelationshipAssociationSerializer,
+    NestedStatusSerializer,
+    NestedWebhookSerializer,
+)
 
 #
 # Computed Fields

--- a/nautobot/extras/datasources/registry.py
+++ b/nautobot/extras/datasources/registry.py
@@ -1,5 +1,4 @@
 """Registry-related APIs for datasources."""
-from collections import OrderedDict
 
 from nautobot.extras.choices import JobResultStatusChoices, LogLevelChoices
 from nautobot.extras.context_managers import change_logging

--- a/nautobot/extras/filters.py
+++ b/nautobot/extras/filters.py
@@ -14,7 +14,7 @@ from nautobot.utilities.filters import (
     TagFilter,
 )
 from nautobot.virtualization.models import Cluster, ClusterGroup
-from .choices import *
+from .choices import CustomFieldTypeChoices, CustomFieldFilterLogicChoices, JobResultStatusChoices
 from .models import (
     ComputedField,
     ConfigContext,

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -29,7 +29,6 @@ from nautobot.utilities.forms import (
     BOOLEAN_WITH_BLANK_CHOICES,
 )
 from nautobot.virtualization.models import Cluster, ClusterGroup
-from .choices import *
 from .datasources import get_datasource_content_choices
 from .models import (
     ComputedField,
@@ -51,7 +50,14 @@ from .models import (
     Webhook,
 )
 from .utils import FeatureQuery
-from nautobot.extras import choices
+from nautobot.extras.choices import (
+    CustomFieldFilterLogicChoices,
+    JobExecutionType,
+    JobResultStatusChoices,
+    ObjectChangeActionChoices,
+    RelationshipSideChoices,
+    RelationshipTypeChoices,
+)
 
 
 #
@@ -767,7 +773,7 @@ class JobScheduleForm(BootstrapMixin, forms.Form):
     """
 
     _schedule_type = forms.ChoiceField(
-        choices=choices.JobExecutionType,
+        choices=JobExecutionType,
         help_text="The job can either run immediately, once in the future, or on a recurring schedule.",
         label="Type",
     )
@@ -788,7 +794,7 @@ class JobScheduleForm(BootstrapMixin, forms.Form):
         """
         cleaned_data = super().clean()
 
-        if cleaned_data["_schedule_type"] != choices.JobExecutionType.TYPE_IMMEDIATELY:
+        if cleaned_data["_schedule_type"] != JobExecutionType.TYPE_IMMEDIATELY:
             if not cleaned_data["_schedule_name"]:
                 raise ValidationError({"_schedule_name": "Please provide a name for the job schedule."})
 

--- a/nautobot/extras/models/change_logging.py
+++ b/nautobot/extras/models/change_logging.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 
 from nautobot.utilities.utils import serialize_object
 from nautobot.core.models import BaseModel
-from nautobot.extras.choices import *
+from nautobot.extras.choices import ObjectChangeActionChoices
 
 
 #

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -12,13 +12,12 @@ from django.db import models
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
-from nautobot.extras.choices import *
+from nautobot.extras.choices import CustomFieldFilterLogicChoices, CustomFieldTypeChoices
 from nautobot.extras.models import ChangeLoggedModel
 from nautobot.extras.tasks import delete_custom_field_data, update_custom_field_choice_data
 from nautobot.extras.utils import FeatureQuery, extras_features
 from nautobot.core.fields import AutoSlugField
 from nautobot.core.models import BaseModel
-from nautobot.utilities.fields import JSONArrayField
 from nautobot.utilities.forms import (
     CSVChoiceField,
     CSVMultipleChoiceField,

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -14,12 +14,11 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import signals
-from django.http import HttpResponse, request
+from django.http import HttpResponse
 from django.urls import reverse
 from django.utils import timezone
 from django_celery_beat.clockedschedule import clocked
 from django_celery_beat.managers import ExtendedManager
-from django_celery_beat.utils import make_aware, now
 from graphene_django.settings import graphene_settings
 from graphql import get_default_backend
 from graphql.error import GraphQLSyntaxError
@@ -33,8 +32,14 @@ from nautobot.core.celery import NautobotKombuJSONEncoder
 from nautobot.core.fields import AutoSlugField
 from nautobot.core.models import BaseModel
 from nautobot.core.models.generics import OrganizationalModel
-from nautobot.extras.choices import *
-from nautobot.extras.constants import *
+from nautobot.extras.choices import (
+    CustomLinkButtonClassChoices,
+    LogLevelChoices,
+    JobExecutionType,
+    JobResultStatusChoices,
+    WebhookHttpMethodChoices,
+)
+from nautobot.extras.constants import HTTP_CONTENT_TYPE_JSON
 from nautobot.extras.models import ChangeLoggedModel
 from nautobot.extras.models.customfields import CustomFieldModel
 from nautobot.extras.models.relationships import RelationshipModel
@@ -857,7 +862,7 @@ class JobResult(BaseModel, CustomFieldModel):
         logger (logging.logger): Optional logger to also output the message to
         """
         if level_choice not in LogLevelChoices.as_dict():
-            raise Exception(f"Unknown logging level: {level}")
+            raise Exception(f"Unknown logging level: {level_choice}")
 
         if not self.data:
             self.data = {}

--- a/nautobot/extras/plugins/urls.py
+++ b/nautobot/extras/plugins/urls.py
@@ -1,7 +1,6 @@
 from django.apps import apps
 from django.conf import settings
 from django.conf.urls import include
-from django.contrib.admin.views.decorators import staff_member_required
 from django.urls import path
 
 from nautobot.extras.plugins.utils import import_object

--- a/nautobot/extras/registry.py
+++ b/nautobot/extras/registry.py
@@ -1,4 +1,4 @@
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 
 
 class Registry(dict):

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -19,7 +19,7 @@ from nautobot.utilities.tables import (
     ContentTypesColumn,
     ToggleColumn,
 )
-from .jobs import get_job_classpaths, Job
+from .jobs import Job
 from .models import (
     ComputedField,
     ConfigContext,

--- a/nautobot/extras/templatetags/computed_fields.py
+++ b/nautobot/extras/templatetags/computed_fields.py
@@ -1,9 +1,9 @@
 from django import template
 from django.contrib.contenttypes.models import ContentType
-from django.utils.html import format_html, escape
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
-from nautobot.extras.models import CustomLink, ComputedField
+from nautobot.extras.models import ComputedField
 
 
 register = template.Library()

--- a/nautobot/extras/tests/dummy_jobs/test_ipaddress_vars.py
+++ b/nautobot/extras/tests/dummy_jobs/test_ipaddress_vars.py
@@ -1,6 +1,6 @@
 import json
 
-from nautobot.extras.jobs import *
+from nautobot.extras.jobs import Job, IPAddressVar, IPAddressWithMaskVar
 
 
 name = "IP Addresses"

--- a/nautobot/extras/tests/dummy_jobs/test_object_vars.py
+++ b/nautobot/extras/tests/dummy_jobs/test_object_vars.py
@@ -1,8 +1,7 @@
 import json
 
 from nautobot.dcim.models import DeviceRole
-from nautobot.extras.jobs import *
-
+from nautobot.extras.jobs import Job, ObjectVar, MultiObjectVar
 
 name = "Object Vars"
 

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -6,12 +6,10 @@ from unittest import skipIf
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
 from django.http import Http404
 from django.test import override_settings
 from django.urls import reverse
 from django.utils.timezone import make_aware, now
-from django_rq.queues import get_connection
 from rest_framework import status
 
 from nautobot.core.celery import app

--- a/nautobot/extras/tests/test_changelog.py
+++ b/nautobot/extras/tests/test_changelog.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from nautobot.dcim.models import Site
-from nautobot.extras.choices import *
+from nautobot.extras.choices import CustomFieldTypeChoices, ObjectChangeActionChoices
 from nautobot.extras.models import CustomField, CustomFieldChoice, ObjectChange, Status, Tag
 from nautobot.utilities.testing import APITestCase
 from nautobot.utilities.testing.utils import post_data

--- a/nautobot/extras/tests/test_context_managers.py
+++ b/nautobot/extras/tests/test_context_managers.py
@@ -1,11 +1,10 @@
-import django_rq
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from nautobot.core.celery import app
 from nautobot.dcim.models import Site
-from nautobot.extras.choices import *
+from nautobot.extras.choices import ObjectChangeActionChoices
 from nautobot.extras.context_managers import web_request_context
 from nautobot.extras.models import ObjectChange, Webhook
 

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -9,7 +9,7 @@ from nautobot.dcim.filters import SiteFilterSet
 from nautobot.dcim.forms import SiteCSVForm
 from nautobot.dcim.models import Site, Rack, Device
 from nautobot.dcim.tables import SiteTable
-from nautobot.extras.choices import *
+from nautobot.extras.choices import CustomFieldTypeChoices, CustomFieldFilterLogicChoices
 from nautobot.extras.models import ComputedField, CustomField, CustomFieldChoice, Status
 from nautobot.utilities.tables import CustomFieldColumn
 from nautobot.utilities.testing import APITestCase, CeleryTestCase, TestCase

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -6,8 +6,21 @@ from django.test import TestCase
 
 from nautobot.dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Platform, Rack, Region, Site
 from nautobot.extras.choices import ObjectChangeActionChoices
-from nautobot.extras.constants import *
-from nautobot.extras.filters import *
+from nautobot.extras.constants import HTTP_CONTENT_TYPE_JSON
+from nautobot.extras.filters import (
+    ConfigContextFilterSet,
+    CustomLinkFilterSet,
+    ExportTemplateFilterSet,
+    GraphQLQueryFilterSet,
+    ImageAttachmentFilterSet,
+    ObjectChangeFilterSet,
+    RelationshipFilterSet,
+    RelationshipAssociationFilterSet,
+    TagFilterSet,
+    StatusFilterSet,
+    WebhookFilterSet,
+)
+
 from nautobot.extras.models import (
     ConfigContext,
     CustomLink,

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from nautobot.dcim.models import DeviceRole, Site
 from nautobot.extras.choices import JobResultStatusChoices
 from nautobot.extras.jobs import get_job, run_job
-from nautobot.extras.models import FileAttachment, FileProxy, JobResult
+from nautobot.extras.models import FileProxy, JobResult
 from nautobot.utilities.testing import TestCase
 
 

--- a/nautobot/extras/tests/test_plugins.py
+++ b/nautobot/extras/tests/test_plugins.py
@@ -15,7 +15,7 @@ from nautobot.extras.plugins.exceptions import PluginImproperlyConfigured
 from nautobot.extras.plugins.utils import load_plugin
 from nautobot.extras.plugins.validators import wrap_model_clean_methods
 from nautobot.extras.registry import registry, DatasourceContent
-from nautobot.utilities.testing import APIViewTestCases, TestCase, ViewTestCases, disable_warnings, extract_page_body
+from nautobot.utilities.testing import APIViewTestCases, TestCase, ViewTestCases, extract_page_body
 
 from dummy_plugin import config as dummy_config
 from dummy_plugin.datasources import refresh_git_text_files

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 
 from nautobot.dcim.models import Site, Rack
 from nautobot.ipam.models import VLAN
-from nautobot.extras.choices import *
+from nautobot.extras.choices import RelationshipTypeChoices
 from nautobot.extras.models import Relationship, RelationshipAssociation
 from nautobot.utilities.testing import TestCase
 from nautobot.utilities.forms import (

--- a/nautobot/extras/tests/test_scripts.py
+++ b/nautobot/extras/tests/test_scripts.py
@@ -5,7 +5,21 @@ from django.test import TestCase, override_settings
 from netaddr import IPAddress, IPNetwork
 
 from nautobot.dcim.models import DeviceRole
-from nautobot.extras.scripts import *
+from nautobot.extras.scripts import (
+    Script,
+    StringVar,
+    TextVar,
+    IntegerVar,
+    BooleanVar,
+    ChoiceVar,
+    MultiChoiceVar,
+    ObjectVar,
+    MultiObjectVar,
+    FileVar,
+    IPAddressVar,
+    IPAddressWithMaskVar,
+    IPNetworkVar,
+)
 
 CHOICES = (("ff0000", "Red"), ("00ff00", "Green"), ("0000ff", "Blue"))
 

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -14,7 +14,7 @@ from unittest import mock
 
 from nautobot.dcim.models import ConsolePort, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
 from nautobot.extras.choices import CustomFieldTypeChoices, JobExecutionType, ObjectChangeActionChoices
-from nautobot.extras.constants import *
+from nautobot.extras.constants import HTTP_CONTENT_TYPE_JSON
 from nautobot.extras.jobs import Job
 from nautobot.extras.models import (
     ConfigContext,

--- a/nautobot/extras/urls.py
+++ b/nautobot/extras/urls.py
@@ -5,7 +5,6 @@ from nautobot.extras.models import (
     ComputedField,
     ConfigContext,
     ConfigContextSchema,
-    CustomField,
     CustomLink,
     ExportTemplate,
     GitRepository,

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1,6 +1,5 @@
 import inspect
-import json
-from datetime import datetime, time
+from datetime import datetime
 
 from django import template
 from django.contrib import messages
@@ -11,12 +10,10 @@ from django.http import Http404, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.timezone import make_aware
 from django.views.generic import View
 from django_tables2 import RequestConfig
 from jsonschema.validators import Draft7Validator
 
-from nautobot.core.celery import app
 from nautobot.core.views import generic
 from nautobot.dcim.models import Device
 from nautobot.dcim.tables import DeviceTable

--- a/nautobot/extras/webhooks.py
+++ b/nautobot/extras/webhooks.py
@@ -2,10 +2,10 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils import timezone
 
 from nautobot.utilities.api import get_serializer_for_model
-from nautobot.extras.choices import *
 from nautobot.extras.models import Webhook
 from nautobot.extras.registry import registry
 from nautobot.extras.tasks import process_webhook
+from .choices import ObjectChangeActionChoices
 
 
 def enqueue_webhooks(instance, user, request_id, action):

--- a/nautobot/ipam/api/serializers.py
+++ b/nautobot/ipam/api/serializers.py
@@ -19,7 +19,7 @@ from nautobot.extras.api.serializers import (
     StatusModelSerializerMixin,
     TaggedObjectSerializer,
 )
-from nautobot.ipam.choices import *
+from nautobot.ipam.choices import IPAddressFamilyChoices, IPAddressRoleChoices, ServiceProtocolChoices
 from nautobot.ipam import constants
 from nautobot.ipam.models import (
     Aggregate,
@@ -38,10 +38,25 @@ from nautobot.utilities.api import get_serializer_for_model
 from nautobot.virtualization.api.nested_serializers import (
     NestedVirtualMachineSerializer,
 )
-from .nested_serializers import *
+from .nested_serializers import (
+    IPFieldSerializer,
+    NestedIPAddressSerializer,
+    NestedRIRSerializer,
+    NestedRoleSerializer,
+    NestedRouteTargetSerializer,
+    NestedVLANGroupSerializer,
+    NestedVLANSerializer,
+    NestedVRFSerializer,
+)
 
+# This import is separated from the above import, as the variable(s) are not actually used anywhere in this file,
+# but still required for brief fields functionality to work
+from .nested_serializers import (  # noqa: F401
+    NestedAggregateSerializer,
+    NestedPrefixSerializer,
+    NestedServiceSerializer,
+)
 
-#
 # VRFs
 #
 

--- a/nautobot/ipam/fields.py
+++ b/nautobot/ipam/fields.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.datastructures import DictWrapper
 import netaddr
 
 from .formfields import IPNetworkFormField

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -1,8 +1,7 @@
 import django_filters
 import netaddr
 from django.core.exceptions import ValidationError
-from django.db.models import Q, F
-from django.db.models.functions import Length
+from django.db.models import Q
 from netaddr.core import AddrFormatError
 
 from nautobot.dcim.models import Device, Interface, Region, Site
@@ -15,15 +14,13 @@ from nautobot.tenancy.filters import TenancyFilterSet
 from nautobot.utilities.filters import (
     BaseFilterSet,
     MultiValueCharFilter,
-    MultiValueNumberFilter,
     NameSlugSearchFilterSet,
     NumericArrayFilter,
     TagFilter,
     TreeNodeMultipleChoiceFilter,
 )
 from nautobot.virtualization.models import VirtualMachine, VMInterface
-from .choices import *
-from .constants import IPV4_BYTE_LENGTH, IPV6_BYTE_LENGTH
+from .choices import IPAddressRoleChoices
 from .models import (
     Aggregate,
     IPAddress,

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -36,8 +36,15 @@ from nautobot.utilities.forms import (
     BOOLEAN_WITH_BLANK_CHOICES,
 )
 from nautobot.virtualization.models import Cluster, VirtualMachine, VMInterface
-from .choices import *
-from .constants import *
+from .choices import IPAddressRoleChoices, IPAddressFamilyChoices, ServiceProtocolChoices
+from .constants import (
+    PREFIX_LENGTH_MIN,
+    PREFIX_LENGTH_MAX,
+    IPADDRESS_MASK_LENGTH_MIN,
+    IPADDRESS_MASK_LENGTH_MAX,
+    SERVICE_PORT_MIN,
+    SERVICE_PORT_MAX,
+)
 from .models import (
     Aggregate,
     IPAddress,

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from django.db.models import F
+from django.db.models import F, Q
 from django.urls import reverse
 from django.utils.functional import classproperty
 
@@ -17,8 +17,14 @@ from nautobot.core.models.generics import OrganizationalModel, PrimaryModel
 from nautobot.utilities.utils import array_to_string, serialize_object, UtilizationData
 from nautobot.virtualization.models import VirtualMachine, VMInterface
 from nautobot.utilities.fields import JSONArrayField
-from .choices import *
-from .constants import *
+from .choices import IPAddressRoleChoices, ServiceProtocolChoices
+from .constants import (
+    VRF_RD_MAX_LENGTH,
+    IPADDRESS_ASSIGNMENT_MODELS,
+    IPADDRESS_ROLES_NONUNIQUE,
+    SERVICE_PORT_MIN,
+    SERVICE_PORT_MAX,
+)
 from .fields import VarbinaryIPField
 from .querysets import PrefixQuerySet, AggregateQuerySet, IPAddressQuerySet
 from .validators import DNSValidator

--- a/nautobot/ipam/querysets.py
+++ b/nautobot/ipam/querysets.py
@@ -10,7 +10,6 @@ from django.db.models import (
     OuterRef,
     Subquery,
     Q,
-    QuerySet,
     UUIDField,
     Value,
 )

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -9,7 +9,7 @@ from rest_framework import status
 
 from nautobot.dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 from nautobot.extras.models import Status
-from nautobot.ipam.choices import *
+from nautobot.ipam.choices import ServiceProtocolChoices
 from nautobot.ipam.models import (
     Aggregate,
     IPAddress,

--- a/nautobot/ipam/tests/test_filters.py
+++ b/nautobot/ipam/tests/test_filters.py
@@ -10,8 +10,21 @@ from nautobot.dcim.models import (
     Site,
 )
 from nautobot.extras.models import Status
-from nautobot.ipam.choices import *
-from nautobot.ipam.filters import *
+from nautobot.ipam.choices import IPAddressRoleChoices, ServiceProtocolChoices
+from nautobot.ipam.filters import (
+    VRFFilterSet,
+    RouteTargetFilterSet,
+    RIRFilterSet,
+    AggregateFilterSet,
+    RoleFilterSet,
+    PrefixFilterSet,
+    IPAddressFilterSet,
+    VLANGroupFilterSet,
+    VLANFilterSet,
+    ServiceFilterSet,
+)
+
+
 from nautobot.ipam.models import (
     Aggregate,
     IPAddress,

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -1,4 +1,3 @@
-import copy
 from unittest import skipIf
 
 import netaddr

--- a/nautobot/ipam/tests/test_views.py
+++ b/nautobot/ipam/tests/test_views.py
@@ -4,7 +4,7 @@ from netaddr import IPNetwork
 
 from nautobot.dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 from nautobot.extras.models import Status
-from nautobot.ipam.choices import *
+from nautobot.ipam.choices import IPAddressRoleChoices, ServiceProtocolChoices
 from nautobot.ipam.models import (
     Aggregate,
     IPAddress,

--- a/nautobot/ipam/utils.py
+++ b/nautobot/ipam/utils.py
@@ -1,6 +1,6 @@
 import netaddr
 
-from .constants import *
+from .constants import VLAN_VID_MIN, VLAN_VID_MAX
 from .models import Prefix, VLAN
 
 

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from django.db.models.expressions import RawSQL
 from django.shortcuts import get_object_or_404, redirect, render
 from django_tables2 import RequestConfig
@@ -9,7 +9,7 @@ from nautobot.utilities.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.utilities.utils import count_related
 from nautobot.virtualization.models import VirtualMachine, VMInterface
 from . import filters, forms, tables
-from .constants import *
+from .choices import IPAddressRoleChoices
 from .models import (
     Aggregate,
     IPAddress,

--- a/nautobot/tenancy/api/serializers.py
+++ b/nautobot/tenancy/api/serializers.py
@@ -3,8 +3,11 @@ from rest_framework import serializers
 from nautobot.extras.api.customfields import CustomFieldModelSerializer
 from nautobot.extras.api.serializers import TaggedObjectSerializer
 from nautobot.tenancy.models import Tenant, TenantGroup
-from .nested_serializers import *
+from .nested_serializers import NestedTenantGroupSerializer
 
+# This import is separated from the above import, as the variable(s) are not actually used anywhere in this file,
+# but still required for brief fields functionality to work
+from .nested_serializers import NestedTenantSerializer  # noqa: F401
 
 #
 # Tenants

--- a/nautobot/tenancy/tests/test_filters.py
+++ b/nautobot/tenancy/tests/test_filters.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from nautobot.tenancy.filters import *
+from nautobot.tenancy.filters import TenantGroupFilterSet, TenantFilterSet
 from nautobot.tenancy.models import Tenant, TenantGroup
 
 

--- a/nautobot/users/api/serializers.py
+++ b/nautobot/users/api/serializers.py
@@ -9,7 +9,11 @@ from nautobot.core.api import (
     ValidatedModelSerializer,
 )
 from nautobot.users.models import ObjectPermission
-from .nested_serializers import *
+from .nested_serializers import NestedGroupSerializer, NestedUserSerializer
+
+# This import is separated from the above import, as the variable(s) are not actually used anywhere in this file,
+# but still required for brief fields functionality to work
+from .nested_serializers import NestedObjectPermissionSerializer  # noqa: F401
 
 
 class UserSerializer(ValidatedModelSerializer):

--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -18,7 +18,7 @@ from nautobot.extras.utils import FeatureQuery
 from nautobot.utilities.choices import unpack_grouped_choices
 from nautobot.utilities.validators import EnhancedURLValidator
 from . import widgets
-from .constants import *
+from .constants import ALPHANUMERIC_EXPANSION_PATTERN, IP4_EXPANSION_PATTERN, IP6_EXPANSION_PATTERN
 from .utils import expand_alphanumeric_pattern, expand_ipaddress_pattern, parse_numeric_range
 
 __all__ = (

--- a/nautobot/utilities/forms/utils.py
+++ b/nautobot/utilities/forms/utils.py
@@ -4,7 +4,7 @@ from django import forms
 from django.forms.models import fields_for_model
 
 from nautobot.utilities.querysets import RestrictedQuerySet
-from .constants import *
+from .constants import ALPHANUMERIC_EXPANSION_PATTERN, IP4_EXPANSION_PATTERN, IP6_EXPANSION_PATTERN
 
 __all__ = (
     "add_blank_choice",

--- a/nautobot/utilities/forms/widgets.py
+++ b/nautobot/utilities/forms/widgets.py
@@ -2,7 +2,6 @@ import json
 from urllib.parse import urljoin
 
 from django import forms
-from django.conf import settings
 from django.urls import get_script_prefix
 
 from nautobot.utilities.choices import ColorChoices

--- a/nautobot/utilities/management/commands/makemigrations.py
+++ b/nautobot/utilities/management/commands/makemigrations.py
@@ -1,5 +1,5 @@
 # noinspection PyUnresolvedReferences
-from django.core.management.commands.makemigrations import Command
+from django.core.management.commands.makemigrations import Command  # noqa: F401
 from django.db import models
 
 from . import custom_deconstruct

--- a/nautobot/utilities/query_functions.py
+++ b/nautobot/utilities/query_functions.py
@@ -1,4 +1,4 @@
-from django.db.models import Aggregate, JSONField, Value
+from django.db.models import Aggregate, JSONField
 
 from django.contrib.postgres.aggregates.mixins import OrderableAggMixin
 from django.db import NotSupportedError

--- a/nautobot/utilities/testing/integration.py
+++ b/nautobot/utilities/testing/integration.py
@@ -5,8 +5,7 @@ from celery.contrib.testing.worker import start_worker
 from django.contrib.auth import get_user_model
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.conf import settings
-from django.db.utils import IntegrityError
-from django.test import Client, tag
+from django.test import tag
 from django.urls import reverse
 from django.utils.functional import classproperty
 from selenium import webdriver

--- a/nautobot/utilities/tests/test_filters.py
+++ b/nautobot/utilities/tests/test_filters.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from mptt.fields import TreeForeignKey
 from taggit.managers import TaggableManager
 
-from nautobot.dcim.choices import *
+from nautobot.dcim.choices import DeviceFaceChoices
 from nautobot.dcim.fields import MACAddressField
 from nautobot.dcim.filters import DeviceFilterSet, SiteFilterSet
 from nautobot.dcim.models import (

--- a/nautobot/utilities/tests/test_forms.py
+++ b/nautobot/utilities/tests/test_forms.py
@@ -5,7 +5,7 @@ from netaddr import IPNetwork
 
 from nautobot.ipam.forms import IPAddressCSVForm, ServiceForm
 from nautobot.ipam.models import IPAddress, Prefix
-from nautobot.utilities.forms.fields import CSVDataField, DynamicModelMultipleChoiceField, NumericArrayField
+from nautobot.utilities.forms.fields import CSVDataField, DynamicModelMultipleChoiceField
 from nautobot.utilities.forms.utils import (
     expand_alphanumeric_pattern,
     expand_ipaddress_pattern,

--- a/nautobot/virtualization/api/serializers.py
+++ b/nautobot/virtualization/api/serializers.py
@@ -24,7 +24,6 @@ from nautobot.ipam.api.nested_serializers import (
 )
 from nautobot.ipam.models import VLAN
 from nautobot.tenancy.api.nested_serializers import NestedTenantSerializer
-from nautobot.virtualization.choices import *
 from nautobot.virtualization.models import (
     Cluster,
     ClusterGroup,
@@ -32,8 +31,16 @@ from nautobot.virtualization.models import (
     VirtualMachine,
     VMInterface,
 )
-from .nested_serializers import *
+from .nested_serializers import (
+    NestedClusterGroupSerializer,
+    NestedClusterSerializer,
+    NestedClusterTypeSerializer,
+    NestedVirtualMachineSerializer,
+)
 
+# This import is separated from the above import, as the variable(s) are not actually used anywhere in this file,
+# but still required for brief fields functionality to work
+from .nested_serializers import NestedVMInterfaceSerializer  # noqa: F401
 
 #
 # Clusters

--- a/nautobot/virtualization/filters.py
+++ b/nautobot/virtualization/filters.py
@@ -16,7 +16,6 @@ from nautobot.utilities.filters import (
     TagFilter,
     TreeNodeMultipleChoiceFilter,
 )
-from .choices import *
 from .models import Cluster, ClusterGroup, ClusterType, VirtualMachine, VMInterface
 
 __all__ = (

--- a/nautobot/virtualization/forms.py
+++ b/nautobot/virtualization/forms.py
@@ -37,14 +37,12 @@ from nautobot.utilities.forms import (
     DynamicModelMultipleChoiceField,
     ExpandableNameField,
     form_from_model,
-    JSONField,
     SlugField,
     SmallTextarea,
     StaticSelect2,
     TagFilterField,
     BOOLEAN_WITH_BLANK_CHOICES,
 )
-from .choices import *
 from .models import Cluster, ClusterGroup, ClusterType, VirtualMachine, VMInterface
 
 

--- a/nautobot/virtualization/models.py
+++ b/nautobot/virtualization/models.py
@@ -21,7 +21,6 @@ from nautobot.utilities.fields import NaturalOrderingField
 from nautobot.utilities.ordering import naturalize_interface
 from nautobot.utilities.query_functions import CollateAsChar
 from nautobot.utilities.utils import serialize_object
-from .choices import *
 
 
 __all__ = (

--- a/nautobot/virtualization/tests/test_filters.py
+++ b/nautobot/virtualization/tests/test_filters.py
@@ -4,8 +4,13 @@ from nautobot.dcim.models import DeviceRole, Platform, Region, Site
 from nautobot.extras.models import Status
 from nautobot.ipam.models import IPAddress
 from nautobot.tenancy.models import Tenant, TenantGroup
-from nautobot.virtualization.choices import *
-from nautobot.virtualization.filters import *
+from nautobot.virtualization.filters import (
+    ClusterTypeFilterSet,
+    ClusterGroupFilterSet,
+    ClusterFilterSet,
+    VirtualMachineFilterSet,
+    VMInterfaceFilterSet,
+)
 from nautobot.virtualization.models import (
     Cluster,
     ClusterGroup,

--- a/nautobot/virtualization/tests/test_models.py
+++ b/nautobot/virtualization/tests/test_models.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 
 from nautobot.extras.models import Status
 from nautobot.tenancy.models import Tenant
-from nautobot.virtualization.models import *
+from nautobot.virtualization.models import VirtualMachine, ClusterType, Cluster
 
 
 class VirtualMachineTestCase(TestCase):

--- a/nautobot/virtualization/tests/test_views.py
+++ b/nautobot/virtualization/tests/test_views.py
@@ -6,7 +6,6 @@ from nautobot.dcim.models import DeviceRole, Platform, Site
 from nautobot.extras.models import ConfigContextSchema, Status
 from nautobot.ipam.models import VLAN
 from nautobot.utilities.testing import ViewTestCases, post_data
-from nautobot.virtualization.choices import *
 from nautobot.virtualization.models import (
     Cluster,
     ClusterGroup,

--- a/tasks.py
+++ b/tasks.py
@@ -15,11 +15,9 @@ limitations under the License.
 from distutils.util import strtobool
 import os
 import re
-from time import sleep
 
 from invoke import Collection, task as invoke_task
 from invoke.exceptions import Exit
-import requests
 
 
 def is_truthy(arg):


### PR DESCRIPTION
### Fixes: #222


I wanted to be productive today but not exert any real brain power, this is what I came up with :) 

This removes nearly all import wildcards, and tuns on flake8 F401, F403, and F405. A few things to note:

I ignored the following with `noqa`, as I presumed they were likely needed, but would be good to have someone verify.
```
development/nautobot_config.py:5:1: F403 'from nautobot.core.settings import *' used; unable to detect undefined names
nautobot/core/__init__.py:1:1: F401 'nautobot.core.checks' imported but unused
nautobot/core/admin.py:1:1: F401 'django.conf.settings' imported but unused
nautobot/utilities/management/commands/makemigrations.py:2:1: F401 'django.core.management.commands.makemigrations.Command' imported but unused

development/nautobot_config.py:46:27: F405 'INSTALLED_APPS' may be undefined, or defined from star imports: nautobot.core.settings
development/nautobot_config.py:47:5: F405 'INSTALLED_APPS' may be undefined, or defined from star imports: nautobot.core.settings
development/nautobot_config.py:48:61: F405 'MIDDLEWARE' may be undefined, or defined from star imports: nautobot.core.settings
development/nautobot_config.py:49:5: F405 'MIDDLEWARE' may be undefined, or defined from star imports: nautobot.core.settings
```

I believe I found a bug in `/Users/kencelenza/github/nautobot/nautobot/extras/models/models.py` using variable of `level` instead of `level_choice`.

The api tests for any nested serializer using the`?brief=True` feature started to fail. I add all of those imports back explicitly and documented, but it would be good to have someone who understands the root of the issue better to evaluate. Here is an example.
```
# This import is separated from the above import, as the variable(s) are not actually used anywhere in this file,
# but still required for brief fields functionality to work
from .nested_serializers import (  # noqa: F401
    NestedConfigContextSerializer,
    NestedCustomLinkSerializer,
    NestedExportTemplateSerializer,
    NestedGitRepositorySerializer,
    NestedGraphQLQuerySerializer,
    NestedImageAttachmentSerializer,
    NestedRelationshipAssociationSerializer,
    NestedStatusSerializer,
    NestedWebhookSerializer,
)
```

I have added this to the flake8 ignore as well, as this could presumably have undesirable 

```
per-file-ignores =
    nautobot/dcim/tables/__init__.py:F401,F403,F405
    nautobot/dcim/models/__init__.py:F401,F403,F405
    nautobot/utilities/forms/__init__.py:F401,F403,F405
    nautobot/utilities/testing/__init__.py:F401,F403,F405
```
The pattern that it is ignoring is 
```
from .cables import *
from .devices import *
from .devicetypes import *
from .power import *
from .racks import *
from .sites import *
```

This presumably enables the following
```
from nautobot.dcim import tables as dcim_tables
dcim_tables.CableTable
```
I could potentially add all of the imports explicitly, but I figure we could do that in another PR once there was agreement.
