### PR TITLE
Custom Select Validation Regex

### DIFF
--- a/nautobot/docs/additional-features/custom-fields.md
+++ b/nautobot/docs/additional-features/custom-fields.md
@@ -36,10 +36,13 @@ Nautobot supports limited custom validation for custom field values. Following a
 * Text: Regular expression (optional)
 * Integer: Minimum and/or maximum value (optional)
 * Selection: Must exactly match one of the prescribed choices
+  * Selection Fields: Regular expression (optional)
 
 ### Custom Selection Fields
 
 Choices are stored as independent values and are assigned a numeric weight which affects their ordering in selection lists and dropdowns. Note that choice values are saved exactly as they appear, so it's best to avoid superfluous punctuation or symbols where possible.
+
+Regular expression can optionally be defined on custom selection choices to validate the field choice in the user-interface and the API.
 
 If a default value is specified for a selection field, it must exactly match one of the provided choices. Note that the default value can only be set on the custom field after its corresponding choice has been added.
 

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -678,7 +678,7 @@ class CustomFieldAPITest(APITestCase):
 
         data = {"field": self.cf_select.id, "value": "ABC", "weight": 100}
         response = self.client.post(url, data, format="json", **self.header)
-        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
 
 
 class CustomFieldImportTest(TestCase):

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -225,7 +225,6 @@ class CustomFieldAPITest(APITestCase):
         CustomFieldChoice.objects.create(field=cls.cf_select, value="Foo")
         CustomFieldChoice.objects.create(field=cls.cf_select, value="Bar")
         CustomFieldChoice.objects.create(field=cls.cf_select, value="Baz")
-        CustomFieldChoice.objects.create(field=cls.cf_select, value="1234")
         cls.cf_select.default = "Foo"
         cls.cf_select.save()
 

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -216,8 +216,10 @@ class CustomFieldAPITest(APITestCase):
         cls.cf_url.content_types.set([content_type])
 
         # Select custom field
-        cls.cf_select = CustomField(type=CustomFieldTypeChoices.TYPE_SELECT, name="choice_field")
-        cls.cf_select.validation_regex = r"^\S{3}$"
+        cls.cf_select = CustomField(
+            type=CustomFieldTypeChoices.TYPE_SELECT,
+            name="choice_field",
+        )
         cls.cf_select.save()
         cls.cf_select.content_types.set([content_type])
         CustomFieldChoice.objects.create(field=cls.cf_select, value="Foo")


### PR DESCRIPTION
### Fixes: #876

- [ √] Adds validation regex to the select custom field types.

#### Use-case
Outside users are given the ability to add items to custom field selections, and automation keys off of these values. Via UI or API when creating an additional custom field choice, this would add a preventative measure from adding a value that did not conform to a pre-defined validation check. 

<img width="756" alt="Screen Shot 2021-10-29 at 11 20 25 AM" src="https://user-images.githubusercontent.com/7542351/139470387-830196ae-506f-4f69-a904-c228ba223855.png">

