### PR TITLE
Fix provision_field overriding custom field

### DIFF
--- a/nautobot/extras/tasks.py
+++ b/nautobot/extras/tasks.py
@@ -93,7 +93,7 @@ def provision_field(field_id, content_type_pk_set):
         for ct in ContentType.objects.filter(pk__in=content_type_pk_set):
             model = ct.model_class()
             for obj in model.objects.all():
-                obj._custom_field_data[field.name] = field.default
+                obj._custom_field_data.setdefault(field.name, field.default)
                 obj.save()
 
 

--- a/nautobot/extras/tests/dummy_jobs/test_site_with_custom_field.py
+++ b/nautobot/extras/tests/dummy_jobs/test_site_with_custom_field.py
@@ -1,0 +1,26 @@
+from django.contrib.contenttypes.models import ContentType
+
+from nautobot.dcim.models import Site
+from nautobot.extras.choices import CustomFieldTypeChoices
+from nautobot.extras.jobs import Job
+from nautobot.extras.models import CustomField
+
+
+class TestCreateSiteWithCustomField(Job):
+    class Meta:
+        name = "Site and Custom Field Creation"
+        description = "Site with a custom field"
+
+    def run(self, data, commit):
+        obj_type = ContentType.objects.get_for_model(Site)
+        cf = CustomField.objects.create(name="cf1", type=CustomFieldTypeChoices.TYPE_TEXT)
+        cf.content_types.set([obj_type])
+
+        self.log_success(obj=cf, message="CustomField created successfully.")
+
+        site = Site.objects.create(name="Test Site", slug="test-site")
+        site.cf[cf.name] = "some-value"
+        site.save()
+        self.log_success(obj=site, message="Created a new site")
+
+        return "Job completed."

--- a/nautobot/extras/tests/dummy_jobs/test_site_with_custom_field.py
+++ b/nautobot/extras/tests/dummy_jobs/test_site_with_custom_field.py
@@ -13,14 +13,18 @@ class TestCreateSiteWithCustomField(Job):
 
     def run(self, data, commit):
         obj_type = ContentType.objects.get_for_model(Site)
-        cf = CustomField.objects.create(name="cf1", type=CustomFieldTypeChoices.TYPE_TEXT)
+        cf = CustomField.objects.create(name="cf1", type=CustomFieldTypeChoices.TYPE_TEXT, default="-")
         cf.content_types.set([obj_type])
 
         self.log_success(obj=cf, message="CustomField created successfully.")
 
-        site = Site.objects.create(name="Test Site", slug="test-site")
-        site.cf[cf.name] = "some-value"
-        site.save()
-        self.log_success(obj=site, message="Created a new site")
+        site_1 = Site.objects.create(name="Test Site One", slug="test-site-one")
+        site_1.cf[cf.name] = "some-value"
+        site_1.save()
+        self.log_success(obj=site_1, message="Created a new site")
+
+
+        site_2 = Site.objects.create(name="Test Site Two", slug="test-site-two")
+        self.log_success(obj=site_2, message="Created another new site")
 
         return "Job completed."

--- a/nautobot/extras/tests/dummy_jobs/test_site_with_custom_field.py
+++ b/nautobot/extras/tests/dummy_jobs/test_site_with_custom_field.py
@@ -23,7 +23,6 @@ class TestCreateSiteWithCustomField(Job):
         site_1.save()
         self.log_success(obj=site_1, message="Created a new site")
 
-
         site_2 = Site.objects.create(name="Test Site Two", slug="test-site-two")
         self.log_success(obj=site_2, message="Created another new site")
 

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -610,4 +610,3 @@ class JobSiteCustomFieldTest(CeleryTestCase):
             site_2 = Site.objects.filter(slug="test-site-two")
             self.assertEqual(site_2.count(), 1)
             self.assertEqual(site_2[0].cf["cf1"], "-")
-

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -566,38 +566,48 @@ class RunJobManagementCommandTest(CeleryTestCase):
 
 
 @mock.patch("nautobot.extras.models.models.JOB_LOGS", None)
-class JobSiteCustomFieldTest(TestCase):
+class JobSiteCustomFieldTest(CeleryTestCase):
     """Test a job that creates a site and a custom field."""
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.job_content_type = ContentType.objects.get(app_label="extras", model="job")
 
     def setUp(self):
         super().setUp()
+        user = User.objects.create(username="User1")
 
         self.request = RequestFactory().request(SERVER_NAME="WebRequestContext")
         self.request.id = uuid.uuid4()
-        self.request.user = self.user
+        self.request.user = user
 
     def test_run(self):
         with self.settings(JOBS_ROOT=os.path.join(settings.BASE_DIR, "extras/tests/dummy_jobs")):
+            self.clear_worker()
+
+            job_content_type = ContentType.objects.get(app_label="extras", model="job")
             job_name = "local/test_site_with_custom_field/TestCreateSiteWithCustomField"
             job_class = get_job(job_name)
 
             job_result = JobResult.objects.create(
                 name=job_class.class_path,
-                obj_type=self.job_content_type,
+                obj_type=job_content_type,
                 user=None,
                 job_id=uuid.uuid4(),
             )
 
             # Run the job
             run_job(data={}, request=self.request, commit=True, job_result_pk=job_result.pk)
+
+            self.wait_on_active_tasks()
             job_result.refresh_from_db()
+
             self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
 
-            site = Site.objects.filter(slug="test-site")
-            self.assertEqual(site.count(), 1)
+            # Test site with a value for custom_field
+            site_1 = Site.objects.filter(slug="test-site-one")
+            self.assertEqual(site_1.count(), 1)
             self.assertEqual(CustomField.objects.filter(name="cf1").count(), 1)
-            self.assertEqual(site[0].cf["cf1"], "some-value")
+            self.assertEqual(site_1[0].cf["cf1"], "some-value")
+
+            # Test site with default value for custom field
+            site_2 = Site.objects.filter(slug="test-site-two")
+            self.assertEqual(site_2.count(), 1)
+            self.assertEqual(site_2[0].cf["cf1"], "-")
+


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1249 
<!--
    Please include a summary of the proposed changes below.
-->

- Set instance` _custom_field_data` default value instead of its value i.e replace `obj._custom_field_data[field.name] = field.default` with `obj._custom_field_data.setdefault(field.name, field.default)`
- Add relevant test
