### PR TITLE
Update docs and task for docker image publishing

### DIFF
--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -4,36 +4,45 @@ Nautobot is packaged as a Docker image for use in a production environment. The 
 
 ## Tags
 
-The Docker image is published to Docker Hub.
+A set of Docker images are built for each Nautobot release and published to both [Docker Hub](https://hub.docker.com/r/networktocode/nautobot/) and [GitHub Packages](https://github.com/nautobot/nautobot/pkgs/container/nautobot).
 
-To get the image from Docker Hub run:
+Additionally, GitHub Actions are used to automatically build images corresponding to each commit to the `develop` and `next` branches; these images are only published to GitHub Packages.
 
-```no-highlight
-docker image pull networktocode/nautobot
-```
-
-The following tags are available:
-
-* `X.Y.Z` these images are built with the same baseline as the released Python packages based on the default python version (3.6) docker container
-* `X.Y.Z-py${PYTHON_VER}` these images are built with the same baseline as the released Python packages based on the python version ($PYTHON_VER) docker container
-* `stable` these images are built from the latest code in the main branch (should be the latest released version) based on the default python version (3.6) docker container
-* `stable-py${PYTHON_VER}` these images are built from the latest code in the main branch (should be the latest released version) based on the python version ($PYTHON_VER) docker container
-* `latest` these images are built from the latest code in the develop branch based on the default python version (3.6) docker container
-* `latest-py${PYTHON_VER}` these images are built from the latest code in the develop branch based on the python version ($PYTHON_VER) docker container
-* `develop` these images are built from the latest code in the develop branch on each commit based on the default python version (3.6) docker container
-* `develop-${GIT_SHA:0:7}-$(date +%s)` tags for each commit to the develop branch based on the default python version (3.6) docker container
-* `develop-py${PYTHON_VER}` these images are built from the latest code in the develop branch on each commit based on the python version ($PYTHON_VER) docker container
-* `develop-${GIT_SHA:0:7}-$(date +%s)-py${PYTHON_VER}` tags for each commit to the develop branch based on the python version ($PYTHON_VER) docker container
-* `next` these images are built from the latest code in the next branch on each commit based on the default python version (3.6) docker container
-* `next-${GIT_SHA:0:7}-$(date +%s)` tags for each commit to the next branch based on the default python version (3.6) docker container
-* `next-py${PYTHON_VER}` these images are built from the latest code in the next branch on each commit based on the python version ($PYTHON_VER) docker container
-* `next-${GIT_SHA:0:7}-$(date +%s)-py${PYTHON_VER}` tags for each commit to the next branch based on the python version ($PYTHON_VER) docker container
-
-To pull a specific tag you can append the image name with `:tag` for example, to pull the 1.0.0 image:
+To get a specific tagged image from Docker Hub or GitHub Packages run:
 
 ```no-highlight
-$ docker image pull networktocode/nautobot:1.0.0
+docker image pull networktocode/nautobot:${TAG}
 ```
+
+or
+
+```no-highlight
+docker pull ghcr.io/nautobot/nautobot:${TAG}
+```
+
+The following tags are available on both Docker Hub and GitHub Packages:
+
+| Tag                               | Nautobot Version      | Python Version | Example        |
+| --------------------------------- | --------------------- | -------------- | -------------- |
+| `${NAUTOBOT_VER}`                 | As specified          | 3.6            | `1.1.6`        |
+| `${NAUTOBOT_VER}-py${PYTHON_VER}` | As specified          | As specified   | `1.1.6-py3.8`  |
+| `stable`                          | Latest stable release | 3.6            | `stable`       |
+| `stable-py${PYTHON_VER}`          | Latest stable release | As specified   | `stable-py3.8` |
+
+The following additional tags are only available from GitHub Packages:
+
+| Tag                                                  | Nautobot Branch              | Python Version |
+| ---------------------------------------------------- | ---------------------------- | -------------- |
+| `latest`                                             | `develop`, the latest commit | 3.6            |
+| `latest-py${PYTHON_VER}`                             | `develop`, the latest commit | As specified   |
+| `develop`                                            | `develop`, the latest commit | 3.6            |
+| `develop-py${PYTHON_VER}`                            | `develop`, the latest commit | As specified   |
+| `develop-${GIT_SHA:0:7}-$(date +%s)`                 | `develop`, a specific commit | 3.6            |
+| `develop-${GIT_SHA:0:7}-$(date +%s)-py${PYTHON_VER}` | `develop`, a specific commit | As specified   |
+| `next`                                               | `next`, the latest commit    | 3.6            |
+| `next-py${PYTHON_VER}`                               | `next`, the latest commit    | As specified   |
+| `next-${GIT_SHA:0:7}-$(date +%s)`                    | `next`, a specific commit    | 3.6            |
+| `next-${GIT_SHA:0:7}-$(date +%s)-py${PYTHON_VER}`    | `next`, a specific commit    | As specified   |
 
 Currently images are pushed for the following python versions:
 
@@ -43,7 +52,7 @@ Currently images are pushed for the following python versions:
 * 3.9
 
 !!! info
-    A dev image `networktocode/nautobot-dev` is also provided with the same tags, this image provides the development dependencies needed to build Nautobot.  This container can be used as a base for development to develop additional Nautobot plugins but should **NOT** be used in production.
+    Developer images `networktocode/nautobot-dev:${TAG}` and `ghcr.io/nautobot/nautobot-dev:${TAG}` are also provided with the same tags as above. These images provide the development dependencies needed to build Nautobot; they can be used as a base for development to develop additional Nautobot plugins but should **NOT** be used in production.
 
 ## Getting Started
 

--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -4,11 +4,11 @@ Nautobot is packaged as a Docker image for use in a production environment. The 
 
 ## Tags
 
-A set of Docker images are built for each Nautobot release and published to both [Docker Hub](https://hub.docker.com/r/networktocode/nautobot/) and [GitHub Packages](https://github.com/nautobot/nautobot/pkgs/container/nautobot).
+A set of Docker images are built for each Nautobot release and published to both [Docker Hub](https://hub.docker.com/r/networktocode/nautobot/) and the [GitHub Container Registry](https://github.com/nautobot/nautobot/pkgs/container/nautobot).
 
-Additionally, GitHub Actions are used to automatically build images corresponding to each commit to the `develop` and `next` branches; these images are only published to GitHub Packages.
+Additionally, GitHub Actions are used to automatically build images corresponding to each commit to the `develop` and `next` branches; these images are only published to the GitHub Container Registry.
 
-To get a specific tagged image from Docker Hub or GitHub Packages run:
+To get a specific tagged image from Docker Hub or the GitHub Container Registry run:
 
 ```no-highlight
 docker image pull networktocode/nautobot:${TAG}
@@ -20,7 +20,7 @@ or
 docker pull ghcr.io/nautobot/nautobot:${TAG}
 ```
 
-The following tags are available on both Docker Hub and GitHub Packages:
+The following tags are available on both Docker Hub and the GitHub Container Registry:
 
 | Tag                               | Nautobot Version      | Python Version | Example        |
 | --------------------------------- | --------------------- | -------------- | -------------- |
@@ -29,7 +29,7 @@ The following tags are available on both Docker Hub and GitHub Packages:
 | `stable`                          | Latest stable release | 3.6            | `stable`       |
 | `stable-py${PYTHON_VER}`          | Latest stable release | As specified   | `stable-py3.8` |
 
-The following additional tags are only available from GitHub Packages:
+The following additional tags are only available from the GitHub Container Registry:
 
 | Tag                                                  | Nautobot Branch              | Python Version |
 | ---------------------------------------------------- | ---------------------------- | -------------- |

--- a/tasks.py
+++ b/tasks.py
@@ -59,15 +59,6 @@ namespace.configure(
                 "networktocode/nautobot-dev",
                 "ghcr.io/nautobot/nautobot-dev",
             ],
-            # Image names to use when building from "develop" branch
-            "docker_image_names_develop": [
-                # Production containers - not containing development tools
-                "networktocode/nautobot",
-                "ghcr.io/nautobot/nautobot",
-                # Development containers - include development tools like linters
-                "networktocode/nautobot-dev",
-                "ghcr.io/nautobot/nautobot-dev",
-            ],
         }
     }
 )
@@ -200,27 +191,23 @@ def get_nautobot_version():
     }
 )
 def docker_push(context, branch, commit="", datestamp=""):
-    """Tags and pushes docker images to the appropriate repos, intended for CI use only."""
+    """Tags and pushes docker images to the appropriate repos, intended for release use only.
+
+    Before running this command, you **must** be on the `main` branch and **must** have run
+    the appropriate set of `invoke buildx` commands. Refer to the developer release-checklist docs for details.
+    """
     nautobot_version = get_nautobot_version()
 
     docker_image_tags_main = [
-        f"latest-py{context.nautobot.python_ver}",
+        f"stable-py{context.nautobot.python_ver}",
         f"{nautobot_version}-py{context.nautobot.python_ver}",
-    ]
-    docker_image_tags_develop = [
-        f"develop-py{context.nautobot.python_ver}",
-        f"develop-py{context.nautobot.python_ver}-{commit}-{datestamp}",
     ]
 
     if context.nautobot.python_ver == "3.6":
-        docker_image_tags_main += ["latest", f"{nautobot_version}"]
-        docker_image_tags_develop += ["develop", f"develop-{commit}-{datestamp}"]
+        docker_image_tags_main += ["stable", f"{nautobot_version}"]
     if branch == "main":
         docker_image_names = context.nautobot.docker_image_names_main
         docker_image_tags = docker_image_tags_main
-    elif branch == "develop":
-        docker_image_names = context.nautobot.docker_image_names_develop
-        docker_image_tags = docker_image_tags_develop
     else:
         raise Exit(f"Unknown Branch ({branch}) Specified", 1)
 


### PR DESCRIPTION
### Fixes: #N/A

It was brought to my attention after publishing Nautobot 1.1.6 that our docs about available Docker image tags were out of sync with our actual practice - specifically, I tagged the 1.1.6 images as `latest` via the `invoke docker-push` action, but per our docs `latest` is now used for images built from `develop`, and release images should instead be tagged as `stable`. I've updated the `invoke docker-push` task accordingly in this PR, and once it's approved I will re-publish the 1.1.6 images under the appropriate `stable` labels.

Additionally, **only** our release images are manually built and published to both Docker Hub and GitHub Packages; the per-commit builds from `develop` and `next` are automatically built via GitHub actions and are published only to GitHub Packages. I updated the relevant documentation page to hopefully present this information more clearly.