### PR TITLE
Add fallback for NAPALM_USERNAME/PASSWORD when secrets group is not present

### DIFF
--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -494,6 +494,9 @@ class DeviceViewSet(ConfigContextQuerySetMixin, StatusViewSetMixin, CustomFieldM
                     password = settings.NAPALM_PASSWORD
             except SecretError as exc:
                 raise ServiceUnavailable(f"Unable to retrieve device credentials: {exc.message}") from exc
+        else:
+            username = settings.NAPALM_USERNAME
+            password = settings.NAPALM_PASSWORD
 
         optional_args = settings.NAPALM_ARGS.copy()
         if device.platform.napalm_args is not None:


### PR DESCRIPTION
### Fixes: #1116

Regression introduced by #868 adding logic to handle the case where a SecretsGroup is associated to a Device, but missing the case where one is not present. We have no automated unit tests for the NAPALM integration feature (😭) so this wasn't caught.