### PR TITLE
Implement Dry Run Feature on Create, Update of Git Repository

### DIFF
--- a/nautobot/extras/datasources/__init__.py
+++ b/nautobot/extras/datasources/__init__.py
@@ -1,4 +1,5 @@
 from .git import (
+    enqueue_git_repository_diff_origin_and_local,
     enqueue_pull_git_repository_and_refresh_data,
     ensure_git_repository,
 )
@@ -9,6 +10,7 @@ from .registry import (
 )
 
 __all__ = (
+    "enqueue_git_repository_diff_origin_and_local",
     "enqueue_pull_git_repository_and_refresh_data",
     "ensure_git_repository",
     "get_datasource_content_choices",

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -314,11 +314,7 @@ def git_repository_dry_run(repository_record, job_result=None, logger=None):
             # Log each modified files
             for item in modified_files:
                 log_message = f"{item.status} - `{item.text}`"
-                job_result.log(
-                    log_message,
-                    level_choice=LogLevelChoices.LOG_INFO, 
-                    logger=logger
-                    )
+                job_result.log(log_message, level_choice=LogLevelChoices.LOG_INFO, logger=logger)
         else:
             job_result.log("Repository has no changes", level_choice=LogLevelChoices.LOG_INFO, logger=logger)
 

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -925,7 +925,7 @@ def refresh_git_export_templates(repository_record, job_result, delete=False):
 
 def update_git_export_templates(repository_record, job_result):
     """Refresh any export templates provided by this Git repository.
-    
+
     Templates are located in GIT_ROOT/<repo>/export_templates/<app_label>/<model>/<template name>.
     """
     export_template_path = os.path.join(repository_record.filesystem_path, "export_templates")

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -45,6 +45,7 @@ logger = logging.getLogger("nautobot.datasources.git")
 # namedtuple takes a job_result(JobResult instance) and a repository_record(GitRepository instance).
 GitJobResult = namedtuple("GitJobResult", ["job_result", "repository_record"])
 
+# namedtuple takes from_url(remote git repository url), to_path(local path of git repo), from_branch(git branch)
 GitRepoInfo = namedtuple("GitRepoInfo", ["from_url", "to_path", "from_branch"])
 
 

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -313,7 +313,12 @@ def git_repository_dry_run(repository_record, job_result=None, logger=None):
         if modified_files:
             # Log each modified files
             for item in modified_files:
-                job_result.log(item, level_choice=LogLevelChoices.LOG_INFO, logger=logger)
+                log_message = f"{item.status} - `{item.text}`"
+                job_result.log(
+                    log_message,
+                    level_choice=LogLevelChoices.LOG_INFO, 
+                    logger=logger
+                    )
         else:
             job_result.log("Repository has no changes", level_choice=LogLevelChoices.LOG_INFO, logger=logger)
 

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -492,8 +492,10 @@ def update_git_config_contexts(repository_record, job_result):
 def import_config_context(context_data, repository_record, job_result, logger):
     """
     Parse a given dictionary of data to create/update a ConfigContext record.
+
     The dictionary is expected to have a key "_metadata" which defines properties on the ConfigContext record itself
     (name, weight, description, etc.), while all other keys in the dictionary will go into the record's "data" field.
+
     Note that we don't use extras.api.serializers.ConfigContextSerializer, despite superficial similarities;
     the reason is that the serializer only allows us to identify related objects (Region, Site, DeviceRole, etc.)
     by their database primary keys, whereas here we need to be able to look them up by other values such as slug.
@@ -923,6 +925,7 @@ def refresh_git_export_templates(repository_record, job_result, delete=False):
 
 def update_git_export_templates(repository_record, job_result):
     """Refresh any export templates provided by this Git repository.
+    
     Templates are located in GIT_ROOT/<repo>/export_templates/<app_label>/<model>/<template name>.
     """
     export_template_path = os.path.join(repository_record.filesystem_path, "export_templates")

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -42,6 +42,11 @@ from .utils import files_from_contenttype_directories
 
 logger = logging.getLogger("nautobot.datasources.git")
 
+# namedtuple takes a job_result(JobResult instance) and a repository_record(GitRepository instance).
+GitJobResult = namedtuple("GitJobResult", ["job_result", "repository_record"])
+
+GitRepoInfo = namedtuple("GitRepoInfo", ["from_url", "to_path", "from_branch"])
+
 
 def enqueue_git_repository_helper(repository, request, func, **kwargs):
     """
@@ -71,8 +76,15 @@ def enqueue_pull_git_repository_and_refresh_data(repository, request):
 
 
 def get_job_result_and_repository_record(repository_pk, job_result_pk, logger):
-    """Get JobResult instance and GitRepository instance"""
-    GitJobResult = namedtuple("GitJobResult", ["job_result", "repository_record"])
+    """
+    Get JobResult instance and GitRepository instance
+
+    Returns:
+        namedtuple (GitJobResult): (
+            job_result: JobResult object,
+            repository_record: GitRepository object
+        )
+    """
 
     job_result = JobResult.objects.get(pk=job_result_pk)
     repository_record = GitRepository.objects.get(pk=repository_pk)
@@ -190,13 +202,13 @@ def git_repository_diff_origin_and_local(repository_pk, request, job_result_pk, 
 
 def get_repo_from_url_to_path_and_from_branch(repository_record):
     """Returns the from_url, to_path and from_branch of a Git Repo
-    :return (namedtuple): (
+    Returns:
+        namedtuple (GitRepoInfo): (
         from_url: git repo url with token or user if available,
         to_path: path to location of git repo on local machine
         from_branch: current git repo branch
     )
     """
-    GitRepo = namedtuple("GitRepo", ["from_url", "to_path", "from_branch"])
 
     # Inject username and/or token into source URL if necessary
     from_url = repository_record.remote_url
@@ -240,7 +252,7 @@ def get_repo_from_url_to_path_and_from_branch(repository_record):
     to_path = repository_record.filesystem_path
     from_branch = repository_record.branch
 
-    return GitRepo(from_url=from_url, to_path=to_path, from_branch=from_branch)
+    return GitRepoInfo(from_url=from_url, to_path=to_path, from_branch=from_branch)
 
 
 def ensure_git_repository(repository_record, job_result=None, logger=None, head=None):

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -116,6 +116,7 @@ class RelationshipModelForm(forms.ModelForm):
     def clean(self):
         """
         Verify that any requested RelationshipAssociations do not violate relationship cardinality restrictions.
+        
         - For TYPE_ONE_TO_MANY and TYPE_ONE_TO_ONE relations, if the form's object is on the "source" side of
           the relationship, verify that the requested "destination" object(s) do not already have any existing
           RelationshipAssociation to a different source object.

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -116,7 +116,7 @@ class RelationshipModelForm(forms.ModelForm):
     def clean(self):
         """
         Verify that any requested RelationshipAssociations do not violate relationship cardinality restrictions.
-        
+
         - For TYPE_ONE_TO_MANY and TYPE_ONE_TO_ONE relations, if the form's object is on the "source" side of
           the relationship, verify that the requested "destination" object(s) do not already have any existing
           RelationshipAssociation to a different source object.

--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -116,7 +116,6 @@ class RelationshipModelForm(forms.ModelForm):
     def clean(self):
         """
         Verify that any requested RelationshipAssociations do not violate relationship cardinality restrictions.
-
         - For TYPE_ONE_TO_MANY and TYPE_ONE_TO_ONE relations, if the form's object is on the "source" side of
           the relationship, verify that the requested "destination" object(s) do not already have any existing
           RelationshipAssociation to a different source object.
@@ -739,6 +738,13 @@ class GitRepositoryForm(BootstrapMixin, RelationshipModelForm):
             "provided_contents",
             "tags",
         ]
+
+    def clean(self):
+        super().clean()
+
+        # set dryrun after a successful clean
+        if "_dryrun_create" in self.data or "_dryrun_update" in self.data:
+            self.instance.set_dryrun()
 
 
 class GitRepositoryCSVForm(CSVModelForm):

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -124,7 +124,7 @@ class GitRepository(PrimaryModel):
         """
         Add _dryrun flag.
 
-        The existence of this flag indicates that the next sync of this repo (on save()) should be a dry-run only;
+        The existence of this flag indicates that the next sync of this repo (on save()) should be a dry-run only.
         """
         self._dryrun = True
 

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -120,6 +120,14 @@ class GitRepository(PrimaryModel):
     def filesystem_path(self):
         return os.path.join(settings.GIT_ROOT, self.slug)
 
+    def set_dryrun(self):
+        """
+        Add _dryrun flag.
+
+        The existence of this flag indicates that the next sync of this repo (on save()) should be a dry-run only;
+        """
+        self._dryrun = True
+
     def save(self, *args, trigger_resync=True, **kwargs):
         if self.__initial_token and self._token == self.TOKEN_PLACEHOLDER:
             # User edited the repo but did NOT specify a new token value. Make sure we keep the existing value.
@@ -141,13 +149,20 @@ class GitRepository(PrimaryModel):
                         self.filesystem_path,
                     )
 
-            if trigger_resync:
+            dry_run = hasattr(self, "_dryrun")
+            if trigger_resync or dry_run:
                 assert self.request is not None, "No HTTP request associated with this update!"
                 from nautobot.extras.datasources import (
                     enqueue_pull_git_repository_and_refresh_data,
+                    enqueue_git_repository_diff_origin_and_local,
                 )
 
-                enqueue_pull_git_repository_and_refresh_data(self, self.request)
+                # NOTE: if dry_run is True, there would be no need to trigger a resync
+                # regardless of the trigger_resync value (True/False)
+                if dry_run:
+                    enqueue_git_repository_diff_origin_and_local(self, self.request)
+                else:
+                    enqueue_pull_git_repository_and_refresh_data(self, self.request)
 
             # Update cached values
             self.__initial_token = self._token

--- a/nautobot/extras/templates/extras/gitrepository.html
+++ b/nautobot/extras/templates/extras/gitrepository.html
@@ -4,6 +4,13 @@
 {% block extra_buttons %}
         {% if perms.extras.change_gitrepository %}
             <form class="form-inline" style="display: inline-block"
+                  method="post" action="{% url 'extras:gitrepository_dryrun' slug=object.slug %}">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-info">
+                    <i class="mdi mdi-book-refresh" aria-hidden="true"></i> Dry-Run
+                </button>
+            </form>
+            <form class="form-inline" style="display: inline-block"
                   method="post" action="{% url 'extras:gitrepository_sync' slug=object.slug %}">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-primary">

--- a/nautobot/extras/templates/extras/gitrepository_object_edit.html
+++ b/nautobot/extras/templates/extras/gitrepository_object_edit.html
@@ -1,0 +1,13 @@
+{% extends 'generic/object_edit.html' %}
+
+{% block buttons %}
+    {% if editing %}
+        <button type="submit" name="_dryrun_update" class="btn btn-warning">Update & Dry Run</button>
+        <button type="submit" name="_update" class="btn btn-primary">Update & Sync</button>
+    {% else %}
+        <button type="submit" name="_dryrun_create" class="btn btn-info">Create & Dry Run</button>
+        <button type="submit" name="_create" class="btn btn-primary">Create & Sync</button>
+        <button type="submit" name="_addanother" class="btn btn-primary">Create and Add Another</button>
+    {% endif %}
+    <a href="{{ return_url }}" class="btn btn-default">Cancel</a>
+{% endblock %}

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -696,14 +696,14 @@ class GitTest(TestCase):
 
                 MockGitRepo.side_effect = create_empty_repo
 
-                self.dummy_request.id = uuid.uuid4()
+                self.mock_request.id = uuid.uuid4()
                 self.job_result = JobResult.objects.create(
                     name=self.repo.name,
                     obj_type=ContentType.objects.get_for_model(GitRepository),
                     job_id=uuid.uuid4(),
                 )
 
-                git_repository_diff_origin_and_local(self.repo.pk, self.dummy_request, self.job_result.pk)
+                git_repository_diff_origin_and_local(self.repo.pk, self.mock_request, self.job_result.pk)
                 self.job_result.refresh_from_db()
 
                 self.assertEqual(self.job_result.status, JobResultStatusChoices.STATUS_COMPLETED, self.job_result.data)

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -18,7 +18,7 @@ from nautobot.extras.choices import (
     SecretsGroupAccessTypeChoices,
     SecretsGroupSecretTypeChoices,
 )
-from nautobot.extras.datasources.git import pull_git_repository_and_refresh_data
+from nautobot.extras.datasources.git import pull_git_repository_and_refresh_data, git_repository_diff_origin_and_local
 from nautobot.extras.datasources.registry import get_datasource_contents
 from nautobot.extras.models import (
     ConfigContext,
@@ -109,6 +109,131 @@ class GitTest(TestCase):
                 },
             },
         }
+
+    def populate_repo(self, path, url, *args, **kwargs):
+        os.makedirs(path)
+        # Just make config_contexts and export_templates directories as we don't load jobs
+        os.makedirs(os.path.join(path, "config_contexts"))
+        os.makedirs(os.path.join(path, "config_contexts", "devices"))
+        os.makedirs(os.path.join(path, "config_context_schemas"))
+        os.makedirs(os.path.join(path, "export_templates", "dcim", "device"))
+        os.makedirs(os.path.join(path, "export_templates", "ipam", "vlan"))
+        with open(os.path.join(path, "config_contexts", "context.yaml"), "w") as fd:
+            yaml.dump(
+                {
+                    "_metadata": {
+                        "name": "Frobozz 1000 NTP servers",
+                        "weight": 1500,
+                        "description": "NTP servers for Frobozz 1000 devices **only**",
+                        "is_active": True,
+                        "schema": "Config Context Schema 1",
+                        "device_types": [{"slug": self.device_type.slug}],
+                    },
+                    "ntp-servers": ["172.16.10.22", "172.16.10.33"],
+                },
+                fd,
+            )
+        with open(
+            os.path.join(path, "config_contexts", "devices", "test-device.json"),
+            "w",
+        ) as fd:
+            json.dump({"dns-servers": ["8.8.8.8"]}, fd)
+        with open(os.path.join(path, "config_context_schemas", "schema-1.yaml"), "w") as fd:
+            yaml.dump(self.config_context_schema, fd)
+        with open(
+            os.path.join(path, "export_templates", "dcim", "device", "template.j2"),
+            "w",
+        ) as fd:
+            fd.write("{% for device in queryset %}\n{{ device.name }}\n{% endfor %}")
+        with open(
+            os.path.join(path, "export_templates", "dcim", "device", "template2.html"),
+            "w",
+        ) as fd:
+            fd.write("<!DOCTYPE html>/n{% for device in queryset %}\n{{ device.name }}\n{% endfor %}")
+        with open(
+            os.path.join(path, "export_templates", "ipam", "vlan", "template.j2"),
+            "w",
+        ) as fd:
+            fd.write("{% for vlan in queryset %}\n{{ vlan.name }}\n{% endfor %}")
+        return mock.DEFAULT
+
+    def empty_repo(self, path, url, *args, **kwargs):
+        os.remove(os.path.join(path, "config_contexts", "context.yaml"))
+        os.remove(os.path.join(path, "config_contexts", "devices", "test-device.json"))
+        os.remove(os.path.join(path, "config_context_schemas", "schema-1.yaml"))
+        os.remove(os.path.join(path, "export_templates", "dcim", "device", "template.j2"))
+        os.remove(os.path.join(path, "export_templates", "dcim", "device", "template2.html"))
+        os.remove(os.path.join(path, "export_templates", "ipam", "vlan", "template.j2"))
+        return mock.DEFAULT
+
+    def assert_config_context_schema_record_exists(self, name):
+        """Helper Func to assert ConfigContextSchema with name=name exists"""
+        config_context_schema_record = ConfigContextSchema.objects.get(
+            name=name,
+            owner_object_id=self.repo.pk,
+            owner_content_type=ContentType.objects.get_for_model(GitRepository),
+        )
+        config_context_schema = self.config_context_schema
+        config_context_schema_metadata = config_context_schema["_metadata"]
+        self.assertIsNotNone(config_context_schema_record)
+        self.assertEqual(config_context_schema_metadata["name"], config_context_schema_record.name)
+        self.assertEqual(config_context_schema["data_schema"], config_context_schema_record.data_schema)
+
+    def assert_device_exists(self, name):
+        """Helper function to assert device exists"""
+        device = Device.objects.get(name=name)
+        self.assertIsNotNone(device.local_context_data)
+        self.assertEqual({"dns-servers": ["8.8.8.8"]}, device.local_context_data)
+        self.assertEqual(device.local_context_data_owner, self.repo)
+
+    def assert_export_template_device(self, name):
+        export_template_device = ExportTemplate.objects.get(
+            owner_object_id=self.repo.pk,
+            owner_content_type=ContentType.objects.get_for_model(GitRepository),
+            content_type=ContentType.objects.get_for_model(Device),
+            name=name,
+        )
+        self.assertIsNotNone(export_template_device)
+        self.assertEqual(export_template_device.mime_type, "text/plain")
+
+    def assert_config_context_exists(self, name):
+        """Helper function to assert ConfigContext exists"""
+        config_context = ConfigContext.objects.get(
+            name=name,
+            owner_object_id=self.repo.pk,
+            owner_content_type=ContentType.objects.get_for_model(GitRepository),
+        )
+        self.assertIsNotNone(config_context)
+        self.assertEqual(1500, config_context.weight)
+        self.assertEqual("NTP servers for Frobozz 1000 devices **only**", config_context.description)
+        self.assertTrue(config_context.is_active)
+        self.assertEqual(list(config_context.device_types.all()), [self.device_type])
+        self.assertEqual(
+            {"ntp-servers": ["172.16.10.22", "172.16.10.33"]},
+            config_context.data,
+        )
+        self.assertEqual(self.config_context_schema["_metadata"]["name"], config_context.schema.name)
+
+    def assert_export_template_html_exist(self, name):
+        """Helper function to assert ExportTemplate exists"""
+        export_template_html = ExportTemplate.objects.get(
+            owner_object_id=self.repo.pk,
+            owner_content_type=ContentType.objects.get_for_model(GitRepository),
+            content_type=ContentType.objects.get_for_model(Device),
+            name=name,
+        )
+        self.assertIsNotNone(export_template_html)
+        self.assertEqual(export_template_html.mime_type, "text/html")
+
+    def assert_export_template_vlan_exists(self, name):
+        """Helper function to assert ExportTemplate exists"""
+        export_template_vlan = ExportTemplate.objects.get(
+            owner_object_id=self.repo.pk,
+            owner_content_type=ContentType.objects.get_for_model(GitRepository),
+            content_type=ContentType.objects.get_for_model(VLAN),
+            name=name,
+        )
+        self.assertIsNotNone(export_template_vlan)
 
     def test_pull_git_repository_and_refresh_data_with_no_data(self, MockGitRepo):
         """
@@ -293,54 +418,7 @@ class GitTest(TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             with self.settings(GIT_ROOT=tempdir):
 
-                def populate_repo(path, url):
-                    os.makedirs(path)
-                    # Just make config_contexts and export_templates directories as we don't load jobs
-                    os.makedirs(os.path.join(path, "config_contexts"))
-                    os.makedirs(os.path.join(path, "config_contexts", "devices"))
-                    os.makedirs(os.path.join(path, "config_context_schemas"))
-                    os.makedirs(os.path.join(path, "export_templates", "dcim", "device"))
-                    os.makedirs(os.path.join(path, "export_templates", "ipam", "vlan"))
-                    with open(os.path.join(path, "config_contexts", "context.yaml"), "w") as fd:
-                        yaml.dump(
-                            {
-                                "_metadata": {
-                                    "name": "Frobozz 1000 NTP servers",
-                                    "weight": 1500,
-                                    "description": "NTP servers for Frobozz 1000 devices **only**",
-                                    "is_active": True,
-                                    "schema": "Config Context Schema 1",
-                                    "device_types": [{"slug": self.device_type.slug}],
-                                },
-                                "ntp-servers": ["172.16.10.22", "172.16.10.33"],
-                            },
-                            fd,
-                        )
-                    with open(
-                        os.path.join(path, "config_contexts", "devices", "test-device.json"),
-                        "w",
-                    ) as fd:
-                        json.dump({"dns-servers": ["8.8.8.8"]}, fd)
-                    with open(os.path.join(path, "config_context_schemas", "schema-1.yaml"), "w") as fd:
-                        yaml.dump(self.config_context_schema, fd)
-                    with open(
-                        os.path.join(path, "export_templates", "dcim", "device", "template.j2"),
-                        "w",
-                    ) as fd:
-                        fd.write("{% for device in queryset %}\n{{ device.name }}\n{% endfor %}")
-                    with open(
-                        os.path.join(path, "export_templates", "dcim", "device", "template2.html"),
-                        "w",
-                    ) as fd:
-                        fd.write("<!DOCTYPE html>/n{% for device in queryset %}\n{{ device.name }}\n{% endfor %}")
-                    with open(
-                        os.path.join(path, "export_templates", "ipam", "vlan", "template.j2"),
-                        "w",
-                    ) as fd:
-                        fd.write("{% for vlan in queryset %}\n{{ vlan.name }}\n{% endfor %}")
-                    return mock.DEFAULT
-
-                MockGitRepo.side_effect = populate_repo
+                MockGitRepo.side_effect = self.populate_repo
                 MockGitRepo.return_value.checkout.return_value = self.COMMIT_HEXSHA
 
                 # Run the Git operation and refresh the object from the DB
@@ -354,80 +432,25 @@ class GitTest(TestCase):
                 )
 
                 # Make sure ConfigContext was successfully loaded from file
-                config_context = ConfigContext.objects.get(
-                    name="Frobozz 1000 NTP servers",
-                    owner_object_id=self.repo.pk,
-                    owner_content_type=ContentType.objects.get_for_model(GitRepository),
-                )
-                self.assertIsNotNone(config_context)
-                self.assertEqual(1500, config_context.weight)
-                self.assertEqual("NTP servers for Frobozz 1000 devices **only**", config_context.description)
-                self.assertTrue(config_context.is_active)
-                self.assertEqual(list(config_context.device_types.all()), [self.device_type])
-                self.assertEqual(
-                    {"ntp-servers": ["172.16.10.22", "172.16.10.33"]},
-                    config_context.data,
-                )
-                self.assertEqual(self.config_context_schema["_metadata"]["name"], config_context.schema.name)
+                self.assert_config_context_exists("Frobozz 1000 NTP servers")
 
                 # Make sure ConfigContextSchema was successfully loaded from file
-                config_context_schema_record = ConfigContextSchema.objects.get(
-                    name="Config Context Schema 1",
-                    owner_object_id=self.repo.pk,
-                    owner_content_type=ContentType.objects.get_for_model(GitRepository),
-                )
-                config_context_schema = self.config_context_schema
-                config_context_schema_metadata = config_context_schema["_metadata"]
-                self.assertIsNotNone(config_context_schema_record)
-                self.assertEqual(config_context_schema_metadata["name"], config_context_schema_record.name)
-                self.assertEqual(config_context_schema["data_schema"], config_context_schema_record.data_schema)
+                self.assert_config_context_schema_record_exists("Config Context Schema 1")
 
                 # Make sure Device local config context was successfully populated from file
-                device = Device.objects.get(name=self.device.name)
-                self.assertIsNotNone(device.local_context_data)
-                self.assertEqual({"dns-servers": ["8.8.8.8"]}, device.local_context_data)
-                self.assertEqual(device.local_context_data_owner, self.repo)
+                self.assert_device_exists(self.device.name)
 
                 # Make sure ExportTemplate was successfully loaded from file
-                export_template_device = ExportTemplate.objects.get(
-                    owner_object_id=self.repo.pk,
-                    owner_content_type=ContentType.objects.get_for_model(GitRepository),
-                    content_type=ContentType.objects.get_for_model(Device),
-                    name="template.j2",
-                )
-                self.assertIsNotNone(export_template_device)
-                self.assertEqual(export_template_device.mime_type, "text/plain")
+                self.assert_export_template_device("template.j2")
 
-                export_template_html = ExportTemplate.objects.get(
-                    owner_object_id=self.repo.pk,
-                    owner_content_type=ContentType.objects.get_for_model(GitRepository),
-                    content_type=ContentType.objects.get_for_model(Device),
-                    name="template2.html",
-                )
-                self.assertIsNotNone(export_template_html)
-                self.assertEqual(export_template_html.mime_type, "text/html")
+                self.assert_export_template_html_exist("template2.html")
 
                 # Make sure ExportTemplate was successfully loaded from file
                 # Case when ContentType.model != ContentType.name, template was added and deleted during sync (#570)
-                export_template_vlan = ExportTemplate.objects.get(
-                    owner_object_id=self.repo.pk,
-                    owner_content_type=ContentType.objects.get_for_model(GitRepository),
-                    content_type=ContentType.objects.get_for_model(VLAN),
-                    name="template.j2",
-                )
-                self.assertIsNotNone(export_template_vlan)
+                self.assert_export_template_vlan_exists("template.j2")
 
                 # Now "resync" the repository, but now those files no longer exist in the repository
-                def empty_repo(path, url):
-                    os.remove(os.path.join(path, "config_contexts", "context.yaml"))
-                    os.remove(os.path.join(path, "config_contexts", "devices", "test-device.json"))
-                    os.remove(os.path.join(path, "config_context_schemas", "schema-1.yaml"))
-                    os.remove(os.path.join(path, "export_templates", "dcim", "device", "template.j2"))
-                    os.remove(os.path.join(path, "export_templates", "dcim", "device", "template2.html"))
-                    os.remove(os.path.join(path, "export_templates", "ipam", "vlan", "template.j2"))
-                    return mock.DEFAULT
-
-                MockGitRepo.side_effect = empty_repo
+                MockGitRepo.side_effect = self.empty_repo
                 # For verisimilitude, don't re-use the old request and job_result
                 self.mock_request.id = uuid.uuid4()
                 self.job_result = JobResult.objects.create(
@@ -662,3 +685,33 @@ class GitTest(TestCase):
                 device = Device.objects.get(name=self.device.name)
                 self.assertIsNone(device.local_context_data)
                 self.assertIsNone(device.local_context_data_owner)
+
+    def test_git_dry_run(self, MockGitRepo):
+        with tempfile.TemporaryDirectory() as tempdir:
+            with self.settings(GIT_ROOT=tempdir):
+
+                def create_empty_repo(path, url, clone_initially=False):
+                    os.makedirs(path, exist_ok=True)
+                    return mock.DEFAULT
+
+                MockGitRepo.side_effect = create_empty_repo
+
+                self.dummy_request.id = uuid.uuid4()
+                self.job_result = JobResult.objects.create(
+                    name=self.repo.name,
+                    obj_type=ContentType.objects.get_for_model(GitRepository),
+                    job_id=uuid.uuid4(),
+                )
+
+                git_repository_diff_origin_and_local(self.repo.pk, self.dummy_request, self.job_result.pk)
+                self.job_result.refresh_from_db()
+
+                self.assertEqual(self.job_result.status, JobResultStatusChoices.STATUS_COMPLETED, self.job_result.data)
+
+                MockGitRepo.return_value.checkout.assert_not_called()
+                MockGitRepo.assert_called_with(
+                    os.path.join(tempdir, self.repo.slug),
+                    self.repo.remote_url,
+                    clone_initially=False,
+                )
+                MockGitRepo.return_value.diff_remote.assert_called()

--- a/nautobot/extras/tests/test_git.py
+++ b/nautobot/extras/tests/test_git.py
@@ -1,0 +1,26 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from nautobot.utilities.git import GitRepo, swap_status_initials
+
+
+@mock.patch("nautobot.utilities.git.Repo")
+class GitRepoTest(TestCase):
+    def test_git_repo(self, RepoMock):
+        RepoMock.init.return_value = RepoMock
+        RepoMock.create_remote.return_value = ""
+        RepoMock.git.diff.return_value = "M\tSample"
+
+        url = "http://localhost.git"
+        repo = GitRepo("path", url, clone_initially=False)
+
+        RepoMock.clone_from.assert_not_called()
+        RepoMock.init.assert_called()
+        RepoMock.create_remote.assert_called()
+        RepoMock.create_remote.assert_called_with("origin", url=url)
+
+        self.assertEqual(
+            repo.diff_remote("main"),
+            [swap_status_initials(line.split("\t")) for line in RepoMock.git.diff.return_value.split("\n")],
+        )

--- a/nautobot/extras/tests/test_git.py
+++ b/nautobot/extras/tests/test_git.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from django.test import TestCase
 
-from nautobot.utilities.git import GitRepo, swap_status_initials
+from nautobot.utilities.git import GitRepo, convert_git_diff_log_to_list
 
 
 @mock.patch("nautobot.utilities.git.Repo")
@@ -20,7 +20,4 @@ class GitRepoTest(TestCase):
         RepoMock.create_remote.assert_called()
         RepoMock.create_remote.assert_called_with("origin", url=url)
 
-        self.assertEqual(
-            repo.diff_remote("main"),
-            [swap_status_initials(line.split("\t")) for line in RepoMock.git.diff.return_value.split("\n")],
-        )
+        self.assertEqual(repo.diff_remote("main"), convert_git_diff_log_to_list(RepoMock.git.diff.return_value))

--- a/nautobot/extras/urls.py
+++ b/nautobot/extras/urls.py
@@ -282,6 +282,11 @@ urlpatterns = [
         views.GitRepositorySyncView.as_view(),
         name="gitrepository_sync",
     ),
+    path(
+        "git-repositories/<str:slug>/dry-run/",
+        views.GitRepositoryDryRunView.as_view(),
+        name="gitrepository_dryrun",
+    ),
     # GraphQL Queries
     path("graphql-queries/", views.GraphQLQueryListView.as_view(), name="graphqlquery_list"),
     path("graphql-queries/add/", views.GraphQLQueryEditView.as_view(), name="graphqlquery_add"),

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -923,7 +923,7 @@ class JobApprovalRequestView(ContentTypePermissionRequiredMixin, View):
     def post(self, request, scheduled_job):
         """
         Act upon one of the 3 submit button actions from the user.
-        
+
         dry-run will immediately enqueue the job with commit=False and send the user to the normal JobResult view
         deny will delete the scheduled_job instance
         approve will mark the scheduled_job as approved, allowing the schedular to schedule the job execution task

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -923,6 +923,7 @@ class JobApprovalRequestView(ContentTypePermissionRequiredMixin, View):
     def post(self, request, scheduled_job):
         """
         Act upon one of the 3 submit button actions from the user.
+        
         dry-run will immediately enqueue the job with commit=False and send the user to the normal JobResult view
         deny will delete the scheduled_job instance
         approve will mark the scheduled_job as approved, allowing the schedular to schedule the job execution task

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -40,8 +40,9 @@ from nautobot.virtualization.tables import VirtualMachineTable
 from . import filters, forms, tables
 from .choices import JobExecutionType, JobResultStatusChoices
 from .datasources import (
-    get_datasource_contents,
+    enqueue_git_repository_diff_origin_and_local,
     enqueue_pull_git_repository_and_refresh_data,
+    get_datasource_contents,
 )
 from .jobs import get_job, get_jobs, run_job, Job
 from .models import (
@@ -555,6 +556,7 @@ class GitRepositoryView(generic.ObjectView):
 class GitRepositoryEditView(generic.ObjectEditView):
     queryset = GitRepository.objects.all()
     model_form = forms.GitRepositoryForm
+    template_name = "extras/gitrepository_object_edit.html"
 
     def alter_obj(self, obj, request, url_args, url_kwargs):
         # A GitRepository needs to know the originating request when it's saved so that it can enqueue using it
@@ -612,20 +614,36 @@ class GitRepositoryBulkDeleteView(generic.BulkDeleteView):
         }
 
 
+def check_and_call_git_repository_function(request, slug, func):
+    """Helper for checking Git permissions and worker availability, then calling provided function if all is well
+    Args:
+        request: request object.
+        slug (str): GitRepository slug value.
+        func (function): Enqueue git repo function.
+    Returns:
+        HttpResponseForbidden or a redirect
+    """
+    if not request.user.has_perm("extras.change_gitrepository"):
+        return HttpResponseForbidden()
+
+    # Allow execution only if a worker process is running.
+    if not get_worker_count(request):
+        messages.error(request, "Unable to run job: Celery worker process not running.")
+    else:
+        repository = get_object_or_404(GitRepository, slug=slug)
+        func(repository, request)
+
+    return redirect("extras:gitrepository_result", slug=slug)
+
+
 class GitRepositorySyncView(View):
     def post(self, request, slug):
-        if not request.user.has_perm("extras.change_gitrepository"):
-            return HttpResponseForbidden()
+        return check_and_call_git_repository_function(request, slug, enqueue_pull_git_repository_and_refresh_data)
 
-        repository = get_object_or_404(GitRepository.objects.all(), slug=slug)
 
-        # Allow execution only if a worker process is running.
-        if not get_worker_count(request):
-            messages.error(request, "Unable to run job: Celery worker process not running.")
-        else:
-            enqueue_pull_git_repository_and_refresh_data(repository, request)
-
-        return redirect("extras:gitrepository_result", slug=slug)
+class GitRepositoryDryRunView(View):
+    def post(self, request, slug):
+        return check_and_call_git_repository_function(request, slug, enqueue_git_repository_diff_origin_and_local)
 
 
 class GitRepositoryResultView(generic.ObjectView):
@@ -905,7 +923,6 @@ class JobApprovalRequestView(ContentTypePermissionRequiredMixin, View):
     def post(self, request, scheduled_job):
         """
         Act upon one of the 3 submit button actions from the user.
-
         dry-run will immediately enqueue the job with commit=False and send the user to the normal JobResult view
         deny will delete the scheduled_job instance
         approve will mark the scheduled_job as approved, allowing the schedular to schedule the job execution task
@@ -1185,7 +1202,6 @@ class ObjectChangeView(generic.ObjectView):
 class ObjectChangeLogView(View):
     """
     Present a history of changes made to a particular object.
-
     base_template: The name of the template to extend. If not provided, "<app>/<model>.html" will be used.
     """
 

--- a/nautobot/utilities/git.py
+++ b/nautobot/utilities/git.py
@@ -25,7 +25,7 @@ GIT_STATUS_MAP = {
 def swap_status_initials(data):
     """Swap Git status initials with its equivalent."""
     initial, text = data.split("\t")
-    return GIT_STATUS_MAP.get(initial) + " - " +f"`{text}`"
+    return GIT_STATUS_MAP.get(initial) + " - " + f"`{text}`"
 
 
 def convert_git_diff_log_to_list(logs):

--- a/nautobot/utilities/git.py
+++ b/nautobot/utilities/git.py
@@ -22,9 +22,25 @@ GIT_STATUS_MAP = {
 }
 
 
-def swap_status_initials(x):
-    """Swap github status initials with its equivalent"""
-    return GIT_STATUS_MAP.get(x[0]) + " - " + x[1]
+def swap_status_initials(data):
+    """Swap Git status initials with its equivalent."""
+    initial, text = data.split("\t")
+    return GIT_STATUS_MAP.get(initial) + " - " + text
+
+
+def convert_git_diff_log_to_list(logs):
+    """
+    Convert Git diff log into a list splitted by \\n
+
+    Example:
+        >>> git_log = "M\tindex.html\nR\tsample.txt"
+        >>> print(convert_git_diff_log_to_list(git_log))
+        ["Modification - index.html", "Renaming - sample.txt"]
+
+
+    """
+    logs = logs.split("\n")
+    return [swap_status_initials(line) for line in logs]
 
 
 class BranchDoesNotExist(Exception):
@@ -120,6 +136,6 @@ class GitRepo:
         logger.debug("Getting diff between local branch and remote branch")
         diff = self.repo.git.diff("--name-status", f"origin/{branch}")
         if diff:  # if diff is not empty
-            return [swap_status_initials(line.split("\t")) for line in diff.split("\n")]
+            return convert_git_diff_log_to_list(diff)
         logger.debug("No Difference")
         return []

--- a/nautobot/utilities/git.py
+++ b/nautobot/utilities/git.py
@@ -8,20 +8,46 @@ from git import Repo
 
 logger = logging.getLogger("nautobot.utilities.git")
 
+# 'A' and 'D' status are swapped because of the way the repo.git.diff was implemented
+# e.g. 'A' actually stands for Addition but in this case is Deletion
+GIT_STATUS_MAP = {
+    "A": "Deletion",
+    "M": "Modification",
+    "C": "Copy",
+    "D": "Addition",
+    "R": "Renaming",
+    "T": "File Type Changed",
+    "U": "File Unmerged",
+    "X": "Unknown",
+}
+
+
+def swap_status_initials(x):
+    """Swap github status initials with its equivalent"""
+    return GIT_STATUS_MAP.get(x[0]) + " - " + x[1]
+
 
 class BranchDoesNotExist(Exception):
     pass
 
 
 class GitRepo:
-    def __init__(self, path, url):
+    def __init__(self, path, url, clone_initially=True):
         """
         Ensure that we have a clone of the given remote Git repository URL at the given local directory path.
+
+        Args:
+            path (str): path to git repo
+            url (str): git repo url
+            clone_initially (bool): True if the repo needs to be cloned
         """
         if os.path.isdir(path):
             self.repo = Repo(path=path)
-        else:
+        elif clone_initially:
             self.repo = Repo.clone_from(url, to_path=path)
+        else:
+            self.repo = Repo.init(path)
+            self.repo.create_remote("origin", url=url)
 
         if url not in self.repo.remotes.origin.urls:
             self.repo.remotes.origin.set_url(url)
@@ -75,3 +101,25 @@ class GitRepo:
         commit_hexsha = self.repo.head.reference.commit.hexsha
         logger.info(f"Latest commit on branch `{branch}` is `{commit_hexsha}`")
         return commit_hexsha
+
+    def diff_remote(self, branch):
+        logger.debug("Fetching from remote.")
+        self.fetch()
+
+        try:
+            self.repo.remotes.origin.refs[branch]
+        except IndexError as git_error:
+            logger.error(
+                "Branch %s does not exist at %s. %s", branch, list(self.repo.remotes.origin.urls)[0], git_error
+            )
+            raise BranchDoesNotExist(
+                f"Please create branch '{branch}' in upstream and try again."
+                f" If this is a new repo, please add a commit before syncing. {git_error}"
+            )
+
+        logger.debug("Getting diff between local branch and remote branch")
+        diff = self.repo.git.diff("--name-status", f"origin/{branch}")
+        if diff:  # if diff is not empty
+            return [swap_status_initials(line.split("\t")) for line in diff.split("\n")]
+        logger.debug("No Difference")
+        return []

--- a/nautobot/utilities/git.py
+++ b/nautobot/utilities/git.py
@@ -36,8 +36,6 @@ def convert_git_diff_log_to_list(logs):
         >>> git_log = "M\tindex.html\nR\tsample.txt"
         >>> print(convert_git_diff_log_to_list(git_log))
         ["Modification - index.html", "Renaming - sample.txt"]
-
-
     """
     logs = logs.split("\n")
     return [swap_status_initials(line) for line in logs]

--- a/nautobot/utilities/git.py
+++ b/nautobot/utilities/git.py
@@ -42,8 +42,7 @@ def convert_git_diff_log_to_list(logs):
         ["Modification - index.html", "Renaming - sample.txt"]
     """
     logs = logs.split("\n")
-    swapped_initials = map(swap_status_initials, logs)
-    return ["{} - `{}`".format(status, text) for status, text in swapped_initials]
+    return [swap_status_initials(line) for line in logs]
 
 
 class BranchDoesNotExist(Exception):

--- a/nautobot/utilities/git.py
+++ b/nautobot/utilities/git.py
@@ -25,7 +25,7 @@ GIT_STATUS_MAP = {
 def swap_status_initials(data):
     """Swap Git status initials with its equivalent."""
     initial, text = data.split("\t")
-    return GIT_STATUS_MAP.get(initial) + " - " + text
+    return GIT_STATUS_MAP.get(initial) + " - " +f"`{text}`"
 
 
 def convert_git_diff_log_to_list(logs):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #5 
Add dry run capability

List Page
<img width="1431" alt="Screenshot 2022-01-31 at 00 38 03" src="https://user-images.githubusercontent.com/94907097/151722784-f3292b00-ef79-43f0-b9c3-5baea42a5fd3.png">

Edit Page
<img width="1680" alt="Screenshot 2022-02-02 at 01 13 03" src="https://user-images.githubusercontent.com/94907097/152072725-6433fc9c-6eb2-42f1-833e-a256881bae66.png">

Create Page
<img width="1677" alt="Screenshot 2022-02-03 at 01 02 39" src="https://user-images.githubusercontent.com/94907097/152260369-e325b354-f11b-4e96-a9e3-5debe154f4ff.png">


**Steps taken to archive a dry-run**
1. if action is create & dryrun, then Initialise an empty Repo, and set origin
2. Fetch from remote without updating local branch
2. Compare file differences between local branch and remote branch
3. Log the file differences & its status if any.


