### PR TITLE
Fix `ObjectEditView.get_object()` to also look for `name` or fallback.

### DIFF
--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -286,7 +286,7 @@ class ObjectEditView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
         # Look up an existing object by slug, PK, or name, if provided.
         for field in ("slug", "pk", "name"):
             if field in kwargs:
-                return get_object_or_404(self.queryset, **dict(field=kwargs[field]))
+                return get_object_or_404(self.queryset, **{field: kwargs[field]})
         return self.queryset.model()
 
     def get_extra_context(self, request, instance):
@@ -417,7 +417,7 @@ class ObjectDeleteView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
         # Look up an existing object by slug or PK, or name if provided.
         for field in ("slug", "pk", "name"):
             if field in kwargs:
-                return get_object_or_404(self.queryset, **dict(field=kwargs[field]))
+                return get_object_or_404(self.queryset, **{field: kwargs[field]})
         return self.queryset.model()
 
     def get(self, request, **kwargs):

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -282,9 +282,11 @@ class ObjectEditView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
         return get_permission_for_model(self.queryset.model, self._permission_action)
 
     def get_object(self, kwargs):
+        """Retrieve an object based on `kwargs."""
         # Look up an existing object by slug or PK, if provided.
-        if kwargs:
-            return get_object_or_404(self.queryset, **kwargs)
+        for field in ("slug", "pk", "name"):
+            if field in kwargs:
+                return get_object_or_404(self.queryset, **dict(field=kwargs[field]))
         return self.queryset.model()
 
     def get_extra_context(self, request, instance):

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -282,8 +282,8 @@ class ObjectEditView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
         return get_permission_for_model(self.queryset.model, self._permission_action)
 
     def get_object(self, kwargs):
-        """Retrieve an object based on `kwargs."""
-        # Look up an existing object by slug or PK, if provided.
+        """Retrieve an object based on `kwargs`."""
+        # Look up an existing object by slug, PK, or name, if provided.
         for field in ("slug", "pk", "name"):
             if field in kwargs:
                 return get_object_or_404(self.queryset, **dict(field=kwargs[field]))
@@ -413,8 +413,12 @@ class ObjectDeleteView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
         return get_permission_for_model(self.queryset.model, "delete")
 
     def get_object(self, kwargs):
-        # Look up object by slug if one has been provided. Otherwise, use PK.
-        return get_object_or_404(self.queryset, **kwargs)
+        """Retrieve an object based on `kwargs`."""
+        # Look up an existing object by slug or PK, or name if provided.
+        for field in ("slug", "pk", "name"):
+            if field in kwargs:
+                return get_object_or_404(self.queryset, **dict(field=kwargs[field]))
+        return self.queryset.model()
 
     def get(self, request, **kwargs):
         obj = self.get_object(kwargs)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1098 
<!--
    Please include a summary of the proposed changes below.
-->

This reverts the change to `ObjectEditView.get_object()` in #735 to ease integration with `CustomField` UI views. This also adds the `name` field as an additional check along-side `pk` and `slug` before the fallback is returned.