### PR TITLE
Enhance 'startplugin' templates

### DIFF
--- a/nautobot/core/templates/plugin_template/tests/test_models.py-tpl
+++ b/nautobot/core/templates/plugin_template/tests/test_models.py-tpl
@@ -1,3 +1,3 @@
-from django.test import TestCase
+from nautobot.utilities.testing import TestCase
 
 from {{ app_name }} import models

--- a/nautobot/core/templates/plugin_template/tests/test_views.py-tpl
+++ b/nautobot/core/templates/plugin_template/tests/test_views.py-tpl
@@ -1,3 +1,3 @@
-from django.test import TestCase
+from nautobot.utilities.testing import TestCase
 
 from {{ app_name }} import views

--- a/nautobot/core/templates/plugin_template/views.py-tpl
+++ b/nautobot/core/templates/plugin_template/views.py-tpl
@@ -1,6 +1,6 @@
 """Views for {{ app_name }}."""
 
 from django.shortcuts import render
-from django.views.generic import views
+from nautobot.core.views import generic
 
 from {{ app_name }} import models


### PR DESCRIPTION
### Fixes: #1405

This PR replaces some imports in the `startplugin` templates.

1. Replaces the `django.views.generic` with `nautobot.core.views` in `views.py-tlp` file.
2. Replaces `django..TestCase` with `nautobot...TestCase` in the `test_views.py-tpl` and `test_models.py-tpl` files.

The first one fixes an error reported in 1405.  
The second replaces the TestCase with the one required for properly running the tests.