### PR TITLE
Pin selenium container versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         ports:
           - "6379:6379"
       selenium:
-        image: "selenium/standalone-firefox:latest"
+        image: "selenium/standalone-firefox:3.141"
         ports:
           - "4444:4444"
     steps:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     env_file:
       - dev.env
   selenium:
-    image: selenium/standalone-firefox:latest
+    image: selenium/standalone-firefox:3.141
     ports:
         - "4444:4444"
     shm_size: 2g


### PR DESCRIPTION
### Fixes: #N/A

Pinning our development and CI Selenium docker image dependencies to the latest in the 3.x release train, as we don't support Selenium 4 yet.