### PR TITLE
This fixes the nav bar menu collapsing too late.

### DIFF
--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -39,15 +39,15 @@ footer p {
     padding-right: 0;
 }
 
-/* Hide the username in the navigation menu on displays less than 1400px wide */
-@media (max-width: 1399px) {
+/* Hide the username in the navigation menu on displays less than 1470px wide */
+@media (max-width: 1469px) {
     #navbar_user {
         display: none;
     }
 }
 
-/* Hide the search bar in the navigation menu on displays less than 1250px wide */
-@media (max-width: 1249px) {
+/* Hide the search bar in the navigation menu on displays less than 1384px wide */
+@media (max-width: 1383px) {
     #navbar_search {
         display: none;
     }
@@ -74,8 +74,8 @@ footer p {
     }
 }
 
-/* Collapse the nav menu on displays less than 980px wide */
-@media (max-width: 979px) {
+/* Collapse the nav menu on displays less than 1180px wide */
+@media (max-width: 1179px) {
     #navbar {
         max-height: calc(80vh - 50px);
         overflow-y: auto;
@@ -83,7 +83,7 @@ footer p {
     .navbar-header {
         float: none;
     }
-    .navbar-left,.navbar-right {
+    .navbar-left, .navbar-right {
         float: none !important;
     }
     .navbar-toggle {
@@ -91,29 +91,29 @@ footer p {
     }
     .navbar-collapse {
         border-top: 1px solid transparent;
-        box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
     }
     .navbar-fixed-top {
         top: 0;
         border-width: 0 0 1px;
     }
     .navbar-collapse.collapse {
-        display: none!important;
+        display: none !important;
         max-height: none;
     }
     .navbar-nav {
         float: none !important;
         margin-top: 7.5px;
     }
-    .navbar-nav>li {
+    .navbar-nav > li {
         float: none;
     }
-    .navbar-nav>li>a {
+    .navbar-nav > li > a {
         padding-top: 10px;
         padding-bottom: 10px;
     }
     .collapse.in {
-        display:block !important;
+        display: block !important;
     }
     #navbar_user {
         display: inline;
@@ -338,7 +338,7 @@ table.report th a {
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0,0,0,0.3);
+    background-color: rgba(0, 0, 0, 0.3);
 }
 
 /* Misc */


### PR DESCRIPTION
Fixes: #1127

I've made the nav menu align and collapse properly using appropriate CSS media queries. I anticipated that "Jobs" will one day soon have its own dropdown on the nav menu so adjusted the widths needed accordingly so that this addition won't break it again.