### PR TITLE
The logs column was renamed to summary, making change to meta.

### DIFF
--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -480,9 +480,9 @@ class JobResultTable(BaseTable):
             "completed",
             "user",
             "status",
-            "logs",
+            "summary",
         )
-        default_columns = ("pk", "created", "related_object", "user", "status", "logs")
+        default_columns = ("pk", "created", "related_object", "user", "status", "summary")
 
 
 #


### PR DESCRIPTION
The JobResultTable had a column renamed, but the rename was not made to the Meta, this corrects that bug.
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: NA
<!--
    Please include a summary of the proposed changes below.
-->
