### PR TITLE
Fix Jobs MultiObjectVar Query Params

### DIFF
--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -34,6 +34,7 @@ from nautobot.utilities.utils import (
 )
 from nautobot.utilities.tables import ButtonsColumn
 from nautobot.utilities.views import ContentTypePermissionRequiredMixin
+from nautobot.utilities.utils import normalize_querydict
 from nautobot.virtualization.models import VirtualMachine
 from nautobot.virtualization.tables import VirtualMachineTable
 from . import filters, forms, tables
@@ -775,8 +776,8 @@ class JobView(ContentTypePermissionRequiredMixin, View):
         job = job_class()
         grouping, module, class_name = class_path.split("/", 2)
 
-        job_form = job.as_form(initial=request.GET)
-        schedule_form = forms.JobScheduleForm(initial=request.GET)
+        job_form = job.as_form(initial=normalize_querydict(request.GET))
+        schedule_form = forms.JobScheduleForm(initial=normalize_querydict(request.GET))
 
         return render(
             request,

--- a/nautobot/virtualization/views.py
+++ b/nautobot/virtualization/views.py
@@ -13,6 +13,7 @@ from nautobot.ipam.models import IPAddress, Service
 from nautobot.ipam.tables import InterfaceIPAddressTable, InterfaceVLANTable
 from nautobot.utilities.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.utilities.utils import count_related
+from nautobot.utilities.utils import normalize_querydict
 from . import filters, forms, tables
 from .models import Cluster, ClusterGroup, ClusterType, VirtualMachine, VMInterface
 
@@ -199,7 +200,7 @@ class ClusterAddDevicesView(generic.ObjectEditView):
 
     def get(self, request, pk):
         cluster = get_object_or_404(self.queryset, pk=pk)
-        form = self.form(cluster, initial=request.GET)
+        form = self.form(cluster, initial=normalize_querydict(request.GET))
 
         return render(
             request,


### PR DESCRIPTION
### Fixes: #926
This PR adds `normalize_querydict` to the JobView's QueryDict which allows passing multiple values for a key (eg. job/?foo=bar&foo=baz).
```
class JobView(ContentTypePermissionRequiredMixin, View):
    #...

    def get(self, request, class_path):
        job_class = self._get_job(class_path)
        job = job_class()
        grouping, module, class_name = class_path.split("/", 2)

        job_form = job.as_form(initial=normalize_querydict(request.GET))
        schedule_form = forms.JobScheduleForm(initial=normalize_querydict(request.GET))
```

Also adds `normalize_querydict` to ClusterAddDevicesView for consistency. But multiple values query doesn't work for ClusterAddDevicesView because of `self.fields["devices"].choices = []` in ClusterAddDevicesForm.