### PR TITLE
Installed locked dependencies in final Docker image as well as dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,6 +92,9 @@ COPY nautobot /source/nautobot
 RUN poetry build && \
     poetry install --no-ansi --extras all
 
+# Convert poetry.lock to a requirements.txt file for use in the cleaninstall container
+RUN poetry export --extras all --format requirements.txt --output /tmp/locked_requirements.txt
+
 ################################ Stage: cleaninstall
 # Build an image with required dependencies to pull the installation from
 FROM base as cleaninstall
@@ -104,7 +107,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y build-essential
 RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi
 
 COPY --from=dev /source/dist/*.whl /tmp
+COPY --from=dev /tmp/locked_requirements.txt /tmp
 
+RUN pip install --no-cache-dir -r /tmp/locked_requirements.txt
 # hadolint ignore=DL3013,SC2102
 RUN for whl in /tmp/nautobot*.whl; do pip install --no-cache-dir ${whl}[all]; done
 


### PR DESCRIPTION
### Fixes: #792

Use the `poetry export` command to create a `locked_requirements.txt` file from within the `dev` container, copy this file into the `cleaninstall` container, and do a `pip install -r locked_requirements.txt` before installing the Nautobot wheel into `cleaninstall`. This ensures that the `final` image gets the same version of its dependencies installed as the `dev` image, minus the dev-only dependencies of course, as can be verified by comparing `pip list` between the two images:

```
diff -uw pip.dev.txt pip.prod.txt              
--- pip.dev.txt	2022-02-01 12:59:10.000000000 -0500
+++ pip.prod.txt	2022-02-01 12:54:56.000000000 -0500
@@ -1,5 +1,5 @@
 Package                        Version
------------------------------- ---------
+------------------------- ---------
 aiocontextvars                 0.2.2
 amqp                           5.0.9
 aniso8601                      7.0.0
@@ -7,7 +7,6 @@
 attrs                          21.4.0
 bcrypt                         3.2.0
 billiard                       3.6.4.0
-black                          21.12b0
 cached-property                1.5.2
 celery                         5.1.2
 certifi                        2021.10.8
@@ -15,15 +14,13 @@
 chardet                        4.0.0
 ciscoconfparse                 1.6.21
 click                          7.1.2
-click-didyoumean               0.3.0
+click-didyoumean          0.0.3
 click-plugins                  1.1.1
 click-repl                     0.2.0
 contextvars                    2.4
 coreapi                        2.3.3
 coreschema                     0.0.4
-coverage                       5.4
 cryptography                   36.0.1
-dataclasses                    0.8
 defusedxml                     0.7.1
 Django                         3.1.14
 django-ajax-tables             1.1.1
@@ -35,7 +32,6 @@
 django-cors-headers            3.7.0
 django-cryptography            1.0
 django-db-file-storage         0.5.5
-django-debug-toolbar           3.2.4
 django-extensions              3.1.5
 django-filter                  2.4.0
 django-health-check            3.16.5
@@ -54,12 +50,9 @@
 djangorestframework            3.12.4
 dnspython                      2.1.0
 drf-yasg                       1.20.0
-dummy-plugin                   1.0.0
 ecdsa                          0.17.0
-flake8                         3.9.2
 funcy                          1.17
 future                         0.18.2
-ghp-import                     2.0.2
 gitdb                          4.0.9
 GitPython                      3.1.18
 graphene                       2.1.9
@@ -72,7 +65,6 @@
 importlib-metadata             4.4.0
 importlib-resources            5.4.0
 inflection                     0.5.1
-invoke                         1.5.1
 ipaddr                         2.2.0
 isodate                        0.6.1
 itypes                         1.2.0
@@ -84,11 +76,6 @@
 lxml                           4.7.1
 Markdown                       3.3.6
 MarkupSafe                     2.0.1
-mccabe                         0.6.1
-mergedeep                      1.3.4
-mkdocs                         1.2.3
-mkdocs-include-markdown-plugin 3.0.1
-mypy-extensions                0.4.3
 mysqlclient                    2.0.3
 napalm                         3.3.1
 nautobot                       1.2.5b1
@@ -101,21 +88,17 @@
 packaging                      21.3
 paramiko                       2.9.2
 passlib                        1.7.4
-pathspec                       0.9.0
 Pillow                         8.3.2
 pip                            21.3.1
-platformdirs                   2.4.0
 prometheus-client              0.12.0
 promise                        2.3
-prompt-toolkit                 3.0.24
+prompt-toolkit            3.0.3
 psycopg2-binary                2.8.6
 pyasn1                         0.4.8
 pyasn1-modules                 0.2.8
-pycodestyle                    2.7.0
 pycparser                      2.21
 pycryptodome                   3.10.4
 pyeapi                         0.8.4
-pyflakes                       2.3.1
 PyJWT                          2.3.0
 PyNaCl                         1.5.0
 pyparsing                      3.0.6
@@ -130,7 +113,6 @@
 pytz                           2021.3
 pyuwsgi                        2.0.20
 PyYAML                         5.4.1
-pyyaml_env_tag                 0.1
 redis                          3.5.3
 requests                       2.25.1
 requests-oauthlib              1.3.0
@@ -140,14 +122,12 @@
 ruamel.yaml.clib               0.2.6
 Rx                             1.6.1
 scp                            0.14.2
-selenium                       3.141.0
 setuptools                     56.0.0
 singledispatch                 3.7.0
 six                            1.16.0
 smmap                          5.0.0
 social-auth-app-django         4.0.0
 social-auth-core               4.1.0
-splinter                       0.14.0
 sqlparse                       0.4.2
 svgwrite                       1.4.1
 swagger-spec-validator         2.7.4
@@ -155,14 +135,11 @@
 text-unidecode                 1.3
 textfsm                        1.1.2
 toml                           0.10.2
-tomli                          1.2.3
 transitions                    0.8.10
-typed-ast                      1.5.1
 typing_extensions              4.0.1
 uritemplate                    4.1.1
 urllib3                        1.26.8
 vine                           5.0.0
-watchdog                       2.1.6
 wcwidth                        0.2.5
 wheel                          0.37.1
 xmlsec                         1.3.12
```

 