### PR TITLE
Added the 'id' and 'name' fields to the NestedJobResultSerializer.

### DIFF
--- a/nautobot/extras/api/nested_serializers.py
+++ b/nautobot/extras/api/nested_serializers.py
@@ -86,7 +86,7 @@ class NestedJobResultSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.JobResult
-        fields = ["url", "created", "completed", "user", "status"]
+        fields = ["id", "url", "name", "created", "completed", "user", "status"]
 
 
 class NestedCustomLinkSerializer(WritableNestedSerializer):


### PR DESCRIPTION
### Fixes: #989

Added the `name` and `id` fields to the `NestedJobResultSerializer`.  As JobResults can be created by numerous plugins, this provides the ability to filter by name when calling the `ObjectVar` to restrict JobResults to specifc types of jobs.
For example:
```
    my_selection = ObjectVar(
        model=JobResult,
        display_field="completed",
        query_params={"name": "plugins/my_plugin.jobs/MyJobOutput"},
    )
```