### PR TITLE
Document how to generate a secret before nautobot-server is available

### DIFF
--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -357,6 +357,13 @@ $ nautobot-server generate_secret_key
 +$_kw69oq&fbkfk6&q-+ksbgzw1&061ghw%420u3(wen54w(m
 ```
 
+Alternatively use the following command to generate a secret even before `nautobot-server` is runable:
+
+```no-highlight
+$ tr -cd '[=CHAR=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*(-_=+)]' < /dev/urandom | fold -w50 | head -n1
+9.V$@Kxkc@@Kd@z<a/=.J-Y;rYc79<y@](9o9(L(*sS)Q+ud5P
+```
+
 !!! warning
     In the case of a highly available installation with multiple web servers, `SECRET_KEY` must be identical among all servers in order to maintain a persistent user session state.
 

--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -360,7 +360,7 @@ $ nautobot-server generate_secret_key
 Alternatively use the following command to generate a secret even before `nautobot-server` is runable:
 
 ```no-highlight
-$ tr -cd '[=CHAR=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*(-_=+)]' < /dev/urandom | fold -w50 | head -n1
+$ LC_ALL=C tr -cd '[:lower:][:digit:]!@#$%^&*(\-_=+)' < /dev/urandom | fold -w50 | head -n1
 9.V$@Kxkc@@Kd@z<a/=.J-Y;rYc79<y@](9o9(L(*sS)Q+ud5P
 ```
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1124
<!--
    Please include a summary of the proposed changes below.
-->

Document how to generate the SECRET_KEY before nautobot-server is configured.
(see: https://nautobot.readthedocs.io/en/latest/configuration/required-settings/#secret_key)

Appended: 

>Alternatively use the following command to generate a secret even before `nautobot-server` is runable:
>
> 
>   ```no-highlight
>   $ tr -cd '[=CHAR=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*(-_=+)]' < /dev/urandom | fold -w50 | head -n1
>   9.V$@Kxkc@@Kd@z<a/=.J-Y;rYc79<y@](9o9(L(*sS)Q+ud5P
>   ```
