### PR TITLE
Rollback #1323

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,9 +92,6 @@ COPY nautobot /source/nautobot
 RUN poetry build && \
     poetry install --no-ansi --extras all
 
-# Convert poetry.lock to a requirements.txt file for use in the cleaninstall container
-RUN poetry export --extras all --format requirements.txt --output /tmp/locked_requirements.txt
-
 ################################ Stage: cleaninstall
 # Build an image with required dependencies to pull the installation from
 FROM base as cleaninstall
@@ -107,9 +104,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y build-essential
 RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi
 
 COPY --from=dev /source/dist/*.whl /tmp
-COPY --from=dev /tmp/locked_requirements.txt /tmp
 
-RUN pip install --no-cache-dir -r /tmp/locked_requirements.txt
 # hadolint ignore=DL3013,SC2102
 RUN for whl in /tmp/nautobot*.whl; do pip install --no-cache-dir ${whl}[all]; done
 

--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -144,7 +144,6 @@ Just as with the UI, the `slug` can still always be explicitly set if desired.
 
 ### Changed
 
-- [#792](https://github.com/nautobot/nautobot/issues/792) - `final` Docker images now are built with the same (non-development-exclusive) installed Python dependencies as the `dev` images.
 - [#1293](https://github.com/nautobot/nautobot/pull/1293) - Reorganized the developer documents somewhat to reduce duplication of information, added diagrams for issue intake process.
 
 ### Fixed


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Reverts #1323
<!--
    Please include a summary of the proposed changes below.
-->

#1323 introduced Docker image build failures for any Python version other than 3.6, due to an apparent bug in Poetry (which I'm working to narrow down to a minimal reproducible example and will file against Poetry when known). See https://github.com/nautobot/nautobot/runs/5040805247?check_suite_focus=true for an example of the failure, but basically it appears to boil down to Poetry mis-handling our conditional dependency on different versions of Celery depending on the Python version:

```
celery==5.1.2; python_version >= "3.6" or python_version < "3.7" \
```

the `or` above would more correctly be an `and`.

Rolling this back for now so as to not block the release of 1.2.5.

