### PR TITLE
Fixing Job dependencies for Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
   container-publish:
     runs-on: "ubuntu-20.04"
     needs:
-      - "integration-test"
+      - "publish_python"
     strategy:
       fail-fast: true
       matrix:
@@ -119,8 +119,8 @@ jobs:
 
   slack-notify:
     needs:
-      - "publish_gh"
-      - "publish_pypi"
+      - "publish_python"
+      - "container-publish"
     runs-on: "ubuntu-20.04"
     env:
       SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ jobs:
           user: "__token__"
           password: "${{ secrets.PYPI_API_TOKEN }}"
 
-  container-publish:
+  publish_containers:
     runs-on: "ubuntu-20.04"
     needs:
-      - "publish_python"
+      - "ci"
     strategy:
       fail-fast: true
       matrix:
@@ -120,7 +120,7 @@ jobs:
   slack-notify:
     needs:
       - "publish_python"
-      - "container-publish"
+      - "publish_containers"
     runs-on: "ubuntu-20.04"
     env:
       SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"


### PR DESCRIPTION
This PR Fixes the broken dependencies from the Release action.  🤞 1.2.6 can use this action.