### PR TITLE
Fix incorrect git command when refreshing existing repository

### DIFF
--- a/nautobot/utilities/git.py
+++ b/nautobot/utilities/git.py
@@ -41,9 +41,11 @@ class GitRepo:
         self.fetch()
         if commit_hexsha:
             # Sanity check - GitPython doesn't provide a handy API for this so we just call a raw Git command:
-            # $ git branch <branch> --contains <commit>
+            # $ git branch origin/<branch> --remotes --contains <commit>
             # prints the branch name if it DOES contain the commit, and nothing if it DOES NOT contain the commit.
-            if branch not in self.repo.git.branch(branch, "--contains", commit_hexsha):
+            # Since we did a `fetch` and not a `pull` above, we need to check for the commit in the remote origin
+            # branch, not the local (not-yet-updated) branch.
+            if branch not in self.repo.git.branch(f"origin/{branch}", "--remotes", "--contains", commit_hexsha):
                 raise RuntimeError(f"Requested to check out commit `{commit_hexsha}`, but it's not in branch {branch}!")
             logger.info(f"Checking out commit `{commit_hexsha}` on branch `{branch}`...")
             self.repo.git.checkout(commit_hexsha)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #N/A
<!--
    Please include a summary of the proposed changes below.
-->

Fix a user-reported issue; fix verified by the user.

In the case where:

1) A git repository has been previously checked out locally (say, in a worker Docker context)
2) The repository has been updated at its source since we did that checkout.
3) We checkout or refresh the local copy of the repository in a different context (say, the main Nautobot context), resulting in the database entry's `commit_hexsha` field being updated to the new value.
4) It becomes time to refresh the repository in the context described in item 1) above

then we were calling `git fetch` followed by `git branch <name> --contains <commit_hexsha>` (to try to verify whether the requested commit exists in the specified branch), which will *fail* because we have locally checked out the branch, but not updated it with the latest commits (since we did a `git fetch`, not a `git pull`), so the local branch *does not* contain the new commit.

The fix is to instead call `git branch origin/<name> --remotes --contains <commit_hexsha>` as our check, because the remote refpoint for the branch *is* updated by `git fetch`.