### PR TITLE
Fixing login template

### DIFF
--- a/nautobot/core/templates/login.html
+++ b/nautobot/core/templates/login.html
@@ -3,7 +3,7 @@
 {% load form_helpers %}
 
 {% block content %}
-<div class="row" style="margin-top: {% if settings.BANNER_LOGIN %}100{% else %}150{% endif %}px;">
+<div class="row" style="margin-top: {% if 'BANNER_LOGIN'|settings_or_config %}100{% else %}150{% endif %}px;">
     <div class="col-sm-4 col-sm-offset-4">
         {% if "BANNER_LOGIN"|settings_or_config %}
             <div style="margin-bottom: 25px">


### PR DESCRIPTION
While troubleshooting another issue I noticed the following stack trace in DEBUG:

```
  Exception while resolving variable 'BANNER_LOGIN' in template 'login.html'.
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/template/base.py", line 829, in _resolve_lookup
    current = current[bit]
  File "/usr/local/lib/python3.6/site-packages/django/utils/functional.py", line 241, in inner
    return func(self._wrapped, *args)
TypeError: 'Settings' object is not subscriptable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/template/base.py", line 837, in _resolve_lookup
    current = getattr(current, bit)
  File "/usr/local/lib/python3.6/site-packages/django/conf/__init__.py", line 83, in __getattr__
    val = getattr(self._wrapped, name)
AttributeError: 'Settings' object has no attribute 'BANNER_LOGIN'
```

Upon investigation it looks like there was one `settings.BANNER_LOGIN` which was missed in Nautobot 1.2 to be switched to `"BANNER_LOGIN"|settings_or_config`. 