### PR TITLE
Update to latest release of Markdown and update importlib-metadata as well

### DIFF
--- a/examples/dummy_plugin/poetry.lock
+++ b/examples/dummy_plugin/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "importlib-metadata"
-version = "3.4.0"
+version = "4.4.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -12,7 +12,7 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "typing-extensions"
@@ -37,12 +37,12 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "00e9aa14eaaa350f90745628e030acad07ba6add00f4cf19f4c564609ad79790"
+content-hash = "be99cad9186b724d8ed99dcd5fb5bdcaa622caf43a8d72de4e5dd5bbf9181a7a"
 
 [metadata.files]
 importlib-metadata = [
-    {file = "importlib_metadata-3.4.0-py3-none-any.whl", hash = "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771"},
-    {file = "importlib_metadata-3.4.0.tar.gz", hash = "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"},
+    {file = "importlib_metadata-4.4.0-py3-none-any.whl", hash = "sha256:960d52ba7c21377c990412aca380bf3642d734c2eaab78a2c39319f67c6a5786"},
+    {file = "importlib_metadata-4.4.0.tar.gz", hash = "sha256:e592faad8de1bda9fe920cf41e15261e7131bcf266c30306eec00e8e225c1dd5"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},

--- a/examples/dummy_plugin/pyproject.toml
+++ b/examples/dummy_plugin/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-importlib-metadata = {version = "~3.10.0", python = "<3.8"}
+importlib-metadata = {version = "~4.4", python = "<3.10"}
 
 [tool.poetry.dev-dependencies]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -633,10 +633,10 @@ description = "Nautobot example plugin that does a whole lot of nothing."
 category = "dev"
 optional = false
 python-versions = "^3.6"
-develop = true
+develop = false
 
 [package.dependencies]
-importlib-metadata = {version = "~3.10.0", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = "~4.4", markers = "python_version < \"3.10\""}
 
 [package.source]
 type = "directory"
@@ -790,7 +790,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "3.10.1"
+version = "4.4.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -907,14 +907,14 @@ zookeeper = ["kazoo (>=1.3.1)"]
 
 [[package]]
 name = "markdown"
-version = "3.3.4"
+version = "3.3.6"
 description = "Python implementation of Markdown."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 
 [package.extras]
 testing = ["coverage", "pyyaml"]
@@ -1567,7 +1567,7 @@ mysql = ["mysqlclient"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "d3c5c789ed40ba26b33717321d9eec000139a16ed5d395d3b624034123da5af1"
+content-hash = "aa64b37fa4e593d0863fc76304932d19f0019fe6a1064ad29e48d8474159c32b"
 
 [metadata.files]
 amqp = [
@@ -1915,8 +1915,8 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.10.1-py3-none-any.whl", hash = "sha256:2ec0faae539743ae6aaa84b49a169670a465f7f5d64e6add98388cc29fd1f2f6"},
-    {file = "importlib_metadata-3.10.1.tar.gz", hash = "sha256:c9356b657de65c53744046fa8f7358afe0714a1af7d570c00c3835c2d724a7c1"},
+    {file = "importlib_metadata-4.4.0-py3-none-any.whl", hash = "sha256:960d52ba7c21377c990412aca380bf3642d734c2eaab78a2c39319f67c6a5786"},
+    {file = "importlib_metadata-4.4.0.tar.gz", hash = "sha256:e592faad8de1bda9fe920cf41e15261e7131bcf266c30306eec00e8e225c1dd5"},
 ]
 importlib-resources = [
     {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
@@ -1948,8 +1948,8 @@ kombu = [
     {file = "kombu-5.1.0.tar.gz", hash = "sha256:01481d99f4606f6939cdc9b637264ed353ee9e3e4f62cfb582324142c41a572d"},
 ]
 markdown = [
-    {file = "Markdown-3.3.4-py3-none-any.whl", hash = "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"},
-    {file = "Markdown-3.3.4.tar.gz", hash = "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49"},
+    {file = "Markdown-3.3.6-py3-none-any.whl", hash = "sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3"},
+    {file = "Markdown-3.3.6.tar.gz", hash = "sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,13 +83,13 @@ graphene-django = "~2.15.0"
 # Graphene Optimizer
 graphene-django-optimizer = "~0.8.0"
 # Package version detection in older versions of Python
-importlib-metadata = {version = "~3.10.0", python = "<3.8"}
+importlib-metadata = {version = "~4.4", python = "<3.10"}
 # Template rendering engine
 Jinja2 = "~2.11.3"
 # Optional data validation of config contexts
 jsonschema = "~3.2.0"
 # Rendering of markdown files to HTML
-Markdown = "3.3.4"
+Markdown = "~3.3.6"
 # MySQL database adapter
 mysqlclient = {version = "~2.0.3", optional = true}
 # IP prefix and address handling


### PR DESCRIPTION
### Fixes: #N/A

The latest 3.3.6 release of the `Markdown` library adds compatibility with Python 3.10, but correspondingly requires a newer version of the `importlib-metadata` library as a dependency. This PR updates both libraries.

This needs some review from plugin authors as I know many of them use `importlib-metadata` to set their `PluginConfig.version` attribute - if they have pinned to the older version of `importlib-metadata` (which they shouldn't do!) this will probably cause a dependency conflict that prevents the plugin from being installed. From a quick GitHub search of the plugins in the `nautobot` organization, the core plugin I can see that appears likely to be impacted in this way is `nautobot-plugin-version-control`.