### PR TITLE
Job aborts when run with value None for an optional ObjectVar

### DIFF
--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -140,6 +140,13 @@ All models that have `slug` fields now use `AutoSlugField` from the `django-exte
 
 Just as with the UI, the `slug` can still always be explicitly set if desired.
 
+## v1.2.5 (2022-??-??)
+
+### Fixed
+
+- [#1233](https://github.com/nautobot/nautobot/issues/1233) - Prevented a job aborting when an optional ObjectVar is
+  provided with a value of None
+
 ## v1.2.4 (2022-??-??)
 
 ### Added
@@ -171,7 +178,6 @@ Just as with the UI, the `slug` can still always be explicitly set if desired.
 - [#1220](https://github.com/nautobot/nautobot/issues/1220) - Fixed an inconsistency in the breadcrumbs seen in various Admin pages.
 - [#1228](https://github.com/nautobot/nautobot/issues/1228) - Fixed a case where a GraphQL query for objects associated by Relationships could potentially throw an exception.
 - [#1229](https://github.com/nautobot/nautobot/pull/1229) - Fixed a template rendering error in the login page.
-- [#1233](https://github.com/nautobot/nautobot/issues/1233) - Prevented a job aborting when an optional ObjectVar is provided with a value of None
 - [#1234](https://github.com/nautobot/nautobot/issues/1234) - Fixed missing changelog support for Custom Fields.
 
 ### Security

--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -171,6 +171,7 @@ Just as with the UI, the `slug` can still always be explicitly set if desired.
 - [#1220](https://github.com/nautobot/nautobot/issues/1220) - Fixed an inconsistency in the breadcrumbs seen in various Admin pages.
 - [#1228](https://github.com/nautobot/nautobot/issues/1228) - Fixed a case where a GraphQL query for objects associated by Relationships could potentially throw an exception.
 - [#1229](https://github.com/nautobot/nautobot/pull/1229) - Fixed a template rendering error in the login page.
+- [#1233](https://github.com/nautobot/nautobot/issues/1233) - Prevented a job aborting when an optional ObjectVar is provided with a value of None
 - [#1234](https://github.com/nautobot/nautobot/issues/1234) - Fixed missing changelog support for Custom Fields.
 
 ### Security

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -324,11 +324,6 @@ class BaseJob:
             except KeyError:
                 continue
 
-            # Note: BooleanVar.required is automatically set to False in its constructor after instantiation
-            is_required = var.field_attrs.get("required", False)
-            if is_required and not value:
-                raise ValidationError
-
             try:
                 if isinstance(var, MultiObjectVar):
                     queryset = var.field_attrs["queryset"].filter(pk__in=value)
@@ -355,9 +350,10 @@ class BaseJob:
                     return_data[field_name] = netaddr.IPNetwork(value)
                 else:
                     return_data[field_name] = value
-            except ObjectDoesNotExist:
-                if is_required:
-                    raise ValidationError(f"Failed to find requested objects for required var {field_name}")
+
+            except ObjectDoesNotExist as e:
+                if var.field_attrs.get("required", False):
+                    return_data[field_name] = str(e)
                 else:
                     return_data[field_name] = None
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -330,10 +330,6 @@ class BaseJob:
                     return_data[field_name] = value
                     continue
 
-            # if value is None and not var.field_attrs.get("required"):
-            #     return_data[field_name] = value
-            #     continue
-
             if isinstance(var, MultiObjectVar):
                 queryset = var.field_attrs["queryset"].filter(pk__in=value)
                 if queryset.count() < len(value):

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -17,7 +17,6 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.validators import RegexValidator
 from django.db import transaction
@@ -324,9 +323,16 @@ class BaseJob:
             except KeyError:
                 continue
 
-            if value is None and not var.field_attrs.get("required", False):
-                return_data[field_name] = value
-                continue
+            if value is None:
+                if var.field_attrs.get("required"):
+                    raise ValidationError(f"{field_name} is a required field")
+                else:
+                    return_data[field_name] = value
+                    continue
+
+            # if value is None and not var.field_attrs.get("required"):
+            #     return_data[field_name] = value
+            #     continue
 
             if isinstance(var, MultiObjectVar):
                 queryset = var.field_attrs["queryset"].filter(pk__in=value)

--- a/nautobot/extras/tests/dummy_jobs/test_object_var_optional.py
+++ b/nautobot/extras/tests/dummy_jobs/test_object_var_optional.py
@@ -11,4 +11,4 @@ class TestOptionalObjectVar(Job):
 
     def run(self, data, commit):
         self.log_info(obj=data["region"], message="The Region if any that the user provided.")
-        return "Nice Region (or not), sis."
+        return "Nice Region (or not)!"

--- a/nautobot/extras/tests/dummy_jobs/test_object_var_required.py
+++ b/nautobot/extras/tests/dummy_jobs/test_object_var_required.py
@@ -1,0 +1,14 @@
+from nautobot.extras.jobs import Job, ObjectVar
+from nautobot.dcim.models import Region
+
+
+class TestRequiredObjectVar(Job):
+    region = ObjectVar(
+        description="Region (required)",
+        model=Region,
+        required=True,
+    )
+
+    def run(self, data, commit):
+        self.log_info(obj=data["region"], message="The Region that the user provided.")
+        return "Nice Region!"

--- a/nautobot/extras/tests/dummy_jobs/test_optional_object_var.py
+++ b/nautobot/extras/tests/dummy_jobs/test_optional_object_var.py
@@ -1,0 +1,14 @@
+from nautobot.extras.jobs import Job, ObjectVar
+from nautobot.dcim.models import Region
+
+
+class TestOptionalObjectVar(Job):
+    region = ObjectVar(
+        description="Region (optional)",
+        model=Region,
+        required=False,
+    )
+
+    def run(self, data, commit):
+        self.log_info(obj=data["region"], message="The Region if any that the user provided.")
+        return "Nice Region (or not), sis."

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -13,7 +13,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test.client import RequestFactory
 
-from nautobot.dcim.models import DeviceRole, Region, Site
+from nautobot.dcim.models import DeviceRole, Site
 from nautobot.extras.choices import JobResultStatusChoices, LogLevelChoices
 from nautobot.extras.jobs import get_job, run_job
 from nautobot.extras.models import FileProxy, JobResult, Status

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -335,43 +335,6 @@ class JobTest(TestCase):
             self.assertEqual(info_log.message, "The Region if any that the user provided.")
             self.assertEqual(job_result.data["output"], "\nNice Region (or not), sis.")
 
-            region = Region.objects.create(name="London", slug="london")
-            data = {
-                "region": region.pk,
-            }
-            # Run the job with the optional var provided
-            run_job(data=data, request=self.request, commit=True, job_result_pk=job_result.pk)
-            job_result.refresh_from_db()
-
-            info_log.delete()
-            info_log = JobLogEntry.objects.filter(
-                job_result=job_result, log_level=LogLevelChoices.LOG_INFO, grouping="run"
-            ).first()
-
-            # Assert stuff
-            self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
-            self.assertEqual(info_log.log_object, "London")
-            self.assertEqual(info_log.message, "The Region if any that the user provided.")
-            self.assertEqual(job_result.data["output"], "\nNice Region (or not), sis.")
-
-            # Run the job with a non-existent region
-            data = {
-                "region": uuid.uuid4(),
-            }
-            run_job(data=data, request=self.request, commit=True, job_result_pk=job_result.pk)
-            job_result.refresh_from_db()
-
-            info_log.delete()
-            info_log = JobLogEntry.objects.filter(
-                job_result=job_result, log_level=LogLevelChoices.LOG_INFO, grouping="run"
-            ).first()
-
-            # Assert stuff
-            self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
-            self.assertEqual(info_log.log_object, None)
-            self.assertEqual(info_log.message, "The Region if any that the user provided.")
-            self.assertEqual(job_result.data["output"], "\nNice Region (or not), sis.")
-
     def test_job_data_as_string(self):
         """
         Test that job doesn't error when not a dictionary.

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -307,7 +307,7 @@ class JobTest(TestCase):
         Test that an optional Object variable field behaves as expected.
         """
         with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
-            module = "test_optional_object_var"
+            module = "test_object_var_optional"
             name = "TestOptionalObjectVar"
             job_class = get_job(f"local/{module}/{name}")
 
@@ -333,7 +333,34 @@ class JobTest(TestCase):
             self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
             self.assertEqual(info_log.log_object, None)
             self.assertEqual(info_log.message, "The Region if any that the user provided.")
-            self.assertEqual(job_result.data["output"], "\nNice Region (or not), sis.")
+            self.assertEqual(job_result.data["output"], "\nNice Region (or not)!")
+
+    def test_required_object_var(self):
+        """
+        Test that a required Object variable field behaves as expected.
+        """
+        with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+            module = "test_object_var_required"
+            name = "TestRequiredObjectVar"
+            job_class = get_job(f"local/{module}/{name}")
+
+            # Prepare the job data
+            job_result = JobResult.objects.create(
+                name=job_class.class_path,
+                obj_type=self.job_content_type,
+                user=None,
+                job_id=uuid.uuid4(),
+            )
+            data = {"region": None}
+            run_job(data=data, request=None, commit=False, job_result_pk=job_result.pk)
+            job_result.refresh_from_db()
+
+            # Assert stuff
+            self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_ERRORED)
+            log_failure = JobLogEntry.objects.filter(
+                grouping="initialization", log_level=LogLevelChoices.LOG_FAILURE
+            ).first()
+            self.assertIn("region is a required field", log_failure.message)
 
     def test_job_data_as_string(self):
         """


### PR DESCRIPTION
### Fixes: #1233
Modified nautobot.extras.jobs.BaseJob.deserialize_data so that it works properly with object vars which aren't required.