### PR TITLE
Revise documentation for Celery Beat scheduler for clarity.

### DIFF
--- a/nautobot/docs/installation/services.md
+++ b/nautobot/docs/installation/services.md
@@ -107,7 +107,7 @@ We'll use `systemd` to control both uWSGI and Nautobot's background worker proce
 
 First, we'll establish the `systemd` unit file for the Nautobot web service. Copy and paste the following into `/etc/systemd/system/nautobot.service`:
 
-```
+```ini
 [Unit]
 Description=Nautobot WSGI Service
 Documentation=https://nautobot.readthedocs.io/en/stable/
@@ -135,18 +135,22 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-### Nautobot Worker Services
+### Nautobot Background Services
 
 !!! note
     Prior to version 1.1.0, Nautobot utilized RQ as the primary background task worker. As of Nautobot 1.1.0, RQ is now *deprecated* and has been replaced with Celery. RQ will still work, but will be removed in a future release. Please [migrate your deployment to utilize Celery as documented below](#migrating-to-celery-from-rq).
 
-Next, we will setup the `systemd` unit for the Celery and Celery Beat workers.
+Next, we will setup the `systemd` units for the Celery worker and Celery Beat scheduler.
 
 #### Celery Worker
 
-Copy and paste the following into `/etc/systemd/system/nautobot-worker.service`:
+The Celery worker service consumes tasks from background task queues and is required for taking advantage of advanced
+Nautobot features including [Jobs](../additional-features/jobs.md), [Custom
+Fields](../additional-features/custom-fields.md), and [Git Repositories](../models/extras/gitrepository.md), among others.
 
-```
+To establish the `systemd` unit file for the Celery worker, copy and paste the following into `/etc/systemd/system/nautobot-worker.service`:
+
+```ini
 [Unit]
 Description=Nautobot Celery Worker
 Documentation=https://nautobot.readthedocs.io/en/stable/
@@ -172,13 +176,16 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-#### Celery Beat Worker
+#### Celery Beat Scheduler
 
-Additionally, paste the following into `/etc/systemd/system/nautobot-beat-worker.service`:
+The Celery Beat scheduler enables the periodic execution of and scheduling of background tasks. It is required to take
+advantage of the [job scheduling and approval](../additional-features/job-scheduling-and-approvals.md) features.
 
-```
+To establish the `systemd` unit file for the Celery Beat scheduler, copy and paste the following into `/etc/systemd/system/nautobot-scheduler.service`:
+
+```ini
 [Unit]
-Description=Nautobot Celery Beat Worker
+Description=Nautobot Celery Beat Scheduler
 Documentation=https://nautobot.readthedocs.io/en/stable/
 After=network-online.target
 Wants=network-online.target
@@ -189,10 +196,10 @@ Environment="NAUTOBOT_ROOT=/opt/nautobot"
 
 User=nautobot
 Group=nautobot
-PIDFile=/var/tmp/nautobot-beat-worker.pid
+PIDFile=/var/tmp/nautobot-scheduler.pid
 WorkingDirectory=/opt/nautobot
 
-ExecStart=/opt/nautobot/bin/nautobot-server celery beat --loglevel INFO --pidfile /var/tmp/nautobot-beat-worker.pid
+ExecStart=/opt/nautobot/bin/nautobot-server celery beat --loglevel INFO --pidfile /var/tmp/nautobot-scheduler.pid
 
 Restart=always
 RestartSec=30
@@ -201,7 +208,6 @@ PrivateTmp=true
 [Install]
 WantedBy=multi-user.target
 ```
-
 
 #### Migrating to Celery from RQ
 
@@ -251,7 +257,7 @@ If you must run the Celery and RQ workers concurrently, you must also configure 
 
 Copy and paste the following into `/etc/systemd/system/nautobot-rq-worker.service`:
 
-```
+```ini
 [Unit]
 Description=Nautobot Request Queue Worker
 Documentation=https://nautobot.readthedocs.io/en/stable/
@@ -284,10 +290,10 @@ Because we just added new service files, you'll need to reload the systemd daemo
 $ sudo systemctl daemon-reload
 ```
 
-Then, start the `nautobot`, `nautobot-worker`, and `nautobot-beat-worker` services and enable them to initiate at boot time:
+Then, start the `nautobot`, `nautobot-worker`, and `nautobot-scheduler` services and enable them to initiate at boot time:
 
 ```no-highlight
-$ sudo systemctl enable --now nautobot nautobot-worker nautobot-beat-worker
+$ sudo systemctl enable --now nautobot nautobot-worker nautobot-scheduler
 ```
 
 If you are also running the RQ worker, repeat the above command for the RQ service:

--- a/nautobot/docs/installation/upgrading.md
+++ b/nautobot/docs/installation/upgrading.md
@@ -8,7 +8,7 @@ additional work, certain releases may introduce breaking or backward-incompatibl
 release notes under the release in which the change went into effect.
 
 !!! note
-    As of Nautobot v1.2.0, Nautobot supports deferring (“scheduling”) Jobs. To facilitate this, a new service called `celery-beat-worker` is now required. Please review the [service installation documentation](./services.md) to find out how to set it up.
+    As of Nautobot v1.2.0, Nautobot supports deferring ("scheduling") Jobs. To facilitate this, a new service called `celery-scheduler` is now required. Please review the [service installation documentation](./services.md) to find out how to set it up.
 
 ## Update Prerequisites to Required Versions
 
@@ -73,8 +73,8 @@ This command performs the following actions:
 
 ## Restart the Nautobot Services
 
-Finally, with root permissions, restart the WSGI and RQ services:
+Finally, with root permissions, restart the web and background services:
 
 ```no-highlight
-$ sudo systemctl restart nautobot nautobot-worker
+$ sudo systemctl restart nautobot nautobot-worker nautobot-scheduler
 ```

--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -73,7 +73,7 @@ Jobs can now be scheduled for execution at a future date and time (such as durin
 !!! note
     Execution of scheduled jobs is dependent on [Celery Beat](https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html); enablement of this system service is a new requirement in Nautobot 1.2.
 
-TODO: add link to relevant documentation on enabling `nautobot-server celery beat` service!
+Please see the documentation on enabling the [Celery Beat scheduler service](../installation/services.md#celery-beat-scheduler) to get started!
 
 #### Organizational Branding ([#859](https://github.com/nautobot/nautobot/issues/859))
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #n/a
<!--
    Please include a summary of the proposed changes below.
-->
- Renamed it from "worker" to "scheduler" because it's not a worker
- Renamed the `systemd` unit file to be `nautobot-scheduler.service`
- Clarified the services documentation around worker and beat
- Revised release notes to link to the updated Celery Beat Scheduler section in the docs
