### PR TITLE
Abort transaction when a job failed

### DIFF
--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1074,9 +1074,10 @@ def run_job(data, request, job_result_pk, commit=True, *args, **kwargs):
                 if job.failed:
                     job.logger.warning("job failed")
                     job_result.set_status(JobResultStatusChoices.STATUS_FAILED)
-                else:
-                    job.logger.info("job completed successfully")
-                    job_result.set_status(JobResultStatusChoices.STATUS_COMPLETED)
+                    raise AbortTransaction()
+
+                job.logger.info("job completed successfully")
+                job_result.set_status(JobResultStatusChoices.STATUS_COMPLETED)
 
                 if not commit:
                     raise AbortTransaction()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1005
<!--
    Please include a summary of the proposed changes below.
-->
Execute `raise AbortTransaction() `when `job.failed` is true
