### PR TITLE
Fixing GHA Syntax and Slack payload.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,9 +134,21 @@ jobs:
         # ENVs cannot be used directly in job.if. This is a workaround to check
         # if SLACK_WEBHOOK_URL is present.
         if: "${{ env.SLACK_WEBHOOK_URL != '' }}"
-        uses: "slackapi/slack-github-action@v1.16.0"
+        uses: "slackapi/slack-github-action@v1.17.0"
         with:
-          payload: { "type": "mrkdwn", "text": "${{ env.SLACK_MESSAGE }}" } # yamllint disable-line rule:quoted-strings rule:braces rule:comments
+          payload: |
+            {
+              "text": "${{ env.SLACK_MESSAGE }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ env.SLACK_MESSAGE }}"
+                  }
+                }
+              ]
+            }
         env:
           SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
           SLACK_WEBHOOK_TYPE: "INCOMING_WEBHOOK"


### PR DESCRIPTION
This should fix https://github.com/nautobot/nautobot/actions/runs/1694687279 the payload should be a string and per the docs at https://github.com/nautobot/nautobot/compare/develop...nniehoff:nn_release_slack?expand=1 it looks like the payload has changed with version 1.17.0