### PR TITLE
Injecting labels into Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,8 @@ jobs:
             type=raw,value={{branch}}-{{sha}}-{{date 'X'}},enable=${{ matrix.python-version == 3.6 }}
             type=raw,value=latest,enable=${{ matrix.python-version == 3.6 && github.ref == 'refs/heads/develop' }}
             type=raw,value=latest-py${{ matrix.python-version }},enable=${{ github.ref == 'refs/heads/develop' }}
+          labels: |
+            org.opencontainers.image.title=Nautobot
       - name: "Build"
         uses: "docker/build-push-action@v2"
         with:
@@ -244,6 +246,7 @@ jobs:
           target: final
           file: "docker/Dockerfile"
           tags: "${{ steps.dockermeta.outputs.tags }}"
+          labels: "${{ steps.dockermeta.outputs.labels }}"
           cache-from: "type=gha,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
           cache-to: "type=gha,mode=max,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
           context: "."
@@ -263,6 +266,8 @@ jobs:
             type=raw,value={{branch}}-{{sha}}-{{date 'X'}},enable=${{ matrix.python-version == 3.6 }}
             type=raw,value=latest,enable=${{ matrix.python-version == 3.6 && github.ref == 'refs/heads/develop' }}
             type=raw,value=latest-py${{ matrix.python-version }},enable=${{ github.ref == 'refs/heads/develop' }}
+          labels: |
+            org.opencontainers.image.title=Nautobot
       - name: "Build Dev Containers"
         uses: "docker/build-push-action@v2"
         with:
@@ -270,6 +275,7 @@ jobs:
           target: final-dev
           file: "docker/Dockerfile"
           tags: "${{ steps.dockerdevmeta.outputs.tags }}"
+          labels: "${{ steps.dockerdevmeta.outputs.labels }}"
           cache-from: "type=gha,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
           cache-to: "type=gha,mode=max,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
           context: "."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,8 @@ jobs:
             type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.6 }}
             type=raw,value=stable,enable=${{ matrix.python-version == 3.6 }}
             type=raw,value=stable-py${{ matrix.python-version }}
+          labels: |
+            org.opencontainers.image.title=Nautobot
       - name: "Build"
         uses: "docker/build-push-action@v2"
         with:
@@ -87,6 +89,7 @@ jobs:
           target: final
           file: "docker/Dockerfile"
           tags: "${{ steps.dockermeta.outputs.tags }}"
+          labels: "${{ steps.dockermeta.outputs.labels }}"
           cache-from: "type=gha,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
           cache-to: "type=gha,mode=max,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
           context: "."
@@ -104,6 +107,8 @@ jobs:
             type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.6 }}
             type=raw,value=stable,enable=${{ matrix.python-version == 3.6 }}
             type=raw,value=stable-py${{ matrix.python-version }}
+          labels: |
+            org.opencontainers.image.title=Nautobot
       - name: "Build Dev Containers"
         uses: "docker/build-push-action@v2"
         with:
@@ -111,6 +116,7 @@ jobs:
           target: final-dev
           file: "docker/Dockerfile"
           tags: "${{ steps.dockerdevmeta.outputs.tags }}"
+          labels: "${{ steps.dockerdevmeta.outputs.labels }}"
           cache-from: "type=gha,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
           cache-to: "type=gha,mode=max,scope=nautobot-${{ steps.gitbranch.outputs.branch }}"
           context: "."


### PR DESCRIPTION
This PR injects labels from the `docker/metadata-action` GHA into the image that is pushed to the registries.  These images are from meet the opencontainers.org standard as defined [here](https://github.com/opencontainers/image-spec/blob/main/annotations.md).  The GHA provides the following tags & labels as seen in the [recent 1.2.7 release GHA run](https://github.com/nautobot/nautobot/runs/5295752772?check_suite_focus=true#step:7:50):

```json
{
    "tags": [
      "networktocode/nautobot:1.2.7-py3.7",
      "networktocode/nautobot:stable-py3.7",
      "ghcr.io/nautobot/nautobot:1.2.7-py3.7",
      "ghcr.io/nautobot/nautobot:stable-py3.7"
    ],
    "labels": {
      "org.opencontainers.image.title": "nautobot",
      "org.opencontainers.image.description": "Network Source of Truth & Network Automation Platform",
      "org.opencontainers.image.url": "https://github.com/nautobot/nautobot",
      "org.opencontainers.image.source": "https://github.com/nautobot/nautobot",
      "org.opencontainers.image.version": "1.2.7-py3.7",
      "org.opencontainers.image.created": "2022-02-22T22:30:10.533Z",
      "org.opencontainers.image.revision": "4da94a0b6d649526a15f13615e1d7c8ba401cd9d",
      "org.opencontainers.image.licenses": "Apache-2.0"
    }
  }
```

The only one we want to override the default of is the title which defaults to `nautobot` instead of `Nautobot`.