### PR TITLE
Fix 1278: Add 'get_absolute_url' method to CircuitTermination model.

### DIFF
--- a/nautobot/circuits/models.py
+++ b/nautobot/circuits/models.py
@@ -240,10 +240,10 @@ class CircuitTermination(BaseModel, PathEndpoint, CableTermination, Relationship
         unique_together = ["circuit", "term_side"]
 
     def __str__(self):
-        return "{} - Side {}".format(self.circuit.cid, self.term_side)
+        return f"Termination {self.term_side}: {self.site}"
 
     def get_absolute_url(self):
-        return reverse("circuits:circuit", args=[self.circuit.pk])
+        return self.site.get_absolute_url()
 
     def to_objectchange(self, action):
         # Annotate the parent Circuit

--- a/nautobot/circuits/models.py
+++ b/nautobot/circuits/models.py
@@ -240,7 +240,7 @@ class CircuitTermination(BaseModel, PathEndpoint, CableTermination, Relationship
         unique_together = ["circuit", "term_side"]
 
     def __str__(self):
-        return "Side {}".format(self.get_term_side_display())
+        return "{} - Side {}".format(self.circuit.cid, self.get_term_side_display())
 
     def get_absolute_url(self):
         return reverse("circuits:circuit", args=[self.circuit.pk])

--- a/nautobot/circuits/models.py
+++ b/nautobot/circuits/models.py
@@ -240,7 +240,7 @@ class CircuitTermination(BaseModel, PathEndpoint, CableTermination, Relationship
         unique_together = ["circuit", "term_side"]
 
     def __str__(self):
-        return "{} - Side {}".format(self.circuit.cid, self.get_term_side_display())
+        return "{} - Side {}".format(self.circuit.cid, self.term_side)
 
     def get_absolute_url(self):
         return reverse("circuits:circuit", args=[self.circuit.pk])

--- a/nautobot/circuits/models.py
+++ b/nautobot/circuits/models.py
@@ -242,6 +242,9 @@ class CircuitTermination(BaseModel, PathEndpoint, CableTermination, Relationship
     def __str__(self):
         return "Side {}".format(self.get_term_side_display())
 
+    def get_absolute_url(self):
+        return reverse("circuits:circuit", args=[self.circuit.pk])
+
     def to_objectchange(self, action):
         # Annotate the parent Circuit
         try:


### PR DESCRIPTION

### Fixes: #1278

This fixes an issue with the CircuitTermination where it did not have a `get_absolute_url` method, due to the lack of a detail CircuitTermination view.  Since the CircuitTermination detail is usually viewed within a panel on the parent Circuit detail page, the parent Circuit url is returned instead.  

Additionally, the CircuitTermination.__str__ method will include the parent Circuit.cid to differentiate it from other CircuitTerminations.
