### PR TITLE
CI Ignore doc changes for example_plugin in next

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable
       - "nautobot/docs/**"
       - "examples/**"
       # The example plugin should probably trigger CI
-      - "!examples/example_plugin"
+      - "!examples/dummy_plugin"
       - "**.md"
       - "development/**"
       - ".github/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:  # yamllint disable
     paths-ignore:
       - "nautobot/docs/**"
       - "examples/**"
+      # The example plugin should probably trigger CI
+      - "!examples/example_plugin"
       - "**.md"
       - "development/**"
       - ".github/**"
+      # If the ci.yaml is updated run CI for the PR
+      - "!.github/workflows/ci.yml"
       - ".devcontainer/**"
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable
       - "nautobot/docs/**"
       - "examples/**"
       # The example plugin should probably trigger CI
-      - "!examples/dummy_plugin"
+      - "!examples/example_plugin"
       - "**.md"
       - "development/**"
       - ".github/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,15 @@
 ---
 name: "CI"
 on:  # yamllint disable
-  - "push"
-  - "pull_request"
+  push:
+  pull_request:
+    paths-ignore:
+      - "nautobot/docs/**"
+      - "examples/**"
+      - "**.md"
+      - "development/**"
+      - ".github/**"
+      - ".devcontainer/**"
 
 jobs:
   black:


### PR DESCRIPTION
This PR is targeted at next to run CI on changes to examples/example_plugin vs dummy plugin.