### PR TITLE
Adds `get_absolute_url` method to BaseJob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ nautobot.pid
 .vscode
 docker-compose.override.yml
 *.env
+.venv
 !dev.env
 *.egg-info
 .python-version

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -23,6 +23,7 @@ from django.db import transaction
 from django.db.models import Model
 from django.db.models.query import QuerySet
 from django.forms import ValidationError
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import classproperty
 import netaddr
@@ -119,6 +120,10 @@ class BaseJob:
 
     def __str__(self):
         return self.name
+
+    @classmethod
+    def get_absolute_url(cls):
+        return reverse("extras:job", kwargs={"class_path": cls.class_path})
 
     @classproperty
     def file_path(cls):


### PR DESCRIPTION
This change follows a discussion on an internal Nautobot office hours to have this method for Jobs as well as Models.