### PR TITLE
Change release type trigger to 'released'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 name: "Release"
 on:
   release:
-    types: ["published"]
+    types: ["released"]
 
 jobs:
   # Ensure CI has passed


### PR DESCRIPTION
Don't run release workflow on pre-releases.
