### PR TITLE
Prevent removing master device from virtual chassis via api

### DIFF
--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -728,6 +728,18 @@ class Device(PrimaryModel, ConfigContextModel, StatusModel):
                 {"vc_position": "A device assigned to a virtual chassis must have its position defined."}
             )
 
+        # Validate device isn't being removed from a virtual chassis when it is the master
+        if not self.virtual_chassis and self.present_in_database:
+            existing_virtual_chassis = Device.objects.get(id=self.id).virtual_chassis
+            if existing_virtual_chassis and existing_virtual_chassis.master == self:
+                raise ValidationError(
+                    {
+                        "virtual_chassis": "The master device for the virtual chassis ({}) may not be removed".format(
+                            existing_virtual_chassis
+                        )
+                    }
+                )
+
     def save(self, *args, **kwargs):
 
         is_new = not self.present_in_database

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -2012,6 +2012,35 @@ class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.json()["master"], None)
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_remove_chassis_from_master_device(self):
+        """Test removing the virtual chassis from the master device."""
+        url = reverse("dcim-api:virtualchassis-list")
+        response = self.client.get(url + "?name=Virtual Chassis 1", **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+        virtual_chassis_1 = response.json()["results"][0]
+
+        # Make sure the master is set
+        self.assertNotEqual(virtual_chassis_1["master"], None)
+
+        master_device = Device.objects.get(pk=virtual_chassis_1["master"]["id"])
+
+        # Set the virtual_chassis of the master device to null
+        url = reverse("dcim-api:device-detail", kwargs={"pk": master_device.id})
+        payload = {
+            "device_type": str(master_device.device_type.id),
+            "device_role": str(master_device.device_role.id),
+            "site": str(master_device.site.id),
+            "status": "active",
+            "virtual_chassis": None,
+        }
+        self.add_permissions("dcim.change_device")
+        response = self.client.patch(url, data=json.dumps(payload), content_type="application/json", **self.header)
+
+        # Make sure deletion attempt failed
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+
 
 class PowerPanelTest(APIViewTestCases.APIViewTestCase):
     model = PowerPanel


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1398 

The UI currently prevents the master device from being removed from a virtual chassis, however, this is possible via the API.  This PR prevents a device from being removed from a virtual chassis if it is the master device.