### PR TITLE
Changing Default docker images to point to python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,9 +221,9 @@ jobs:
           tags: |
             type=raw,value={{branch}}-py${{ matrix.python-version }}
             type=raw,value={{branch}}-{{sha}}-{{date 'X'}}-py${{ matrix.python-version }}
-            type=raw,value={{branch}},enable=${{ matrix.python-version == 3.6 }}
-            type=raw,value={{branch}}-{{sha}}-{{date 'X'}},enable=${{ matrix.python-version == 3.6 }}
-            type=raw,value=latest,enable=${{ matrix.python-version == 3.6 && github.ref == 'refs/heads/develop' }}
+            type=raw,value={{branch}},enable=${{ matrix.python-version == 3.7 }}
+            type=raw,value={{branch}}-{{sha}}-{{date 'X'}},enable=${{ matrix.python-version == 3.7 }}
+            type=raw,value=latest,enable=${{ matrix.python-version == 3.7 && github.ref == 'refs/heads/develop' }}
             type=raw,value=latest-py${{ matrix.python-version }},enable=${{ github.ref == 'refs/heads/develop' }}
       - name: "Build"
         uses: "docker/build-push-action@v2"
@@ -247,9 +247,9 @@ jobs:
           tags: |
             type=raw,value={{branch}}-py${{ matrix.python-version }}
             type=raw,value={{branch}}-{{sha}}-{{date 'X'}}-py${{ matrix.python-version }}
-            type=raw,value={{branch}},enable=${{ matrix.python-version == 3.6 }}
-            type=raw,value={{branch}}-{{sha}}-{{date 'X'}},enable=${{ matrix.python-version == 3.6 }}
-            type=raw,value=latest,enable=${{ matrix.python-version == 3.6 && github.ref == 'refs/heads/develop' }}
+            type=raw,value={{branch}},enable=${{ matrix.python-version == 3.7 }}
+            type=raw,value={{branch}}-{{sha}}-{{date 'X'}},enable=${{ matrix.python-version == 3.7 }}
+            type=raw,value=latest,enable=${{ matrix.python-version == 3.7 && github.ref == 'refs/heads/develop' }}
             type=raw,value=latest-py${{ matrix.python-version }},enable=${{ github.ref == 'refs/heads/develop' }}
       - name: "Build Dev Containers"
         uses: "docker/build-push-action@v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,8 @@ jobs:
             latest=false
           tags: |
             type=raw,value={{version}}-py${{ matrix.python-version }}
-            type=raw,value={{version}},enable=${{ matrix.python-version == 3.6 }}
-            type=raw,value=stable,enable=${{ matrix.python-version == 3.6 }}
+            type=raw,value={{version}},enable=${{ matrix.python-version == 3.7 }}
+            type=raw,value=stable,enable=${{ matrix.python-version == 3.7 }}
             type=raw,value=stable-py${{ matrix.python-version }}
       - name: "Build"
         uses: "docker/build-push-action@v2"
@@ -101,8 +101,8 @@ jobs:
             latest=false
           tags: |
             type=raw,value={{version}}-py${{ matrix.python-version }}
-            type=raw,value={{version}},enable=${{ matrix.python-version == 3.6 }}
-            type=raw,value=stable,enable=${{ matrix.python-version == 3.6 }}
+            type=raw,value={{version}},enable=${{ matrix.python-version == 3.7 }}
+            type=raw,value=stable,enable=${{ matrix.python-version == 3.7 }}
             type=raw,value=stable-py${{ matrix.python-version }}
       - name: "Build Dev Containers"
         uses: "docker/build-push-action@v2"

--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -1,6 +1,6 @@
 # Nautobot Docker Images
 
-Nautobot is packaged as a Docker image for use in a production environment. The published image is based on the `python:3.6-slim` image to maintain the most compatibility with Nautobot deployments. The Docker image and deployment strategies are being actively developed, check back here or join the **#nautobot** Slack channel on [Network to Code](https://networktocode.slack.com) for the most up to date information.
+Nautobot is packaged as a Docker image for use in a production environment. The published image is based on the `python:3.7-slim` image to maintain the most compatibility with Nautobot deployments. The Docker image and deployment strategies are being actively developed, check back here or join the **#nautobot** Slack channel on [Network to Code](https://networktocode.slack.com) for the most up to date information.
 
 ## Tags
 
@@ -24,24 +24,24 @@ The following tags are available on both Docker Hub and the GitHub Container Reg
 
 | Tag                               | Nautobot Version      | Python Version | Example        |
 | --------------------------------- | --------------------- | -------------- | -------------- |
-| `${NAUTOBOT_VER}`                 | As specified          | 3.6            | `1.1.6`        |
-| `${NAUTOBOT_VER}-py${PYTHON_VER}` | As specified          | As specified   | `1.1.6-py3.8`  |
-| `stable`                          | Latest stable release | 3.6            | `stable`       |
+| `${NAUTOBOT_VER}`                 | As specified          | 3.7            | `1.2.3`        |
+| `${NAUTOBOT_VER}-py${PYTHON_VER}` | As specified          | As specified   | `1.2.3-py3.8`  |
+| `stable`                          | Latest stable release | 3.7            | `stable`       |
 | `stable-py${PYTHON_VER}`          | Latest stable release | As specified   | `stable-py3.8` |
 
 The following additional tags are only available from the GitHub Container Registry:
 
 | Tag                                                  | Nautobot Branch              | Python Version |
 | ---------------------------------------------------- | ---------------------------- | -------------- |
-| `latest`                                             | `develop`, the latest commit | 3.6            |
+| `latest`                                             | `develop`, the latest commit | 3.7            |
 | `latest-py${PYTHON_VER}`                             | `develop`, the latest commit | As specified   |
-| `develop`                                            | `develop`, the latest commit | 3.6            |
+| `develop`                                            | `develop`, the latest commit | 3.7            |
 | `develop-py${PYTHON_VER}`                            | `develop`, the latest commit | As specified   |
-| `develop-${GIT_SHA:0:7}-$(date +%s)`                 | `develop`, a specific commit | 3.6            |
+| `develop-${GIT_SHA:0:7}-$(date +%s)`                 | `develop`, a specific commit | 3.7            |
 | `develop-${GIT_SHA:0:7}-$(date +%s)-py${PYTHON_VER}` | `develop`, a specific commit | As specified   |
-| `next`                                               | `next`, the latest commit    | 3.6            |
+| `next`                                               | `next`, the latest commit    | 3.7            |
 | `next-py${PYTHON_VER}`                               | `next`, the latest commit    | As specified   |
-| `next-${GIT_SHA:0:7}-$(date +%s)`                    | `next`, a specific commit    | 3.6            |
+| `next-${GIT_SHA:0:7}-$(date +%s)`                    | `next`, a specific commit    | 3.7            |
 | `next-${GIT_SHA:0:7}-$(date +%s)-py${PYTHON_VER}`    | `next`, a specific commit    | As specified   |
 
 Currently images are pushed for the following python versions:
@@ -218,7 +218,7 @@ networktocode/nautobot                                                    local 
 If you do not have a development environment created you can also build the container using the regular `docker build` command:
 
 ```no-highlight
-$ docker build -t networktocode/nautobot -f ./docker/Dockerfile --build-arg PYTHON_VER=3.6 .
+$ docker build -t networktocode/nautobot -f ./docker/Dockerfile --build-arg PYTHON_VER=3.7 .
 ```
 
 ## Docker Compose

--- a/tasks.py
+++ b/tasks.py
@@ -160,7 +160,7 @@ def buildx(
     cache=False,
     cache_dir="",
     platforms="linux/amd64",
-    tag="networktocode/nautobot-dev-py3.6:local",
+    tag="networktocode/nautobot-dev-py3.7:local",
     target="dev",
 ):
     """Build Nautobot docker image using the experimental buildx docker functionality (multi-arch capablility)."""
@@ -203,7 +203,7 @@ def docker_push(context, branch, commit="", datestamp=""):
         f"{nautobot_version}-py{context.nautobot.python_ver}",
     ]
 
-    if context.nautobot.python_ver == "3.6":
+    if context.nautobot.python_ver == "3.7":
         docker_image_tags_main += ["stable", f"{nautobot_version}"]
     if branch == "main":
         docker_image_names = context.nautobot.docker_image_names_main


### PR DESCRIPTION
This PR changes the default docker images to be based on python 3.7.  Python 3.6 - 3.9 containers are still build but container tags such as `:1.2.3` and `:stable` will be based on Python 3.7.
