### PR TITLE
Implement accordion collapse/expand for jobs list view

### DIFF
--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -6,20 +6,43 @@
         $("button.button-toggle").click(function() {
             $(this).children("i").toggleClass("mdi-chevron-right mdi-chevron-down");
         });
-    </script>
-    <script>
-         $(".accordion-toggle").click(function() {
-             $(this).toggleClass("mdi-chevron-down mdi-chevron-right");
-         });
+	// Toggle v -. >
+        $("#accordion .accordion-toggle").click(function() {
+            $(this).toggleClass("mdi-chevron-down mdi-chevron-right");
+        });
+        // Dynamically collapse/expand all when clicking the "Collapse All" button, and then update the button text.
+        $('#accordion-toggle-all').on('click', function () {
+
+           if ($(this).data("lastState") === null || $(this).data("lastState") === 1) {
+                $('.collapse').collapse('show');
+                $(this).data("lastState", 0);
+
+                $("#accordion .accordion-toggle").addClass("mdi-chevron-down").removeClass("mdi-chevron-right");
+
+                $(this).text("Collapse All");
+           }
+           else {
+                $('[class^=collapseme]').removeData('bs.collapse').collapse({parent: false, toggle: false})
+                .collapse('hide')
+                .removeData('bs.collapse')
+                .collapse({parent: '#accordion', toggle: false});
+
+                $(this).data("lastState", 1);
+                $("#accordion .accordion-toggle").addClass("mdi-chevron-right").removeClass("mdi-chevron-down");
+
+                $(this).text("Expand All");
+            }
+        });
      </script>
 {% endblock %}
 
 {% block content %}
-    <h1>{% block title %}Jobs{% endblock %}</h1>
+<button type="button" class="btn btn-primary pull-right" id="accordion-toggle-all">Collapse All</button>
+<h1>{% block title %}Jobs{% endblock %}</h1>
     <div class="row">
         <div class="col-md-12">
             {% if jobs %}
-                <table class="table table-hover table-headings reports">
+                <table class="table table-hover table-headings reports", id="accordion">
                     <tr>
                         <th>Module / Job</th>
                         <th>Description</th>
@@ -38,7 +61,7 @@
                         </tr>
                         {% for job in module_jobs %}
                             {% if not job.hidden %}
-                            <tr class="collapseme-{{ module|slugify }} collapse in">
+                            <tr class="collapseme-{{ module|slugify }} collapse in" data-parent="#accordion">
                                 <td>
                                     <a href="{% url 'extras:job' class_path=job.class_path %}"
                                        id="{{ job.class_path }}">

--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -8,10 +8,10 @@
         });
     </script>
     <script>
-	$(".accordion-toggle").click(function() {
-	    $(this).toggleClass("mdi-chevron-down mdi-chevron-right");
-        });
-    </script>
+         $(".accordion-toggle").click(function() {
+             $(this).toggleClass("mdi-chevron-down mdi-chevron-right");
+         });
+     </script>
 {% endblock %}
 
 {% block content %}
@@ -19,29 +19,27 @@
     <div class="row">
         <div class="col-md-12">
             {% if jobs %}
-	        <div class="panel-group" id="accordion">
-		    <div class="row panel">
-                        <div class="col-md-2">Module / Job</div>
-                        <div class="col-md-4">Description</div>
-                        <div class="col-md-2 text-right">Last Run</div>
-                        <div class="col-md-2">&nbsp;</div>
-                        <div class="col-md-1">Last Status</div>
-                        <div class="col-md-1">Last Results</div>
-                    </div>
+                <table class="table table-hover table-headings reports">
+                    <tr>
+                        <th>Module / Job</th>
+                        <th>Description</th>
+                        <th class="text-right">Last Run</th>
+                        <th style="width: 40px"></th>
+                        <th style="width: 100px">Last Status</th>
+                        <th style="width: 180px">Last Results</th>
+                    </tr>
                     {% for module, module_jobs in jobs %}
-                        <div class="row panel panel-default">
-			    <div class="panel-heading">
-				<h3 class="panel-title">
-				    <a class="accordion-toggle mdi mdi-chevron-down" type="button" data-toggle="collapse" href=".collapse-{{ module|slugify }}" name="module.{{ module }}">
-					{{ module|bettertitle }}
-				    </a>
-				</h3>
-			    </div>
-			</div>
+                        <tr>
+                            <th colspan="6">
+                                <button type="button" class="btn-link accordion-toggle mdi mdi-chevron-down" name="module.{{ module }}" data-toggle="collapse" data-target=".collapseme-{{ module|slugify }}">
+                                    {{ module|bettertitle }}
+                                </button>
+                            </th>
+                        </tr>
                         {% for job in module_jobs %}
                             {% if not job.hidden %}
-                            <div class="row collapse-{{ module|slugify }} collapse in">
-                                <div class="col-md-2">
+                            <tr class="collapseme-{{ module|slugify }} collapse in">
+                                <td>
                                     <a href="{% url 'extras:job' class_path=job.class_path %}"
                                        id="{{ job.class_path }}">
                                         <strong>{{ job }}</strong>
@@ -49,11 +47,9 @@
                                     {% if job.read_only %}
                                         <label class="label label-default">Read-only</label>
                                     {% endif %}
-                                </div>
-				<div class="col-md-4">
-				    {{ job.description_first_line | render_markdown | placeholder }}
-				</div>
-                                <div class="col-md-2 text-right text-nowrap">
+                                </td>
+                                <td>{{ job.description_first_line | render_markdown | placeholder }}</td>
+                                <td class="text-right text-nowrap">
                                     {% if job.result %}
                                         <a href="{% url 'extras:job_jobresult' pk=job.result.pk %}">
                                             {{ job.result.created }} by {{ job.result.user }}
@@ -61,8 +57,8 @@
                                     {% else %}
                                         <span class="text-muted">Never</span>
                                     {% endif %}
-                                </div>
-				<div class="col-md-2">
+                                </td>
+                                <td>
                                     {% if job.result %}
                                         <a class="btn btn-xs btn-default"
                                            href="{% url 'extras:jobresult_list' %}?name={{ job.class_path|urlencode }}"
@@ -70,11 +66,11 @@
                                             <i class="mdi mdi-history"></i>
                                         </a>
                                     {% endif %}
-                                </div>
-                                <div class="col-md-1">
+                                </td>
+                                <td>
                                     {% include 'extras/inc/job_label.html' with result=job.result %}
-				</div>
-                                <div class="col-md-1 text-nowrap report-stats">
+                                </td>
+                                <td class="text-nowrap report-stats">
                                     {% if job.result %}
                                         <label class="label label-success">{{ job.result.data.total.success }}</label>
                                         <label class="label label-info">{{ job.result.data.total.info }}</label>
@@ -97,23 +93,23 @@
                                     {% else %}
                                         —
                                     {% endif %}
-                                </div>
-                            </div>
+                                </td>
+                            </tr>
                             {% for method, stats in job.result.data.items %}
                                 {% if method != "total" and method != "output" %}
-                                    <div class="row {{ job.class_path }} collapse">
-                                        <div class="col-md-8 method">
+                                    <tr class="{{ job.class_path }} collapse">
+                                        <td colspan="5" class="method">
                                             <a href="{% url 'extras:job_jobresult' pk=job.result.pk %}#{{method}}">
                                                 {{ method }}
                                             </a>
-                                        </div>
-                                        <div class="col-md-4 text-nowrap report-stats">
+                                        </td>
+                                        <td class="text-nowrap report-stats">
                                             <label class="label label-success">{{ stats.success }}</label>
                                             <label class="label label-info">{{ stats.info }}</label>
                                             <label class="label label-warning">{{ stats.warning }}</label>
                                             <label class="label label-danger">{{ stats.failure }}</label>
-                                        </div>
-                                    </div>
+                                        </td>
+                                    </tr>
                                 {% endif %}
                             {% endfor %}
                             {% endif %}

--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -86,6 +86,7 @@
                                     {% endif %}
                                 </td>
                             </tr>
+                            {% endif %}
                             {% for method, stats in job.result.data.items %}
                                 {% if method != "total" and method != "output" %}
                                     <tr class="{{ job.class_path }} collapse">

--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -7,6 +7,11 @@
             $(this).children("i").toggleClass("mdi-chevron-right mdi-chevron-down");
         });
     </script>
+    <script>
+	$(".accordion-toggle").click(function() {
+	    $(this).toggleClass("mdi-chevron-down mdi-chevron-right");
+        });
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -14,23 +19,29 @@
     <div class="row">
         <div class="col-md-12">
             {% if jobs %}
-                <table class="table table-hover table-headings reports">
-                    <tr>
-                        <th>Module / Job</th>
-                        <th>Description</th>
-                        <th class="text-right">Last Run</th>
-                        <th style="width: 40px"></th>
-                        <th style="width: 100px">Last Status</th>
-                        <th style="width: 180px">Last Results</th>
-                    </tr>
+	        <div class="panel-group" id="accordion">
+		    <div class="row panel">
+                        <div class="col-md-2">Module / Job</div>
+                        <div class="col-md-4">Description</div>
+                        <div class="col-md-2 text-right">Last Run</div>
+                        <div class="col-md-2">&nbsp;</div>
+                        <div class="col-md-1">Last Status</div>
+                        <div class="col-md-1">Last Results</div>
+                    </div>
                     {% for module, module_jobs in jobs %}
-                        <tr>
-                            <th colspan="6"><h3><a name="module.{{ module }}"></a>{{ module|bettertitle }}</h3></th>
-                        </tr>
+                        <div class="row panel panel-default">
+			    <div class="panel-heading">
+				<h3 class="panel-title">
+				    <a class="accordion-toggle mdi mdi-chevron-down" type="button" data-toggle="collapse" href=".collapse-{{ module|slugify }}" name="module.{{ module }}">
+					{{ module|bettertitle }}
+				    </a>
+				</h3>
+			    </div>
+			</div>
                         {% for job in module_jobs %}
                             {% if not job.hidden %}
-                            <tr>
-                                <td>
+                            <div class="row collapse-{{ module|slugify }} collapse in">
+                                <div class="col-md-2">
                                     <a href="{% url 'extras:job' class_path=job.class_path %}"
                                        id="{{ job.class_path }}">
                                         <strong>{{ job }}</strong>
@@ -38,9 +49,11 @@
                                     {% if job.read_only %}
                                         <label class="label label-default">Read-only</label>
                                     {% endif %}
-                                </td>
-                                <td>{{ job.description_first_line | render_markdown | placeholder }}</td>
-                                <td class="text-right text-nowrap">
+                                </div>
+				<div class="col-md-4">
+				    {{ job.description_first_line | render_markdown | placeholder }}
+				</div>
+                                <div class="col-md-2 text-right text-nowrap">
                                     {% if job.result %}
                                         <a href="{% url 'extras:job_jobresult' pk=job.result.pk %}">
                                             {{ job.result.created }} by {{ job.result.user }}
@@ -48,8 +61,8 @@
                                     {% else %}
                                         <span class="text-muted">Never</span>
                                     {% endif %}
-                                </td>
-                                <td>
+                                </div>
+				<div class="col-md-2">
                                     {% if job.result %}
                                         <a class="btn btn-xs btn-default"
                                            href="{% url 'extras:jobresult_list' %}?name={{ job.class_path|urlencode }}"
@@ -57,11 +70,11 @@
                                             <i class="mdi mdi-history"></i>
                                         </a>
                                     {% endif %}
-                                </td>
-                                <td>
+                                </div>
+                                <div class="col-md-1">
                                     {% include 'extras/inc/job_label.html' with result=job.result %}
-                                </td>
-                                <td class="text-nowrap report-stats">
+				</div>
+                                <div class="col-md-1 text-nowrap report-stats">
                                     {% if job.result %}
                                         <label class="label label-success">{{ job.result.data.total.success }}</label>
                                         <label class="label label-info">{{ job.result.data.total.info }}</label>
@@ -84,24 +97,23 @@
                                     {% else %}
                                         —
                                     {% endif %}
-                                </td>
-                            </tr>
-                            {% endif %}
+                                </div>
+                            </div>
                             {% for method, stats in job.result.data.items %}
                                 {% if method != "total" and method != "output" %}
-                                    <tr class="{{ job.class_path }} collapse">
-                                        <td colspan="5" class="method">
+                                    <div class="row {{ job.class_path }} collapse">
+                                        <div class="col-md-8 method">
                                             <a href="{% url 'extras:job_jobresult' pk=job.result.pk %}#{{method}}">
                                                 {{ method }}
                                             </a>
-                                        </td>
-                                        <td class="text-nowrap report-stats">
+                                        </div>
+                                        <div class="col-md-4 text-nowrap report-stats">
                                             <label class="label label-success">{{ stats.success }}</label>
                                             <label class="label label-info">{{ stats.info }}</label>
                                             <label class="label label-warning">{{ stats.warning }}</label>
                                             <label class="label label-danger">{{ stats.failure }}</label>
-                                        </td>
-                                    </tr>
+                                        </div>
+                                    </div>
                                 {% endif %}
                             {% endfor %}
                             {% endif %}

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -497,15 +497,18 @@ span.hover_copy:hover .hover_copy_button {
     top: 2px;
 }
 
-/* >>> New CSS for the Jobs list accordion feature */
-h3.panel-title {
-    font-weight: bold;
+/* Jobs list view accordion styling */
+.accordion-toggle {
+    border: 0;
+    color: black;
+    font-size: 24px;
+    padding: 0;
+    text-decoration: none;
 }
-div.row .panel div {
-    font-weight: bold;
+.accordion-toggle:hover, .accordion-toggle:active, .accordion-toggle:visited, .accordion-toggle:link, .accordion-toggle:focus {
+    border: 0;
+    color: black;
+    outline: 0;
+    padding: 0;
+    text-decoration: none;
 }
-.row .collapse {
-    background: #fff;
-    padding-top: 5px;
-}
-/* >>> New CSS for the Jobs list accordion feature */

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -496,3 +496,16 @@ span.hover_copy:hover .hover_copy_button {
     position: relative;
     top: 2px;
 }
+
+/* >>> New CSS for the Jobs list accordion feature */
+h3.panel-title {
+    font-weight: bold;
+}
+div.row .panel div {
+    font-weight: bold;
+}
+.row .collapse {
+    background: #fff;
+    padding-top: 5px;
+}
+/* >>> New CSS for the Jobs list accordion feature */

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -512,3 +512,6 @@ span.hover_copy:hover .hover_copy_button {
     padding: 0;
     text-decoration: none;
 }
+#accordion-toggle-all {
+    display: inline;
+}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #881 

This augments the jobs list view tables with collapsable/expandable table rows.

- It is leveraging the collapse feature of Bootstrap 3.
- Down/right chevrons are used to indicate collapse/expand actions. I experimented with having a "+/-" or "v/>" on the right side and it didn't feel right, because of the font size and the table being full width. I was finding it weird to have it on the right. It didn't immediately stand out as a collapsible option.
- Implemented a "Collapse All" button that changes to "Expand All" when collapsed and cycles between those states.

Default list view
![image](https://user-images.githubusercontent.com/138052/148461436-3184b9b5-41d2-4706-a376-6cdb09e33906.png)

List view with first section collapsed
![image](https://user-images.githubusercontent.com/138052/148461484-f76af2a0-8f1a-41d0-812d-049db963cf5c.png)

When "Collapse All" is clicked it becomes "Expand All"
![image](https://user-images.githubusercontent.com/138052/148461266-29a2c47d-a077-4a87-8b45-9ca9de0adaf9.png)

Individual sections can be expanded/collapsed, but the button still keeps its internal state
![image](https://user-images.githubusercontent.com/138052/148461306-da01fd20-4efe-4b9f-8357-c1a151849012.png)

Clicking "Expand All" expands all accordions and cycles the button back to "Collapse All" (see first screenshot)
