### PR TITLE
Add ORM-based Creation of Tags to Documentation

### DIFF
--- a/nautobot/docs/models/extras/tag.md
+++ b/nautobot/docs/models/extras/tag.md
@@ -16,7 +16,7 @@ The `tag` filter can be specified multiple times to match only objects which hav
 GET /api/dcim/devices/?tag=monitored&tag=deprecated
 ```
 
-Tags can also be created in the ORM of Nautobot. You can create tags and assign the following HEX color values below.
+Tags can also be created in the ORM or REST API of Nautobot. The following HEX color values in the table below correspond to the dropdown selection when building tags using the UI. Any HEX color value can be used with the ORM or REST API, but a non-standard color will cause some inconsistency when editing the tag via the UI.
 
 | Color | HEX value |
 | :------------ | :------------ |

--- a/nautobot/docs/models/extras/tag.md
+++ b/nautobot/docs/models/extras/tag.md
@@ -16,5 +16,48 @@ The `tag` filter can be specified multiple times to match only objects which hav
 GET /api/dcim/devices/?tag=monitored&tag=deprecated
 ```
 
+Tags can also be created in the ORM of Nautobot. You can create tags and assign the following HEX color values below.
+
+| Color | HEX value |
+| :------------ | :------------ |
+| Dark Red | aa1409 |
+| Red | f44336 |
+| Pink | e91e63 |
+| Rose | ffe4e1 |
+| Fuchsia | ff66ff |
+| Purple | 9c27b0 |
+| Dark Purple | 673ab7 |
+| Indigo | 3f51b5 |
+| Blue | 2196f3 |
+| Light blue | 03a9f4 |
+| Cyan | 00bcd4 |
+| Teal | 009688 |
+| Aqua | 00ffff |
+| Dark green | 2f6a31 |
+| Green | 4caf50 |
+| Light green | 8bc34a |
+| Lime | cddc39 |
+| Yellow | ffeb3b |
+| Amber | ffc107 |
+| Orange | ff9800 |
+| Dark orange | ff5722 |
+| Brown | 795548 |
+| Light grey | c0c0c0 |
+| Grey | 9e9e9e |
+| Dark grey | 607d8b |
+| Black | 111111 |
+| White | ffffff |
+
+Example of ORM creation:
+
+```
+Tag.objects.get_or_create(
+    name="Cisco-3650CX",
+    slug="cisco-3650cx",
+    description="Device tag for Cisco 3650CX series",
+    color="2196f3"
+)
+```
+___
 !!! note
     Tags were changed substantially in NetBox v2.9. They are no longer created on-demand when editing an object, and their representation in the REST API now includes a complete depiction of the tag rather than only its label.


### PR DESCRIPTION
Add HEX values for tag creation and example ORM creation.


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #N/A
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Documentation of Tags. Added table of all the HEX color values that are possible when using the ORM to create Tags.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)