### PR TITLE
Fixes navbar blocking the main UI

### DIFF
--- a/nautobot/core/templates/base.html
+++ b/nautobot/core/templates/base.html
@@ -123,7 +123,7 @@
     https://github.com/nautobot/nautobot/issues/1467
     */
     let setBodyPaddingTop = () => {
-        document.querySelector('body').style.paddingTop = `${parseInt(window.getComputedStyle(document.querySelector('.navbar')).height) + 60}px`
+        document.querySelector('body').style.paddingTop = `${parseInt(window.getComputedStyle(document.querySelector('.navbar')).height)+10}px`
     }
     window.addEventListener("resize", setBodyPaddingTop);
     window.addEventListener("load", setBodyPaddingTop);

--- a/nautobot/core/templates/base.html
+++ b/nautobot/core/templates/base.html
@@ -118,6 +118,15 @@
     }).ajaxStop(function() {
         loading.hide();
     });
+    /*
+    this fixes the navbar blocking the main UI from being seen
+    https://github.com/nautobot/nautobot/issues/1467
+    */
+    let setBodyPaddingTop = () => {
+        document.querySelector('body').style.paddingTop = `${parseInt(window.getComputedStyle(document.querySelector('.navbar')).height) + 60}px`
+    }
+    window.addEventListener("resize", setBodyPaddingTop);
+    window.addEventListener("load", setBodyPaddingTop);
 </script>
 {% block javascript %}{% endblock %}
 </body>


### PR DESCRIPTION
# Closes: #1467 
# What's Changed
The body element's padding-top adjusts every time the window loads and/or is resized to make sure the main UI is always visible.