### PR TITLE
Update the advanced logging example

### DIFF
--- a/examples/logging/advanced_requests.md
+++ b/examples/logging/advanced_requests.md
@@ -4,6 +4,9 @@ By default django logs [4xx and 5xx requests](https://docs.djangoproject.com/en/
 but is missing details such as the request user name.  This can be helpful in debugging. This example 
 shows how the request user can be added to the logs for 4xx and 5xx responses.
 
+Using the django-request-logging module can lead to password leaks if not configured correctly. If using in production, make sure that you capture all passwords and mask them in logs. The bellow example uses the `mask_password` function to manipulate the message before logged.
+
+
 ```python
 def add_username(record):
     if hasattr(record, "request") and hasattr(record.request, "user"):
@@ -12,6 +15,9 @@ def add_username(record):
         record.username = ""
     return True
 
+def mask_password(record):
+    record.msg = re.sub(r"password=(.*?)($|&|\n)", r"password=*****\g<2>", record.msg)
+    return True
 
 LOG_LEVEL = "DEBUG" if DEBUG else "INFO"
 LOGGING = {
@@ -37,13 +43,17 @@ LOGGING = {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
             "formatter": "request",
-            "filters": ["add_username"],
+            "filters": ["add_username", "mask_password"],
         },
     },
     "filters": {
         "add_username": {
             "()": "django.utils.log.CallbackFilter",
             "callback": add_username,
+        },
+        "mask_password": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": mask_password,
         }
     },
     "loggers": {


### PR DESCRIPTION
The original example can leak passwords if passwords are sent in a request body. This happens at login for example. We should mask passwords.

