### PR TITLE
Avoid including UI-only form fields in the form submission when editing a Secret

### DIFF
--- a/nautobot/extras/templates/extras/secret_edit.html
+++ b/nautobot/extras/templates/extras/secret_edit.html
@@ -47,7 +47,8 @@
         var parameters_value = {};
 
         $("#parameters_form :input").each(function() {
-            parameters_value[$(this).attr("name")] = $(this).val();
+            var field_key = $(this).attr("id").slice(3);  /* "id_foobar" --> "foobar" */
+            parameters_value[field_key] = $(this).val();
         });
 
         $("#id_parameters").val(JSON.stringify(parameters_value, null, 4));
@@ -65,7 +66,7 @@
         }
 
         for (const key of Object.keys(parameters_value)) {
-            $("#parameters_form [name='" + key + "']").val(parameters_value[key]);
+            $("#parameters_form #id_" + key).val(parameters_value[key]);
         }
     };
 
@@ -88,6 +89,14 @@
             context: this,
             success: function(data) {
                 $("#parameters_form").html(data);
+                /*
+                 * Strip the "name" field from every field in the parameters_form.
+                 * These fields are for user convenience only and should not be included when the form is submitted;
+                 * removing their name causes them to be omitted as desired.
+                 * See also https://github.com/nautobot/nautobot/issues/1335
+                 */
+                $("#parameters_form :input").removeAttr("name");
+
                 $("#parameters_form :input").change(changeProviderParameter);
             },
             error: function() {


### PR DESCRIPTION
### Fixes: #1335

When creating or editing a Secret, we display the provider-specific parameters in one of two ways:
1. As a set of text field inputs
2. As a JSON dictionary in a single textarea field.

The former is presented for ease-of-use in the UI, while the latter is how the parameters are actually presented to Django and stored in the database (as a JSONField).

Issue #1335 arose because we were actually submitting *both* sets of fields as part of the overall create/edit form submission. This would normally be fine (Nautobot will just ignore any fields it doesn't understand) except in the case where one of the provider-parameter text input fields has a name that "shadows" a field on the base form, i.e. we have a name collision between multiple fields.

Fortunately it turns out there's a simple fix: strip the `name` attribute from all of the UI-only fields, as browsers will not submit form fields that have no `name`.

Verified manually by installing the `nautobot-secrets-providers` plugin and creating AWS secrets, which have a provider-specific `"name"` parameter in addition to the general Secret `"name"` field. The browser dev tools (I used Firefox) show that, after my change, the provider-specific UI-only fields are no longer included in the form submission, and the Secret is correctly constructed with the expected `name` and expected AWS-specific parameters.

So yes, we remove the `name` attribute from the form fields so that we don't accidentally submit a field named `"name"` twice in one form submission. Clear as mud? :-)