### PR TITLE
Respect settings.PAGINATE_COUNT in default REST API pagination (#1329)

### DIFF
--- a/nautobot/core/api/pagination.py
+++ b/nautobot/core/api/pagination.py
@@ -52,7 +52,7 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
             except (KeyError, ValueError):
                 pass
 
-        return self.default_limit
+        return get_settings_or_config("PAGINATE_COUNT")
 
     def get_next_link(self):
 

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -1,7 +1,13 @@
 import json
 
+from django.conf import settings
 from django.urls import reverse
+from django.test import override_settings
 
+from constance import config
+from constance.test import override_config
+
+from nautobot.circuits.models import Provider
 from nautobot.utilities.testing import APITestCase
 
 
@@ -24,3 +30,99 @@ class AppTest(APITestCase):
         self.assertEqual(response.status_code, 404)
         response_json = json.loads(response.content)
         self.assertEqual(response_json, {"detail": "Not found."})
+
+
+class APIPaginationTestCase(APITestCase):
+    """
+    Testing our custom API pagination, OptionalLimitOffsetPagination.
+
+    Since there are no "core" API views that are paginated, we test one of our apps' API views.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        for i in range(10):
+            Provider.objects.create(name=f"Provider {i}", slug=f"provider-{i}")
+
+        cls.url = reverse("circuits-api:provider-list")
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"], PAGINATE_COUNT=5, MAX_PAGE_SIZE=10)
+    def test_pagination_defaults_to_paginate_count(self):
+        """If no limit is specified, default pagination to settings.PAGINATE_COUNT."""
+        response = self.client.get(self.url, **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), settings.PAGINATE_COUNT)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"], PAGINATE_COUNT=5, MAX_PAGE_SIZE=10)
+    def test_pagination_respects_specified_limit(self):
+        """Request with a specific limit and verify that it's respected."""
+        limit = settings.PAGINATE_COUNT - 2
+        response = self.client.get(f"{self.url}?limit={limit}", **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), limit)
+
+        limit = settings.PAGINATE_COUNT + 2  # but still less than MAX_PAGE_SIZE
+        response = self.client.get(f"{self.url}?limit={limit}", **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), limit)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"], PAGINATE_COUNT=3, MAX_PAGE_SIZE=5)
+    def test_pagination_limits_to_max_page_size(self):
+        """Request more than the configured MAX_PAGE_SIZE and verify the limit is enforced."""
+        limit = settings.MAX_PAGE_SIZE + 2
+        response = self.client.get(f"{self.url}?limit={limit}", **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), settings.MAX_PAGE_SIZE)
+
+        limit = 0  # as many as permitted
+        response = self.client.get(f"{self.url}?limit={limit}", **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), settings.MAX_PAGE_SIZE)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"], PAGINATE_COUNT=5, MAX_PAGE_SIZE=0)
+    def test_max_page_size_zero(self):
+        """MAX_PAGE_SIZE of zero means no enforced limit."""
+        response = self.client.get(self.url, **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), settings.PAGINATE_COUNT)
+
+        limit = settings.PAGINATE_COUNT
+        response = self.client.get(f"{self.url}?limit={limit}", **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), settings.PAGINATE_COUNT)
+
+        limit = 0  # as many as permitted, i.e. all records
+        response = self.client.get(f"{self.url}?limit={limit}", **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), Provider.objects.count())
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    @override_config(PAGINATE_COUNT=5, MAX_PAGE_SIZE=10)
+    def test_pagination_based_on_constance(self):
+        """In the absence of settings values, constance settings should be respected."""
+        del settings.PAGINATE_COUNT
+        del settings.MAX_PAGE_SIZE
+
+        response = self.client.get(self.url, **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), config.PAGINATE_COUNT)
+
+        limit = config.PAGINATE_COUNT - 2
+        response = self.client.get(f"{self.url}?limit={limit}", **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), limit)
+
+        limit = config.PAGINATE_COUNT + 2
+        response = self.client.get(f"{self.url}?limit={limit}", **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), limit)
+
+        limit = config.MAX_PAGE_SIZE + 2
+        response = self.client.get(f"{self.url}?limit={limit}", **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), config.MAX_PAGE_SIZE)
+
+        limit = 0  # as many as permitted
+        response = self.client.get(f"{self.url}?limit={limit}", **self.header)
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(response.data["results"]), config.MAX_PAGE_SIZE)


### PR DESCRIPTION
### Relates-to #1329

#1079 inadvertently changed the default behavior of the REST API when listing objects to be non-paginated (listing all objects) instead of the former behavior of defaulting to paginating with a limit of `settings.PAGINATE_COUNT`. This PR restores the original behavior, and adds test coverage.