### PR TITLE
Account for missing key scenario in custom field

### DIFF
--- a/nautobot/extras/management/commands/fix_custom_fields.py
+++ b/nautobot/extras/management/commands/fix_custom_fields.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
                     obj_changed = False
                     # Provision CustomFields that are not associated with the object
                     for custom_field in custom_fields_for_content_type:
-                        if not custom_field.name in obj._custom_field_data:
+                        if custom_field.name not in obj._custom_field_data:
                             self.stdout.write(f"Adding missing CustomField {custom_field.name} to {obj}")
                             obj._custom_field_data[custom_field.name] = custom_field.default
                             obj_changed = True


### PR DESCRIPTION
I opted for the `not in` method, as the `.get()` method would cause issues when there is a boolean value of `False`, such as:

```
>>> test = {1: True, 2: False, 3: "one"}
>>> not test.get(2)
True
>>>
```
