### PR TITLE
Workaround for #1169, avoiding confusing 500 error

### DIFF
--- a/nautobot/utilities/templatetags/helpers.py
+++ b/nautobot/utilities/templatetags/helpers.py
@@ -14,7 +14,7 @@ from django_jinja import library
 
 from nautobot.utilities.config import get_settings_or_config
 from nautobot.utilities.forms import TableConfigForm
-from nautobot.utilities.utils import foreground_color
+from nautobot.utilities.utils import foreground_color, UtilizationData
 
 register = template.Library()
 
@@ -451,6 +451,11 @@ def utilization_graph(utilization_data, warning_threshold=75, danger_threshold=9
         dict: Dictionary with utilization, warning threshold, danger threshold, utilization count, and total count for
                 display
     """
+    # See https://github.com/nautobot/nautobot/issues/1169
+    # If `get_utilization()` threw an exception, utilization_data will be an empty string
+    # rather than a UtilizationData instance. Avoid a potentially confusing exception in that case.
+    if not isinstance(utilization_data, UtilizationData):
+        return {}
     return utilization_graph_raw_data(
         numerator=utilization_data.numerator,
         denominator=utilization_data.denominator,


### PR DESCRIPTION

### Fixes: #N/A

Not a fix for #1169, but at least avoid throwing a template rendering error in the case where the `utilization_graph` template tag is passed bad data. With this patch, after deleting the `Container` status, the page at least renders, but all utilization graphs are empty:

![image](https://user-images.githubusercontent.com/5603551/146613457-2ed8f1fd-4036-4bd8-bcfa-2193016f571e.png)
