### PR TITLE
Fixes: #1459

### DIFF
--- a/nautobot/virtualization/views.py
+++ b/nautobot/virtualization/views.py
@@ -39,8 +39,8 @@ class ClusterTypeView(generic.ObjectView):
             .filter(type=instance)
             .prefetch_related("group", "site", "tenant")
         ).annotate(
-            device_count=count_related(Device, 'cluster'),
-            vm_count=count_related(VirtualMachine, 'cluster'),
+            device_count=count_related(Device, "cluster"),
+            vm_count=count_related(VirtualMachine, "cluster"),
         )
 
         cluster_table = tables.ClusterTable(clusters)
@@ -98,8 +98,8 @@ class ClusterGroupView(generic.ObjectView):
             .filter(group=instance)
             .prefetch_related("type", "site", "tenant")
         ).annotate(
-            device_count=count_related(Device, 'cluster'),
-            vm_count=count_related(VirtualMachine, 'cluster'),
+            device_count=count_related(Device, "cluster"),
+            vm_count=count_related(VirtualMachine, "cluster"),
         )
 
         cluster_table = tables.ClusterTable(clusters)

--- a/nautobot/virtualization/views.py
+++ b/nautobot/virtualization/views.py
@@ -38,6 +38,9 @@ class ClusterTypeView(generic.ObjectView):
             Cluster.objects.restrict(request.user, "view")
             .filter(type=instance)
             .prefetch_related("group", "site", "tenant")
+        ).annotate(
+            device_count=count_related(Device, 'cluster'),
+            vm_count=count_related(VirtualMachine, 'cluster')
         )
 
         cluster_table = tables.ClusterTable(clusters)
@@ -94,6 +97,9 @@ class ClusterGroupView(generic.ObjectView):
             Cluster.objects.restrict(request.user, "view")
             .filter(group=instance)
             .prefetch_related("type", "site", "tenant")
+        ).annotate(
+            device_count=count_related(Device, 'cluster'),
+            vm_count=count_related(VirtualMachine, 'cluster')
         )
 
         cluster_table = tables.ClusterTable(clusters)

--- a/nautobot/virtualization/views.py
+++ b/nautobot/virtualization/views.py
@@ -40,7 +40,7 @@ class ClusterTypeView(generic.ObjectView):
             .prefetch_related("group", "site", "tenant")
         ).annotate(
             device_count=count_related(Device, 'cluster'),
-            vm_count=count_related(VirtualMachine, 'cluster')
+            vm_count=count_related(VirtualMachine, 'cluster'),
         )
 
         cluster_table = tables.ClusterTable(clusters)
@@ -99,7 +99,7 @@ class ClusterGroupView(generic.ObjectView):
             .prefetch_related("type", "site", "tenant")
         ).annotate(
             device_count=count_related(Device, 'cluster'),
-            vm_count=count_related(VirtualMachine, 'cluster')
+            vm_count=count_related(VirtualMachine, 'cluster'),
         )
 
         cluster_table = tables.ClusterTable(clusters)


### PR DESCRIPTION
### Fixes: #1459
The PR adds the `annotate` method to clusters in `ClusterTypeView` and `ClusterGroupView`.