### PR TITLE
Without primary_ip, still other methods available

### DIFF
--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -419,8 +419,6 @@ class DeviceViewSet(ConfigContextQuerySetMixin, StatusViewSetMixin, CustomFieldM
         Execute a NAPALM method on a Device
         """
         device = get_object_or_404(self.queryset, pk=pk)
-        if not device.primary_ip:
-            raise ServiceUnavailable("This device does not have a primary IP address configured.")
         if device.platform is None:
             raise ServiceUnavailable("No platform is configured for this device.")
         if not device.platform.napalm_driver:


### PR DESCRIPTION

# Closes: No issue created
# What's Changed

Removed the `ServiceUnavailable` exception when no `primary_ip` is available for a device, because there is an alternative method to connect via `device.name`


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design