### PR TITLE
Special-case handling of same-type non-symmetric relationships in GraphQL

### DIFF
--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -125,7 +125,7 @@ def generate_relationship_resolver(name, resolver_name, relationship, side, peer
         name (str): name of the custom field to resolve
         resolver_name (str): name of the resolver as declare in DjangoObjectType
         relationship (Relationship): Relationship object to generate a resolver for
-        site (site): side of the relationship to use for the resolver
+        side (str): side of the relationship to use for the resolver
         peer_model (Model): Django Model of the peer of this relationship
     """
 

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -8,6 +8,7 @@ from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 from graphql import GraphQLError
+import graphene.types
 from graphene_django import DjangoObjectType
 from graphene_django.settings import graphene_settings
 from graphql.error.located_error import GraphQLLocatedError
@@ -206,13 +207,14 @@ class GraphQLExtendSchemaType(TestCase):
         self.assertTrue(hasattr(schema, "resolve_tags"))
         self.assertIsInstance(getattr(schema, "resolve_tags"), types.FunctionType)
 
-    def test_extend_custom_context(self):
+    def test_extend_config_context(self):
 
         schema = extend_schema_type_config_context(DeviceTypeGraphQL, Device)
         self.assertIn("config_context", schema._meta.fields.keys())
 
     def test_extend_schema_device(self):
 
+        # The below *will* log an error as DeviceTypeGraphQL has already been extended automatically...?
         schema = extend_schema_type(DeviceTypeGraphQL)
         self.assertIn("config_context", schema._meta.fields.keys())
         self.assertTrue(hasattr(schema, "resolve_tags"))
@@ -280,39 +282,84 @@ class GraphQLExtendSchemaRelationship(TestCase):
         )
         self.o2o_1.validated_save()
 
-        self.sites = [
-            Site.objects.create(name="Site A", slug="site-a"),
-            Site.objects.create(name="Site B", slug="site-b"),
-            Site.objects.create(name="Site C", slug="site-c"),
-        ]
+        self.o2os_1 = Relationship(
+            name="Redundant Site",
+            slug="redundant-site",
+            source_type=site_ct,
+            destination_type=site_ct,
+            type="symmetric-one-to-one",
+        )
+        self.o2os_1.validated_save()
 
-        self.racks = [
-            Rack.objects.create(name="Rack A", site=self.sites[0]),
-            Rack.objects.create(name="Rack B", site=self.sites[1]),
-            Rack.objects.create(name="Rack C", site=self.sites[2]),
-        ]
+        self.o2m_same_type_1 = Relationship(
+            name="Some sort of site hierarchy?",
+            slug="site-hierarchy",
+            source_type=site_ct,
+            destination_type=site_ct,
+            type="one-to-many",
+        )
+        self.o2m_same_type_1.validated_save()
 
-        self.vlans = [
-            VLAN.objects.create(name="VLAN A", vid=100, site=self.sites[0]),
-            VLAN.objects.create(name="VLAN B", vid=100, site=self.sites[1]),
-            VLAN.objects.create(name="VLAN C", vid=100, site=self.sites[2]),
-        ]
+        self.site_schema = generate_schema_type(app_name="dcim", model=Site)
+        self.vlan_schema = generate_schema_type(app_name="ipam", model=VLAN)
 
-        self.schema = generate_schema_type(app_name="dcim", model=Site)
+    def test_extend_relationship_default_prefix(self):
+        """Verify that relationships are correctly added to the schema."""
+        schema = extend_schema_type_relationships(self.vlan_schema, VLAN)
 
-    @override_settings(GRAPHQL_CUSTOM_RELATIONSHIP_PREFIX="pr")
-    def test_extend_relationship_w_prefix(self):
-
-        schema = extend_schema_type_relationships(self.schema, Site)
-
-        datas = [
-            {"field_slug": "primary-rack-site"},
-            {"field_slug": "site-vlan"},
-        ]
-
-        for data in datas:
-            field_name = f"rel_{str_to_var_name(data['field_slug'])}"
+        # Relationships on VLAN
+        for rel, peer_side in [
+            (self.m2m_1, "source"),
+            (self.m2m_2, "source"),
+            (self.o2m_1, "source"),
+        ]:
+            field_name = f"rel_{str_to_var_name(rel.slug)}"
             self.assertIn(field_name, schema._meta.fields.keys())
+            self.assertIsInstance(schema._meta.fields[field_name], graphene.types.field.Field)
+            if rel.has_many(peer_side):
+                self.assertIsInstance(schema._meta.fields[field_name].type, graphene.types.structures.List)
+            else:
+                self.assertNotIsInstance(schema._meta.fields[field_name].type, graphene.types.structures.List)
+
+        # Relationships not on VLAN
+        for rel in [self.o2o_1, self.o2os_1]:
+            field_name = f"rel_{str_to_var_name(rel.slug)}"
+            self.assertNotIn(field_name, schema._meta.fields.keys())
+
+    @override_settings(GRAPHQL_RELATIONSHIP_PREFIX="pr")
+    def test_extend_relationship_w_prefix(self):
+        """Verify that relationships are correctly added to the schema when using a custom prefix setting."""
+        schema = extend_schema_type_relationships(self.site_schema, Site)
+
+        # Relationships on Site
+        for rel, peer_side in [
+            (self.o2m_1, "destination"),
+            (self.o2o_1, "source"),
+            (self.o2os_1, "peer"),
+        ]:
+            field_name = f"pr_{str_to_var_name(rel.slug)}"
+            self.assertIn(field_name, schema._meta.fields.keys())
+            self.assertIsInstance(schema._meta.fields[field_name], graphene.types.field.Field)
+            if rel.has_many(peer_side):
+                self.assertIsInstance(schema._meta.fields[field_name].type, graphene.types.structures.List)
+            else:
+                self.assertNotIsInstance(schema._meta.fields[field_name].type, graphene.types.structures.List)
+
+        # Special handling of same-type non-symmetric relationships
+        for rel in [self.o2m_same_type_1]:
+            for peer_side in ["source", "destination"]:
+                field_name = f"pr_{str_to_var_name(rel.slug)}_{peer_side}"
+                self.assertIn(field_name, schema._meta.fields.keys())
+                self.assertIsInstance(schema._meta.fields[field_name], graphene.types.field.Field)
+                if rel.has_many(peer_side):
+                    self.assertIsInstance(schema._meta.fields[field_name].type, graphene.types.structures.List)
+                else:
+                    self.assertNotIsInstance(schema._meta.fields[field_name].type, graphene.types.structures.List)
+
+        # Relationships not on Site
+        for rel in [self.m2m_1, self.m2m_2]:
+            field_name = f"pr_{str_to_var_name(rel.slug)}"
+            self.assertNotIn(field_name, schema._meta.fields.keys())
 
 
 class GraphQLSearchParameters(TestCase):

--- a/nautobot/docs/additional-features/graphql.md
+++ b/nautobot/docs/additional-features/graphql.md
@@ -127,6 +127,76 @@ Result
 }
 ```
 
+## Working with Relationships
+
+Defined [relationships](../models/extras/relationship.md) are available in GraphQL as well. In most cases, the associated objects for a given relationship will be available under the key `rel_<relationship_slug>`. The one exception is for relationships between objects of the same type that are not defined as symmetric; for these relationships it's important to be able to distinguish between the two "sides" of the relationship, and so the associated objects will be available under `rel_<relationship_slug>_source` and/or `rel_<relationship_slug>_destination` as appropriate.
+
+```graphql
+query {
+  ip_addresses {
+    address
+    rel_peer_address {
+      address
+    }
+    rel_parent_child_source {
+      address
+    }
+    rel_parent_child_destination {
+      address
+    }
+  }
+}
+```
+
+Result
+```json
+{
+  "data": {
+    "ip_addresses": [
+      {
+        "address": "10.1.1.1/24",
+        "rel_peer_address": {
+          "address": "10.1.1.2/24"
+        },
+        "rel_parent_child_source": null,
+        "rel_parent_child_destination": [
+          {
+            "address": "10.1.1.1/30"
+          },
+          {
+            "address": "10.1.1.1/32"
+          }
+        ]
+      },
+      {
+        "address": "10.1.1.1/30",
+        "rel_peer_address": null,
+        "rel_parent_child_source": {
+          "address": "10.1.1.1/24"
+        },
+        "rel_parent_child_destination": []
+      },
+      {
+        "address": "10.1.1.1/32",
+        "rel_peer_address": null,
+        "rel_parent_child_source": {
+          "address": "10.1.1.1/24"
+        },
+        "rel_parent_child_destination": []
+      },
+      {
+        "address": "10.1.1.2/24",
+        "rel_peer_address": {
+          "address": "10.1.1.1/24"
+        },
+        "rel_parent_child_source": null,
+        "rel_parent_child_destination": []
+      }
+    ]
+  }
+}
+```
+
 ## Saved Queries
 
 Queries can now be stored inside of Nautobot, allowing the user to easily rerun previously defined queries.


### PR DESCRIPTION
### Related-to: #157

One more incremental PR to add atop #846.

For the special case where a relationship is:

1. between objects of the same class/type
2. non-symmetric

we need the GraphQL representation of the object to make both "sides" of the relationship accessible and distinct. This is especially important in the case of a one-to-many relationship (e.g. parent-child) because in this case the "source" side is a single object while the "destination" side is a list of objects. I opted to go with the simplest possible solution; for *only* the case identified above, when constructing the GraphQL fields for the relationship, append `_source` or `_destination` to the GraphQL field name as appropriate. All other GraphQL relationship fields are unaffected by this change; as such it is a non-breaking change because until #846 is merged, it isn't previously possible to construct this specific case of relationships at all.

```graphql
{
  ip_addresses {
    address
    rel_peer_address {
      address
    }
    rel_parent_child_source {
      address
    }
    rel_parent_child_destination {
      address
    }
  }
}
```

```json
{
  "data": {
    "ip_addresses": [
      {
        "address": "10.1.1.1/24",
        "rel_peer_address": {
          "address": "10.1.1.2/24"
        },
        "rel_parent_child_source": null,
        "rel_parent_child_destination": [
          {
            "address": "10.1.1.1/30"
          },
          {
            "address": "10.1.1.1/32"
          }
        ]
      },
      {
        "address": "10.1.1.1/30",
        "rel_peer_address": null,
        "rel_parent_child_source": {
          "address": "10.1.1.1/24"
        },
        "rel_parent_child_destination": []
      },
      {
        "address": "10.1.1.1/32",
        "rel_peer_address": null,
        "rel_parent_child_source": {
          "address": "10.1.1.1/24"
        },
        "rel_parent_child_destination": []
      },
      {
        "address": "10.1.1.2/24",
        "rel_peer_address": {
          "address": "10.1.1.1/24"
        },
        "rel_parent_child_source": null,
        "rel_parent_child_destination": []
      }
    ]
  }
}
```


Additionally, I discovered that in a number of cases, the logic in the GraphQL schema generator that's supposed to check for and warn about redefining an existing field or type was not implemented correctly, so I've fixed that.