### PR TITLE
Add ability to hide a job in the UI

### DIFF
--- a/examples/dummy_plugin/dummy_plugin/jobs.py
+++ b/examples/dummy_plugin/dummy_plugin/jobs.py
@@ -14,4 +14,11 @@ class DummyJob(Job):
         """
 
 
-jobs = (DummyJob,)
+class DummyHiddenJob(Job):
+    class Meta:
+        hidden = True
+        name = "Dummy hidden job"
+        description = "I should not show in the UI!"
+
+
+jobs = (DummyJob, DummyHiddenJob)

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -113,6 +113,14 @@ class MyJob(Job):
 
 A list of strings (field names) representing the order your form fields should appear. If not defined, fields will appear in order of their definition in the code.
 
+#### `hidden`
+
+Default: `False`
+
+A Boolean that if set to `True` will prevent the job from being displayed in the list of jobs in the Nautobot UI.
+
+Since the jobs execution framework is designed to be generic, there may be several technical jobs defined by users which interact with or are invoked by external systems. In such cases, these jobs are not meant to be executed by a human and likely do not make sense to expose to end users for execution, and thus having them exposed in the UI at all is extraneous.
+
 #### `read_only`
 
 A boolean that designates whether the job is able to make changes to data in the database. The value defaults to `False` but when set to `True`, any data modifications executed from the job's code will be automatically aborted at the end of the job. The job input form is also modified to remove the `commit` checkbox as it is irrelevant for read-only jobs. When a job is marked as read-only, log messages that are normally automatically emitted about the DB transaction state are not included because no changes to data are allowed. Note that user input may still be optionally collected with read-only jobs via job variables, as described below.

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -121,6 +121,13 @@ A Boolean that if set to `True` will prevent the job from being displayed in the
 
 Since the jobs execution framework is designed to be generic, there may be several technical jobs defined by users which interact with or are invoked by external systems. In such cases, these jobs are not meant to be executed by a human and likely do not make sense to expose to end users for execution, and thus having them exposed in the UI at all is extraneous.
 
+Important notes about hidden jobs: 
+
+- This is merely hiding them from the web interface. It is NOT a security feature.
+- While the job will not be shown in the list of jobs on the main Jobs page it will still be able to be executed using the
+REST API or through the UI if a user knows the detail URL for that job.
+- Results for hidden jobs will still appear in the Job Results list after they are run.
+
 #### `read_only`
 
 A boolean that designates whether the job is able to make changes to data in the database. The value defaults to `False` but when set to `True`, any data modifications executed from the job's code will be automatically aborted at the end of the job. The job input form is also modified to remove the `commit` checkbox as it is irrelevant for read-only jobs. When a job is marked as read-only, log messages that are normally automatically emitted about the DB transaction state are not included because no changes to data are allowed. Note that user input may still be optionally collected with read-only jobs via job variables, as described below.

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -93,6 +93,7 @@ class BaseJob:
         - name (str)
         - description (str)
         - commit_default (bool)
+        - hidden (bool)
         - field_order (list)
         - read_only (bool)
         - approval_required (bool)
@@ -169,6 +170,10 @@ class BaseJob:
         Escape various characters so that the class_path can be used as a jQuery selector.
         """
         return cls.class_path.replace("/", r"\/").replace(".", r"\.")
+
+    @classproperty
+    def hidden(cls):
+        return getattr(cls.Meta, "hidden", False)
 
     @classproperty
     def name(cls):

--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -28,6 +28,7 @@
                             <th colspan="6"><h3><a name="module.{{ module }}"></a>{{ module|bettertitle }}</h3></th>
                         </tr>
                         {% for job in module_jobs %}
+                            {% if not job.hidden %}
                             <tr>
                                 <td>
                                     <a href="{% url 'extras:job' class_path=job.class_path %}"
@@ -85,6 +86,7 @@
                                     {% endif %}
                                 </td>
                             </tr>
+                            {% endif %}
                             {% for method, stats in job.result.data.items %}
                                 {% if method != "total" and method != "output" %}
                                     <tr class="{{ job.class_path }} collapse">

--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -86,7 +86,6 @@
                                     {% endif %}
                                 </td>
                             </tr>
-                            {% endif %}
                             {% for method, stats in job.result.data.items %}
                                 {% if method != "total" and method != "output" %}
                                     <tr class="{{ job.class_path }} collapse">
@@ -104,6 +103,7 @@
                                     </tr>
                                 {% endif %}
                             {% endfor %}
+                            {% endif %}
                         {% endfor %}
                     {% endfor %}
                 </table>


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #863 
<!--
    Please include a summary of the proposed changes below.
-->
- This adds a `hidden = True` boolean that can be defined on a job's inner `Meta` class, which if set, will cause the job to not be show in the list of jobs in the web UI
- An example `DummyHiddenJob` has been added to `examples/dummy_plugin.jobs` to demonstrate this functionality.