### PR TITLE
Fixes: #1469

### DIFF
--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -782,6 +782,7 @@ class Device(PrimaryModel, ConfigContextModel, StatusModel):
             self.rack.name if self.rack else None,
             self.position,
             self.get_face_display(),
+            self.secrets_group.name if self.secrets_group else None,
             self.comments,
         )
 


### PR DESCRIPTION
### Fixes: #1469

The PR adds a `secrets_group` name to the device CSV export, which is missing.