### PR TITLE
Refinements to admin config UI

### DIFF
--- a/nautobot/core/templates/admin/config/config.html
+++ b/nautobot/core/templates/admin/config/config.html
@@ -1,5 +1,6 @@
 {% extends "admin/constance/change_list.html" %}
 {% load admin_list static i18n %}
+{% load helpers %}
 
 {% block content %}
     <form action="" method="post" enctype="multipart/form-data" id="changelist-form" class="form form-horizontal">
@@ -33,17 +34,30 @@
                             <div class="panel-heading"><strong>{{ fieldset.title }}</strong></div>
                             <div class="panel-body">
                                 {% for item in fieldset.config_values %}
+                                {% get_attr settings item.name as settings_value %}
                                 <div class="form-group{% if item.form_field.errors %} has-error{% endif %}">
-                                    <label class="col-md-3 control-label" for="{{ item.formfield.id_for_label }}">
-                                        {{ item.name }}
-                                        <span class="help-block">(default: <code>{{ item.default }}</code>)</span>
-                                    </label>
-                                    <div class="col-md-9">
-                                        {{ item.form_field.errors }}
-                                        {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
-                                        {{ item.form_field }}
-                                        <span class="help-block">{{ item.help_text | linebreaksbr }}</span>
-                                    </div>
+                                    {% if settings_value is not None %}
+                                        <div class="alert alert-warning" role="alert">
+                                            <code>{{ item.name }} = {{ settings_value | quote_string }}</code>
+                                            is defined in <code>{{ settings.SETTINGS_PATH }}</code>,
+                                            therefore it is not currently editable here.
+                                            <br>Remove that declaration from <code>{{ settings.SETTINGS_PATH }}</code>
+                                            if you want to manage it via this interface instead.
+                                        </div>
+                                    {% else %}
+                                        <label class="col-md-3 control-label" for="{{ item.formfield.id_for_label }}">
+                                            {{ item.name | split:"_" | join:" " }}
+                                            <span class="help-block">
+                                                (default: <code>{{ item.default }}</code>)
+                                            </span>
+                                        </label>
+                                        <div class="col-md-9">
+                                            {{ item.form_field.errors }}
+                                            {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
+                                                {{ item.form_field }}
+                                            <span class="help-block">{{ item.help_text | linebreaksbr }}</span>
+                                        </div>
+                                    {% endif %}
                                 </div>
                                 {% endfor %}
                             </div>

--- a/nautobot/utilities/templatetags/helpers.py
+++ b/nautobot/utilities/templatetags/helpers.py
@@ -250,9 +250,22 @@ def settings_or_config(key):
     return get_settings_or_config(key)
 
 
+@register.filter
+def quote_string(value):
+    """Add literal quote characters around the provided value if it's a string."""
+    if isinstance(value, str):
+        return f'"{value}"'
+    return value
+
+
 #
 # Tags
 #
+
+
+@register.simple_tag()
+def get_attr(obj, attr, default=None):
+    return getattr(obj, attr, default)
 
 
 @register.simple_tag()


### PR DESCRIPTION
### Fixes: #1095

- I wasn't able to find an easy way to change the URL from `admin/constance/config/` to `admin/config/config/` so this doesn't address that part of #1095.
- In the variable names as presented in the admin config UI, replace `_` with ` ` (i.e. display `RACK ELEVATION DEFAULT UNIT HEIGHT` rather than `RACK_ELEVATION_DEFAULT_UNIT_HEIGHT`) so that long variable names can get wrapped nicely in a narrow browser window rather than overflowing their columns.

![image](https://user-images.githubusercontent.com/5603551/145861548-f66aca5d-5d2e-412c-b7a2-7ae0068e0688.png)

- Add logic to detect whether a value is defined in Django settings (i.e. in `nautobot_config.py`) and if so, replace that field in the admin config UI with an explanatory banner.
- Add a couple of filters/tags in support of the above - I'll add documentation and unit tests for these once #1083 is merged.

![image](https://user-images.githubusercontent.com/5603551/145861502-1adf4105-c7e1-4618-b622-792b6f097488.png)

