### PR TITLE
fixes #1026 - dcim homepage object counts

### DIFF
--- a/nautobot/dcim/homepage.py
+++ b/nautobot/dcim/homepage.py
@@ -1,6 +1,5 @@
-from nautobot.dcim.models.power import PowerFeed, PowerPanel
-from nautobot.dcim.models import Cable, ConsolePort, Interface, PowerOutlet, Rack, Site
 from nautobot.core.apps import HomePageGroup, HomePageItem, HomePagePanel
+from nautobot.dcim import models
 
 
 layout = (
@@ -11,7 +10,7 @@ layout = (
             HomePageItem(
                 name="Sites",
                 link="dcim:site_list",
-                model=Site,
+                model=models.Site,
                 description="Geographic location",
                 permissions=["dcim.view_site"],
                 weight=100,
@@ -25,7 +24,7 @@ layout = (
             HomePageItem(
                 name="Racks",
                 link="dcim:rack_list",
-                model=Rack,
+                model=models.Rack,
                 description="Equipment racks, optionally organized by group",
                 permissions=["dcim.view_rack"],
                 weight=100,
@@ -33,7 +32,7 @@ layout = (
             HomePageItem(
                 name="Device Types",
                 link="dcim:devicetype_list",
-                model=Rack,
+                model=models.DeviceType,
                 description="Physical hardware models by manufacturer",
                 permissions=["dcim.view_devicetype"],
                 weight=200,
@@ -41,7 +40,7 @@ layout = (
             HomePageItem(
                 name="Devices",
                 link="dcim:device_list",
-                model=Rack,
+                model=models.Device,
                 description="Rack-mounted network equipment, servers, and other devices",
                 permissions=["dcim.view_device"],
                 weight=300,
@@ -49,7 +48,7 @@ layout = (
             HomePageItem(
                 name="Virtual Chassis",
                 link="dcim:virtualchassis_list",
-                model=Rack,
+                model=models.VirtualChassis,
                 permissions=["dcim.view_virtualchassis"],
                 description="Represents a set of devices which share a common control plane",
                 weight=400,
@@ -61,28 +60,28 @@ layout = (
                     HomePageItem(
                         name="Cables",
                         link="dcim:cable_list",
-                        model=Cable,
+                        model=models.Cable,
                         permissions=["dcim.view_cable"],
                         weight=100,
                     ),
                     HomePageItem(
                         name="Interfaces",
                         link="dcim:interface_connections_list",
-                        model=Interface,
+                        model=models.Interface,
                         permissions=["dcim.view_interface"],
                         weight=200,
                     ),
                     HomePageItem(
                         name="Console",
                         link="dcim:console_connections_list",
-                        model=ConsolePort,
+                        model=models.ConsolePort,
                         permissions=["dcim.view_consoleport", "dcim.view_consoleserverport"],
                         weight=300,
                     ),
                     HomePageItem(
                         name="Power",
                         link="dcim:power_connections_list",
-                        model=PowerOutlet,
+                        model=models.PowerOutlet,
                         permissions=["dcim.view_powerport", "dcim.view_poweroutlet"],
                         weight=400,
                     ),
@@ -97,7 +96,7 @@ layout = (
             HomePageItem(
                 name="Power Feeds",
                 link="dcim:powerfeed_list",
-                model=PowerFeed,
+                model=models.PowerFeed,
                 description="Electrical circuits delivering power from panels",
                 permissions=["dcim.view_powerfeed"],
                 weight=100,
@@ -105,7 +104,7 @@ layout = (
             HomePageItem(
                 name="Power Panels",
                 link="dcim:powerpanel_list",
-                model=PowerPanel,
+                model=models.PowerPanel,
                 description="Electrical panels receiving utility power",
                 permissions=["dcim.view_powerpanel"],
                 weight=200,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1026 
<!--
    Please include a summary of the proposed changes below.
-->
There was a seemingly simple copy/paste oversight in the implementation of the DCIM HomePageItems such that everything other than Sites uses the Rack model for counts.