### PR TITLE
Implement REST API versioning and consolidate Job REST API endpoints

### DIFF
--- a/nautobot/core/api/versioning.py
+++ b/nautobot/core/api/versioning.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+from django.utils.translation import gettext_lazy as _
+from rest_framework.versioning import AcceptHeaderVersioning
+
+
+class NautobotAcceptHeaderVersioning(AcceptHeaderVersioning):
+    """Extend the DRF AcceptHeaderVersioning class with a more verbose rejection message."""
+
+    invalid_version_message = _(f'Invalid version in "Accept" header. Supported versions are %(versions)s') % {
+        "versions": ", ".join(settings.REST_FRAMEWORK["ALLOWED_VERSIONS"])
+    }

--- a/nautobot/core/api/versioning.py
+++ b/nautobot/core/api/versioning.py
@@ -6,6 +6,6 @@ from rest_framework.versioning import AcceptHeaderVersioning
 class NautobotAcceptHeaderVersioning(AcceptHeaderVersioning):
     """Extend the DRF AcceptHeaderVersioning class with a more verbose rejection message."""
 
-    invalid_version_message = _(f'Invalid version in "Accept" header. Supported versions are %(versions)s') % {
+    invalid_version_message = _('Invalid version in "Accept" header. Supported versions are %(versions)s') % {
         "versions": ", ".join(settings.REST_FRAMEWORK["ALLOWED_VERSIONS"])
     }

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -46,6 +46,16 @@ HTTP_ACTIONS = {
 }
 
 
+class NautobotAPIVersionMixin:
+    """Add Nautobot-specific handling to the base APIView class."""
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        """Returns the final response object."""
+        response = super().finalize_response(request, response, *args, **kwargs)
+        # Add the API version to the response
+        response["API-Version"] = request.version
+        return response
+
 #
 # Mixins
 #
@@ -218,7 +228,13 @@ class ModelViewSetMixin:
             return self.finalize_response(request, Response({"detail": msg}, status=409), *args, **kwargs)
 
 
-class ModelViewSet(BulkUpdateModelMixin, BulkDestroyModelMixin, ModelViewSetMixin, ModelViewSet_):
+class ModelViewSet(
+    BulkUpdateModelMixin,
+    BulkDestroyModelMixin,
+    NautobotAPIVersionMixin,
+    ModelViewSetMixin,
+    ModelViewSet_
+):
     """
     Extend DRF's ModelViewSet to support bulk update and delete functions.
     """
@@ -271,7 +287,7 @@ class ModelViewSet(BulkUpdateModelMixin, BulkDestroyModelMixin, ModelViewSetMixi
         return super().perform_destroy(instance)
 
 
-class ReadOnlyModelViewSet(ModelViewSetMixin, ReadOnlyModelViewSet_):
+class ReadOnlyModelViewSet(NautobotAPIVersionMixin, ModelViewSetMixin, ReadOnlyModelViewSet_):
     """
     Extend DRF's ReadOnlyModelViewSet to support queryset restriction.
     """
@@ -282,7 +298,7 @@ class ReadOnlyModelViewSet(ModelViewSetMixin, ReadOnlyModelViewSet_):
 #
 
 
-class APIRootView(APIView):
+class APIRootView(NautobotAPIVersionMixin, APIView):
     """
     This is the root of the REST API. API endpoints are arranged by app and model name; e.g. `/api/dcim/sites/`.
     """
@@ -342,7 +358,7 @@ class APIRootView(APIView):
         )
 
 
-class StatusView(APIView):
+class StatusView(NautobotAPIVersionMixin, APIView):
     """
     A lightweight read-only endpoint for conveying the current operational status.
     """
@@ -391,7 +407,7 @@ class StatusView(APIView):
 #
 
 
-class GraphQLDRFAPIView(APIView):
+class GraphQLDRFAPIView(NautobotAPIVersionMixin, APIView):
     """
     API View for GraphQL to integrate properly with DRF authentication mecanism.
     The code is a stripped down version of graphene-django default View

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -197,6 +197,12 @@ class ModelViewSetMixin:
         """
         super().initial(request, *args, **kwargs)
 
+        # Django Rest Framework stores the raw API version string e.g. "1.2" as request.version.
+        # For convenience we split it out into integer major/minor versions as well.
+        major, minor = request.version.split(".")
+        request.major_version = int(major)
+        request.minor_version = int(minor)
+
         self.restrict_queryset(request, *args, **kwargs)
 
     def dispatch(self, request, *args, **kwargs):

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -46,19 +46,23 @@ HTTP_ACTIONS = {
 }
 
 
+#
+# Mixins
+#
+
+
 class NautobotAPIVersionMixin:
     """Add Nautobot-specific handling to the base APIView class."""
 
     def finalize_response(self, request, response, *args, **kwargs):
         """Returns the final response object."""
         response = super().finalize_response(request, response, *args, **kwargs)
-        # Add the API version to the response
-        response["API-Version"] = request.version
+        try:
+            # Add the API version to the response, if available
+            response["API-Version"] = request.version
+        except AttributeError:
+            pass
         return response
-
-#
-# Mixins
-#
 
 
 class BulkUpdateModelMixin:
@@ -229,11 +233,11 @@ class ModelViewSetMixin:
 
 
 class ModelViewSet(
+    NautobotAPIVersionMixin,
     BulkUpdateModelMixin,
     BulkDestroyModelMixin,
-    NautobotAPIVersionMixin,
     ModelViewSetMixin,
-    ModelViewSet_
+    ModelViewSet_,
 ):
     """
     Extend DRF's ModelViewSet to support bulk update and delete functions.

--- a/nautobot/core/middleware.py
+++ b/nautobot/core/middleware.py
@@ -97,21 +97,6 @@ class ObjectChangeMiddleware(object):
         return response
 
 
-class APIVersionMiddleware(object):
-    """
-    If the request is for an API endpoint, include the API version as a response header.
-    """
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        response = self.get_response(request)
-        if is_api_request(request):
-            response["API-Version"] = settings.REST_FRAMEWORK_VERSION
-        return response
-
-
 class ExceptionHandlingMiddleware(object):
     """
     Intercept certain exceptions which are likely indicative of installation issues and provide helpful instructions

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -142,8 +142,14 @@ FILTERS_NULL_CHOICE_VALUE = "null"
 #
 
 REST_FRAMEWORK_VERSION = VERSION.rsplit(".", 1)[0]  # Use major.minor as API version
+current_major, current_minor = REST_FRAMEWORK_VERSION.split(".")
+# We support all major.minor API versions from 1.2 to the present latest version.
+# This will need to be elaborated upon when we move to version 2.0
+assert current_major == "1", f"REST_FRAMEWORK_ALLOWED_VERSIONS needs to be updated to handle version {current_major}"
+REST_FRAMEWORK_ALLOWED_VERSIONS = [f"{current_major}.{minor}" for minor in range(2, int(current_minor) + 1)]
+
 REST_FRAMEWORK = {
-    "ALLOWED_VERSIONS": [REST_FRAMEWORK_VERSION],
+    "ALLOWED_VERSIONS": REST_FRAMEWORK_ALLOWED_VERSIONS,
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework.authentication.SessionAuthentication",
         "nautobot.core.api.authentication.TokenAuthentication",
@@ -156,8 +162,10 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.JSONRenderer",
         "nautobot.core.api.renderers.FormlessBrowsableAPIRenderer",
     ),
-    "DEFAULT_VERSION": REST_FRAMEWORK_VERSION,
-    "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.AcceptHeaderVersioning",
+    # Version to use if the client doesn't request otherwise.
+    # This should only change (if at all) with Nautobot major (breaking) releases.
+    "DEFAULT_VERSION": "1.2",
+    "DEFAULT_VERSIONING_CLASS": "nautobot.core.api.versioning.NautobotAcceptHeaderVersioning",
     "PAGE_SIZE": None,
     "SCHEMA_COERCE_METHOD_NAMES": {
         # Default mappings

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -319,7 +319,6 @@ MIDDLEWARE = [
     "nautobot.core.middleware.ExceptionHandlingMiddleware",
     "nautobot.core.middleware.RemoteUserMiddleware",
     "nautobot.core.middleware.ExternalAuthMiddleware",
-    "nautobot.core.middleware.APIVersionMiddleware",
     "nautobot.core.middleware.ObjectChangeMiddleware",
     "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -449,6 +449,9 @@ The `class_path` is often represented as a string in the format of `<grouping_na
 `local/example/MyJobWithNoVars` or `plugins/nautobot_golden_config.jobs/BackupJob`. Understanding the definitions of these
 elements will be important in running jobs programmatically.
 
+!!! note
+    In Nautobot 1.3 and later, with the addition of Job database models, it is now generally possible and preferable to refer to a job by its UUID primary key, similar to other Nautobot database models, rather than its `class_path`.
+
 ### Via the Web UI
 
 Jobs can be run via the web UI by navigating to the job, completing any required form data (if any), and clicking the "Run Job" button.
@@ -457,10 +460,7 @@ Once a job has been run, the latest [`JobResult`](../models/extras/jobresult.md)
 
 ### Via the API
 
-To run a job via the REST API, issue a POST request to the job's endpoint `/api/extras/jobs/<class_path>/run`. You can optionally provide JSON data to set the `commit` flag, specify any required user input `data`, and/or provide optional scheduling information as described in [the section on scheduling and approvals](./job-scheduling-and-approvals.md).
-
-!!! note
-    [See above](#jobs-and-class_path) for information on constructing the `class_path` for any given Job.
+To run a job via the REST API, issue a POST request to the job's endpoint `/api/extras/jobs/<uuid>/run`. You can optionally provide JSON data to set the `commit` flag, specify any required user input `data`, and/or provide optional scheduling information as described in [the section on scheduling and approvals](./job-scheduling-and-approvals.md).
 
 For example, to run a job with no user inputs and without committing any anything to the database:
 
@@ -468,8 +468,8 @@ For example, to run a job with no user inputs and without committing any anythin
 curl -X POST \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
--H "Accept: application/json; indent=4" \
-http://nautobot/api/extras/jobs/local/example/MyJobWithNoVars/run/
+-H "Accept: application/json; version=1.3; indent=4" \
+http://nautobot/api/extras/jobs/$JOB_ID/run/
 ```
 
 Or to run a job that expects user inputs, and commit changes to the database:
@@ -478,8 +478,8 @@ Or to run a job that expects user inputs, and commit changes to the database:
 curl -X POST \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
--H "Accept: application/json; indent=4" \
-http://nautobot/api/extras/jobs/local/example/MyJobWithVars/run/ \
+-H "Accept: application/json; version=1.3; indent=4" \
+http://nautobot/api/extras/jobs/$JOB_ID/run/ \
 --data '{"data": {"string_variable": "somevalue", "integer_variable": 123}, "commit": true}'
 ```
 
@@ -544,8 +544,8 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.test import TransactionTestCase
 
-from nautobot.extras.jobs import get_job, run_job
-from nautobot.extras.models import JobResult, JobLogEntry
+from nautobot.extras.jobs import run_job
+from nautobot.extras.models import Job, JobResult, JobLogEntry
 
 
 if "job_logs" in settings.DATABASES:
@@ -559,10 +559,12 @@ class MyJobTestCase(TransactionTestCase):
 
     def test_my_job(self):
         # Testing of Job "MyJob" in file "my_job_file.py" in $JOBS_ROOT
-        job_class = get_job("local/my_job_file/MyJob")
+        job = Job.objects.get(job_class_name="MyJob", module_name="my_job_file", source="local")
+        # or, job = Job.objects.get_for_class_path("local/my_job_file/MyJob")
         job_result = JobResult.objects.create(
-            name=job_class.class_path,
+            name=job.class_path,
             obj_type=ContentType.objects.get(app_label="extras", model="job"),
+            job_model=job,
             job_id=uuid.uuid4(),
         )
         run_job(data={"my_variable": "my_value"}, request=None, commit=False, job_result_pk=job_result.pk)

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -460,7 +460,7 @@ Once a job has been run, the latest [`JobResult`](../models/extras/jobresult.md)
 
 ### Via the API
 
-To run a job via the REST API, issue a POST request to the job's endpoint `/api/extras/jobs/<uuid>/run`. You can optionally provide JSON data to set the `commit` flag, specify any required user input `data`, and/or provide optional scheduling information as described in [the section on scheduling and approvals](./job-scheduling-and-approvals.md).
+To run a job via the REST API, issue a POST request to the job's endpoint `/api/extras/jobs/<uuid>/run/`. You can optionally provide JSON data to set the `commit` flag, specify any required user input `data`, and/or provide optional scheduling information as described in [the section on scheduling and approvals](./job-scheduling-and-approvals.md).
 
 For example, to run a job with no user inputs and without committing any anything to the database:
 

--- a/nautobot/docs/release-notes/version-1.3.md
+++ b/nautobot/docs/release-notes/version-1.3.md
@@ -28,11 +28,8 @@ Installed Jobs are now represented by a data model in the Nautobot database. Thi
 - The Jobs listing UI view can now be filtered and searched like most other Nautobot table/list views.
 - Job attributes (name, description, approval requirements, etc.) can now be managed via the Nautobot UI by an administrator or user with appropriate permissions to customize or override the attributes defined in the Job source code.
 - Jobs can now be identified by a `slug` as well as by their `class_path`.
-- A new set of REST API endpoints have been added at `api/extras/job-models`. The existing `api/extras/jobs` REST API continues to work but should be considered as deprecated.
-
-!!! warning
-    The new Jobs REST API endpoint URL is likely to change before the final release of Nautobot 1.3.
-
+- A new set of REST API endpoints have been added to `api/extras/jobs/<uuid>/`. The existing `api/extras/jobs/<class_path>` REST API endpoints continue to work but should be considered as deprecated.
+  - A new version of the REST API `api/extras/jobs/` list endpoint has been implemented as well, but by default this endpoint continues to demonstrate the pre-1.3 behavior unless the REST API client explicitly requests API `version=1.3`. See the section on REST API versioning, below, for more details.
 - As a minor security measure, newly installed Jobs default to `enabled = False`, preventing them from being run until an administrator or user with appropriate permissions updates them to be enabled for running.
 
 !!! note
@@ -47,6 +44,18 @@ A [data model](../models/circuits/providernetwork.md) has been added to support 
 #### Python 3.10 Support ([#1255](https://github.com/nautobot/nautobot/pull/1255))
 
 Python 3.10 is officially supported by Nautobot now, and we are building and publishing Docker images with Python 3.10 now.
+
+#### REST API Versioning ([#1465](https://github.com/nautobot/nautobot/issues/1465))
+
+Nautobot's REST API now supports multiple versions, which may requested by modifying the HTTP Accept header on any requests sent by a REST API client. Details are in the [REST API documentation](../rest-api/overview.md#versioning), but in brief:
+
+- The only REST API endpoint that is versioned in the 1.3.0 release is the `api/extras/jobs/` listing endpoint, as described above. All others are currently un-versioned. However, over time more versioned REST APIs will be developed, so this is important to understand for all REST API consumers.
+- If a REST API client does not request a specific REST API version (in other words, requests `Accept: application/json` rather than `Accept: application/json; version=1.3`) the API behavior will be compatible with Nautobot 1.2, at a minimum for the remainder of the Nautobot 1.x release cycle.
+- The API behavior may change to a newer default version in a Nautobot major release (e.g. 2.0).
+- To request an updated (non-backwards-compatible) API endpoint, an API version must be requested corresponding at a minimum to the Nautobot major.minor version where the updated API endpoint was introduced (so to interact with the new Jobs REST API, `Accept: application/json; version=1.3`).
+
+!!! tip
+    As a best practice, when developing a Nautobot REST API integration, your client should _always_ request the current API version it is being developed against, rather than relying on the default API behavior (which may change with a new Nautobot major release, as noted, and which also may not include the latest and greatest API endpoints already available but not yet made default in the current release).
 
 ### Changed
 

--- a/nautobot/docs/release-notes/version-1.3.md
+++ b/nautobot/docs/release-notes/version-1.3.md
@@ -28,8 +28,8 @@ Installed Jobs are now represented by a data model in the Nautobot database. Thi
 - The Jobs listing UI view can now be filtered and searched like most other Nautobot table/list views.
 - Job attributes (name, description, approval requirements, etc.) can now be managed via the Nautobot UI by an administrator or user with appropriate permissions to customize or override the attributes defined in the Job source code.
 - Jobs can now be identified by a `slug` as well as by their `class_path`.
-- A new set of REST API endpoints have been added to `api/extras/jobs/<uuid>/`. The existing `api/extras/jobs/<class_path>` REST API endpoints continue to work but should be considered as deprecated.
-  - A new version of the REST API `api/extras/jobs/` list endpoint has been implemented as well, but by default this endpoint continues to demonstrate the pre-1.3 behavior unless the REST API client explicitly requests API `version=1.3`. See the section on REST API versioning, below, for more details.
+- A new set of REST API endpoints have been added to `/api/extras/jobs/<uuid>/`. The existing `/api/extras/jobs/<class_path>/` REST API endpoints continue to work but should be considered as deprecated.
+  - A new version of the REST API `/api/extras/jobs/` list endpoint has been implemented as well, but by default this endpoint continues to demonstrate the pre-1.3 behavior unless the REST API client explicitly requests API `version=1.3`. See the section on REST API versioning, below, for more details.
 - As a minor security measure, newly installed Jobs default to `enabled = False`, preventing them from being run until an administrator or user with appropriate permissions updates them to be enabled for running.
 
 !!! note
@@ -49,10 +49,10 @@ Python 3.10 is officially supported by Nautobot now, and we are building and pub
 
 Nautobot's REST API now supports multiple versions, which may requested by modifying the HTTP Accept header on any requests sent by a REST API client. Details are in the [REST API documentation](../rest-api/overview.md#versioning), but in brief:
 
-- The only REST API endpoint that is versioned in the 1.3.0 release is the `api/extras/jobs/` listing endpoint, as described above. All others are currently un-versioned. However, over time more versioned REST APIs will be developed, so this is important to understand for all REST API consumers.
+- The only REST API endpoint that is versioned in the 1.3.0 release is the `/api/extras/jobs/` listing endpoint, as described above. All others are currently un-versioned. However, over time more versioned REST APIs will be developed, so this is important to understand for all REST API consumers.
 - If a REST API client does not request a specific REST API version (in other words, requests `Accept: application/json` rather than `Accept: application/json; version=1.3`) the API behavior will be compatible with Nautobot 1.2, at a minimum for the remainder of the Nautobot 1.x release cycle.
 - The API behavior may change to a newer default version in a Nautobot major release (e.g. 2.0).
-- To request an updated (non-backwards-compatible) API endpoint, an API version must be requested corresponding at a minimum to the Nautobot major.minor version where the updated API endpoint was introduced (so to interact with the new Jobs REST API, `Accept: application/json; version=1.3`).
+- To request an updated (non-backwards-compatible) API endpoint, an API version must be requested corresponding at a minimum to the Nautobot `major.minor` version where the updated API endpoint was introduced (so to interact with the new Jobs REST API, `Accept: application/json; version=1.3`).
 
 !!! tip
     As a best practice, when developing a Nautobot REST API integration, your client should _always_ request the current API version it is being developed against, rather than relying on the default API behavior (which may change with a new Nautobot major release, as noted, and which also may not include the latest and greatest API endpoints already available but not yet made default in the current release).

--- a/nautobot/docs/rest-api/overview.md
+++ b/nautobot/docs/rest-api/overview.md
@@ -130,38 +130,38 @@ Breaking (non-backward-compatible) REST API changes also may be introduced in ma
 - Changed field types (for example, changing a single value to a list of values)
 - Redesigned API (for example, listing and accessing Job instances by UUID primary-key instead of by class-path string)
 
-Per Nautobot's feature-deprecation policy, the previous REST API version will continue to be supported for some time before eventually being removed.
+Per Nautobot's [feature-deprecation policy](../development/index.md#deprecation-policy), the previous REST API version will continue to be supported for some time before eventually being removed.
 
 !!! important
     When breaking changes are introduced in a minor release, for compatibility as described above, the default REST API behavior within the remainder of the current major release cycle will continue to be the previous (unchanged) API version. API clients must "opt in" to the new version of the API by explicitly requesting the new API version.
 
 !!! tip
-    This is another reason to always specify the exact major.minor Nautobot REST API version when developing a REST API client integration, as it guarantees that the client will be receiving the latest API feature set available in that release rather than possibly defaulting to an older REST API version that is still default but is now deprecated.
+    This is another reason to always specify the exact `major.minor` Nautobot REST API version when developing a REST API client integration, as it guarantees that the client will be receiving the latest API feature set available in that release rather than possibly defaulting to an older REST API version that is still default but is now deprecated.
 
 ### Example of API Version Behavior
 
 As an example, let us say that Nautobot 1.3 introduced a new, _non-backwards-compatible_ REST API for the `/api/extras/jobs/` endpoint, and also introduced a new, _backwards-compatible_ set of additional fields on the `/api/dcim/sites/` endpoint. Depending on what API version a REST client interacting with Nautobot 1.3 specified (or didn't specify), it would see the following responses from the server:
 
-| API endpoint       | Requested API version | Response                                     |
-| ------------------ | --------------------- | -------------------------------------------- |
-| `/api/extras/jobs` | (unspecified)         | Deprecated 1.2-compatible REST API           |
-| `/api/extras/jobs` | `version=1.2`         | Deprecated 1.2-compatible REST API           |
-| `/api/extras/jobs` | `version=1.3`         | New/updated 1.3-compatible REST API          |
+| API endpoint        | Requested API version | Response                                     |
+| ------------------- | --------------------- | -------------------------------------------- |
+| `/api/extras/jobs/` | (unspecified)         | Deprecated 1.2-compatible REST API           |
+| `/api/extras/jobs/` | `version=1.2`         | Deprecated 1.2-compatible REST API           |
+| `/api/extras/jobs/` | `version=1.3`         | New/updated 1.3-compatible REST API          |
 
 !!! important
     Note again that if not specifying an API version, the client _would not_ receive the latest API version when breaking changes are present. Even though the server had Nautobot version 1.3, the default Jobs REST API behavior would be that of Nautobot 1.2. Only by actually specifying `version=1.3` was the client able to access the new Jobs REST API.
 
-| API endpoint       | Requested API version | Response                                     |
-| ------------------ | --------------------- | -------------------------------------------- |
-| `/api/dcim/sites`  | (unspecified)         | 1.3-updated, 1.2-compatible REST API         |
-| `/api/dcim/sites`  | `version=1.2`         | 1.3-updated, 1.2-compatible REST API         |
-| `/api/dcim/sites`  | `version=1.3`         | 1.3-updated, 1.2-compatible REST API         |
+| API endpoint        | Requested API version | Response                                     |
+| ------------------- | --------------------- | -------------------------------------------- |
+| `/api/dcim/sites/`  | (unspecified)         | 1.3-updated, 1.2-compatible REST API         |
+| `/api/dcim/sites/`  | `version=1.2`         | 1.3-updated, 1.2-compatible REST API         |
+| `/api/dcim/sites/`  | `version=1.3`         | 1.3-updated, 1.2-compatible REST API         |
 
-| API endpoint       | Requested API version | Response                                     |
-| ------------------ | --------------------- | -------------------------------------------- |
-| `/api/dcim/racks`  | (unspecified)         | 1.2-compatible REST API (unchanged)          |
-| `/api/dcim/racks`  | `version=1.2`         | 1.2-compatible REST API (unchanged)          |
-| `/api/dcim/racks`  | `version=1.3`         | 1.3-compatible REST API (unchanged from 1.2) |
+| API endpoint        | Requested API version | Response                                     |
+| ------------------- | --------------------- | -------------------------------------------- |
+| `/api/dcim/racks/`  | (unspecified)         | 1.2-compatible REST API (unchanged)          |
+| `/api/dcim/racks/`  | `version=1.2`         | 1.2-compatible REST API (unchanged)          |
+| `/api/dcim/racks/`  | `version=1.3`         | 1.3-compatible REST API (unchanged from 1.2) |
 
 ## Serialization
 

--- a/nautobot/docs/rest-api/overview.md
+++ b/nautobot/docs/rest-api/overview.md
@@ -93,6 +93,76 @@ GET /api/dcim/interfaces/?device_id=6a522ebb-5739-4c5c-922f-ab4a2dc12eb0
 
 See the [filtering documentation](filtering.md) for more details.
 
+## Versioning
+
+As of Nautobot 1.3, the REST API supports multiple versions. A REST API client may request the API version as implemented in a given Nautobot release by including the major.minor version number in the HTTP Accept header, for example `Accept: application/json; version=1.3`.
+
+### Default Versions and Backward Compatibility
+
+By default, a REST API request that does not specify an API version number will default to compatibility with a specified Nautobot version. This default REST API version can be expected to remain constant throughout the lifespan of a given Nautobot major release.
+
+!!! note
+    For Nautobot 1.x, the default API behavior is to be compatible with the REST API of Nautobot version 1.2, in other words, for all Nautobot 1.x versions (beginning with Nautobot 1.2.0), `Accept: application/json` is functionally equivalent to `Accept: application/json; version=1.2`.
+
+!!! tip
+    The default REST API version compatibility may change in a subsequent Nautobot major release, so as a best practice, it is recommended that a REST API client _should always_ request the exact Nautobot REST API version that it is compatible with, rather than relying on the default behavior to remain constant.
+
+!!! tip
+    Any successful REST API response will include an `API-Version` header showing the API version that is in use for the specific API request being handled.
+
+### Non-Breaking Changes
+
+Non-breaking (forward- and backward-compatible) REST API changes may be introduced in major or minor Nautobot releases. Since these changes are non-breaking, they will *not* correspond to the introduction of a new API version, but will be added seamlessly to the existing API version, and so will immediately be available to existing REST API clients. Examples would include:
+
+- Addition of new fields in GET responses
+- Understanding of new, _optional_ fields in POST/PUT/PATCH requests
+- Deprecation (but not removal) of existing fields
+
+!!! important
+    There is no way to "opt out" of backwards-compatible enhancements to the REST API; because they are fully backwards-compatible there should never be a need to do so. Thus, for example, a client requesting API version `1.2` from a Nautobot 1.3 server may actually receive the (updated but still backwards-compatible) `1.3` API version as a response. For this reason, clients should always default to ignoring additional fields in an API response that they do not understand, rather than reporting an error.
+
+### Breaking Changes
+
+Breaking (non-backward-compatible) REST API changes also may be introduced in major or minor Nautobot releases. Examples would include:
+
+- Removal of deprecated fields
+- Addition of new, _required_ fields in POST/PUT/PATCH requests
+- Changed field types (for example, changing a single value to a list of values)
+- Redesigned API (for example, listing and accessing Job instances by UUID primary-key instead of by class-path string)
+
+Per Nautobot's feature-deprecation policy, the previous REST API version will continue to be supported for some time before eventually being removed.
+
+!!! important
+    When breaking changes are introduced in a minor release, for compatibility as described above, the default REST API behavior within the remainder of the current major release cycle will continue to be the previous (unchanged) API version. API clients must "opt in" to the new version of the API by explicitly requesting the new API version.
+
+!!! tip
+    This is another reason to always specify the exact major.minor Nautobot REST API version when developing a REST API client integration, as it guarantees that the client will be receiving the latest API feature set available in that release rather than possibly defaulting to an older REST API version that is still default but is now deprecated.
+
+### Example of API Version Behavior
+
+As an example, let us say that Nautobot 1.3 introduced a new, _non-backwards-compatible_ REST API for the `/api/extras/jobs/` endpoint, and also introduced a new, _backwards-compatible_ set of additional fields on the `/api/dcim/sites/` endpoint. Depending on what API version a REST client interacting with Nautobot 1.3 specified (or didn't specify), it would see the following responses from the server:
+
+| API endpoint       | Requested API version | Response                                     |
+| ------------------ | --------------------- | -------------------------------------------- |
+| `/api/extras/jobs` | (unspecified)         | Deprecated 1.2-compatible REST API           |
+| `/api/extras/jobs` | `version=1.2`         | Deprecated 1.2-compatible REST API           |
+| `/api/extras/jobs` | `version=1.3`         | New/updated 1.3-compatible REST API          |
+
+!!! important
+    Note again that if not specifying an API version, the client _would not_ receive the latest API version when breaking changes are present. Even though the server had Nautobot version 1.3, the default Jobs REST API behavior would be that of Nautobot 1.2. Only by actually specifying `version=1.3` was the client able to access the new Jobs REST API.
+
+| API endpoint       | Requested API version | Response                                     |
+| ------------------ | --------------------- | -------------------------------------------- |
+| `/api/dcim/sites`  | (unspecified)         | 1.3-updated, 1.2-compatible REST API         |
+| `/api/dcim/sites`  | `version=1.2`         | 1.3-updated, 1.2-compatible REST API         |
+| `/api/dcim/sites`  | `version=1.3`         | 1.3-updated, 1.2-compatible REST API         |
+
+| API endpoint       | Requested API version | Response                                     |
+| ------------------ | --------------------- | -------------------------------------------- |
+| `/api/dcim/racks`  | (unspecified)         | 1.2-compatible REST API (unchanged)          |
+| `/api/dcim/racks`  | `version=1.2`         | 1.2-compatible REST API (unchanged)          |
+| `/api/dcim/racks`  | `version=1.3`         | 1.3-compatible REST API (unchanged from 1.2) |
+
 ## Serialization
 
 The REST API employs two types of serializers to represent model data: base serializers and nested serializers. The base serializer is used to present the complete view of a model. This includes all database table fields which comprise the model, and may include additional metadata. A base serializer includes relationships to parent objects, but **does not** include child objects. For example, the `VLANSerializer` includes a nested representation its parent VLANGroup (if any), but does not include any assigned Prefixes.
@@ -175,7 +245,7 @@ Together, these values identify a unique object in Nautobot. The assigned object
 curl -X POST \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
--H "Accept: application/json; indent=4" \
+-H "Accept: application/json; version=1.3; indent=4" \
 http://nautobot/api/ipam/ip-addresses/ \
 --data '{
     "address": "192.0.2.1/24",
@@ -284,7 +354,8 @@ Here is an example of a paginated response:
 
 ```
 HTTP 200 OK
-Allow: GET, POST, OPTIONS
+Allow: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+API-Version: 1.2
 Content-Type: application/json
 Vary: Accept
 
@@ -334,10 +405,12 @@ The maximum number of objects that can be returned is limited by the [`MAX_PAGE_
 
 ### Retrieving Multiple Objects
 
-To query Nautobot for a list of objects, make a `GET` request to the model's _list_ endpoint. Objects are listed under the response object's `results` parameter.
+To query Nautobot for a list of objects, make a `GET` request to the model's _list_ endpoint. Objects are listed under the response object's `results` parameter. Specifying the `Accept` header with the Nautobot API version is not required, but is strongly recommended.
 
 ```no-highlight
-curl -s -X GET http://nautobot/api/ipam/ip-addresses/ | jq '.'
+curl -s -X GET \
+-H "Accept: application/json; version=1.3" \
+http://nautobot/api/ipam/ip-addresses/ | jq '.'
 ```
 
 ```json
@@ -374,7 +447,9 @@ To query Nautobot for a single object, make a `GET` request to the model's _deta
     Note that the trailing slash is required. Omitting this will return a 302 redirect.
 
 ```no-highlight
-curl -s -X GET http://nautobot/api/ipam/ip-addresses/bd307eca-de34-4bda-9195-d69ca52206d6/ | jq '.'
+curl -s -X GET \
+-H "Accept: application/json; version=1.3" \
+http://nautobot/api/ipam/ip-addresses/bd307eca-de34-4bda-9195-d69ca52206d6/ | jq '.'
 ```
 
 ```json
@@ -387,12 +462,13 @@ curl -s -X GET http://nautobot/api/ipam/ip-addresses/bd307eca-de34-4bda-9195-d69
 
 ### Creating a New Object
 
-To create a new object, make a `POST` request to the model's _list_ endpoint with JSON data pertaining to the object being created. Note that a REST API token is required for all write operations; see the [authentication documentation](../authentication/) for more information. Also be sure to set the `Content-Type` HTTP header to `application/json`.
+To create a new object, make a `POST` request to the model's _list_ endpoint with JSON data pertaining to the object being created. Note that a REST API token is required for all write operations; see the [authentication documentation](../authentication/) for more information. Also be sure to set the `Content-Type` HTTP header to `application/json`. As always, it's a good practice to also set the `Accept` HTTP header to include the requested REST API version.
 
 ```no-highlight
 curl -s -X POST \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
+-H "Accept: application/json; version=1.3" \
 http://nautobot/api/ipam/prefixes/ \
 --data '{"prefix": "192.0.2.0/24", "site": 8df9e629-4338-438b-8ea9-06114f7be08e}' | jq '.'
 ```
@@ -436,7 +512,7 @@ To create multiple instances of a model using a single request, make a `POST` re
 ```no-highlight
 curl -X POST -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
--H "Accept: application/json; indent=4" \
+-H "Accept: application/json; version=1.3; indent=4" \
 http://nautobot/api/dcim/sites/ \
 --data '[
 {"name": "Site 1", "slug": "site-1", "region": {"name": "United States"}},
@@ -470,12 +546,13 @@ http://nautobot/api/dcim/sites/ \
 
 ### Updating an Object
 
-To modify an object which has already been created, make a `PATCH` request to the model's _detail_ endpoint specifying its UUID. Include any data which you wish to update on the object. As with object creation, the `Authorization` and `Content-Type` headers must also be specified.
+To modify an object which has already been created, make a `PATCH` request to the model's _detail_ endpoint specifying its UUID. Include any data which you wish to update on the object. As with object creation, the `Authorization` and `Content-Type` headers must also be specified, and specifying the `Accept` header is also strongly recommended.
 
 ```no-highlight
 curl -s -X PATCH \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
+-H "Accept: application/json; version=1.3" \
 http://nautobot/api/ipam/prefixes/b484b0ac-12e3-484a-84c0-aa17955eaedc/ \
 --data '{"status": "reserved"}' | jq '.'
 ```
@@ -523,6 +600,7 @@ Multiple objects can be updated simultaneously by issuing a `PUT` or `PATCH` req
 curl -s -X PATCH \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
+-H "Accept: application/json; version=1.3" \
 http://nautobot/api/dcim/sites/ \
 --data '[{"id": "18de055e-3ea9-4cc3-ba78-b7eef6f0d589", "status": "active"}, {"id": "1a414273-3d68-4586-ba22-6ae0a5702b8f", "status": "active"}]'
 ```
@@ -539,6 +617,7 @@ To delete an object from Nautobot, make a `DELETE` request to the model's _detai
 ```no-highlight
 curl -s -X DELETE \
 -H "Authorization: Token $TOKEN" \
+-H "Accept: application/json; version=1.3" \
 http://nautobot/api/ipam/prefixes/48df6965-0fcb-4155-b5f8-00fe8b9b01af/
 ```
 
@@ -555,6 +634,7 @@ Nautobot supports the simultaneous deletion of multiple objects of the same type
 curl -s -X DELETE \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
+-H "Accept: application/json; version=1.3" \
 http://nautobot/api/dcim/sites/ \
 --data '[{"id": "18de055e-3ea9-4cc3-ba78-b7eef6f0d589"}, {"id": "1a414273-3d68-4586-ba22-6ae0a5702b8f"}, {"id": "c2516019-caf6-41f0-98a6-4276c1a73fa3"}]'
 ```

--- a/nautobot/extras/api/nested_serializers.py
+++ b/nautobot/extras/api/nested_serializers.py
@@ -108,7 +108,7 @@ class NestedImageAttachmentSerializer(WritableNestedSerializer):
 
 
 class NestedJobSerializer(serializers.ModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:jobmodel-detail")
+    url = serializers.HyperlinkedIdentityField(view_name="extras-api:job-detail")
 
     class Meta:
         model = models.Job

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -745,6 +745,7 @@ class JobClassSerializer(serializers.Serializer):
         lookup_url_kwarg="class_path",
     )
     id = serializers.CharField(read_only=True, source="class_path")
+    pk = serializers.SerializerMethodField(read_only=True)
     name = serializers.CharField(max_length=255, read_only=True)
     description = serializers.CharField(max_length=255, required=False, read_only=True)
     test_methods = serializers.ListField(child=serializers.CharField(max_length=255))
@@ -753,6 +754,17 @@ class JobClassSerializer(serializers.Serializer):
 
     def get_vars(self, instance):
         return {k: v.__class__.__name__ for k, v in instance._get_vars().items()}
+
+    @swagger_serializer_method(serializer_or_field=serializers.UUIDField)
+    def get_pk(self, instance):
+        try:
+            jobs = Job.objects
+            if "request" in self.context and self.context["request"].user is not None:
+                jobs = jobs.restrict(self.context["request"].user, "view")
+            job_model = jobs.get_for_class_path(instance.class_path)
+            return job_model.pk
+        except Job.DoesNotExist:
+            return None
 
 
 class JobClassDetailSerializer(JobClassSerializer):

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -602,7 +602,7 @@ class ImageAttachmentSerializer(ValidatedModelSerializer):
 
 
 class JobSerializer(TaggedObjectSerializer, CustomFieldModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:jobmodel-detail")
+    url = serializers.HyperlinkedIdentityField(view_name="extras-api:job-detail")
 
     class Meta:
         model = Job
@@ -749,7 +749,7 @@ class JobClassSerializer(serializers.Serializer):
     description = serializers.CharField(max_length=255, required=False, read_only=True)
     test_methods = serializers.ListField(child=serializers.CharField(max_length=255))
     vars = serializers.SerializerMethodField(read_only=True)
-    result = NestedJobResultSerializer()
+    result = NestedJobResultSerializer(required=False)
 
     def get_vars(self, instance):
         return {k: v.__class__.__name__ for k, v in instance._get_vars().items()}

--- a/nautobot/extras/api/urls.py
+++ b/nautobot/extras/api/urls.py
@@ -40,9 +40,7 @@ router.register("graphql-queries", views.GraphQLQueryViewSet)
 router.register("image-attachments", views.ImageAttachmentViewSet)
 
 # Jobs
-router.register("job-models", views.JobModelViewSet, basename="jobmodel")
-# 2.0 TODO: remove JobViewSet, rename JobModelViewSet
-router.register("jobs", views.JobViewSet, basename="job")
+router.register("jobs", views.JobViewSet)
 
 # Job Log Entries
 router.register("job-logs", views.JobLogEntryViewSet)

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -487,10 +487,22 @@ class JobViewSet(
         return Response(serializer.data)
 
     @swagger_auto_schema(
-        responses={"200": serializers.JobClassDetailSerializer()}, operation_id="extras_jobs_read_deprecated"
+        deprecated=True,
+        operation_id="extras_jobs_read_deprecated",
+        responses={"200": serializers.JobClassDetailSerializer()},
     )
-    @action(methods=["get"], detail=False, url_path="(?P<class_path>[^/]+/[^/]+/[^/]+)", url_name="detail")
+    @action(
+        detail=False,  # a /jobs/... URL, not a /jobs/<pk>/... URL
+        methods=["get"],
+        url_path="(?P<class_path>[^/]+/[^/]+/[^/]+)",  # /api/extras/jobs/<class_path>/
+        url_name="detail",
+    )
     def retrieve_deprecated(self, request, class_path):
+        """
+        Get details of a Job as identified by its class-path.
+
+        This API endpoint is deprecated; it is recommended to use the extras_jobs_read endpoint instead.
+        """
         if not request.user.has_perm("extras.view_job"):
             raise PermissionDenied("This user does not have permission to view jobs.")
         try:
@@ -514,6 +526,7 @@ class JobViewSet(
     @swagger_auto_schema(responses={"200": serializers.JobVariableSerializer(many=True)})
     @action(detail=True)
     def variables(self, request, pk):
+        """Get details of the input variables that may/must be specified to run a particular Job."""
         job_model = self.get_object()
         job_class = job_model.job_class
         if job_class is None:
@@ -559,28 +572,36 @@ class JobViewSet(
         }
 
     @swagger_auto_schema(
-        method="post",
+        methods=["post"],
         request_body=serializers.JobInputSerializer,
         responses={"201": serializers.JobRunResponseSerializer},
     )
     @action(detail=True, methods=["post"], permission_classes=[JobRunTokenPermissions])
     def run(self, request, *args, pk, **kwargs):
-        # Newer model-based view
+        """Run the specified Job."""
         job_model = self.get_object()
         return _run_job(request, job_model)
 
     @swagger_auto_schema(
-        responses={"200": serializers.JobClassDetailSerializer()}, operation_id="extras_jobs_run_deprecated"
+        deprecated=True,
+        methods=["post"],
+        request_body=serializers.JobInputSerializer,
+        responses={"200": serializers.JobClassDetailSerializer()},
+        operation_id="extras_jobs_run_deprecated",
     )
     @action(
         detail=False,  # a /jobs/... URL, not a /jobs/<pk>/... URL
         methods=["post"],
         permission_classes=[JobRunTokenPermissions],
-        url_path="(?P<class_path>[^/]+/[^/]+/[^/]+)/run",
+        url_path="(?P<class_path>[^/]+/[^/]+/[^/]+)/run",  # /api/extras/jobs/<class_path>/run/
         url_name="run",
     )
     def run_deprecated(self, request, class_path):
-        # Legacy JobClass-based view
+        """
+        Run a Job as identified by its class-path.
+
+        This API endpoint is deprecated; it is recommended to use the extras_jobs_run endpoint instead.
+        """
         if not request.user.has_perm("extras.run_job"):
             raise PermissionDenied("This user does not have permission to run jobs.")
         try:

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -11,7 +11,6 @@ from graphql import GraphQLError
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import MethodNotAllowed, PermissionDenied
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.routers import APIRootView
 from rest_framework import mixins, viewsets

--- a/nautobot/extras/plugins/views.py
+++ b/nautobot/extras/plugins/views.py
@@ -14,6 +14,7 @@ from rest_framework.views import APIView
 
 from django_tables2 import RequestConfig
 
+from nautobot.core.api.views import NautobotAPIVersionMixin
 from nautobot.utilities.forms import TableConfigForm
 from nautobot.utilities.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.extras.plugins.tables import InstalledPluginsTable
@@ -82,7 +83,7 @@ class InstalledPluginDetailView(LoginRequiredMixin, View):
         )
 
 
-class InstalledPluginsAPIView(APIView):
+class InstalledPluginsAPIView(NautobotAPIVersionMixin, APIView):
     """
     API view for listing all installed plugins
     """
@@ -112,7 +113,7 @@ class InstalledPluginsAPIView(APIView):
         return Response([self._get_plugin_data(apps.get_app_config(plugin)) for plugin in settings.PLUGINS])
 
 
-class PluginsAPIRootView(APIView):
+class PluginsAPIRootView(NautobotAPIVersionMixin, APIView):
     _ignore_model_permissions = True
     exclude_from_schema = True
     swagger_schema = None

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1258,6 +1258,7 @@ class JobTestVersion13(
     APIViewTestCases.DeleteObjectViewTestCase,
 ):
     """Test cases for the Jobs REST API under API version 1.3 - first version introducing JobModel-based APIs."""
+
     model = Job
     brief_fields = ["grouping", "id", "job_class_name", "module_name", "name", "source", "url"]
     choices_fields = None

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -945,7 +945,9 @@ class ImageAttachmentTest(
 
 
 class JobAPIRunTestMixin:
-    """Mixin providing test cases for the "run" API endpoint, shared between JobModelTestCase and JobTest."""
+    """
+    Mixin providing test cases for the "run" API endpoint, shared between the different versions of Job API testing.
+    """
 
     def get_run_url(self, class_path="local/api_test_job/APITestJob"):
         """To be implemented by classes using this mixin."""
@@ -1247,7 +1249,7 @@ class JobAPIRunTestMixin:
         )
 
 
-class JobModelTestCase(
+class JobTestVersion13(
     JobAPIRunTestMixin,
     # note no CreateObjectViewTestCase - we do not support user creation of Job records
     APIViewTestCases.GetObjectViewTestCase,
@@ -1255,6 +1257,7 @@ class JobModelTestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
 ):
+    """Test cases for the Jobs REST API under API version 1.3 - first version introducing JobModel-based APIs."""
     model = Job
     brief_fields = ["grouping", "id", "job_class_name", "module_name", "name", "source", "url"]
     choices_fields = None
@@ -1289,6 +1292,7 @@ class JobModelTestCase(
     validation_excluded_fields = []
 
     run_success_response_status = status.HTTP_201_CREATED
+    api_version = "1.3"
 
     def setUp(self):
         super().setUp()
@@ -1298,27 +1302,13 @@ class JobModelTestCase(
 
     def get_run_url(self, class_path="local/api_test_job/APITestJob"):
         job_model = Job.objects.get_for_class_path(class_path)
-        return reverse("extras-api:jobmodel-run", kwargs={"pk": job_model.pk})
-
-    def _get_detail_url(self, instance):
-        """
-        Override default implementation as we're under "jobmodel-detail" rather than "job-detail".
-        """
-        viewname = f"{self._get_view_namespace()}:jobmodel-detail"
-        return reverse(viewname, kwargs={"pk": instance.pk})
-
-    def _get_list_url(self):
-        """
-        Override default implementation as we're under "jobmodel-list" rather than "job-list".
-        """
-        viewname = f"{self._get_view_namespace()}:jobmodel-list"
-        return reverse(viewname)
+        return reverse("extras-api:job-run", kwargs={"pk": job_model.pk})
 
     def test_get_job_variables(self):
         """Test the job/<pk>/variables API endpoint."""
         self.add_permissions("extras.view_job")
         response = self.client.get(
-            reverse(f"{self._get_view_namespace()}:jobmodel-variables", kwargs={"pk": self.job_model.pk}),
+            reverse(f"{self._get_view_namespace()}:job-variables", kwargs={"pk": self.job_model.pk}),
             **self.header,
         )
         self.assertEqual(4, len(response.data))  # 4 variables, in order
@@ -1378,13 +1368,14 @@ class JobModelTestCase(
         self.assertIsNone(response.data["job_result"])
 
 
-class JobTest(
+class JobTestVersion12(
     JobAPIRunTestMixin,
     APITestCase,
 ):
-    """Tests for deprecated Job-class-based views."""
+    """Test cases for the Jobs REST API under API version 1.2 - deprecated JobClass-based API pattern."""
 
     run_success_response_status = status.HTTP_200_OK
+    api_version = "1.2"
 
     def setUp(self):
         super().setUp()
@@ -1452,6 +1443,16 @@ class JobTest(
         url = reverse("extras-api:job-detail", kwargs={"class_path": "local/api_test_job/NoSuchJob"})
         response = self.client.get(url, **self.header)
         self.assertHttpStatus(response, status.HTTP_404_NOT_FOUND)
+
+
+class JobTestVersionDefault(JobTestVersion12):
+    """
+    Test cases for the Jobs REST API when not explicitly requesting a specific API version.
+
+    Currently we default to version 1.2, but this may change in a future major release.
+    """
+
+    api_version = None
 
 
 class JobResultTest(APITestCase):

--- a/nautobot/utilities/testing/api.py
+++ b/nautobot/utilities/testing/api.py
@@ -35,10 +35,12 @@ class APITestCase(ModelTestCase):
 
     client_class: Test client class
     view_namespace: Namespace for API views. If None, the model's app_label will be used.
+    api_version: Specific API version to test. Leave unset to test the default behavior. Override with set_api_version()
     """
 
     client_class = APIClient
     view_namespace = None
+    api_version = None
 
     def setUp(self):
         """
@@ -49,6 +51,15 @@ class APITestCase(ModelTestCase):
         self.add_permissions(*self.user_permissions)
         self.token = Token.objects.create(user=self.user)
         self.header = {"HTTP_AUTHORIZATION": "Token {}".format(self.token.key)}
+        if self.api_version:
+            self.set_api_version(self.api_version)
+
+    def set_api_version(self, api_version):
+        """Set or unset a specific API version for requests in this test case."""
+        if api_version is None:
+            self.header["HTTP_ACCEPT"] = "application/json"
+        else:
+            self.header["HTTP_ACCEPT"] = f"application/json; version={api_version}"
 
     def _get_view_namespace(self):
         if self.view_namespace:
@@ -156,6 +167,8 @@ class APIViewTestCases:
             else:
                 response = self.client.get(url, **self.header)
                 self.assertHttpStatus(response, status.HTTP_200_OK)
+                self.assertIsInstance(response.data, dict)
+                self.assertIn("results", response.data)
                 self.assertEqual(len(response.data["results"]), self._get_queryset().count())
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
@@ -168,6 +181,8 @@ class APIViewTestCases:
             response = self.client.get(url, **self.header)
 
             self.assertHttpStatus(response, status.HTTP_200_OK)
+            self.assertIsInstance(response.data, dict)
+            self.assertIn("results", response.data)
             self.assertEqual(len(response.data["results"]), self._get_queryset().count())
             self.assertEqual(sorted(response.data["results"][0]), self.brief_fields)
 
@@ -207,6 +222,8 @@ class APIViewTestCases:
             # Try GET to permitted objects
             response = self.client.get(self._get_list_url(), **self.header)
             self.assertHttpStatus(response, status.HTTP_200_OK)
+            self.assertIsInstance(response.data, dict)
+            self.assertIn("results", response.data)
             self.assertEqual(len(response.data["results"]), 2)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])


### PR DESCRIPTION
### Fixes: #1465 

- Extend existing REST API AcceptHeaderVersioning (already in Nautobot since the NetBox days)
   - Now accept REST API versions from 1.2 forward, instead of only accepting the current Nautobot major.minor version.
   - Now default to REST API version 1.2 unless a different version is specifically requested
   - REST API responses still include "API-Version" header, but instead of always reporting the current Nautobot version, now report the API version that was used.
      - Because this needs to happen *after* django-rest-framework does its initial processing of the request to identify the API version, the previous middleware-based approach could no longer be used, and instead it's now implemented via a view mixin class `NautobotAPIVersionMixin`.
- Add detailed documentation about how REST API versioning works and what expectations clients should have from now on.
- Consolidate the separate `JobModelViewSet` and `JobViewSet` classes and the separate `api/extras/jobs/` and `/api/extras/job-models/` URL patterns into a combined viewset and URL pattern
  - The only API URL/view that actually needs to branch on API version is the `api/extras/jobs/` list URL - for API versions 1.2 and earlier (default) it still will return the job-class listing, whereas clients explicitly requesting API version 1.3 or later they will now get the new job-model listing.
  - All other API URL patterns and views are distinct (`/api/extras/jobs/<uuid:pk>/...` versus `/api/extras/jobs/<str:class_path>/...`) and so do not actually need to enforce API versioning.
- Extend the APITestCase class to make it easy to specify a particular API version being tested.
  - Restructured the Jobs API testing a bit so that it now runs one set of tests with "version=1.3", another set of tests with "version=1.2", and a third set of tests (same as the 1.2 tests) without specifying an API version so as to confirm that the default behavior is correct.