### PR TITLE
Add passing of **kwargs to Celery

### DIFF
--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -812,7 +812,7 @@ class JobResult(BaseModel, CustomFieldModel):
             self.completed = timezone.now()
 
     @classmethod
-    def enqueue_job(cls, func, name, obj_type, user, *args, schedule=None, **kwargs):
+    def enqueue_job(cls, func, name, obj_type, user, celery_kwargs=None, *args, schedule=None, **kwargs):
         """
         Create a JobResult instance and enqueue a job using the given callable
 
@@ -820,15 +820,18 @@ class JobResult(BaseModel, CustomFieldModel):
         name: Name for the JobResult instance
         obj_type: ContentType to link to the JobResult instance obj_type
         user: User object to link to the JobResult instance
+        celery_kwargs: Dictionary of kwargs to pass as **kwargs to celery
         args: additional args passed to the callable
         schedule: Optional ScheduledJob instance to link to the JobResult
-        kwargs: additional kargs passed to the callable
+        kwargs: additional kwargs passed to the callable
         """
         job_result = cls.objects.create(name=name, obj_type=obj_type, user=user, job_id=uuid.uuid4(), schedule=schedule)
 
         kwargs["job_result_pk"] = job_result.pk
 
-        func.apply_async(args=args, kwargs=kwargs, task_id=str(job_result.job_id))
+        celery_kwargs = celery_kwargs or {}
+
+        func.apply_async(args=args, kwargs=kwargs, task_id=str(job_result.job_id), **celery_kwargs)
 
         return job_result
 

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -820,7 +820,7 @@ class JobResult(BaseModel, CustomFieldModel):
         name: Name for the JobResult instance
         obj_type: ContentType to link to the JobResult instance obj_type
         user: User object to link to the JobResult instance
-        celery_kwargs: Dictionary of kwargs to pass as **kwargs to celery
+        celery_kwargs: Dictionary of kwargs to pass as **kwargs to Celery when job is queued
         args: additional args passed to the callable
         schedule: Optional ScheduledJob instance to link to the JobResult
         kwargs: additional kwargs passed to the callable
@@ -829,7 +829,9 @@ class JobResult(BaseModel, CustomFieldModel):
 
         kwargs["job_result_pk"] = job_result.pk
 
-        celery_kwargs = celery_kwargs or {}
+        # Prepare kwargs that will be sent to Celery
+        if celery_kwargs is None:
+            celery_kwargs = {}
 
         func.apply_async(args=args, kwargs=kwargs, task_id=str(job_result.job_id), **celery_kwargs)
 

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -870,9 +870,6 @@ class JobView(ContentTypePermissionRequiredMixin, View):
 
                 return redirect("extras:job_jobresult", pk=job_result.pk)
 
-            # TODO: Define interface/API for getting queue (or other kwargs in future) for celery_kwargs
-            celery_kwargs = {}
-
         return render(
             request,
             "extras/job.html",
@@ -936,8 +933,7 @@ class JobApprovalRequestView(ContentTypePermissionRequiredMixin, View):
                 job_content_type,
                 scheduled_job.user,
                 request.user,
-                celery_kwargs=celery_kwargs,
-                data=job_class.serialize_data(form.cleaned_data),
+                data=job_class.serialize_data(initial),
                 request=copy_safe_request(request),
                 commit=False,  # force a dry-run
             )

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -936,7 +936,7 @@ class JobApprovalRequestView(ContentTypePermissionRequiredMixin, View):
                 job_content_type,
                 scheduled_job.user,
                 request.user,
-                celery_kwargs,
+                celery_kwargs=celery_kwargs,
                 data=job_class.serialize_data(form.cleaned_data),
                 request=copy_safe_request(request),
                 commit=False,  # force a dry-run

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -870,6 +870,9 @@ class JobView(ContentTypePermissionRequiredMixin, View):
 
                 return redirect("extras:job_jobresult", pk=job_result.pk)
 
+            # TODO: Define interface/API for getting queue (or other kwargs in future) for celery_kwargs
+            celery_kwargs = {}
+
         return render(
             request,
             "extras/job.html",
@@ -933,7 +936,8 @@ class JobApprovalRequestView(ContentTypePermissionRequiredMixin, View):
                 job_content_type,
                 scheduled_job.user,
                 request.user,
-                data=job_class.serialize_data(initial),
+                celery_kwargs,
+                data=job_class.serialize_data(form.cleaned_data),
                 request=copy_safe_request(request),
                 commit=False,  # force a dry-run
             )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #<ISSUE NUMBER GOES HERE>
<!--
    Please include a summary of the proposed changes below.
-->
Add acceptance of `celery_kwargs` to Job's `enqueue_job` method and have that passed to celery in order to allow Jobs to specify a particular queue to place the task into.