### PR TITLE
Correct bad logic in optimization of single-object GraphQL endpoints

### DIFF
--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -235,7 +235,9 @@ def generate_single_item_resolver(schema_type, resolver_name):
 
         obj_id = kwargs.get("id", None)
         if obj_id:
-            return gql_optimizer.query(model.objects.restrict(info.context.user, "view").get(pk=obj_id), info)
+            return gql_optimizer.query(
+                model.objects.restrict(info.context.user, "view").filter(pk=obj_id), info
+            ).first()
         return None
 
     single_resolver.__name__ = resolver_name

--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -132,6 +132,7 @@ Just as with the UI, the `slug` can still always be explicitly set if desired.
 
 - [#1078](https://github.com/nautobot/nautobot/issues/1078) - Fixed missing support for filtering several models by their custom fields and/or created/updated stamps.
 - [#1093](https://github.com/nautobot/nautobot/pull/1093) - Improved REST API performance by adding caching of serializer "opt-in fields".
+- [#1112](https://github.com/nautobot/nautobot/issues/1112) - Fixed broken single-object GraphQL query endpoints.
 
 ## v1.2.0b1 (2021-11-19)
 


### PR DESCRIPTION
### Fixes: #1112

The optimization implementation in #769 for single-object GraphQL queries (e.g. `device`, `circuit`, as opposed to list queries `devices`, `circuits`) was incorrect - graphene-django-optimizer acts on querysets, not single objects, so we need to optimize a `.filter(pk=pk)` queryset instead of a `.get(pk=pk)` single object.

It appears that we didn't have any unit test coverage for single-object GraphQL queries, so I've added a couple of them and verified that this issue is caught by one of the added tests.
