### PR TITLE
Move Selenium environment variable comments in dev.env to new lines

### DIFF
--- a/development/dev.env
+++ b/development/dev.env
@@ -33,8 +33,10 @@ POSTGRES_USER=nautobot
 REDIS_PASSWORD=decinablesprewad
 
 # Needed for Selenium integration tests
-NAUTOBOT_SELENIUM_URL=http://selenium:4444/wd/hub  # WebDriver (Selenium client)
-NAUTOBOT_SELENIUM_HOST=nautobot  # LiveServer (Nautobot server)
+# WebDriver (Selenium client)
+NAUTOBOT_SELENIUM_URL=http://selenium:4444/wd/hub
+# LiveServer (Nautobot server)
+NAUTOBOT_SELENIUM_HOST=nautobot
 
 # Allow self signed git repositories for config contexts, export templates, ...
 # GIT_SSL_NO_VERIFY="1"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1360
<!--
    Please include a summary of the proposed changes below.
-->

`.env` files should not have comments on the same line. In some shells this is being picked up as a whole string, confirmed by running `invoke cli` and then `echo $NAUTOBOT_SELENIUM_URL`:

```
➜ invoke cli
Running docker-compose command "exec nautobot bash"
root@e42dd3602726:/source# echo $NAUTOBOT_SELENIUM_URL
http://selenium:4444/wd/hub # WebDriver (Selenium client)
```

Instead it should return:

```
➜ invoke cli
Running docker-compose command "exec nautobot bash"
root@e42dd3602726:/source# echo $NAUTOBOT_SELENIUM_URL
http://selenium:4444/wd/hub
```