### PR TITLE
[WIP] Set Default Docker Compose Platform

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -105,7 +105,11 @@ def docker_compose(context, command, **kwargs):
         compose_command += f" {service}"
 
     print(f'Running docker-compose command "{command}"')
-    return context.run(compose_command, env={"PYTHON_VER": context.nautobot.python_ver, "DOCKER_DEFAULT_PLATFORM": "linux/amd64"}, **kwargs)
+    return context.run(
+        compose_command,
+        env={"PYTHON_VER": context.nautobot.python_ver, "DOCKER_DEFAULT_PLATFORM": "linux/amd64"},
+        **kwargs,
+    )
 
 
 def run_command(context, command, **kwargs):

--- a/tasks.py
+++ b/tasks.py
@@ -105,7 +105,7 @@ def docker_compose(context, command, **kwargs):
         compose_command += f" {service}"
 
     print(f'Running docker-compose command "{command}"')
-    return context.run(compose_command, env={"PYTHON_VER": context.nautobot.python_ver}, **kwargs)
+    return context.run(compose_command, env={"PYTHON_VER": context.nautobot.python_ver, "DOCKER_DEFAULT_PLATFORM": "linux/amd64"}, **kwargs)
 
 
 def run_command(context, command, **kwargs):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #DNE
<!--
    Please include a summary of the proposed changes below.
-->

WIP: Don't know if we want to take this ENV_VAR as an argument and allow it to be overridden.


While developers on Apple Silicon platforms can run their entire environment under Rosetta to get around this, we know dependencies currently don't support arm64 images at the moment.

With just telling Docker what we want the default platform the images to be based on we can get the `docker-compose` command to work without any specific Rosetta or Docker Desktop settings.

This is following similar to how we have the buildx settings being set to default to `amd64`: https://github.com/nautobot/nautobot/blob/5c256026027efb2abd224e0e8e16a744de6c1341/tasks.py#L158-L168

Working `invoke` commands:

```
➜ arch
arm64

➜ docker info
Client:
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc., v0.7.1)
  compose: Docker Compose (Docker Inc., v2.2.3)
  scan: Docker Scan (Docker Inc., v0.16.0)

Server:
 Containers: 9
  Running: 7
  Paused: 0
  Stopped: 2
 Images: 4
 Server Version: 20.10.12
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: cgroupfs
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 io.containerd.runtime.v1.linux runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 7b11cfaabd73bb80907dd23182b9347b4245eb5d
 runc version: v1.0.2-0-g52b36a2
 init version: de40ad0
 Security Options:
  seccomp
   Profile: default
  cgroupns
 Kernel Version: 5.10.76-linuxkit
 Operating System: Docker Desktop
 OSType: linux
 Architecture: aarch64
 CPUs: 4
 Total Memory: 7.765GiB
 Name: docker-desktop
 ID: T5WO:5QSM:PZLV:UMLQ:BDCM:36NX:AMHH:HNOQ:I2JB:NC7E:PRE3:UZM6
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false

➜ docker version
Client:
 Cloud integration: v1.0.22
 Version:           20.10.12
 API version:       1.41
 Go version:        go1.16.12
 Git commit:        e91ed57
 Built:             Mon Dec 13 11:46:56 2021
 OS/Arch:           darwin/arm64
 Context:           default
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          20.10.12
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.16.12
  Git commit:       459d0df
  Built:            Mon Dec 13 11:43:07 2021
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.4.12
  GitCommit:        7b11cfaabd73bb80907dd23182b9347b4245eb5d
 runc:
  Version:          1.0.2
  GitCommit:        v1.0.2-0-g52b36a2
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0

➜ invoke migrate
...
#21 32.81 Skipping virtualenv creation, as specified in config file.
#21 45.61 Installing dependencies from lock file
#21 57.12 Warning: The lock file is not up to date with the latest changes in pyproject.toml. You may be getting outdated dependencies. Run update to update them.
#21 67.27
#21 67.27 No dependencies to install or update
#21 67.53
#21 67.53 Installing the current project: nautobot (1.2.5-beta.1)
#21 DONE 67.9s

#22 exporting to image
#22 sha256:e8c613e07b0b7ff33893b694f7759a10d42e180f2b4dc349fb57dc6b71dcab00
#22 exporting layers
#22 exporting layers 1.6s done
#22 writing image sha256:df6d30ceece6faf8621820877dfe9525790c8f5adeff1ba7e302a637ae8af7cc done
#22 naming to docker.io/networktocode/nautobot-dev-py3.6:local done
#22 DONE 1.6s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them


➜ invoke migrate
Running docker-compose command "ps --services --filter status=running"
Running docker-compose command "run --entrypoint 'nautobot-server migrate' nautobot"
[+] Running 4/0
 ⠿ Network nautobot_default       Created                                                      0.0s
 ⠿ Container nautobot-redis-1     Created                                                      0.0s
 ⠿ Container nautobot-selenium-1  Created                                                      0.1s
 ⠿ Container nautobot-postgres-1  Created                                                      0.0s
[+] Running 3/3
 ⠿ Container nautobot-postgres-1  Started                                                      0.2s
 ⠿ Container nautobot-selenium-1  Started                                                      0.3s
 ⠿ Container nautobot-redis-1     Started                                                      0.2s
Operations to perform:
  Apply all migrations: admin, auth, circuits, contenttypes, database, dcim, django_celery_beat, extras, ipam, sessions, social_django, taggit, tenancy, users, virtualization
Running migrations:
  Applying dcim.0004_initial_part_4... OK
  Applying extras.0003_initial_part_3... OK
  Applying extras.0004_populate_default_status_records...
    Model dcim.Device
      Adding and linking status Offline
      Adding and linking status Active
      Adding and linking status Planned
      Adding and linking status Staged
      Adding and linking status Failed
      Adding and linking status Inventory
      Adding and linking status Decommissioning
...
  Applying virtualization.0002_virtualmachine_local_context_schema... OK
  Applying virtualization.0003_vminterface_verbose_name... OK
  Applying virtualization.0004_auto_slug... OK


➜ invoke createsuperuser
Running docker-compose command "ps --services --filter status=running"
Running docker-compose command "run --entrypoint 'nautobot-server createsuperuser --username admin' nautobot"
[+] Running 3/0
 ⠿ Container nautobot-redis-1     Running                                                      0.0s
 ⠿ Container nautobot-selenium-1  Running                                                      0.0s
 ⠿ Container nautobot-postgres-1  Running                                                      0.0s
Email address: bryan.culver@networktocode.com
Password:
Password (again):
Superuser created successfully.


➜ invoke debug
Starting Nautobot in debug mode...
Running docker-compose command "up"
Container nautobot-selenium-1  Running
Container nautobot-postgres-1  Running
Container nautobot-redis-1  Running
Container nautobot-nautobot-1  Creating
Container nautobot-nautobot-1  Created
Container nautobot-worker-1  Creating
Container nautobot-celery_worker-1  Creating
Container nautobot-celery_beat-1  Creating
Container nautobot-celery_worker-1  Created
Container nautobot-worker-1  Created
Container nautobot-celery_beat-1  Created
Attaching to nautobot-celery_beat-1, nautobot-celery_worker-1, nautobot-nautobot-1, nautobot-postgres-1, nautobot-redis-1, nautobot-selenium-1, nautobot-worker-1
...
nautobot-nautobot-1       | System check identified no issues (0 silenced).
nautobot-nautobot-1       | January 31, 2022 - 20:39:25
nautobot-nautobot-1       | Django version 3.1.14, using settings 'nautobot_config'
nautobot-nautobot-1       | Starting development server at http://0.0.0.0:8080/
nautobot-nautobot-1       | Quit the server with CONTROL-C.
nautobot-nautobot-1       | 20:39:25.103 INFO    nautobot             __init__.py                              setup() :
nautobot-nautobot-1       |   Nautobot initialized!
nautobot-nautobot-1       | 20:39:28.428 INFO    django.server :
nautobot-nautobot-1       |   "GET /health/ HTTP/1.1" 200 11760
...
```