### PR TITLE
Proper validation of inputs to Job runner REST API

### DIFF
--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -899,13 +899,13 @@ class JobScheduleForm(BootstrapMixin, forms.Form):
         """
         cleaned_data = super().clean()
 
-        if cleaned_data["_schedule_type"] != JobExecutionType.TYPE_IMMEDIATELY:
-            if not cleaned_data["_schedule_name"]:
+        if "_schedule_type" in cleaned_data and cleaned_data.get("_schedule_type") != JobExecutionType.TYPE_IMMEDIATELY:
+            if not cleaned_data.get("_schedule_name"):
                 raise ValidationError({"_schedule_name": "Please provide a name for the job schedule."})
 
             if (
-                not cleaned_data["_schedule_start_time"]
-                or cleaned_data["_schedule_start_time"] < ScheduledJob.earliest_possible_time()
+                not cleaned_data.get("_schedule_start_time")
+                or cleaned_data.get("_schedule_start_time") < ScheduledJob.earliest_possible_time()
             ):
                 raise ValidationError(
                     {

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -416,7 +416,7 @@ class BaseJob:
                 raise ValidationError({k: "Job data contained an unknown property"})
 
         # defer validation to the form object
-        f = self.as_form(data=data)
+        f = self.as_form(data=self.deserialize_data(data))
         if not f.is_valid():
             raise ValidationError(f.errors)
 


### PR DESCRIPTION
### Fixes: #958 

- In Job.validate_data(), call `deserialize_data()` on the provided data dictionary before using it to instantiate the JobForm. Verified that I can successfully run jobs containing ObjectVar and IPAddressVar both through the UI and through the REST API now.
- In JobScheduleForm, handle the case where scheduler data keys are not provided (as may be the case when running a Job through the REST API)
- Replace use of `skipIf` in various extras API tests with simply mocking out the `get_worker_count()` method as needed.