### PR TITLE
Don't try to sort `SecretsProvider` class objects in plugin config features registry

### DIFF
--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -169,7 +169,7 @@ class PluginConfig(NautobotConfig):
         if secrets_providers is not None:
             for secrets_provider in secrets_providers:
                 register_secrets_provider(secrets_provider)
-            self.features["secrets_providers"] = sorted(secrets_providers)
+            self.features["secrets_providers"] = sorted(p() for p in secrets_providers)
 
     @classmethod
     def validate(cls, user_config, nautobot_version):

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -169,7 +169,7 @@ class PluginConfig(NautobotConfig):
         if secrets_providers is not None:
             for secrets_provider in secrets_providers:
                 register_secrets_provider(secrets_provider)
-            self.features["secrets_providers"] = sorted(p() for p in secrets_providers)
+            self.features["secrets_providers"] = secrets_providers
 
     @classmethod
     def validate(cls, user_config, nautobot_version):

--- a/nautobot/extras/secrets/__init__.py
+++ b/nautobot/extras/secrets/__init__.py
@@ -1,17 +1,12 @@
 from abc import ABC, abstractmethod, abstractproperty
-from functools import total_ordering
 
 from nautobot.extras.registry import registry
 
 from .exceptions import SecretError, SecretParametersError, SecretProviderError, SecretValueNotFoundError
 
 
-@total_ordering
 class SecretsProvider(ABC):
     """Abstract base class for concrete providers of secret retrieval features."""
-
-    def __lt__(self, other):
-        return self.slug.lower() < other.slug.lower()
 
     def __repr__(self):
         return f"<{self.name}>"

--- a/nautobot/extras/secrets/__init__.py
+++ b/nautobot/extras/secrets/__init__.py
@@ -1,12 +1,20 @@
 from abc import ABC, abstractmethod, abstractproperty
+from functools import total_ordering
 
 from nautobot.extras.registry import registry
 
 from .exceptions import SecretError, SecretParametersError, SecretProviderError, SecretValueNotFoundError
 
 
+@total_ordering
 class SecretsProvider(ABC):
     """Abstract base class for concrete providers of secret retrieval features."""
+
+    def __lt__(self, other):
+        return self.slug.lower() < other.slug.lower()
+
+    def __repr__(self):
+        return f"<{self.name}>"
 
     @abstractproperty
     def slug(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:  n/a
<!--
    Please include a summary of the proposed changes below.
-->

This fixes a `TypeError` that is occurring when more than a single `SecretsProvider` instance is processed at once such as the case with the unreleased `nautobot-plugin-secrets-providers` plugin that is bundling two providers.

This is the traceback that occurs:

```python
Traceback (most recent call last):
  File "/Users/jathan/Library/Caches/pypoetry/virtualenvs/nautobot-secrets-providers-UI3Itdc9-py3.9/bin/nautobot-server", line 8, in <module>
    sys.exit(main())
  File "/Users/jathan/Library/Caches/pypoetry/virtualenvs/nautobot-secrets-providers-UI3Itdc9-py3.9/lib/python3.9/site-packages/nautobot/core/cli.py", line 54, in main
    run_app(
  File "/Users/jathan/Library/Caches/pypoetry/virtualenvs/nautobot-secrets-providers-UI3Itdc9-py3.9/lib/python3.9/site-packages/nautobot/core/runner/runner.py", line 266, in run_app
    management.execute_from_command_line([runner_name, command] + command_args)
  File "/Users/jathan/Library/Caches/pypoetry/virtualenvs/nautobot-secrets-providers-UI3Itdc9-py3.9/lib/python3.9/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/Users/jathan/Library/Caches/pypoetry/virtualenvs/nautobot-secrets-providers-UI3Itdc9-py3.9/lib/python3.9/site-packages/django/core/management/__init__.py", line 377, in execute
    django.setup()
  File "/Users/jathan/Library/Caches/pypoetry/virtualenvs/nautobot-secrets-providers-UI3Itdc9-py3.9/lib/python3.9/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/Users/jathan/Library/Caches/pypoetry/virtualenvs/nautobot-secrets-providers-UI3Itdc9-py3.9/lib/python3.9/site-packages/django/apps/registry.py", line 122, in populate
    app_config.ready()
  File "/Users/jathan/Library/Caches/pypoetry/virtualenvs/nautobot-secrets-providers-UI3Itdc9-py3.9/lib/python3.9/site-packages/nautobot/extras/plugins/__init__.py", line 172, in ready
    self.features["secrets_providers"] = sorted(secrets_providers)
TypeError: '<' not supported between instances of 'ABCMeta' and 'ABCMeta'
```

- Updated `PluginConfig.ready()` base method to not try to sort list of incoming `SecretsProvider` classes
- Added a `__repr__` to `SecretsProvider` so that instances look prettier when debugging.