### PR TITLE
Fix relationship issues with missing models for defined contenttypes

### DIFF
--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -134,6 +134,7 @@ Just as with the UI, the `slug` can still always be explicitly set if desired.
 - [#1093](https://github.com/nautobot/nautobot/pull/1093) - Improved REST API performance by adding caching of serializer "opt-in fields".
 - [#1112](https://github.com/nautobot/nautobot/issues/1112) - Fixed broken single-object GraphQL query endpoints.
 - [#1116](https://github.com/nautobot/nautobot/issues/1116) - Fixed UnboundLocalError when using device NAPALM integration
+- [#1121](https://github.com/nautobot/nautobot/pull/1121) - Fixed issue with handling of relationships referencing no-longer-present model classes.
 
 ## v1.2.0b1 (2021-11-19)
 

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -1,5 +1,6 @@
 import logging
 from collections import OrderedDict
+
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation


### PR DESCRIPTION
### Fixes: #N/A

Fix a user-reported issue, the symptom being errors like the following when trying to edit a model instance:

```
<class 'AttributeError'>

'NoneType' object has no attribute 'objects'

Python version: 3.8.12
Nautobot version: 1.2.0b1
```

The issue is that if we define a Relationship between core models and models from a plugin, then subsequently disable or uninstall the plugin, then the ContentTypes for the plugin still exist in the DB (and hence the Relationship still references them) but Nautobot doesn't know about the actual data models associated with those ContentTypes. Thus, `content_type.model_class()` returns `None` rather than a model class as expected. We didn't have logic in the Relationships code to handle the case where `model_class` is `None`, resulting in the above error symptom.

Rather than adding a signal or startup code to automatically delete Relationships that reference ContentTypes with no associated model classes, which could be problematic if for instance a plugin is only temporarily disabled to troubleshoot some other issue, I've just added error handling logic for the various cases I was able to reproduce with the above trigger:

- When editing a core model that has Relationships that reference a model-less ContentType, instead of providing a `DynamicModel[Multiple]ChoiceField` for the relationship, provide a simple `MultipleChoiceField` with no selectable options. (I wasn't able to figure out a straightforward way to omit the relationship from the edit form entirely in this case)
- When displaying a detail view of a core model that has such Relationships, if the relationship doesn't explicitly provide a label to use for the target objects, use the name of the relationship as the fallback label (instead of trying to use the target object model class's name, which we don't have).
- When cleaning a Relationship edit form, if it references a content type that doesn't have an associated model class, raise a ValidationError. (This shouldn't be possible to trigger via normal workflows, since the content-type dropdowns are populated based on the available model classes, but I include it for sake of completeness.)