### PR TITLE
Webhooks provide old data together with new data

### DIFF
--- a/nautobot/extras/models/change_logging.py
+++ b/nautobot/extras/models/change_logging.py
@@ -28,6 +28,10 @@ class ChangeLoggedModel(models.Model):
     class Meta:
         abstract = True
 
+    def snapshot(self):
+        """Save a snapshot of the object's current state."""
+        self._prechange_snapshot = serialize_object(self)
+
     def to_objectchange(self, action):
         """
         Return a new ObjectChange representing a change made to this object. This will typically be called automatically

--- a/nautobot/extras/tasks.py
+++ b/nautobot/extras/tasks.py
@@ -98,7 +98,7 @@ def provision_field(field_id, content_type_pk_set):
 
 
 @nautobot_task
-def process_webhook(webhook_pk, data, model_name, event, timestamp, username, request_id):
+def process_webhook(webhook_pk, data, snapshot, model_name, event, timestamp, username, request_id):
     """
     Make a POST request to the defined Webhook
     """
@@ -113,6 +113,7 @@ def process_webhook(webhook_pk, data, model_name, event, timestamp, username, re
         "username": username,
         "request_id": request_id,
         "data": data,
+        "snapshot": snapshot
     }
 
     # Build the headers for the HTTP request

--- a/nautobot/extras/tasks.py
+++ b/nautobot/extras/tasks.py
@@ -113,7 +113,7 @@ def process_webhook(webhook_pk, data, snapshot, model_name, event, timestamp, us
         "username": username,
         "request_id": request_id,
         "data": data,
-        "snapshot": snapshot
+        "snapshot": snapshot,
     }
 
     # Build the headers for the HTTP request

--- a/nautobot/extras/tests/test_webhooks.py
+++ b/nautobot/extras/tests/test_webhooks.py
@@ -79,10 +79,12 @@ class WebhookTest(APITestCase):
                 "request": None,
             }
             serializer = SiteSerializer(site, context=serializer_context)
+            snapshot = None
 
             process_webhook(
                 webhook.pk,
                 serializer.data,
+                snapshot,
                 Site._meta.model_name,
                 ObjectChangeActionChoices.ACTION_CREATE,
                 timestamp,

--- a/nautobot/extras/webhooks.py
+++ b/nautobot/extras/webhooks.py
@@ -35,7 +35,7 @@ def enqueue_webhooks(instance, user, request_id, action):
             "request": None,
         }
         serializer = serializer_class(instance, context=serializer_context)
-        snapshot = getattr(instance, '_prechange_snapshot', None)
+        snapshot = getattr(instance, "_prechange_snapshot", None)
 
         # Enqueue the webhooks
         for webhook in webhooks:

--- a/nautobot/extras/webhooks.py
+++ b/nautobot/extras/webhooks.py
@@ -35,12 +35,14 @@ def enqueue_webhooks(instance, user, request_id, action):
             "request": None,
         }
         serializer = serializer_class(instance, context=serializer_context)
+        snapshot = getattr(instance, '_prechange_snapshot', None)
 
         # Enqueue the webhooks
         for webhook in webhooks:
             args = [
                 webhook.pk,
                 serializer.data,
+                snapshot,
                 instance._meta.model_name,
                 action,
                 str(timezone.now()),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #330
Add feature to Webhooks to provide both old data together with new data

### Snapshot
A Snapshot(a.k.a old data) in this context is the current serialised state of a Model instance before any modifications are made.
Calling .snapshot() on an instance saves the serialized state of that model in _prechange_snapshot
e.g
```
class Site(models.Model):
  ...

  def snapshot(self):
         self._prechange_snapshot = serialize_object(self)
```


**How snapshots are taken**
```
Site.objects.create(name="Initial Site name", slug="site-1")

obj = get_object_or_404(Site, pk=1)
obj.snapshot  # Saves a snapshot
obj.name = "Updated Site name"
obj.save()
```

**To safely get the snapshot of an Instance**
```
snapshot = getattr(obj, "_prechange_snapshot", None)
# snapshot output
 {
   "name": "Initial Site name",
   "slug": "site-1"
 }
```

### Workflow on how snapshots are taken
**Scenario 1 - Update a Site**
1. User clicks on the edit button of a Site.

2. User updates the desired fields, and clicks update. 
_A snapshot of the object is taken in `ObjectEditView.get_object()` [L291](https://github.com/nautobot/nautobot/pull/1310/files#diff-6d6d85115c2145f877fca192b072690e4d8945d576ca00bff5ad903cce84c2bcR291), This way a snapshot is taken right on time before the instance is updated_

3. webhook is triggered & the snapshot of the site instance is gotten [L38](https://github.com/nautobot/nautobot/pull/1310/files#diff-b13ba2af18422828dc8d1c2b59283e9d81044dfc3d9d6fabe042ba4a335460b1R38), and added to the request body [L45](https://github.com/nautobot/nautobot/pull/1310/files#diff-b13ba2af18422828dc8d1c2b59283e9d81044dfc3d9d6fabe042ba4a335460b1R45), [L116](https://github.com/nautobot/nautobot/pull/1310/files#diff-37ccb0d12d2ea242fbc295e9d85ecf7d8cb4ca933030c05b8aa31b65e92bb0b0R116)

```
{
    "event": "created",
    "timestamp": "2020-02-25 15:10:26.010582+00:00",
    "model": "site",
    "username": "jstretch",
    "request_id": "fdbca812-3142-4783-b364-2e2bd5c16c6a",
    "data": {
        "id": 19,
        "name": "Updated Site name",
        "slug": "site-1"
        },
        ...
    },
    "snapshot": {
        "id": 19,
        "name": "Initial Site name",
        "slug": "site-1"
        },
        ...
    }
}
```



