### PR TITLE
Initial return ipam custom lookups

### DIFF
--- a/nautobot/docs/installation/migrating-from-netbox.md
+++ b/nautobot/docs/installation/migrating-from-netbox.md
@@ -136,9 +136,6 @@ Custom Fields have been overhauled for asserting data integrity and improving us
 !!! tip
 	Nautobot 1.2 and later supports most of the same filter-based network membership queries as NetBox. See [below](#membership-lookups) and the [filtering documentation](../rest-api/filtering.md#Network-and-Host-Fields) for more details. (Prior to Nautobot 1.2, IPAM network objects only supported model-manager-based methods for network membership filtering.) 
 
-!!! note
-	Nautobot did not mimic the support of non-subnets for the `net_in` query to avoid mistakes and confusion caused by an IP address being mistaken for a /32 as an example.
-
 All IPAM objects with network field types (`ipam.Aggregate`, `ipam.IPAddress`, and `ipam.Prefix`) are no longer hard-coded to use PostgreSQL-only `inet` or `cidr` field types and are now using a custom implementation leveraging SQL-standard `varbinary` field types.
 
 #### Technical Details
@@ -326,6 +323,8 @@ Nautobot 1.0.x and 1.1.x did not support the custom lookup expressions that NetB
 
 In Nautobot 1.2.0 and later, both model manager methods and custom lookup expressions are supported for this purpose, but the latter are now preferred for most use cases and are generally equivalent to their counterparts in NetBox.
 
+!!! note
+	Nautobot did not mimic the support of non-subnets for the `net_in` query to avoid mistakes and confusion caused by an IP address being mistaken for a /32 as an example.
 
 ##### net_mask_length
 

--- a/nautobot/docs/installation/migrating-from-netbox.md
+++ b/nautobot/docs/installation/migrating-from-netbox.md
@@ -134,7 +134,7 @@ Custom Fields have been overhauled for asserting data integrity and improving us
 ### IPAM Network Field Types
 
 !!! tip
-	Prior to Nautobot 1.2, IPAM network objects were overhauled and network membership queries using nested filter expressions and custom lookups will required updats in your code. Since Nautobot 1.2, you can use the same custom lookups for all use cases within MySQL and most use cases for Postgresql. See [filtering documentation](../rest-api/filtering.md#Network-and-Host-Fields) for more details.
+	Nautobot 1.2 and later supports most of the same filter-based network membership queries as NetBox. See [below](#membership-lookups) and the [filtering documentation](../rest-api/filtering.md#Network-and-Host-Fields) for more details. (Prior to Nautobot 1.2, IPAM network objects only supported model-manager-based methods for network membership filtering.) 
 
 !!! note
 	Nautobot did not mimic the support of non-subnets for the `net_in` query to avoid mistakes and confusion caused by an IP address being mistaken for a /32 as an example.

--- a/nautobot/docs/rest-api/filtering.md
+++ b/nautobot/docs/rest-api/filtering.md
@@ -85,3 +85,32 @@ String based (char) fields (Name, Address, etc) support these lookup expressions
 
 Certain other fields, namely foreign key relationships support just the negation
 expression: `n`.
+
+
+### Network and Host Fields
+
+There are [Custom Lookups](https://docs.djangoproject.com/en/3.2/howto/custom-lookups/) built for the `VarbinaryIPField` field types. While
+the `VarbinaryIPField` is applied to fields for network, host, and broadcast, the below filters only apply to network and host. The design
+makes an assumption that there is in fact a broadcast (of type `VarbinaryIPField`) and prefix_length (of type `Integer`) within the same
+model. This assumption is used to understand the relevant scope of the network in question and is important to note when extending the
+Nautobot core or plugin data model.
+
+- `**` `exact` - An exact match of an IP or network address, e.g. `host__exact="10.0.0.1"`
+- `**` `iexact` - An exact match of an IP or network address, e.g. `host__iexact="10.0.0.1"`
+- `**` `startswith` - Determine if IP or network starts with the value provided, e.g. `host__startswith="10.0.0."`
+- `**` `istartswith` - Determine if IP or network starts with the value provided, e.g. `host__istartswith="10.0.0."`
+- `**` `endswith` - Determine if IP or network ends with the value provided, e.g. `host__endswith="0.1"`
+- `**` `iendswith` - Determine if IP or network ends with the value provided, e.g. `host__iendswith="0.1"`
+- `**` `regex` - Determine if IP or network matches the pattern provided, e.g.` host__regex=r"10\.(.*)\.1`
+- `**` `iregex` - Determine if IP or network matches the pattern provided, e.g.` host__iregex=r"10\.(.*)\.1`
+- `net_contained` - Given a network, determine which networks are contained within the provided e.g. `network__net_contained="192.0.0.0/8"` would include 192.168.0.0/24 in the result
+- `net_contained_or_equal` - Given a network, determine which networks are contained or is within the provided e.g. `network__net_contained_or_equal="192.0.0.0/8"` would include 192.168.0.0/24 and 192.0.0.0/8 in the result
+- `net_contains` - Given a network, determine which networks contain the provided network e.g. `network__net_contains="192.168.0.0/16"` would include 192.0.0.0/8 in the result
+- `net_contains_or_equals` - Given a network, determine which networks contain or is the provided network e.g. `network__net_contains="192.168.0.0/16"` would include 192.0.0.0/8 and 192.168.0.0/16 in the result
+- `net_equals` - Given a network, determine which which networks are an exact match. e.g. `network__net_equals="192.168.0.0/16"` would include only 192.168.0.0/16 in the result
+- `net_host` - Determine which networks are parent of the provided IP, e.g. `host__net_host="10.0.0.1"`  would include 10.0.0.1/32 and 10.0.0.0/24 in the result
+- `net_host_contained` - Given a network, select IPs whose host address falls within that network, e.g. `host__net_host_contained="10.0.0.0/24"` would include 10.0.0.1/8 and 10.0.0.254/32 in the result
+- `net_in` - Given a list of networks, select addresses within those networks, e.g. `host__net_in=["10.0.0.0/24", "2001:db8::/64"]` would include hosts 10.0.0.1/16 and 2001:db8::1/65 in the result
+- `family` - Given an IP address family of 4 or 6, provide hosts or networks that are that IP version type, e.g. `host__family=6` would include 2001:db8::1 in the result
+
+> Note: The fields denoted with `**` are only supported in the MySQL dialect (and not Postgresql) at the current time.

--- a/nautobot/docs/rest-api/filtering.md
+++ b/nautobot/docs/rest-api/filtering.md
@@ -109,8 +109,8 @@ Nautobot core or plugin data model.
 - `net_contains_or_equals` - Given a network, determine which networks contain or is the provided network e.g. `network__net_contains="192.168.0.0/16"` would include 192.0.0.0/8 and 192.168.0.0/16 in the result
 - `net_equals` - Given a network, determine which which networks are an exact match. e.g. `network__net_equals="192.168.0.0/16"` would include only 192.168.0.0/16 in the result
 - `net_host` - Determine which networks are parent of the provided IP, e.g. `host__net_host="10.0.0.1"`  would include 10.0.0.1/32 and 10.0.0.0/24 in the result
-- `net_host_contained` - Given a network, select IPs whose host address falls within that network, e.g. `host__net_host_contained="10.0.0.0/24"` would include 10.0.0.1/8 and 10.0.0.254/32 in the result
-- `net_in` - Given a list of networks, select addresses within those networks, e.g. `host__net_in=["10.0.0.0/24", "2001:db8::/64"]` would include hosts 10.0.0.1/16 and 2001:db8::1/65 in the result
+- `net_host_contained` - Given a network, select IPs whose host address (regardless of its subnet mask) falls within that network , e.g. `host__net_host_contained="10.0.0.0/24"` would include hosts 10.0.0.1/8 and 10.0.0.254/32 in the result
+- `net_in` - Given a list of networks, select addresses (regardless of their subnet masks) within those networks, e.g. `host__net_in=["10.0.0.0/24", "2001:db8::/64"]` would include hosts 10.0.0.1/16 and 2001:db8::1/65 in the result
 - `family` - Given an IP address family of 4 or 6, provide hosts or networks that are that IP version type, e.g. `host__family=6` would include 2001:db8::1 in the result
 
 > Note: The fields denoted with `**` are only supported in the MySQL dialect (and not Postgresql) at the current time.

--- a/nautobot/ipam/fields.py
+++ b/nautobot/ipam/fields.py
@@ -3,6 +3,7 @@ from django.db import models
 import netaddr
 
 from .formfields import IPNetworkFormField
+from . import lookups
 
 
 class VarbinaryIPField(models.BinaryField):
@@ -89,3 +90,21 @@ class VarbinaryIPField(models.BinaryField):
         defaults = {"form_class": self.form_class()}
         defaults.update(kwargs)
         return super().formfield(**defaults)
+
+
+VarbinaryIPField.register_lookup(lookups.IExact)
+VarbinaryIPField.register_lookup(lookups.EndsWith)
+VarbinaryIPField.register_lookup(lookups.IEndsWith)
+VarbinaryIPField.register_lookup(lookups.StartsWith)
+VarbinaryIPField.register_lookup(lookups.IStartsWith)
+VarbinaryIPField.register_lookup(lookups.Regex)
+VarbinaryIPField.register_lookup(lookups.IRegex)
+VarbinaryIPField.register_lookup(lookups.NetContained)
+VarbinaryIPField.register_lookup(lookups.NetContainedOrEqual)
+VarbinaryIPField.register_lookup(lookups.NetContains)
+VarbinaryIPField.register_lookup(lookups.NetContainsOrEquals)
+VarbinaryIPField.register_lookup(lookups.NetEquals)
+VarbinaryIPField.register_lookup(lookups.NetHost)
+VarbinaryIPField.register_lookup(lookups.NetIn)
+VarbinaryIPField.register_lookup(lookups.NetHostContained)
+VarbinaryIPField.register_lookup(lookups.NetFamily)

--- a/nautobot/ipam/lookups.py
+++ b/nautobot/ipam/lookups.py
@@ -1,0 +1,277 @@
+import netaddr
+from django.db import NotSupportedError
+from django.db import connection as _connection
+from django.db.models import Lookup, lookups
+
+
+def _mysql_varbin_to_broadcast():
+    return "HEX(broadcast)"
+
+
+def _mysql_varbin_to_hex(lhs):
+    return f"HEX({lhs})"
+
+
+def _mysql_varbin_to_network():
+    return "HEX(network)"
+
+
+def _postgresql_varbin_to_broadcast(length):
+    return f"right(broadcast::text, -1)::varbit::bit({length})"
+
+
+def _postgresql_varbin_to_integer(lhs, length):
+    return f"right({lhs}::text, -1)::varbit::bit({length})"
+
+
+def _postgresql_varbin_to_network(lhs, length):
+    # convert to bitstring, 0 out everything larger than prefix_length
+    return f"lpad(right({lhs}::text, -1)::varbit::text, prefix_length, '0')::bit({length})"
+
+
+def py_to_hex(ip, length):
+    return str(hex(int(ip)))[2:].zfill(int(length / 4))
+
+
+def get_ip_info(field_name, ip_str):
+    """Function to set all details about an IP, that may be needed."""
+    ip_details = IPDetails()
+    ip = netaddr.IPNetwork(ip_str)
+    if field_name == "network":
+        ip_details.addr = ip.network
+    elif field_name == "host":
+        ip_details.addr = ip.ip
+    ip_details.ip = ip
+    ip_details.prefix = ip.prefixlen
+    ip_details.length = ip_details.to_len[ip.version]
+
+    if _connection.vendor == "mysql":
+        ip_details.rhs = py_to_hex(ip.ip, ip_details.length)
+        ip_details.net_addr = f"'{py_to_hex(ip.network, ip_details.length)}'"
+        ip_details.bcast_addr = f"'{py_to_hex(ip[-1], ip_details.length)}'"
+        ip_details.q_net = _mysql_varbin_to_network()
+        ip_details.q_bcast = _mysql_varbin_to_broadcast()
+        ip_details.q_ip = _mysql_varbin_to_hex(field_name)
+
+    elif _connection.vendor == "postgresql":
+        ip_details.rhs = bin(int(ip_details.addr))[2:].zfill(ip_details.length)
+        ip_details.addr_str = f"B'{bin(int(ip_details.addr))[2:].zfill(ip_details.length)}'"
+        ip_details.net_addr = f"B'{bin(int(ip.network))[2:].zfill(ip_details.length)}'"
+        ip_details.bcast_addr = f"B'{bin(int(ip[-1]))[2:].zfill(ip_details.length)}'"
+        ip_details.q_net = _postgresql_varbin_to_network(field_name, ip_details.length)
+        ip_details.q_bcast = _postgresql_varbin_to_broadcast(ip_details.length)
+        ip_details.q_ip = _postgresql_varbin_to_integer(field_name, ip_details.length)
+
+    return ip_details
+
+
+class IPDetails(object):
+    """Class for setting up all details about an IP they may be needed"""
+
+    net = None
+    addr = None
+    ip = None
+    prefix = None
+    length = None
+    addr_str = None
+    rhs = None
+    net_addr = None
+    bcast_addr = None
+    q_net = None
+    q_bcast = None
+    q_ip = None
+    to_len = {4: 32, 6: 128}
+
+
+class StringMatchMixin(object):
+    def process_lhs(self, qn, connection, lhs=None):
+        lhs = lhs or self.lhs
+        lhs_string, lhs_params = qn.compile(lhs)
+        if connection.vendor == "postgresql":
+            raise NotSupportedError("Lookup not supported on postgresql.")
+        return f"INET6_NTOA({lhs_string})", lhs_params
+
+
+class Exact(StringMatchMixin, lookups.Exact):
+    pass
+
+
+class IExact(StringMatchMixin, lookups.IExact):
+    pass
+
+
+class EndsWith(StringMatchMixin, lookups.EndsWith):
+    pass
+
+
+class IEndsWith(StringMatchMixin, lookups.IEndsWith):
+    pass
+
+
+class StartsWith(StringMatchMixin, lookups.StartsWith):
+    pass
+
+
+class IStartsWith(StringMatchMixin, lookups.IStartsWith):
+    pass
+
+
+class Regex(StringMatchMixin, lookups.Regex):
+    pass
+
+
+class IRegex(StringMatchMixin, lookups.IRegex):
+    pass
+
+
+class NetworkFieldMixin(object):
+    def get_prep_lookup(self):
+        field_name = self.lhs.field.name
+        if field_name not in ["host", "network"]:
+            raise NotSupportedError(f"Lookup only provided on the host and network fields, not {field_name}.")
+        if field_name == "network" and self.lookup_name in ["net_host", "net_host_contained", "net_in"]:
+            raise NotSupportedError(f"Lookup for network field does not include the {self.lookup_name} lookup.")
+        if field_name == "host" and self.lookup_name not in ["net_host", "net_host_contained", "net_in"]:
+            raise NotSupportedError(f"Lookup for host field does not include the {self.lookup_name} lookup.")
+        self.ip = get_ip_info(field_name, self.rhs)
+        return str(self.ip.ip)
+
+    def process_rhs(self, qn, connection):
+        sql, params = super().process_rhs(qn, connection)
+        params[0] = self.ip.rhs
+        return sql, params
+
+
+class NetEquals(NetworkFieldMixin, Lookup):
+    lookup_name = "net_equals"
+
+    def as_sql(self, qn, connection):
+        _, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        query = f"prefix_length = {self.ip.prefix} AND {rhs} = {self.ip.q_ip}"
+        return query, lhs_params + rhs_params
+
+
+class NetContainsOrEquals(NetworkFieldMixin, Lookup):
+    lookup_name = "net_contains_or_equals"
+
+    def as_sql(self, qn, connection):
+        _, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        query = f"prefix_length <= {self.ip.prefix} AND {rhs} BETWEEN {self.ip.q_net} AND {self.ip.q_bcast}"
+        return query, lhs_params + rhs_params
+
+
+class NetContains(NetworkFieldMixin, Lookup):
+    lookup_name = "net_contains"
+
+    def as_sql(self, qn, connection):
+        _, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        query = f"prefix_length < {self.ip.prefix} AND {rhs} BETWEEN {self.ip.q_net} AND {self.ip.q_bcast}"
+        return query, lhs_params + rhs_params
+
+
+class NetContainedOrEqual(NetworkFieldMixin, Lookup):
+    lookup_name = "net_contained_or_equal"
+
+    def as_sql(self, qn, connection):
+        _, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        query = f"prefix_length >= {self.ip.prefix} AND {self.ip.q_net} BETWEEN {rhs} AND {self.ip.bcast_addr}"
+        return query, lhs_params + rhs_params
+
+
+class NetContained(NetworkFieldMixin, Lookup):
+    lookup_name = "net_contained"
+
+    def as_sql(self, qn, connection):
+        _, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        query = f"prefix_length > {self.ip.prefix} AND {self.ip.q_net} BETWEEN {rhs} AND {self.ip.bcast_addr}"
+        return query, lhs_params + rhs_params
+
+
+class NetHost(Lookup):
+    lookup_name = "net_host"
+
+    def get_prep_lookup(self):
+        field_name = self.lhs.field.name
+        if field_name != "host":
+            raise NotSupportedError(f"Lookup only provided on the host fields, not {field_name}.")
+        self.ip = get_ip_info(field_name, self.rhs)
+        return str(self.ip.ip)
+
+    def process_rhs(self, qn, connection):
+        sql, params = super().process_rhs(qn, connection)
+        params[0] = self.ip.rhs
+        return sql, params
+
+    def process_lhs(self, qn, connection, lhs=None):
+        lhs = lhs or self.lhs
+        _, lhs_params = qn.compile(lhs)
+        return self.ip.q_ip, lhs_params
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        return "%s = %s" % (lhs, rhs), lhs_params + rhs_params
+
+
+class NetIn(Lookup):
+    lookup_name = "net_in"
+
+    def get_prep_lookup(self):
+        field_name = self.lhs.field.name
+        if field_name != "host":
+            raise NotSupportedError(f"Lookup only provided on the host field, not {field_name}.")
+        self.ips = []
+        for _ip in self.rhs:
+            ip = get_ip_info(field_name, _ip)
+            self.ips.append(ip)
+        # This is to satisfy an issue with django cacheops, specifically this line:
+        # https://github.com/Suor/django-cacheops/blob/a5ed1ac28c7259f5ad005e596cc045d1d61e2c51/cacheops/query.py#L175
+        # Without 1, and one 1 value as %s, will result in stacktrace. A non-impacting condition is added to the query
+        if _connection.vendor == "mysql":
+            self.query_starter = "'1' NOT IN %s AND "
+        elif _connection.vendor == "postgresql":
+            self.query_starter = "'1' != ANY(%s) AND "
+        return self.rhs
+
+    def as_sql(self, qn, connection):
+        _, lhs_params = self.process_lhs(qn, connection)
+        _, rhs_params = self.process_rhs(qn, connection)
+        query = self.query_starter
+        query += "OR ".join(f"{ip.q_ip} BETWEEN {ip.net_addr} AND {ip.bcast_addr} " for ip in self.ips)
+        return query, lhs_params + rhs_params
+
+
+class NetHostContained(NetworkFieldMixin, Lookup):
+    lookup_name = "net_host_contained"
+
+    def as_sql(self, qn, connection):
+        _, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        query = f"{self.ip.q_ip} BETWEEN {rhs} AND {self.ip.bcast_addr}"
+        return query, lhs_params + rhs_params
+
+
+class NetFamily(Lookup):
+    lookup_name = "family"
+
+    def get_prep_lookup(self):
+        if self.rhs not in [4, 6]:
+            raise NotSupportedError("Family must be either integer of value 4 or 6")
+        if self.rhs == 6:
+            self.rhs = 16
+        return self.rhs
+
+    def process_lhs(self, qn, connection, lhs=None):
+        lhs = lhs or self.lhs
+        lhs_string, lhs_params = qn.compile(lhs)
+        return "LENGTH(%s)" % lhs_string, lhs_params
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        return "%s = %s" % (lhs, rhs), lhs_params + rhs_params


### PR DESCRIPTION
### Fixes:  #982 partial #130

Looking to provide custom lookups again for VarbinaryField. Before I went too far, I thought I would see if this would be an acceptable solution. This only includes a postgres version *currently*, it should be somewhat trivial to add to MySQL as well. 

Demonstrating this in action
```
>>> Prefix.objects.filter(network__net_contains='10.2.200.0/24')
<PrefixQuerySet [<Prefix: 10.2.200.0/24>]>
>>> Prefix.objects.filter(network__net_contains='10.2.0.0/16')
<PrefixQuerySet [<Prefix: 10.2.200.0/24>]>
>>> Prefix.objects.filter(network__net_contains='10.2.0.0/17')
<PrefixQuerySet []>
```

Looking at the NetBox which seems to take patterns from https://github.com/jimfunk/django-postgresql-netfields, I think I can reproduce most of the functionality

```
'net_contains_or_equals'   | Good
'net_contains'             | Good
'net_contained'            | Good
'net_contained_or_equal'   | Good
'net_host'                 | Unclear?
'net_in'                   | Good
'net_host_contained'       | Good
'net_mask_length'          | Good
'host'                     | Not sure what it does?
'inet'                     | Not sure what it does?
```