### PR TITLE
Add family to IPAddressType for GraphQL.

### DIFF
--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1006,6 +1006,7 @@ query {
                 virtual_machine { name }
             }
         }
+        family
         interface { name }
         vminterface { name }
     }
@@ -1018,6 +1019,7 @@ query {
                 entry["address"], (str(self.ipaddr1.address), str(self.ipaddr2.address), str(self.vmipaddr.address))
             )
             self.assertIn("assigned_object", entry)
+            self.assertIn(entry["family"], (4, 6))
             if entry["address"] == str(self.vmipaddr.address):
                 self.assertEqual(entry["assigned_object"]["name"], self.vminterface.name)
                 self.assertEqual(entry["vminterface"]["name"], self.vminterface.name)

--- a/nautobot/ipam/graphql/types.py
+++ b/nautobot/ipam/graphql/types.py
@@ -37,6 +37,7 @@ class IPAddressType(gql_optimizer.OptimizedDjangoObjectType):
 
     address = graphene.String()
     assigned_object = AssignedObjectType()
+    family = graphene.Int()
     interface = graphene.Field("nautobot.dcim.graphql.types.InterfaceType")
     vminterface = graphene.Field("nautobot.virtualization.graphql.types.VMInterfaceType")
 
@@ -53,6 +54,9 @@ class IPAddressType(gql_optimizer.OptimizedDjangoObjectType):
         if self.assigned_object:
             return self.assigned_object
         return None
+
+    def resolve_family(self, args):
+        return self.family
 
     def resolve_interface(self, args):
         if self.assigned_object and type(self.assigned_object).__name__ == "Interface":


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1131
<!--
    Please include a summary of the proposed changes below.
-->
Here is the GraphQL query:

```
{
  ip_addresses(family: 4) {
    address
    family
  }
}
```

Results:

```
{
  "data": {
    "ip_addresses": [
      {
        "address": "192.168.1.1/32",
        "family": 4
      }
    ]
  }
}
```