### PR TITLE
Handle address values such as ::1/128 correctly

### DIFF
--- a/nautobot/ipam/fields.py
+++ b/nautobot/ipam/fields.py
@@ -39,12 +39,17 @@ class VarbinaryIPField(models.BinaryField):
         Parse `str`, `bytes` (varbinary), or `netaddr.IPAddress to `netaddr.IPAddress`.
         """
         try:
-            value = int.from_bytes(value, "big")
+            int_value = int.from_bytes(value, "big")
+            # Distinguish between
+            # \x00\x00\x00\x01 (IPv4 0.0.0.1) and
+            # \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 (IPv6 ::1), among other cases
+            version = 4 if len(value) == 4 else 6
+            value = int_value
         except TypeError:
-            pass  # It's a string
+            version = None  # It's a string, IP version should be self-evident
 
         try:
-            return netaddr.IPAddress(value)
+            return netaddr.IPAddress(value, version=version)
         except netaddr.AddrFormatError:
             raise ValidationError("Invalid IP address format: {}".format(value))
         except (TypeError, ValueError) as e:

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -55,6 +55,13 @@ class TestVarbinaryIPField(TestCase):
         # IPAddress => netaddr.IPAddress
         self.assertEqual(self.field._parse_address(obj), obj)
 
+        # Special cases involving values that could be IPv4 or IPv6 if naively interpreted
+        self.assertEqual(self.field._parse_address(bytes(netaddr.IPAddress("0.0.0.1"))), netaddr.IPAddress("0.0.0.1"))
+        self.assertEqual(self.field._parse_address(bytes(netaddr.IPAddress("::1"))), netaddr.IPAddress("::1"))
+        self.assertEqual(
+            self.field._parse_address(bytes(netaddr.IPAddress("::192.0.2.15"))), netaddr.IPAddress("::192.0.2.15")
+        )
+
     def test_parse_address_failure(self):
         """"Test `VarbinaryIPField._parse_address` FAIL."""
 


### PR DESCRIPTION
### Fixes: #969

Basically the issue was (thanks to @FragmentedPacket for the initial investigation that pointed me in this direction) that while we were correctly distinguishing between IPv6 values (::1 = `b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'`) and IPv4 values (0.0.0.1 = `b'\x00\x00\x00\x01'`) when writing to the database, on the side where we were loading the value from the DB back into an IPAddress, we weren't taking the length of the binary bytes into account. Adding a check for that lets us trivially distinguish between IPv4 and IPv6 addresses and handle them correctly.