### PR TITLE
Add URM as Fiber Optic Port Type

### DIFF
--- a/nautobot/dcim/choices.py
+++ b/nautobot/dcim/choices.py
@@ -940,7 +940,9 @@ class PortTypeChoices(ChoiceSet):
     TYPE_SPLICE = "splice"
     TYPE_CS = "cs"
     TYPE_SN = "sn"
-    TYPE_URM = "URM"
+    TYPE_URM_P2 = 'urm-p2'
+    TYPE_URM_P4 = 'urm-p4'
+    TYPE_URM_P8 = 'urm-p8'
 
     CHOICES = (
         (
@@ -974,8 +976,10 @@ class PortTypeChoices(ChoiceSet):
                 (TYPE_ST, "ST"),
                 (TYPE_CS, "CS"),
                 (TYPE_SN, "SN"),
+                (TYPE_URM_P2, 'URM-P2'),
+                (TYPE_URM_P4, 'URM-P4'),
+                (TYPE_URM_P8, 'URM-P8'),
                 (TYPE_SPLICE, "Splice"),
-                (TYPE_URM, "URM"),
             ),
         ),
     )

--- a/nautobot/dcim/choices.py
+++ b/nautobot/dcim/choices.py
@@ -940,9 +940,9 @@ class PortTypeChoices(ChoiceSet):
     TYPE_SPLICE = "splice"
     TYPE_CS = "cs"
     TYPE_SN = "sn"
-    TYPE_URM_P2 = 'urm-p2'
-    TYPE_URM_P4 = 'urm-p4'
-    TYPE_URM_P8 = 'urm-p8'
+    TYPE_URM_P2 = "urm-p2"
+    TYPE_URM_P4 = "urm-p4"
+    TYPE_URM_P8 = "urm-p8"
 
     CHOICES = (
         (
@@ -976,9 +976,9 @@ class PortTypeChoices(ChoiceSet):
                 (TYPE_ST, "ST"),
                 (TYPE_CS, "CS"),
                 (TYPE_SN, "SN"),
-                (TYPE_URM_P2, 'URM-P2'),
-                (TYPE_URM_P4, 'URM-P4'),
-                (TYPE_URM_P8, 'URM-P8'),
+                (TYPE_URM_P2, "URM-P2"),
+                (TYPE_URM_P4, "URM-P4"),
+                (TYPE_URM_P8, "URM-P8"),
                 (TYPE_SPLICE, "Splice"),
             ),
         ),

--- a/nautobot/dcim/choices.py
+++ b/nautobot/dcim/choices.py
@@ -940,6 +940,7 @@ class PortTypeChoices(ChoiceSet):
     TYPE_SPLICE = "splice"
     TYPE_CS = "cs"
     TYPE_SN = "sn"
+    TYPE_URM = "URM"
 
     CHOICES = (
         (
@@ -974,6 +975,7 @@ class PortTypeChoices(ChoiceSet):
                 (TYPE_CS, "CS"),
                 (TYPE_SN, "SN"),
                 (TYPE_SPLICE, "Splice"),
+                (TYPE_URM, "URM"),
             ),
         ),
     )


### PR DESCRIPTION
Add 'URM' as Port Type for fiber ports.

URM is a German standard according to DIN SPEC 40032:2013-10 and compareable to MPO in sense of density.

Compare:
https://www.beuth.de/de/technische-regel/din-spec-40032/190360639
https://de.wikipedia.org/wiki/LWL-Steckverbinder#URM

Taken from https://github.com/netbox-community/netbox/pull/7052
