### PR TITLE
Revise IPAddress edit view to allow previously set primary state to be cleared

### DIFF
--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -731,9 +731,6 @@ class IPAddressForm(
         # Device/VirtualMachine. It will not be saved until after `IPAddress.clean()` succeeds which
         # also checks for the `_primary_ip_unset_by_form` value.
         if not primary_for_parent and self.instance._original_assigned_object is not None:
-            ip_version = self.instance.address.version
-            parent = self.instance._original_assigned_object.parent
-            setattr(parent, f"primary_ip{ip_version}", None)  # e.g. `primary_ip4` or `primary_ip6`
             self.instance._primary_ip_unset_by_form = True
 
     def save(self, *args, **kwargs):
@@ -751,7 +748,10 @@ class IPAddressForm(
         # Save the `original_assigned_object.parent` if `_primary_ip_unset_by_form` was set in `clean()`
         primary_ip_unset_by_form = getattr(self.instance, "_primary_ip_unset_by_form", False)
         if primary_ip_unset_by_form:
-            self.instance._original_assigned_object.parent.save()
+            ip_version = self.instance.address.version
+            parent = self.instance._original_assigned_object.parent
+            setattr(parent, f"primary_ip{ip_version}", None)  # e.g. `primary_ip4` or `primary_ip6`
+            parent.save()
 
         return ipaddress
 

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -730,7 +730,7 @@ class IPAddressForm(
         # If `primary_for_parent` is unset, clear the `primary_ip{version}` for the
         # Device/VirtualMachine. It will not be saved until after `IPAddress.clean()` succeeds which
         # also checks for the `_primary_ip_unset_by_form` value.
-        if not primary_for_parent and hasattr(self.instance._original_assigned_object, "parent"):
+        if not primary_for_parent and self.instance._original_assigned_object is not None:
             ip_version = self.instance.address.version
             parent = self.instance._original_assigned_object.parent
             setattr(parent, f"primary_ip{ip_version}", None)  # e.g. `primary_ip4` or `primary_ip6`


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1053 
<!--
    Please include a summary of the proposed changes below.
-->
- Unchecking "Make this primary IP for the device/VM" when editing an `IPAddress`, will now clear the state on the assigned Device/VM.
- If the device/interface are also cleared in the same edit session, the original `assigned_object` is stashed on the `IPAddress` instance to be saved when `IPAddressForm.save()` is called
- Within `IPAddress.clean()`, the value of `primary_ip{version}` is only validated if the caller is not `IPAddressForm.clean()`
- This is gated by a boolean that is saved at `IPAddresss._primary_ip_unset_by_form` by `IPAddressForm.clean()` if the `primary_for_parent` checkbox is not set
- The previous logic in `IPAddressForm.save()` that was performing this behavior was removed because as best I could tell **it was never actually called**
- Additionally, `IPAddress.save()` has been removed, and the logic to lowercase `self.dns_name` has been moved to IPAddress.clean()`
