### PR TITLE
Add present_in_database check when caching initial properties of a DeviceType

### DIFF
--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1251,3 +1251,19 @@ query {
                 result = self.execute_query(query)
                 self.assertIsNone(result.errors)
                 self.assertEqual(len(result.data["webhooks"]), nbr_expected_results)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_query_device_types(self):
+        """Test querying of device types, specifically checking for issue #1203."""
+        query = """
+        query {
+            device_types {
+                model
+            }
+        }
+        """
+        result = self.execute_query(query)
+        self.assertIsNone(result.errors)
+        self.assertIsInstance(result.data, dict, result)
+        self.assertIsInstance(result.data["device_types"], list, result)
+        self.assertEqual(result.data["device_types"][0]["model"], self.devicetype.model, result)

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -149,11 +149,11 @@ class DeviceType(PrimaryModel):
         super().__init__(*args, **kwargs)
 
         # Save a copy of u_height for validation in clean()
-        self._original_u_height = self.u_height
+        self._original_u_height = self.u_height if self.present_in_database else 1
 
         # Save references to the original front/rear images
-        self._original_front_image = self.front_image
-        self._original_rear_image = self.rear_image
+        self._original_front_image = self.front_image if self.present_in_database else None
+        self._original_rear_image = self.rear_image if self.present_in_database else None
 
     def get_absolute_url(self):
         return reverse("dcim:devicetype", args=[self.pk])
@@ -296,9 +296,9 @@ class DeviceType(PrimaryModel):
         ret = super().save(*args, **kwargs)
 
         # Delete any previously uploaded image files that are no longer in use
-        if self.front_image != self._original_front_image:
+        if self._original_front_image and self.front_image != self._original_front_image:
             self._original_front_image.delete(save=False)
-        if self.rear_image != self._original_rear_image:
+        if self._original_rear_image and self.rear_image != self._original_rear_image:
             self._original_rear_image.delete(save=False)
 
         return ret


### PR DESCRIPTION
### Fixes: #1203 

I'm not sure why this started failing in 1.2.x and not before, but in any case, the fix here is similar to what was done for the Cable model in #769 - when `__init__`ing a DeviceType instance, only try to read from its "original" properties if it's already present in the database and hence *has* relevant values for these properties.

I also added a test case for the GraphQL query that demonstrates this issue.