### PR TITLE
Add hidden form fields to admin config UI as needed. Fixes #1154

### DIFF
--- a/nautobot/core/templates/admin/config/config.html
+++ b/nautobot/core/templates/admin/config/config.html
@@ -44,8 +44,9 @@
                                             <br>Remove that declaration from <code>{{ settings.SETTINGS_PATH }}</code>
                                             if you want to manage it via this interface instead.
                                         </div>
+                                        {{ item.form_field.as_hidden }}
                                     {% else %}
-                                        <label class="col-md-3 control-label" for="{{ item.formfield.id_for_label }}">
+                                        <label class="col-md-3 control-label" for="{{ item.form_field.id_for_label }}">
                                             {{ item.name | split:"_" | join:" " }}
                                             <span class="help-block">
                                                 (default: <code>{{ item.default }}</code>)

--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -156,6 +156,7 @@ Just as with the UI, the `slug` can still always be explicitly set if desired.
 - [#1112](https://github.com/nautobot/nautobot/issues/1112) - Fixed broken single-object GraphQL query endpoints.
 - [#1116](https://github.com/nautobot/nautobot/issues/1116) - Fixed UnboundLocalError when using device NAPALM integration
 - [#1121](https://github.com/nautobot/nautobot/pull/1121) - Fixed issue with handling of relationships referencing no-longer-present model classes.
+- [#1154](https://github.com/nautobot/nautobot/issues/1154) - Fixed inability to save changes in Admin Configuration UI.
 
 ### Removed
 


### PR DESCRIPTION
### Fixes: #1154

When any of the potentially configurable settings for Constance were defined in `nautobot_config.py`, #1151 changed the template rendering to omit the corresponding fields. This caused the Constance form validation to silently fail due to missing inputs, preventing any config changes from actually saving.

Solution: instead of omitting them completely, include any non-configurable properties in the rendered template as hidden fields. I've verified that this allows config changes to be saved.

Also fix a bug in the template that @lampwins brought to my attention.