### PR TITLE
JobResult detail view refresh while waiting on log results.

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -294,6 +294,7 @@ INSTALLED_APPS = [
     "health_check.storage",
     "django_extensions",
     "constance.backends.database",
+    "django_ajax_tables",
 ]
 
 # Middleware

--- a/nautobot/extras/templates/extras/inc/jobresult.html
+++ b/nautobot/extras/templates/extras/inc/jobresult.html
@@ -41,21 +41,16 @@
 {% include 'inc/custom_fields_panel.html' %}
 {% plugin_right_page result %}
 </div>
-{% if log_table %}
-    <form method="post">
+
+<form method="post">
     {% csrf_token %}
     <div class="panel panel-default">
-    <div class="panel-heading">
-        <strong>Logs</strong>
-        <div class="pull-right col-md-2 noprint">
-            <input class="form-control log-filter" type="text" placeholder="Filter" title="Filter log level (regular expressions supported)" style="height: 23px" />
+        <div class="panel-heading">
+            <strong>Logs</strong>
+            <div class="pull-right col-md-2 noprint">
+                <input class="form-control log-filter" type="text" placeholder="Filter" title="Filter log level (regular expressions supported)" style="height: 23px" />
+            </div>
         </div>
+        {% ajax_table "log_table" "extras:jobresult_log-table" pk=result.pk %}
     </div>
-    {% ajax_table "log_table" "extras:jobresult_log-table" pk=result.pk %}
-    </div>
-    </form>
-{% else %}
-    <div class="alert alert-danger" role="alert">
-        No table of job logs was provided, perhaps you are using an out-of-date plugin?
-    </div>
-{% endif %}
+</form>

--- a/nautobot/extras/templates/extras/inc/jobresult.html
+++ b/nautobot/extras/templates/extras/inc/jobresult.html
@@ -39,7 +39,6 @@
 {% plugin_right_page result %}
 </div>
 
-{% if log_table %}
     <form method="post">
     {% csrf_token %}
     <div class="panel panel-default">
@@ -58,8 +57,3 @@
     </div>
     </form>
     {% table_config_form log_table %}
-{% else %}
-    <div class="alert alert-danger" role="alert">
-        No table of job logs was provided, perhaps you are using an out-of-date plugin?
-    </div>
-{% endif %}

--- a/nautobot/extras/templates/extras/inc/jobresult.html
+++ b/nautobot/extras/templates/extras/inc/jobresult.html
@@ -1,6 +1,7 @@
 {% load helpers %}
 {% load custom_links %}
 {% load form_helpers %}
+{% load ajax_table %}
 {% load render_table from django_tables2 %}
 {% load log_levels %}
 {% load plugins %}
@@ -25,11 +26,13 @@
         </tr>
         <tr>
             <td>Duration</td>
+            <td id="pending-result-loader">
             {% if result.completed %}
-                <td>{{ result.duration }}</td>
+                {{ result.duration }}
             {% else %}
-                <td><img id="pending-result-loader" src="{% static 'img/ajax-loader.gif' %}"></td>
+                <img src="{% static 'img/ajax-loader.gif' %}">
             {% endif %}
+            </td>
         </tr>
     </table>
 </div>
@@ -38,22 +41,21 @@
 {% include 'inc/custom_fields_panel.html' %}
 {% plugin_right_page result %}
 </div>
-
+{% if log_table %}
     <form method="post">
     {% csrf_token %}
     <div class="panel panel-default">
     <div class="panel-heading">
         <strong>Logs</strong>
-        <div class="pull-right noprint">
-            {% if request.user.is_authenticated %}
-                <button type="button" class="btn btn-default btn-xs" data-toggle="modal" data-target="#JobLogEntryTable_config" title="Configure table"><i class="mdi mdi-cog"></i> Configure</button>
-            {% endif %}
-        </div>
         <div class="pull-right col-md-2 noprint">
             <input class="form-control log-filter" type="text" placeholder="Filter" title="Filter log level (regular expressions supported)" style="height: 23px" />
         </div>
     </div>
-    {% render_table log_table 'inc/table.html' %}
+    {% ajax_table "log_table" "extras:jobresult_log-table" pk=result.pk %}
     </div>
     </form>
-    {% table_config_form log_table %}
+{% else %}
+    <div class="alert alert-danger" role="alert">
+        No table of job logs was provided, perhaps you are using an out-of-date plugin?
+    </div>
+{% endif %}

--- a/nautobot/extras/templates/extras/inc/jobresult_js.html
+++ b/nautobot/extras/templates/extras/inc/jobresult_js.html
@@ -8,10 +8,6 @@ var pending_result_id = "{{ result.pk }}";
 var pending_result_id = null;
 {% endif %}
 
-function jobTerminatedAction(){
-    refreshWindow();
-}
-
 </script>
 <script src="{% static 'js/job_result.js' %}?v{{ settings.VERSION }}"
         onerror="window.location='{% url 'media_failure' %}?filename=js/job_result.js'"></script>

--- a/nautobot/extras/urls.py
+++ b/nautobot/extras/urls.py
@@ -340,6 +340,7 @@ urlpatterns = [
     # Generic job results
     path("job-results/", views.JobResultListView.as_view(), name="jobresult_list"),
     path("job-results/<uuid:pk>/", views.JobResultView.as_view(), name="jobresult"),
+    path("job-results/<uuid:pk>/log-table/", views.JobLogEntryTableView.as_view(), name="jobresult_log-table"),
     path(
         "job-results/delete/",
         views.JobResultBulkDeleteView.as_view(),

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -55,7 +55,6 @@ from .models import (
     GraphQLQuery,
     ImageAttachment,
     ObjectChange,
-    JobLogEntry,
     JobResult,
     Relationship,
     RelationshipAssociation,
@@ -643,12 +642,8 @@ class GitRepositoryResultView(generic.ObjectView):
             .first()
         )
 
-        logs = JobLogEntry.objects.restrict(request.user, "view").filter(job_result=job_result)
-        log_table = tables.JobLogEntryTable(data=logs, user=request.user)
-
         return {
             "result": job_result,
-            "log_table": log_table,
             "base_template": "extras/gitrepository.html",
             "object": instance,
             "active_tab": "result",
@@ -1107,15 +1102,10 @@ class JobResultView(generic.ObjectView):
         elif related_object:
             associated_record = related_object
 
-        # This is used as a sentinel for backwards compatibility since the table
-        # object is rendered inside of `JobLogEntryTableView`.
-        log_table = True
-
         return {
             "job": job,
             "associated_record": associated_record,
             "result": instance,
-            "log_table": log_table,
         }
 
 

--- a/nautobot/project-static/js/job_result.js
+++ b/nautobot/project-static/js/job_result.js
@@ -31,15 +31,7 @@ $(document).ready(function(){
                 context: this,
                 success: function(data) {
                     updatePendingStatusLabel(data.status);
-                    if (data.status.value === 'completed' || data.status.value === 'failed' || data.status.value === 'errored'){
-                        jobTerminatedAction()
-                    } else {
-                        setTimeout(checkPendingResult, timeout);
-                        if (timeout < 10000) {
-                            // back off each iteration, until we reach a 10s interval
-                            timeout += 1000
-                        }
-                    }
+                    setTimeout(jobTerminatedAction, 1000);
                 }
             });
         })();

--- a/nautobot/project-static/js/job_result.js
+++ b/nautobot/project-static/js/job_result.js
@@ -1,15 +1,20 @@
 var url = nautobot_api_path + "extras/job-results/";
 var timeout = 1000;
+var terminal_statuses = ['completed', 'failed', 'errored'];
 
-function updatePendingStatusLabel(status){
+function updatePendingStatusLabel(status) {
+    // Updates "Status" label in "Summary of Results" table in JobResult detail view.
     var labelClass;
-    if (status.value === 'failed' || status.value === 'errored'){
+    if (status.value === 'failed' || status.value === 'errored') {
         labelClass = 'danger';
-    } else if (status.value === 'running'){
+    }
+    else if (status.value === 'running') {
         labelClass = 'warning';
-    } else if (status.value === 'completed'){
+    }
+    else if (status.value === 'completed') {
         labelClass = 'success';
-    } else {
+    }
+    else {
         labelClass = 'default';
     }
     var elem = $('#pending-result-label > label');
@@ -17,21 +22,40 @@ function updatePendingStatusLabel(status){
     elem.text(status.label);
 }
 
-function refreshWindow(){
-    window.location.reload();
+function updateLogTable(result_id) {
+    // Calls `update_log_table` to refresh the jobs table from the `/log-table/` endpoint
+    update_log_table('', '/extras/job-results/' + result_id + '/log-table/');
 }
 
 $(document).ready(function(){
-    if (pending_result_id !== null){
-        (function checkPendingResult(){
+    if (pending_result_id !== null) {
+        (function checkPendingResult() {
+            // Keep checking results, update the table, and refresh the logs. When done, refresh the
+            // page to finalize the job results output.
             $.ajax({
                 url: url + pending_result_id + '/',
                 method: 'GET',
                 dataType: 'json',
                 context: this,
                 success: function(data) {
+                    // Update the status label
                     updatePendingStatusLabel(data.status);
-                    setTimeout(jobTerminatedAction, 1000);
+
+                    // Update the job logs table
+                    updateLogTable(pending_result_id);
+
+                    // If there is a terminal status, refresh the page.
+                    if (terminal_statuses.includes(data.status.value)) {
+                        window.location.reload();
+                    }
+                    // Otherwise call myself again after `timeout`.
+                    else {
+                        setTimeout(checkPendingResult, timeout);
+                        // Back off each iteration, until we reach a 10s interval.
+                        if (timeout < 10000) {
+                            timeout += 1000
+                        }
+                    }
                 }
             });
         })();

--- a/poetry.lock
+++ b/poetry.lock
@@ -11,7 +11,7 @@ contextvars = {version = "2.4", markers = "python_version < \"3.7\""}
 
 [[package]]
 name = "amqp"
-version = "5.0.7"
+version = "5.0.9"
 description = "Low-level AMQP client for Python (fork of amqplib)."
 category = "main"
 optional = false
@@ -196,7 +196,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "ciscoconfparse"
-version = "1.6.10"
+version = "1.6.12"
 description = "Parse, Audit, Query, Build, and Modify Cisco IOS-style and JunOS-style configurations"
 category = "main"
 optional = true
@@ -375,6 +375,14 @@ sqlparse = ">=0.2.2"
 [package.extras]
 argon2 = ["argon2-cffi (>=16.1.0)"]
 bcrypt = ["bcrypt"]
+
+[[package]]
+name = "django-ajax-tables"
+version = "1.1.1"
+description = "Django tag for ajax-enabled tables"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "django-appconf"
@@ -779,7 +787,7 @@ pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
 name = "funcy"
-version = "1.16"
+version = "1.17"
 description = "A fancy and practical functional tools"
 category = "main"
 optional = false
@@ -2100,7 +2108,7 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "6ff7ed1d124aad8400509fb36711876dcab953514918349ba02a4dbd6d96d18d"
+content-hash = "bb88fd01bd07efbf050fef65dc5b4464337325ced8e4e1cecfecefbcd70f7c10"
 
 [metadata.files]
 aiocontextvars = [
@@ -2108,8 +2116,8 @@ aiocontextvars = [
     {file = "aiocontextvars-0.2.2.tar.gz", hash = "sha256:f027372dc48641f683c559f247bd84962becaacdc9ba711d583c3871fb5652aa"},
 ]
 amqp = [
-    {file = "amqp-5.0.7-py3-none-any.whl", hash = "sha256:4d9cb6b5d69183ba279e97382ff68a071864c25b561d206dab73499d3ed26d1c"},
-    {file = "amqp-5.0.7.tar.gz", hash = "sha256:d757b78fd7d3c6bb60e3ee811b68145583643747ed3ec253329f086aa3a72a5d"},
+    {file = "amqp-5.0.9-py3-none-any.whl", hash = "sha256:9cd81f7b023fc04bbb108718fbac674f06901b77bfcdce85b10e2a5d0ee91be5"},
+    {file = "amqp-5.0.9.tar.gz", hash = "sha256:1e5f707424e544078ca196e72ae6a14887ce74e02bd126be54b7c03c971bef18"},
 ]
 aniso8601 = [
     {file = "aniso8601-7.0.0-py2.py3-none-any.whl", hash = "sha256:d10a4bf949f619f719b227ef5386e31f49a2b6d453004b21f02661ccc8670c7b"},
@@ -2209,8 +2217,8 @@ chardet = [
     {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
 ]
 ciscoconfparse = [
-    {file = "ciscoconfparse-1.6.10-py3-none-any.whl", hash = "sha256:2e7c5a3c9b0b12df9825c850ff78a8a3b7d1adda8c62f3ac1b6aa0746f97ec23"},
-    {file = "ciscoconfparse-1.6.10.tar.gz", hash = "sha256:aa0329e240013b8a72cff8f1c749e565ed00554f64dc0bf20889054aea0ba640"},
+    {file = "ciscoconfparse-1.6.12-py3-none-any.whl", hash = "sha256:9e0e06020a6fc5460ade511e544c617d55493701cf46caabe11e5e09d91b4911"},
+    {file = "ciscoconfparse-1.6.12.tar.gz", hash = "sha256:2d97844eeac6b4aa1f76e63255ddb0819d8fc0f3bf3a6ae23d45da251be59657"},
 ]
 click = [
     {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
@@ -2331,6 +2339,10 @@ django = [
     {file = "Django-3.1.14-py3-none-any.whl", hash = "sha256:0fabc786489af16ad87a8c170ba9d42bfd23f7b699bd5ef05675864e8d012859"},
     {file = "Django-3.1.14.tar.gz", hash = "sha256:72a4a5a136a214c39cf016ccdd6b69e2aa08c7479c66d93f3a9b5e4bb9d8a347"},
 ]
+django-ajax-tables = [
+    {file = "django_ajax_tables-1.1.1-py3-none-any.whl", hash = "sha256:62e0138949153c0a994eefbf469f5496b1ad98bc073e170bc021a1aada7a32d0"},
+    {file = "django_ajax_tables-1.1.1.tar.gz", hash = "sha256:5a7e7bc7940aa6332a564916cde22010a858a3d29fc1090ce8061010ec76337c"},
+]
 django-appconf = [
     {file = "django-appconf-1.0.5.tar.gz", hash = "sha256:be3db0be6c81fa84742000b89a81c016d70ae66a7ccb620cdef592b1f1a6aaa4"},
     {file = "django_appconf-1.0.5-py3-none-any.whl", hash = "sha256:ae9f864ee1958c815a965ed63b3fba4874eec13de10236ba063a788f9a17389d"},
@@ -2448,8 +2460,8 @@ flake8 = [
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
 funcy = [
-    {file = "funcy-1.16-py2.py3-none-any.whl", hash = "sha256:1d3fc5d42cf7564a6b2be04042d0df7a50c77903cf760a34786d0c9ebd659b25"},
-    {file = "funcy-1.16.tar.gz", hash = "sha256:2775409b7dc9106283f1224d97e6df5f2c02e7291c8caed72764f5a115dffb50"},
+    {file = "funcy-1.17-py2.py3-none-any.whl", hash = "sha256:ba7af5e58bfc69321aaf860a1547f18d35e145706b95d1b3c966abc4f0b60309"},
+    {file = "funcy-1.17.tar.gz", hash = "sha256:40b9b9a88141ae6a174df1a95861f2b82f2fdc17669080788b73a3ed9370e968"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ python = "^3.6"
 celery = "~5.1.0"
 # Fundamental web framework for Nautobot
 Django = "~3.1.12"
+# Adds AJAX capabilities to django-tables2
+django-ajax-tables = "~1.1.1"
 # LDAP Support
 django-auth-ldap = {version = "~3.0.0", optional = true}
 # Caching with Redis


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #650 
<!--
    Please include a summary of the proposed changes below.
-->

- Added [`django-ajax-tables`](https://pypi.org/project/django-ajax-tables/) as a dependency
- Added commenting to `js/job_result.js` so it is easier to read and maintain
- Revised `job_result.js::checkPendingResult()` to also call `updateLogTable()` and moved terminal job statuses to their own `terminal_statuses` array
- Eliminated extraneous single-line functions like `refreshWindow()` and `jobTerminatedAction()`
- Implemented `nautobot.extras.views.JobLogEntryTableView` that is routed as a detail endpoint on `JobResultView` at `/log-table/` that is used to refresh the job logs table in the UI
- Revised `nautbot.extras.views.JobResultView` to set `log_table = True` to behave as a sentinel in `JobResultView` for backwards compatibility