### PR TITLE
Fix job result migration

### DIFF
--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -460,26 +460,42 @@ class BaseJob:
     def log_success(self, obj=None, message=None):
         """
         Record a successful test against an object. Logging a message is optional.
+        If the object provided is a string, treat it as a message. This is a carryover of Netbox Report API
         """
-        self._log(obj, message, level_choice=LogLevelChoices.LOG_SUCCESS)
+        if isinstance(obj, str) and message is None:
+            self._log(obj=None, message=obj, level_choice=LogLevelChoices.LOG_SUCCESS)
+        else:
+            self._log(obj, message, level_choice=LogLevelChoices.LOG_SUCCESS)
 
     def log_info(self, obj=None, message=None):
         """
         Log an informational message.
+        If the object provided is a string, treat it as a message. This is a carryover of Netbox Report API
         """
-        self._log(obj, message, level_choice=LogLevelChoices.LOG_INFO)
+        if isinstance(obj, str) and message is None:
+            self._log(obj=None, message=obj, level_choice=LogLevelChoices.LOG_INFO)
+        else:
+            self._log(obj, message, level_choice=LogLevelChoices.LOG_INFO)
 
     def log_warning(self, obj=None, message=None):
         """
         Log a warning.
+        If the object provided is a string, treat it as a message. This is a carryover of Netbox Report API
         """
-        self._log(obj, message, level_choice=LogLevelChoices.LOG_WARNING)
+        if isinstance(obj, str) and message is None:
+            self._log(obj=None, message=obj, level_choice=LogLevelChoices.LOG_WARNING)
+        else:
+            self._log(obj, message, level_choice=LogLevelChoices.LOG_WARNING)
 
     def log_failure(self, obj=None, message=None):
         """
         Log a failure. Calling this method will automatically mark the overall job as failed.
+        If the object provided is a string, treat it as a message. This is a carryover of Netbox Report API
         """
-        self._log(obj, message, level_choice=LogLevelChoices.LOG_FAILURE)
+        if isinstance(obj, str) and message is None:
+            self._log(obj=None, message=obj, level_choice=LogLevelChoices.LOG_FAILURE)
+        else:
+            self._log(obj, message, level_choice=LogLevelChoices.LOG_FAILURE)
         self.failed = True
 
     # Convenience functions

--- a/nautobot/extras/tests/dummy_jobs/test_ipaddress_vars.py
+++ b/nautobot/extras/tests/dummy_jobs/test_ipaddress_vars.py
@@ -38,7 +38,7 @@ class TestIPAddresses(Job):
         ipv6_network = data["ipv6_network"]
 
         # Log the data as JSON so we can pull it back out for testing.
-        self.log_info(obj=json.dumps({k: str(v) for k, v in data.items()}))
+        self.log_info(obj=json.dumps({k: str(v) for k, v in data.items()}), message="IP Address Test")
 
         self.log_warning(f"IPv4: {ipv4_address}")
         self.log_warning(f"IPv4: {ipv4_with_mask}")

--- a/nautobot/extras/tests/dummy_jobs/test_object_vars.py
+++ b/nautobot/extras/tests/dummy_jobs/test_object_vars.py
@@ -26,4 +26,4 @@ class TestObjectVars(Job):
 
         self.log_success(message="Job didn't crash!")
 
-        return "Nice Roles, bro."
+        return "Nice Roles!"

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -299,8 +299,9 @@ class JobTest(TestCase):
             # Assert stuff
             self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
             self.assertEqual({"role": str(d.pk), "roles": [str(d.pk)]}, job_result_data)
-            self.assertEqual(info_log.log_object, "Role: role")
-            self.assertEqual(job_result.data["output"], "\nNice Roles, bro.")
+            self.assertEqual(info_log.log_object, None)
+            self.assertEqual(info_log.message, "Role: role")
+            self.assertEqual(job_result.data["output"], "\nNice Roles!")
 
     def test_optional_object_var(self):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1431
<!--
    Please include a summary of the proposed changes below.
-->
The Job result migration does not properly handle logs where the message is stored in the object position. Logging messages to the object was a result of the Netbox Report API that was kept in place to maintain compatibility.

This PR also updates the log functions to check if the log object is a string and should therefore be in the message field instead of the object field.