### PR TITLE
Add Advanced tab to Device detail views

### DIFF
--- a/nautobot/dcim/templates/dcim/device.html
+++ b/nautobot/dcim/templates/dcim/device.html
@@ -4,6 +4,8 @@
 {% load render_table from django_tables2 %}
 
 {% block content %}
+<div class="tab-content">
+  <div id="main" role="tabpanel" class="tab-pane {% if active_tab == 'device' and not request.GET.tab or request.GET.tab == 'main' %}active{% else %}fade{% endif %}">
     <div class="row">
         <div class="col-md-12">
             <div class="tab-content">
@@ -315,4 +317,21 @@
             </div>
         </div>
     </div>
+  </div>
+  <div id="advanced" role="tabpanel" class="tab-pane {% if active_tab == 'device' and request.GET.tab == 'advanced' %}active{% else %}fade{% endif %}">
+    <div class="row">
+        <div class="col-md-6">
+            {% include 'inc/object_details_advanced_panel.html' %}
+        </div>
+        <div class="col-md-6">
+            {% block advanced_content_right_page %}{% endblock advanced_content_right_page %}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            {% block advanced_content_full_width_page %}{% endblock advanced_content_full_width_page %}
+        </div>
+    </div>
+  </div>
+<div>
 {% endblock content %}

--- a/nautobot/dcim/templates/dcim/device/base.html
+++ b/nautobot/dcim/templates/dcim/device/base.html
@@ -63,8 +63,13 @@
 {% endblock masthead %}
 
 {% block nav_tabs %}
-        <li role="presentation" {% if active_tab == 'device' %} class="active"{% endif %}>
+        <li role="presentation" {% if active_tab == 'device' and not request.GET.tab or request.GET.tab == "main" %} class="active"{% endif %}>
             <a href="{% url 'dcim:device' pk=object.pk %}">Device</a>
+        </li>
+        <li role="presentation"{% if active_tab == 'device' and request.GET.tab == 'advanced' %} class="active"{% endif %}>
+            <a href="{% url 'dcim:device' pk=object.pk %}#advanced" onclick="switch_tab(this.href)" aria-controls="advanced" role="tab" data-toggle="tab">
+                Advanced
+            </a>
         </li>
         {% with interface_count=object.vc_interfaces.count %}
             {% if interface_count %}
@@ -151,20 +156,3 @@
             </li>
         {% endif %}
 {% endblock nav_tabs %}
-
-{% block javascript %}
-<script src="{% static 'clipboard.js/clipboard-2.0.6.min.js' %}"
-    onerror="window.location='{% url 'media_failure' %}?filename=clipboard.js/clipboard-2.0.6.min.js'">
-</script>
-<script>
-    var clipboard = new ClipboardJS('.btn');
-
-    clipboard.on('success', function (e) {
-        console.log(e);
-    });
-
-    clipboard.on('error', function (e) {
-        console.log(e);
-    });
-</script>
-{% endblock javascript %}

--- a/nautobot/dcim/templates/dcim/device/config.html
+++ b/nautobot/dcim/templates/dcim/device/config.html
@@ -32,6 +32,7 @@
 {% endblock content %}
 
 {% block javascript %}
+{{ block.super }}
 <script type="text/javascript">
 $(document).ready(function() {
     $.ajax({

--- a/nautobot/dcim/templates/dcim/device/consoleports.html
+++ b/nautobot/dcim/templates/dcim/device/consoleports.html
@@ -48,6 +48,7 @@
 {% endblock content %}
 
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/connection_toggles.js' %}?v{{ settings.VERSION }}"></script>
     <script src="{% static 'js/tableconfig.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock javascript %}

--- a/nautobot/dcim/templates/dcim/device/consoleserverports.html
+++ b/nautobot/dcim/templates/dcim/device/consoleserverports.html
@@ -48,6 +48,7 @@
 {% endblock content %}
 
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/connection_toggles.js' %}?v{{ settings.VERSION }}"></script>
     <script src="{% static 'js/tableconfig.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock javascript %}

--- a/nautobot/dcim/templates/dcim/device/devicebays.html
+++ b/nautobot/dcim/templates/dcim/device/devicebays.html
@@ -45,5 +45,6 @@
 {% endblock content %}
 
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/tableconfig.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock javascript %}

--- a/nautobot/dcim/templates/dcim/device/frontports.html
+++ b/nautobot/dcim/templates/dcim/device/frontports.html
@@ -48,6 +48,7 @@
 {% endblock content %}
 
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/connection_toggles.js' %}?v{{ settings.VERSION }}"></script>
     <script src="{% static 'js/tableconfig.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock javascript %}

--- a/nautobot/dcim/templates/dcim/device/interfaces.html
+++ b/nautobot/dcim/templates/dcim/device/interfaces.html
@@ -51,6 +51,7 @@
 {% endblock content %}
 
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/connection_toggles.js' %}?v{{ settings.VERSION }}"></script>
     <script src="{% static 'js/interface_filtering.js' %}?v{{ settings.VERSION }}"></script>
     <script src="{% static 'js/tableconfig.js' %}?v{{ settings.VERSION }}"></script>

--- a/nautobot/dcim/templates/dcim/device/inventory.html
+++ b/nautobot/dcim/templates/dcim/device/inventory.html
@@ -45,5 +45,6 @@
 {% endblock content %}
 
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/tableconfig.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock javascript %}

--- a/nautobot/dcim/templates/dcim/device/lldp_neighbors.html
+++ b/nautobot/dcim/templates/dcim/device/lldp_neighbors.html
@@ -49,6 +49,7 @@
 {% endblock %}
 
 {% block javascript %}
+{{ block.super }}
 <script type="text/javascript">
 $(document).ready(function() {
     $.ajax({

--- a/nautobot/dcim/templates/dcim/device/poweroutlets.html
+++ b/nautobot/dcim/templates/dcim/device/poweroutlets.html
@@ -48,6 +48,7 @@
 {% endblock content %}
 
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/connection_toggles.js' %}?v{{ settings.VERSION }}"></script>
     <script src="{% static 'js/tableconfig.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock javascript %}

--- a/nautobot/dcim/templates/dcim/device/powerports.html
+++ b/nautobot/dcim/templates/dcim/device/powerports.html
@@ -48,6 +48,7 @@
 {% endblock content %}
 
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/connection_toggles.js' %}?v{{ settings.VERSION }}"></script>
     <script src="{% static 'js/tableconfig.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock javascript %}

--- a/nautobot/dcim/templates/dcim/device/rearports.html
+++ b/nautobot/dcim/templates/dcim/device/rearports.html
@@ -48,6 +48,7 @@
 {% endblock content %}
 
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/connection_toggles.js' %}?v{{ settings.VERSION }}"></script>
     <script src="{% static 'js/tableconfig.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock javascript %}

--- a/nautobot/dcim/templates/dcim/device/status.html
+++ b/nautobot/dcim/templates/dcim/device/status.html
@@ -66,6 +66,7 @@
 {% endblock content %}
 
 {% block javascript %}
+{{ block.super }}
 <script type="text/javascript">
 $(document).ready(function() {
     $.ajax({


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #966 
<!--
    Please include a summary of the proposed changes below.
-->

The Device detail view (and associated sub-pages, such as Interfaces, Status, Config Context, etc) are based on a sub-template that inherits from `object_detail.html`, `nautobot/dcim/templates/dcim/device/base.html`. This template overrides the `nav_tabs` block so the "Advanced" tab from object_detail.html was missing.

- Add "Advanced" tab to `nautobot/dcim/templates/dcim/device/base.html`
- Add content of "Advanced" tab to `nautobot/dcim/templates/dcim/device/device.html` (needed because it fully overrides the `block content` from `object_detail.html`, instead of just using `content_left_page`, `content_right_page`, and `content_full_width_page`).
- #933 added some Javascript to `object_detail.html` that offers all of the functionality previously in `nautobot/dcim/templates/dcim/device/base.html` and more - so remove the custom Javascript block from `nautobot/dcim/templates/dcim/device/base.html`.
- The sub-templates under Device (Interfaces, Status, Config Context, etc.) were overriding the Javascript block from the base template rather than extending it. Add `{{ block.super }}` to each of these templates so that the `object_detail.html` JS remains in effect.

![image](https://user-images.githubusercontent.com/5603551/136581715-dabd9ecc-70f1-4c5e-b85c-af72faf8bd5a.png)

![image](https://user-images.githubusercontent.com/5603551/136581764-d3dfc4df-0806-4834-8933-4f37c3edbfc9.png)

