### PR TITLE
Push Docker Images for develop/next branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       - "black"
       - "flake8"
       - "hadolint"
+
   tests-postgres:
     runs-on: "ubuntu-20.04"
     strategy:
@@ -102,6 +103,7 @@ jobs:
         run: "poetry run invoke unittest-coverage"
     needs:
       - "check-migrations"
+
   tests-mysql:
     runs-on: "ubuntu-20.04"
     strategy:
@@ -145,6 +147,7 @@ jobs:
         run: "poetry run invoke unittest-coverage"
     needs:
       - "check-migrations"
+
   integration-test:
     runs-on: "ubuntu-20.04"
     env:
@@ -183,3 +186,80 @@ jobs:
     needs:
       - "tests-postgres"
       - "tests-mysql"
+
+  container-build:
+    runs-on: "ubuntu-20.04"
+    if: "github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/next')"
+    needs:
+      - "integration-test"
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [ "3.6", "3.7", "3.8", "3.9" ]
+    env:
+      INVOKE_NAUTOBOT_PYTHON_VER: "${{ matrix.python-version }}"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v2"
+      - run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: "gitbranch"
+      - name: "Set up Docker Buildx"
+        uses: "docker/setup-buildx-action@v1"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Docker Metadata"
+        id: "dockermeta"
+        uses: "docker/metadata-action@v3"
+        with:
+          images: "ghcr.io/nautobot/nautobot"
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value={{branch}}-py${{ matrix.python-version }}
+            type=raw,value={{branch}}-{{sha}}-{{date 'X'}}-py${{ matrix.python-version }}
+            type=raw,value={{branch}},enable=${{ matrix.python-version == 3.6 }}
+            type=raw,value={{branch}}-{{sha}}-{{date 'X'}},enable=${{ matrix.python-version == 3.6 }}
+            type=raw,value=latest,enable=${{ matrix.python-version == 3.6 && github.ref == 'refs/heads/develop' }}
+            type=raw,value=latest-py${{ matrix.python-version }},enable=${{ github.ref == 'refs/heads/develop' }}
+      - name: "Build"
+        uses: "docker/build-push-action@v2"
+        with:
+          push: true
+          target: final
+          file: "docker/Dockerfile"
+          tags: "${{ steps.dockermeta.outputs.tags }}"
+          cache-from: "type=gha,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
+          cache-to: "type=gha,mode=max,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
+          context: "."
+          build-args: |
+            PYTHON_VER=${{ matrix.python-version }}
+      - name: "Docker Dev Metadata"
+        id: "dockerdevmeta"
+        uses: "docker/metadata-action@v3"
+        with:
+          images: "ghcr.io/nautobot/nautobot-dev"
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value={{branch}}-py${{ matrix.python-version }}
+            type=raw,value={{branch}}-{{sha}}-{{date 'X'}}-py${{ matrix.python-version }}
+            type=raw,value={{branch}},enable=${{ matrix.python-version == 3.6 }}
+            type=raw,value={{branch}}-{{sha}}-{{date 'X'}},enable=${{ matrix.python-version == 3.6 }}
+            type=raw,value=latest,enable=${{ matrix.python-version == 3.6 && github.ref == 'refs/heads/develop' }}
+            type=raw,value=latest-py${{ matrix.python-version }},enable=${{ github.ref == 'refs/heads/develop' }}
+      - name: "Build Dev Containers"
+        uses: "docker/build-push-action@v2"
+        with:
+          push: true
+          target: final-dev
+          file: "docker/Dockerfile"
+          tags: "${{ steps.dockerdevmeta.outputs.tags }}"
+          cache-from: "type=gha,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
+          cache-to: "type=gha,mode=max,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
+          context: "."
+          build-args: |
+            PYTHON_VER=${{ matrix.python-version }}

--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -15,13 +15,19 @@ docker image pull networktocode/nautobot
 The following tags are available:
 
 * `X.Y.Z` these images are built with the same baseline as the released Python packages based on the default python version (3.6) docker container
-* `latest` these images are built from the latest code in the main branch (should be the latest released version) based on the default python version (3.6) docker container
 * `X.Y.Z-py${PYTHON_VER}` these images are built with the same baseline as the released Python packages based on the python version ($PYTHON_VER) docker container
-* `latest-py${PYTHON_VER}` these images are built from the latest code in the main branch (should be the latest released version) based on the python version ($PYTHON_VER) docker container
+* `stable` these images are built from the latest code in the main branch (should be the latest released version) based on the default python version (3.6) docker container
+* `stable-py${PYTHON_VER}` these images are built from the latest code in the main branch (should be the latest released version) based on the python version ($PYTHON_VER) docker container
+* `latest` these images are built from the latest code in the develop branch based on the default python version (3.6) docker container
+* `latest-py${PYTHON_VER}` these images are built from the latest code in the develop branch based on the python version ($PYTHON_VER) docker container
 * `develop` these images are built from the latest code in the develop branch on each commit based on the default python version (3.6) docker container
 * `develop-${GIT_SHA:0:7}-$(date +%s)` tags for each commit to the develop branch based on the default python version (3.6) docker container
 * `develop-py${PYTHON_VER}` these images are built from the latest code in the develop branch on each commit based on the python version ($PYTHON_VER) docker container
 * `develop-${GIT_SHA:0:7}-$(date +%s)-py${PYTHON_VER}` tags for each commit to the develop branch based on the python version ($PYTHON_VER) docker container
+* `next` these images are built from the latest code in the next branch on each commit based on the default python version (3.6) docker container
+* `next-${GIT_SHA:0:7}-$(date +%s)` tags for each commit to the next branch based on the default python version (3.6) docker container
+* `next-py${PYTHON_VER}` these images are built from the latest code in the next branch on each commit based on the python version ($PYTHON_VER) docker container
+* `next-${GIT_SHA:0:7}-$(date +%s)-py${PYTHON_VER}` tags for each commit to the next branch based on the python version ($PYTHON_VER) docker container
 
 To pull a specific tag you can append the image name with `:tag` for example, to pull the 1.0.0 image:
 
@@ -34,7 +40,7 @@ Currently images are pushed for the following python versions:
 * 3.6
 * 3.7
 * 3.8
-* 3.9 _For Testing Only_
+* 3.9
 
 !!! info
     A dev image `networktocode/nautobot-dev` is also provided with the same tags, this image provides the development dependencies needed to build Nautobot.  This container can be used as a base for development to develop additional Nautobot plugins but should **NOT** be used in production.


### PR DESCRIPTION
This should be merged before #1056 

This PR adds the automation to automatically push images to ghcr.io on commits to either the develop or next branch. This is the framework for also doing this on release in a future PR. Per the documentation, we will push develop* next* and latest* tagged images. the latest tag will follow the develop branch and the stable tag will follow the released version per the docs.

On a push to develop this will push the following images:

ghcr.io/nautobot/nautobot:develop-py3.6
ghcr.io/nautobot/nautobot:develop-1cade8f-1636131511-py3.6
ghcr.io/nautobot/nautobot:develop
ghcr.io/nautobot/nautobot:develop-1cade8f-1636131511
ghcr.io/nautobot/nautobot:latest
ghcr.io/nautobot/nautobot:latest-py3.6
ghcr.io/nautobot/nautobot-dev:develop-py3.6
ghcr.io/nautobot/nautobot-dev:develop-1cade8f-1636131512-py3.6
ghcr.io/nautobot/nautobot-dev:develop
ghcr.io/nautobot/nautobot-dev:develop-1cade8f-1636131512
ghcr.io/nautobot/nautobot-dev:latest
ghcr.io/nautobot/nautobot-dev:latest-py3.6
ghcr.io/nautobot/nautobot:develop-py3.7
ghcr.io/nautobot/nautobot:develop-1cade8f-1636131518-py3.7
ghcr.io/nautobot/nautobot:latest-py3.7
ghcr.io/nautobot/nautobot-dev:develop-py3.7
ghcr.io/nautobot/nautobot-dev:develop-1cade8f-1636131519-py3.7
ghcr.io/nautobot/nautobot-dev:latest-py3.7
ghcr.io/nautobot/nautobot:develop-py3.8
ghcr.io/nautobot/nautobot:develop-1cade8f-1636131520-py3.8
ghcr.io/nautobot/nautobot:latest-py3.8
ghcr.io/nautobot/nautobot-dev:develop-py3.8
ghcr.io/nautobot/nautobot-dev:develop-1cade8f-1636131521-py3.8
ghcr.io/nautobot/nautobot-dev:latest-py3.8
ghcr.io/nautobot/nautobot:develop-py3.9
ghcr.io/nautobot/nautobot:develop-1cade8f-1636131513-py3.9
ghcr.io/nautobot/nautobot:latest-py3.9
ghcr.io/nautobot/nautobot-dev:develop-py3.9
ghcr.io/nautobot/nautobot-dev:develop-1cade8f-1636131513-py3.9
ghcr.io/nautobot/nautobot-dev:latest-py3.9

On a push to next this will push the following images:

ghcr.io/nautobot/nautobot:next-py3.6
ghcr.io/nautobot/nautobot:next-1cade8f-1636131978-py3.6
ghcr.io/nautobot/nautobot:next
ghcr.io/nautobot/nautobot:next-1cade8f-1636131978
ghcr.io/nautobot/nautobot-dev:next-py3.6
ghcr.io/nautobot/nautobot-dev:next-1cade8f-1636131979-py3.6
ghcr.io/nautobot/nautobot-dev:next
ghcr.io/nautobot/nautobot-dev:next-1cade8f-1636131979
ghcr.io/nautobot/nautobot:next-py3.7
ghcr.io/nautobot/nautobot:next-1cade8f-1636131982-py3.7
ghcr.io/nautobot/nautobot-dev:next-py3.7
ghcr.io/nautobot/nautobot-dev:next-1cade8f-1636131982-py3.7
ghcr.io/nautobot/nautobot:next-py3.8
ghcr.io/nautobot/nautobot:next-1cade8f-1636131981-py3.8
ghcr.io/nautobot/nautobot-dev:next-py3.8
ghcr.io/nautobot/nautobot-dev:next-1cade8f-1636131981-py3.8
ghcr.io/nautobot/nautobot:next-py3.9
ghcr.io/nautobot/nautobot:next-1cade8f-1636131979-py3.9
ghcr.io/nautobot/nautobot-dev:next-py3.9
ghcr.io/nautobot/nautobot-dev:next-1cade8f-1636131979-py3.9