### PR TITLE
Fixes #1193 - Set job log created date to use ISO format in JobResult detail view

### DIFF
--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -389,7 +389,7 @@ def log_entry_color_css(record):
 
 
 class JobLogEntryTable(BaseTable):
-    created = tables.DateTimeColumn(verbose_name="Time", format="c")
+    created = tables.DateTimeColumn(verbose_name="Time", format="H:i:s.u")
     grouping = tables.Column()
     log_level = tables.Column(
         verbose_name="Level",

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -389,7 +389,7 @@ def log_entry_color_css(record):
 
 
 class JobLogEntryTable(BaseTable):
-    created = tables.DateTimeColumn(verbose_name="Time", format="H:i:s.u")
+    created = tables.DateTimeColumn(verbose_name="Time", format="Y-m-d H:i:s.u")
     grouping = tables.Column()
     log_level = tables.Column(
         verbose_name="Level",

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -389,7 +389,7 @@ def log_entry_color_css(record):
 
 
 class JobLogEntryTable(BaseTable):
-    created = tables.DateTimeColumn(verbose_name="Time", format=settings.SHORT_DATETIME_FORMAT)
+    created = tables.DateTimeColumn(verbose_name="Time", format="c")
     grouping = tables.Column()
     log_level = tables.Column(
         verbose_name="Level",


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1193
<!--
    Please include a summary of the proposed changes below.
-->
Set job log created date to use ISO format in `JobResult` detail view.

![Cursor_and_Notification_Center](https://user-images.githubusercontent.com/138052/146959420-0191f3c5-7d34-4fd8-a542-146b3a393412.png)

