### PR TITLE
Fix AttributeError when adding VM Component interfaces

### DIFF
--- a/nautobot/virtualization/forms.py
+++ b/nautobot/virtualization/forms.py
@@ -701,4 +701,3 @@ class VMInterfaceBulkCreateForm(
         "mode",
         "tags",
     )
-

--- a/nautobot/virtualization/forms.py
+++ b/nautobot/virtualization/forms.py
@@ -8,6 +8,7 @@ from nautobot.dcim.forms import InterfaceCommonForm, INTERFACE_MODE_HELP_TEXT
 from nautobot.dcim.models import Device, DeviceRole, Platform, Rack, Region, Site
 from nautobot.extras.forms import (
     AddRemoveTagsForm,
+    CustomFieldBulkCreateForm,
     CustomFieldBulkEditForm,
     CustomFieldFilterForm,
     CustomFieldModelCSVForm,
@@ -679,18 +680,25 @@ class VMInterfaceFilterForm(BootstrapMixin, CustomFieldFilterForm):
 #
 
 
-class VirtualMachineBulkAddComponentForm(BootstrapMixin, forms.Form):
+class VirtualMachineBulkAddComponentForm(CustomFieldBulkCreateForm, BootstrapMixin, forms.Form):
     pk = forms.ModelMultipleChoiceField(queryset=VirtualMachine.objects.all(), widget=forms.MultipleHiddenInput())
     name_pattern = ExpandableNameField(label="Name")
+    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
 
-    def clean_tags(self):
-        # Because we're feeding TagField data (on the bulk edit form) to another TagField (on the model form), we
-        # must first convert the list of tags to a string.
-        return ",".join(self.cleaned_data.get("tags"))
+    class Meta:
+        nullable_fields = []
 
 
 class VMInterfaceBulkCreateForm(
-    form_from_model(VMInterface, ["enabled", "mtu", "description", "tags"]),
+    form_from_model(VMInterface, ["enabled", "mtu", "description", "mode"]),
     VirtualMachineBulkAddComponentForm,
 ):
-    pass
+    field_order = (
+        "name_pattern",
+        "enabled",
+        "mtu",
+        "description",
+        "mode",
+        "tags",
+    )
+

--- a/nautobot/virtualization/tests/test_views.py
+++ b/nautobot/virtualization/tests/test_views.py
@@ -1,9 +1,10 @@
 from django.test import override_settings
+from django.contrib.contenttypes.models import ContentType
 from netaddr import EUI
 
 from nautobot.dcim.choices import InterfaceModeChoices
 from nautobot.dcim.models import DeviceRole, Platform, Site
-from nautobot.extras.models import ConfigContextSchema, Status
+from nautobot.extras.models import ConfigContextSchema, CustomField, Status
 from nautobot.ipam.models import VLAN
 from nautobot.utilities.testing import ViewTestCases, post_data
 from nautobot.virtualization.models import (
@@ -300,6 +301,11 @@ class VMInterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             VLAN.objects.create(vid=103, name="VLAN103", site=site),
         )
 
+        obj_type = ContentType.objects.get_for_model(VMInterface)
+        cf = CustomField.objects.create(name="custom_field_1", type="text")
+        cf.save()
+        cf.content_types.set([obj_type])
+
         tags = cls.create_tags("Alpha", "Bravo", "Charlie")
 
         cls.form_data = {
@@ -312,6 +318,7 @@ class VMInterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             "mode": InterfaceModeChoices.MODE_TAGGED,
             "untagged_vlan": vlans[0].pk,
             "tagged_vlans": [v.pk for v in vlans[1:4]],
+            "custom_field_1": "Custom Field Data",
             "tags": [t.pk for t in tags],
         }
 
@@ -325,6 +332,7 @@ class VMInterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             "mode": InterfaceModeChoices.MODE_TAGGED,
             "untagged_vlan": vlans[0].pk,
             "tagged_vlans": [v.pk for v in vlans[1:4]],
+            "custom_field_1": "Custom Field Data",
             "tags": [t.pk for t in tags],
         }
 
@@ -342,4 +350,5 @@ class VMInterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             "mode": InterfaceModeChoices.MODE_TAGGED,
             "untagged_vlan": vlans[0].pk,
             "tagged_vlans": [v.pk for v in vlans[1:4]],
+            "custom_field_1": "New Custom Field Data",
         }


### PR DESCRIPTION
### Fixes: #1043
Fix AttributeError when adding VM Component interfaces:
```
<class 'AttributeError'>

type object 'VMInterface' has no attribute 'get'

Python version: 3.6.13
Nautobot version: 1.2.0b2
```

`VirtualMachineBulkAddComponentForm` didn't process Custom fields correctly, adding `CustomFieldBulkCreateForm` class fixed the issue.
Additionally, `tags` field updated to use `DynamicModelMultipleChoiceField`.
