### PR TITLE
Addition to #1200 - Remove no-longer-needed log_table context data

### DIFF
--- a/nautobot/extras/templates/extras/inc/jobresult.html
+++ b/nautobot/extras/templates/extras/inc/jobresult.html
@@ -41,21 +41,16 @@
 {% include 'inc/custom_fields_panel.html' %}
 {% plugin_right_page result %}
 </div>
-{% if log_table %}
-    <form method="post">
+
+<form method="post">
     {% csrf_token %}
     <div class="panel panel-default">
-    <div class="panel-heading">
-        <strong>Logs</strong>
-        <div class="pull-right col-md-2 noprint">
-            <input class="form-control log-filter" type="text" placeholder="Filter" title="Filter log level (regular expressions supported)" style="height: 23px" />
+        <div class="panel-heading">
+            <strong>Logs</strong>
+            <div class="pull-right col-md-2 noprint">
+                <input class="form-control log-filter" type="text" placeholder="Filter" title="Filter log level (regular expressions supported)" style="height: 23px" />
+            </div>
         </div>
+        {% ajax_table "log_table" "extras:jobresult_log-table" pk=result.pk %}
     </div>
-    {% ajax_table "log_table" "extras:jobresult_log-table" pk=result.pk %}
-    </div>
-    </form>
-{% else %}
-    <div class="alert alert-danger" role="alert">
-        No table of job logs was provided, perhaps you are using an out-of-date plugin?
-    </div>
-{% endif %}
+</form>

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -55,7 +55,6 @@ from .models import (
     GraphQLQuery,
     ImageAttachment,
     ObjectChange,
-    JobLogEntry,
     JobResult,
     Relationship,
     RelationshipAssociation,
@@ -643,12 +642,8 @@ class GitRepositoryResultView(generic.ObjectView):
             .first()
         )
 
-        logs = JobLogEntry.objects.restrict(request.user, "view").filter(job_result=job_result)
-        log_table = tables.JobLogEntryTable(data=logs, user=request.user)
-
         return {
             "result": job_result,
-            "log_table": log_table,
             "base_template": "extras/gitrepository.html",
             "object": instance,
             "active_tab": "result",
@@ -1107,15 +1102,10 @@ class JobResultView(generic.ObjectView):
         elif related_object:
             associated_record = related_object
 
-        # This is used as a sentinel for backwards compatibility since the table
-        # object is rendered inside of `JobLogEntryTableView`.
-        log_table = True
-
         return {
             "job": job,
             "associated_record": associated_record,
             "result": instance,
-            "log_table": log_table,
         }
 
 


### PR DESCRIPTION
This change atop the current diffs in #1200 appears to make the job log entries display correctly in the nautobot-ssot view as well as the core views.