### PR TITLE
Issue #1312: Filter view fix

### DIFF
--- a/nautobot/ipam/tests/test_views.py
+++ b/nautobot/ipam/tests/test_views.py
@@ -286,7 +286,7 @@ class PrefixTestCase(ViewTestCases.PrimaryObjectViewTestCase, ViewTestCases.List
     def test_empty_queryset(self):
         """
         Testing filtering items for non-existent Status actually returns 0 results. For issue #1312 in which the filter
-        view expected to return 0 reesults was instead returning items in list. Used the Status of "depricated" in this test,
+        view expected to return 0 results was instead returning items in list. Used the Status of "deprecated" in this test,
         but the same behavior was observerd in other filters, such as IPv4/IPv6.
         """
         prefixes = self._get_queryset().all()

--- a/nautobot/ipam/tests/test_views.py
+++ b/nautobot/ipam/tests/test_views.py
@@ -1,6 +1,7 @@
 import datetime
 
 from netaddr import IPNetwork
+from django.test import override_settings
 
 from nautobot.dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 from nautobot.extras.models import Status
@@ -19,6 +20,7 @@ from nautobot.ipam.models import (
 )
 from nautobot.tenancy.models import Tenant
 from nautobot.utilities.testing import ViewTestCases
+from nautobot.utilities.testing.utils import extract_page_body
 
 
 class VRFTestCase(ViewTestCases.PrimaryObjectViewTestCase):
@@ -202,7 +204,7 @@ class RoleTestCase(ViewTestCases.OrganizationalObjectViewTestCase):
         cls.slug_test_object = "Role 8"
 
 
-class PrefixTestCase(ViewTestCases.PrimaryObjectViewTestCase):
+class PrefixTestCase(ViewTestCases.PrimaryObjectViewTestCase, ViewTestCases.ListObjectsViewTestCase):
     model = Prefix
 
     @classmethod
@@ -279,6 +281,24 @@ class PrefixTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "is_pool": False,
             "description": "New description",
         }
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_empty_queryset(self):
+        """
+        Testing filtering items for non-existent Status actually returns 0 results. For issue #1312 in which the filter
+        view expected to return 0 reesults was instead returning items in list. Used the Status of "depricated" in this test,
+        but the same behavior was observerd in other filters, such as IPv4/IPv6.
+        """
+        prefixes = self._get_queryset().all()
+        self.assertEqual(prefixes.count(), 3)
+
+        url = self._get_url("list")
+        response = self.client.get(f"{url}?status=deprecated")
+        self.assertHttpStatus(response, 200)
+        content = extract_page_body(response.content.decode(response.charset))
+
+        for prefix in prefixes:
+            self.assertNotIn(prefix.get_absolute_url(), content, msg=content)
 
 
 class IPAddressTestCase(ViewTestCases.PrimaryObjectViewTestCase):

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -399,17 +399,15 @@ class PrefixListView(generic.ObjectListView):
     filterset_form = forms.PrefixFilterForm
     table = tables.PrefixDetailTable
     template_name = "ipam/prefix_list.html"
-    # `queryset` is implemented as a property, see below
 
     def __init__(self, *args, **kwargs):
         # Set the internal queryset value
         self._queryset = None
+        self.queryset = self.set_queryset()
         super().__init__(*args, **kwargs)
 
-    @property
-    def queryset(self):
+    def set_queryset(self):
         """
-        Property getter for queryset that acts upon `settings.DISABLE_PREFIX_LIST_HIERARCHY`
 
         By default we annotate the prefix hierarchy such that child prefixes are indented in the table.
         When `settings.DISABLE_PREFIX_LIST_HIERARCHY` is True, we do not annotate the queryset, and the
@@ -430,13 +428,6 @@ class PrefixListView(generic.ObjectListView):
             self._queryset = Prefix.objects.annotate_tree()
 
         return self._queryset
-
-    @queryset.setter
-    def queryset(self, value):
-        """
-        Property setter for `queryset`
-        """
-        self._queryset = value
 
 
 class PrefixView(generic.ObjectView):

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -403,11 +403,12 @@ class PrefixListView(generic.ObjectListView):
     def __init__(self, *args, **kwargs):
         # Set the internal queryset value
         self._queryset = None
-        self.queryset = self.set_queryset()
         super().__init__(*args, **kwargs)
 
-    def set_queryset(self):
+    @property
+    def queryset(self):
         """
+        Property getter for queryset that acts upon `settings.DISABLE_PREFIX_LIST_HIERARCHY`
 
         By default we annotate the prefix hierarchy such that child prefixes are indented in the table.
         When `settings.DISABLE_PREFIX_LIST_HIERARCHY` is True, we do not annotate the queryset, and the
@@ -415,7 +416,7 @@ class PrefixListView(generic.ObjectListView):
 
         TODO(john): When the base views support a formal `get_queryset()` method, this approach is not needed
         """
-        if self._queryset:
+        if self._queryset is not None:
             return self._queryset
 
         if get_settings_or_config("DISABLE_PREFIX_LIST_HIERARCHY"):
@@ -428,6 +429,13 @@ class PrefixListView(generic.ObjectListView):
             self._queryset = Prefix.objects.annotate_tree()
 
         return self._queryset
+
+    @queryset.setter
+    def queryset(self, value):
+        """
+        Property setter for 'queryset'
+        """
+        self._queryset = value
 
 
 class PrefixView(generic.ObjectView):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1312 
<!--
    Please include a summary of the proposed changes below.
-->
This change is to address a bug in the filter view in which searching for a Status that no prefixes were assigned to was returning all prefixes instead of 0 prefixes. The behavior was also observed in searching for IPv6 when there were no IPv6 addresses populated. 