### PR TITLE
Fix extraneous endif in job_list.html

### DIFF
--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -61,81 +61,80 @@
                         </tr>
                         {% for job in module_jobs %}
                             {% if not job.hidden %}
-                            <tr class="collapseme-{{ module|slugify }} collapse in" data-parent="#accordion">
-                                <td>
-                                    <a href="{% url 'extras:job' class_path=job.class_path %}"
-                                       id="{{ job.class_path }}">
-                                        <strong>{{ job }}</strong>
-                                    </a>
-                                    {% if job.read_only %}
-                                        <label class="label label-default">Read-only</label>
-                                    {% endif %}
-                                </td>
-                                <td>{{ job.description_first_line | render_markdown | placeholder }}</td>
-                                <td class="text-right text-nowrap">
-                                    {% if job.result %}
-                                        <a href="{% url 'extras:job_jobresult' pk=job.result.pk %}">
-                                            {{ job.result.created }} by {{ job.result.user }}
+                                <tr class="collapseme-{{ module|slugify }} collapse in" data-parent="#accordion">
+                                    <td>
+                                        <a href="{% url 'extras:job' class_path=job.class_path %}"
+                                           id="{{ job.class_path }}">
+                                            <strong>{{ job }}</strong>
                                         </a>
-                                    {% else %}
-                                        <span class="text-muted">Never</span>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if job.result %}
-                                        <a class="btn btn-xs btn-default"
-                                           href="{% url 'extras:jobresult_list' %}?name={{ job.class_path|urlencode }}"
-                                           title="See job history">
-                                            <i class="mdi mdi-history"></i>
-                                        </a>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% include 'extras/inc/job_label.html' with result=job.result %}
-                                </td>
-                                <td class="text-nowrap report-stats">
-                                    {% if job.result %}
-                                        <label class="label label-success">{{ job.result.data.total.success }}</label>
-                                        <label class="label label-info">{{ job.result.data.total.info }}</label>
-                                        <label class="label label-warning">{{ job.result.data.total.warning }}</label>
-                                        <label class="label label-danger">{{ job.result.data.total.failure }}</label>
-                                        {% comment %}
-                                            Every job.result.data has keys 'output', 'total', those don't count.
-                                            Only show the "more" button if there's more than one result grouping;
-                                            i.e. 'output' + 'total' + 'grouping1' + 'grouping2' (+ ...)
-                                        {% endcomment %}
-                                        {% if job.result.data and job.result.data|length > 3 %}
-                                            <button class="btn btn-xs btn-default button-toggle" type="button"
-                                                    data-toggle="collapse"
-                                                    data-target=".{{ job.class_path_js_escaped }}"
-                                                    aria-controls="{{ job.class_path }}"
-                                                    title="Show / hide detailed results">
-                                                Details <i class="mdi mdi-chevron-right"></i>
-                                            </button>
+                                        {% if job.read_only %}
+                                            <label class="label label-default">Read-only</label>
                                         {% endif %}
-                                    {% else %}
-                                        —
-                                    {% endif %}
-                                </td>
-                            </tr>
-                            {% endif %}
-                            {% for method, stats in job.result.data.items %}
-                                {% if method != "total" and method != "output" %}
-                                    <tr class="{{ job.class_path }} collapse">
-                                        <td colspan="5" class="method">
-                                            <a href="{% url 'extras:job_jobresult' pk=job.result.pk %}#{{method}}">
-                                                {{ method }}
+                                    </td>
+                                    <td>{{ job.description_first_line | render_markdown | placeholder }}</td>
+                                    <td class="text-right text-nowrap">
+                                        {% if job.result %}
+                                            <a href="{% url 'extras:job_jobresult' pk=job.result.pk %}">
+                                                {{ job.result.created }} by {{ job.result.user }}
                                             </a>
-                                        </td>
-                                        <td class="text-nowrap report-stats">
-                                            <label class="label label-success">{{ stats.success }}</label>
-                                            <label class="label label-info">{{ stats.info }}</label>
-                                            <label class="label label-warning">{{ stats.warning }}</label>
-                                            <label class="label label-danger">{{ stats.failure }}</label>
-                                        </td>
-                                    </tr>
-                                {% endif %}
-                            {% endfor %}
+                                        {% else %}
+                                            <span class="text-muted">Never</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if job.result %}
+                                            <a class="btn btn-xs btn-default"
+                                               href="{% url 'extras:jobresult_list' %}?name={{ job.class_path|urlencode }}"
+                                               title="See job history">
+                                                <i class="mdi mdi-history"></i>
+                                            </a>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% include 'extras/inc/job_label.html' with result=job.result %}
+                                    </td>
+                                    <td class="text-nowrap report-stats">
+                                        {% if job.result %}
+                                            <label class="label label-success">{{ job.result.data.total.success }}</label>
+                                            <label class="label label-info">{{ job.result.data.total.info }}</label>
+                                            <label class="label label-warning">{{ job.result.data.total.warning }}</label>
+                                            <label class="label label-danger">{{ job.result.data.total.failure }}</label>
+                                            {% comment %}
+                                                Every job.result.data has keys 'output', 'total', those don't count.
+                                                Only show the "more" button if there's more than one result grouping;
+                                                i.e. 'output' + 'total' + 'grouping1' + 'grouping2' (+ ...)
+                                            {% endcomment %}
+                                            {% if job.result.data and job.result.data|length > 3 %}
+                                                <button class="btn btn-xs btn-default button-toggle" type="button"
+                                                        data-toggle="collapse"
+                                                        data-target=".{{ job.class_path_js_escaped }}"
+                                                        aria-controls="{{ job.class_path }}"
+                                                        title="Show / hide detailed results">
+                                                    Details <i class="mdi mdi-chevron-right"></i>
+                                                </button>
+                                            {% endif %}
+                                        {% else %}
+                                            —
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                {% for method, stats in job.result.data.items %}
+                                    {% if method != "total" and method != "output" %}
+                                        <tr class="{{ job.class_path }} collapse">
+                                            <td colspan="5" class="method">
+                                                <a href="{% url 'extras:job_jobresult' pk=job.result.pk %}#{{method}}">
+                                                    {{ method }}
+                                                </a>
+                                            </td>
+                                            <td class="text-nowrap report-stats">
+                                                <label class="label label-success">{{ stats.success }}</label>
+                                                <label class="label label-info">{{ stats.info }}</label>
+                                                <label class="label label-warning">{{ stats.warning }}</label>
+                                                <label class="label label-danger">{{ stats.failure }}</label>
+                                            </td>
+                                        </tr>
+                                    {% endif %}
+                                {% endfor %}
                             {% endif %}
                         {% endfor %}
                     {% endfor %}


### PR DESCRIPTION
### Fixes: CI failure

Somehow, #1209 got committed to `next` twice. 6c9e0f6ab94718a875c824ac4ac5f1c6aaa7c177 added an `if` at line 31 and an `endif` at line 89, while b1e6826c3439a161011623a3d5f15a2b8f059e15 added an `if` at line 31 and an `endif` at line 106. The latter is correct.

This PR removes the extraneous `endif` from the former line 89, which became line 121, and also corrects the indentation of HTML within the `if ... endif` block so as to make the scope of the block more obvious.