### PR TITLE
Add Ability to Filter Objects Missing Custom Field Values via `null`

### DIFF
--- a/nautobot/extras/filters.py
+++ b/nautobot/extras/filters.py
@@ -327,6 +327,17 @@ class CustomFieldFilter(django_filters.Filter):
             # Contains handles lists within the JSON data for multi select fields
             self.lookup_expr = "contains"
 
+    
+    def filter(self, qs, value):
+        if "_custom_field_data" in self.field_name and value in ("null", "0"):
+            self.lookup_expr = "exact"
+            value = None
+            lookup = '%s__%s' % (self.field_name, self.lookup_expr)
+            return self.get_method(qs)(**{lookup: value})
+        return super().filter(qs, value)
+
+        
+
 
 class CustomFieldModelFilterSet(django_filters.FilterSet):
     """

--- a/nautobot/extras/filters.py
+++ b/nautobot/extras/filters.py
@@ -328,12 +328,11 @@ class CustomFieldFilter(django_filters.Filter):
             self.lookup_expr = "contains"
 
     def filter(self, qs, value):
-        NULL_FIELDS = ("null", "0")
 
-        if "_custom_field_data" in self.field_name and value in NULL_FIELDS:
-            lookup_exact = "%s__%s" % (self.field_name, "exact")
-            lookup_isnull = "%s__%s" % (self.field_name, "isnull")
-            return self.get_method(qs)(Q(**{lookup_exact: None}) | Q(**{lookup_isnull: True}))
+        if "_custom_field_data" in self.field_name and value == "null":
+            return self.get_method(qs)(
+                Q(**{f"{self.field_name}__exact": None}) | Q(**{f"{self.field_name}__isnull": True})
+            )
         return super().filter(qs, value)
 
 

--- a/nautobot/extras/filters.py
+++ b/nautobot/extras/filters.py
@@ -328,11 +328,12 @@ class CustomFieldFilter(django_filters.Filter):
             self.lookup_expr = "contains"
 
     def filter(self, qs, value):
-        if "_custom_field_data" in self.field_name and value in ("null", "0"):
-            self.lookup_expr = "exact"
-            value = None
-            lookup = "%s__%s" % (self.field_name, self.lookup_expr)
-            return self.get_method(qs)(**{lookup: value})
+        NULL_FIELDS = ("null", "0", 0)
+
+        if "_custom_field_data" in self.field_name and value in NULL_FIELDS:
+            lookup_exact = "%s__%s" % (self.field_name, "exact")
+            lookup_isnull = "%s__%s" % (self.field_name, "isnull")
+            return self.get_method(qs)(Q(**{lookup_exact: None}) | Q(**{lookup_isnull: True}))
         return super().filter(qs, value)
 
 

--- a/nautobot/extras/filters.py
+++ b/nautobot/extras/filters.py
@@ -327,16 +327,13 @@ class CustomFieldFilter(django_filters.Filter):
             # Contains handles lists within the JSON data for multi select fields
             self.lookup_expr = "contains"
 
-    
     def filter(self, qs, value):
         if "_custom_field_data" in self.field_name and value in ("null", "0"):
             self.lookup_expr = "exact"
             value = None
-            lookup = '%s__%s' % (self.field_name, self.lookup_expr)
+            lookup = "%s__%s" % (self.field_name, self.lookup_expr)
             return self.get_method(qs)(**{lookup: value})
         return super().filter(qs, value)
-
-        
 
 
 class CustomFieldModelFilterSet(django_filters.FilterSet):

--- a/nautobot/extras/filters.py
+++ b/nautobot/extras/filters.py
@@ -328,7 +328,7 @@ class CustomFieldFilter(django_filters.Filter):
             self.lookup_expr = "contains"
 
     def filter(self, qs, value):
-        NULL_FIELDS = ("null", "0", 0)
+        NULL_FIELDS = ("null", "0")
 
         if "_custom_field_data" in self.field_name and value in NULL_FIELDS:
             lookup_exact = "%s__%s" % (self.field_name, "exact")

--- a/nautobot/extras/filters.py
+++ b/nautobot/extras/filters.py
@@ -328,8 +328,7 @@ class CustomFieldFilter(django_filters.Filter):
             self.lookup_expr = "contains"
 
     def filter(self, qs, value):
-
-        if "_custom_field_data" in self.field_name and value == "null":
+        if value == "null":
             return self.get_method(qs)(
                 Q(**{f"{self.field_name}__exact": None}) | Q(**{f"{self.field_name}__isnull": True})
             )

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -1195,7 +1195,7 @@ class CustomFieldFilterTest(TestCase):
 
     def test_filter_null_values(self):
         self.assertEquals(self.filterset({"cf_cf8": "null"}, self.queryset).qs.count(), 2)
-        self.assertEquals(self.filterset({"cf_cf9": "0"}, self.queryset).qs.count(), 1)
+        self.assertEquals(self.filterset({"cf_cf9": "null"}, self.queryset).qs.count(), 1)
 
 
 class CustomFieldChoiceTest(TestCase):

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -1194,10 +1194,8 @@ class CustomFieldFilterTest(TestCase):
         self.assertEqual(self.filterset({"cf_cf9": "Bar"}, self.queryset).qs.count(), 1)
 
     def test_filter_null_values(self):
-        self.assertEquals(self.filterset({"cf_cf1": 0}, self.queryset).qs.count(), 2)
-        self.assertEquals(self.filterset({"cf_cf2": False}, self.queryset).qs.count(), 2)
         self.assertEquals(self.filterset({"cf_cf8": "null"}, self.queryset).qs.count(), 2)
-        self.assertEquals(self.filterset({"cf_cf9": "null"}, self.queryset).qs.count(), 1)
+        self.assertEquals(self.filterset({"cf_cf9": "0"}, self.queryset).qs.count(), 1)
 
 
 class CustomFieldChoiceTest(TestCase):

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -1193,6 +1193,12 @@ class CustomFieldFilterTest(TestCase):
         self.assertEqual(self.filterset({"cf_cf9": "Foo"}, self.queryset).qs.count(), 2)
         self.assertEqual(self.filterset({"cf_cf9": "Bar"}, self.queryset).qs.count(), 1)
 
+    def test_filter_null_values(self):
+        self.assertEquals(self.filterset({"cf_cf1": 0}, self.queryset).qs.count(), 2)
+        self.assertEquals(self.filterset({"cf_cf2": False}, self.queryset).qs.count(), 2)
+        self.assertEquals(self.filterset({"cf_cf8": "null"}, self.queryset).qs.count(), 2)
+        self.assertEquals(self.filterset({"cf_cf9": "null"}, self.queryset).qs.count(), 1)
+
 
 class CustomFieldChoiceTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #795
<!--
    Please include a summary of the proposed changes below.
-->
filter objects with missing custom fields values using `null`