### PR TITLE
Doc: How to search for users in multiple LDAP groups

### DIFF
--- a/nautobot/docs/configuration/authentication/ldap.md
+++ b/nautobot/docs/configuration/authentication/ldap.md
@@ -128,12 +128,6 @@ AUTH_LDAP_USER_ATTR_MAP = {
 
 The following snippet shows how to search for users in multiple LDAP groups:
 
-- Import LDAPSearchUnion
-
-    ```python
-    from django_auth_ldap.config import ..., LDAPSearchUnion
-    ```
-
 - Define the user-groups in *.env file (delimiter `';'`)
 
     ```bash
@@ -141,7 +135,13 @@ The following snippet shows how to search for users in multiple LDAP groups:
     NAUTOBOT_AUTH_LDAP_USER_SEARCH_DN=OU=IT-Admins,OU=special-users,OU=Acme-User,DC=Acme,DC=local;OU=Infrastruktur,OU=IT,OU=my-location,OU=User,OU=Acme-User,DC=Acme,DC=local
     ```
 
-- Replace the AUTH_LDAP_USER_SEARCH command from above with:
+- Import LDAPSearchUnion in `nautobot_config.py`
+
+    ```python
+    from django_auth_ldap.config import ..., LDAPSearchUnion
+    ```
+
+- In `nautobot_config.py` replace the AUTH_LDAP_USER_SEARCH command from above with:
 
     ```bash
     user_search_dn_list = str(AUTH_LDAP_USER_SEARCH_DN).split(";")

--- a/nautobot/docs/configuration/authentication/ldap.md
+++ b/nautobot/docs/configuration/authentication/ldap.md
@@ -126,7 +126,7 @@ AUTH_LDAP_USER_ATTR_MAP = {
 }
 ```
 
-The following snippet shows how to search for users in multiple LDAP groups:
+#### Searching in Multiple LDAP Groups
 
 - Define the user-groups in *.env file (delimiter `';'`)
 

--- a/nautobot/docs/configuration/authentication/ldap.md
+++ b/nautobot/docs/configuration/authentication/ldap.md
@@ -88,7 +88,7 @@ LDAP_IGNORE_CERT_ERRORS = True
 
 STARTTLS can be configured by setting `AUTH_LDAP_START_TLS = True` and using the `ldap://` URI scheme.
 
-Apply TLS settings to the internal SSL context on nautobot by configuring `ldap.OPT_X_TLS_NEWCTX` with value `0`. 
+Apply TLS settings to the internal SSL context on nautobot by configuring `ldap.OPT_X_TLS_NEWCTX` with value `0`.
 
 ```
 AUTH_LDAP_SERVER_URI = "ldap://ad.example.com"
@@ -127,6 +127,12 @@ AUTH_LDAP_USER_ATTR_MAP = {
 ```
 
 The following snippet shows how to search for users in multiple LDAP groups:
+
+- Import LDAPSearchUnion
+
+    ```python
+    from django_auth_ldap.config import ..., LDAPSearchUnion
+    ```
 
 - Define the user-groups in *.env file (delimiter `';'`)
 

--- a/nautobot/docs/configuration/authentication/ldap.md
+++ b/nautobot/docs/configuration/authentication/ldap.md
@@ -126,6 +126,25 @@ AUTH_LDAP_USER_ATTR_MAP = {
 }
 ```
 
+The following snippet shows how to search for users in multiple LDAP groups:
+
+- Define the user-groups in *.env file (delimiter `';'`)
+
+    ```bash
+    # Groups to search for user objects. "(sAMAccountName=%(user)s),..."
+    NAUTOBOT_AUTH_LDAP_USER_SEARCH_DN=OU=IT-Admins,OU=special-users,OU=Acme-User,DC=Acme,DC=local;OU=Infrastruktur,OU=IT,OU=my-location,OU=User,OU=Acme-User,DC=Acme,DC=local
+    ```
+
+- Replace the AUTH_LDAP_USER_SEARCH command from above with:
+
+    ```bash
+    user_search_dn_list = str(AUTH_LDAP_USER_SEARCH_DN).split(";")
+    ldapsearch_objects = []
+    for sdn in user_search_dn_list:
+        ldapsearch_objects.append(LDAPSearch(sdn.strip(), ldap.SCOPE_SUBTREE, "(sAMAccountName=%(user)s)"))
+    AUTH_LDAP_USER_SEARCH = LDAPSearchUnion(*ldapsearch_objects)
+    ```
+
 ### User Groups for Permissions
 
 !!! info

--- a/nautobot/docs/configuration/authentication/ldap.md
+++ b/nautobot/docs/configuration/authentication/ldap.md
@@ -128,28 +128,29 @@ AUTH_LDAP_USER_ATTR_MAP = {
 
 #### Searching in Multiple LDAP Groups
 
-- Define the user-groups in *.env file (delimiter `';'`)
+Define the user-groups in your environment, such as a *.env file (delimiter `';'`):
 
-    ```bash
-    # Groups to search for user objects. "(sAMAccountName=%(user)s),..."
-    NAUTOBOT_AUTH_LDAP_USER_SEARCH_DN=OU=IT-Admins,OU=special-users,OU=Acme-User,DC=Acme,DC=local;OU=Infrastruktur,OU=IT,OU=my-location,OU=User,OU=Acme-User,DC=Acme,DC=local
-    ```
+```python
+# Groups to search for user objects. "(sAMAccountName=%(user)s),..."
+NAUTOBOT_AUTH_LDAP_USER_SEARCH_DN=OU=IT-Admins,OU=special-users,OU=Acme-User,DC=Acme,DC=local;OU=Infrastruktur,OU=IT,OU=my-location,OU=User,OU=Acme-User,DC=Acme,DC=local
+```
 
-- Import LDAPSearchUnion in `nautobot_config.py`
+Import LDAPSearchUnion in `nautobot_config.py`, and replace the AUTH_LDAP_USER_SEARCH command from above:
 
-    ```python
-    from django_auth_ldap.config import ..., LDAPSearchUnion
-    ```
+```python
+from django_auth_ldap.config import ..., LDAPSearchUnion
 
-- In `nautobot_config.py` replace the AUTH_LDAP_USER_SEARCH command from above with:
+# ...
 
-    ```bash
+AUTH_LDAP_USER_SEARCH_DN = os.getenv("NAUTOBOT_AUTH_LDAP_USER_SEARCH_DN", "")
+
+if AUTH_LDAP_USER_SEARCH_DN != "":
     user_search_dn_list = str(AUTH_LDAP_USER_SEARCH_DN).split(";")
     ldapsearch_objects = []
     for sdn in user_search_dn_list:
         ldapsearch_objects.append(LDAPSearch(sdn.strip(), ldap.SCOPE_SUBTREE, "(sAMAccountName=%(user)s)"))
     AUTH_LDAP_USER_SEARCH = LDAPSearchUnion(*ldapsearch_objects)
-    ```
+```
 
 ### User Groups for Permissions
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
<!--
    Please include a summary of the proposed changes below.
-->
Extend <https://nautobot.readthedocs.io/en/latest/configuration/authentication/ldap/#user-authentication> documentation to show how to search multiple LDAP Groups for users.

## Added text:

The following snippet shows how to search for users in multiple LDAP groups:

- Define the user-groups in *.env file (delimiter `';'`)

    ```bash
    # Groups to search for user objects. "(sAMAccountName=%(user)s),..."
    NAUTOBOT_AUTH_LDAP_USER_SEARCH_DN=OU=IT-Admins,OU=special-users,OU=Acme-User,DC=Acme,DC=local;OU=Infrastruktur,OU=IT,OU=my-location,OU=User,OU=Acme-User,DC=Acme,DC=local
    ```

- Import LDAPSearchUnion in `nautobot_config.py`

    ```python
    from django_auth_ldap.config import ..., LDAPSearchUnion
    ```

- In `nautobot_config.py` replace the AUTH_LDAP_USER_SEARCH command from above with:

    ```bash
    user_search_dn_list = str(AUTH_LDAP_USER_SEARCH_DN).split(";")
    ldapsearch_objects = []
    for sdn in user_search_dn_list:
        ldapsearch_objects.append(LDAPSearch(sdn.strip(), ldap.SCOPE_SUBTREE, "(sAMAccountName=%(user)s)"))
    AUTH_LDAP_USER_SEARCH = LDAPSearchUnion(*ldapsearch_objects)
    ```

