### PR TITLE
Remove more Python 3.6 stuff

### DIFF
--- a/examples/example_plugin/poetry.lock
+++ b/examples/example_plugin/poetry.lock
@@ -16,28 +16,28 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.0"
-description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "zipp"
-version = "3.4.1"
-description = "Backport of pathlib-compatible object wrapper for zip files"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
+[[package]]
+name = "zipp"
+version = "3.7.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6"
-content-hash = "be99cad9186b724d8ed99dcd5fb5bdcaa622caf43a8d72de4e5dd5bbf9181a7a"
+python-versions = "^3.7"
+content-hash = "2a22bc82ee811629ebb42029928b90ed925c20022b06c4f1e165419536891759"
 
 [metadata.files]
 importlib-metadata = [
@@ -45,11 +45,10 @@ importlib-metadata = [
     {file = "importlib_metadata-4.4.0.tar.gz", hash = "sha256:e592faad8de1bda9fe920cf41e15261e7131bcf266c30306eec00e8e225c1dd5"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
-    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
-    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 zipp = [
-    {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},
-    {file = "zipp-3.4.1.tar.gz", hash = "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"},
+    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
+    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
 ]

--- a/examples/example_plugin/pyproject.toml
+++ b/examples/example_plugin/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 importlib-metadata = {version = "~4.4", python = "<3.10"}
 
 [tool.poetry.dev-dependencies]
@@ -20,7 +20,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 120
-target-version = ['py36']
+target-version = ['py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/nautobot/docs/installation/index.md
+++ b/nautobot/docs/installation/index.md
@@ -14,7 +14,7 @@ The following minimum versions are required for Nautobot to operate:
 
 | Dependency | Role         | Minimum Version |
 |------------|--------------|-----------------|
-| Python     | Application  | 3.6             |
+| Python     | Application  | 3.7             |
 | PostgreSQL | Database     | 9.6             |
 | MySQL      | Database     | 8.0             |
 | Redis      | Cache, Queue | 4.0             |

--- a/nautobot/docs/installation/upgrading.md
+++ b/nautobot/docs/installation/upgrading.md
@@ -27,11 +27,11 @@ As of Nautobot v1.2.0, Nautobot supports deferring ("scheduling") Jobs. To facil
 
 ## Update Prerequisites to Required Versions
 
-Nautobot v1.0.0 and later requires the following:
+Nautobot v1.3.0 and later requires the following:
 
 | Dependency | Minimum Version |
 |------------|-----------------|
-| Python     | 3.6             |
+| Python     | 3.7             |
 | PostgreSQL | 9.6             |
 | Redis      | 4.0             |
 

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -78,7 +78,7 @@ Version [0.1.0]:
 Description []:  An example Nautobot plugin
 Author [, n to skip]:  Bob Jones
 License []:  Apache 2.0
-Compatible Python versions [^3.8]:  ^3.6
+Compatible Python versions [^3.8]:  ^3.7
 
 Would you like to define your main dependencies interactively? (yes/no) [yes] no
 Would you like to define your development dependencies interactively? (yes/no) [yes] no

--- a/tasks.py
+++ b/tasks.py
@@ -42,7 +42,7 @@ namespace.configure(
     {
         "nautobot": {
             "project_name": "nautobot",
-            "python_ver": "3.6",
+            "python_ver": "3.7",
             "local": False,
             "compose_dir": os.path.join(os.path.dirname(__file__), "development/"),
             "compose_files": [


### PR DESCRIPTION
### Relates-to: #1268 

- Change the default Python version in tasks.py to 3.7
- Update the minimum Python version of the example-plugin 
- A couple of documentation updates