### PR TITLE
Enforce `approval_required=True` when a job is run without a schedule

### DIFF
--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -325,7 +325,7 @@ class ImageAttachmentViewSet(ModelViewSet):
 #
 
 
-def _create_schedule(serializer, data, commit, job, approval_required, request):
+def _create_schedule(serializer, data, commit, job, job_model, request):
     """
     This is an internal function to create a scheduled job from API data.
     It has to handle boths once-offs (i.e. of type TYPE_FUTURE) and interval
@@ -349,13 +349,14 @@ def _create_schedule(serializer, data, commit, job, approval_required, request):
         name=name,
         task="nautobot.extras.jobs.scheduled_job_handler",
         job_class=job.class_path,
+        job_model=job_model,
         start_time=time,
         description=f"Nautobot job {name} scheduled by {request.user} on {time}",
         kwargs=job_kwargs,
         interval=type_,
         one_off=(type_ == JobExecutionType.TYPE_FUTURE),
         user=request.user,
-        approval_required=approval_required,
+        approval_required=job_model.approval_required,
     )
     scheduled_job.save()
     return scheduled_job
@@ -395,14 +396,24 @@ def _run_job(request, job_model, legacy_response=False):
         raise CeleryWorkerNotRunningException()
 
     job_content_type = ContentType.objects.get(app_label="extras", model="job")
-
     schedule_data = input_serializer.data.get("schedule")
-    # BUG TODO: it looks like by omitting "schedule" you can immediately run an approval_required job here...
+
+    # Default to a null JobResult.
+    job_result = None
+
+    # Assert that a job with `approval_required=True` has a schedule that enforces approval and
+    # executes immediately.
+    if schedule_data is None and job_model.approval_required:
+        schedule_data = {"interval": JobExecutionType.TYPE_IMMEDIATELY}
+
+    # Try to create a ScheduledJob, or...
     if schedule_data:
-        schedule = _create_schedule(schedule_data, data, commit, job, job_model.approval_required, request)
-        job_result = None
+        schedule = _create_schedule(schedule_data, data, commit, job, job_model, request)
     else:
         schedule = None
+
+    # ... If we can't create one, create a JobResult instead.
+    if schedule is None:
         job_result = JobResult.enqueue_job(
             run_job,
             job.class_path,

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -949,6 +949,12 @@ class JobAPIRunTestMixin:
     Mixin providing test cases for the "run" API endpoint, shared between the different versions of Job API testing.
     """
 
+    def setUp(self):
+        super().setUp()
+        self.job_model = Job.objects.get_for_class_path("local/api_test_job/APITestJob")
+        self.job_model.enabled = True
+        self.job_model.validated_save()
+
     def get_run_url(self, class_path="local/api_test_job/APITestJob"):
         """To be implemented by classes using this mixin."""
         raise NotImplementedError
@@ -1094,6 +1100,47 @@ class JobAPIRunTestMixin:
         self.assertHttpStatus(response, self.run_success_response_status)
 
         schedule = ScheduledJob.objects.last()
+        self.assertEqual(schedule.kwargs["data"]["var4"], str(device_role.pk))
+
+        return (response, schedule)  # so subclasses can do additional testing
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    @mock.patch("nautobot.extras.api.views.get_worker_count")
+    def test_run_job_object_var_no_schedule(self, mock_get_worker_count):
+        """
+        Run a job without providing a schedule and if approval_required.
+
+        Assert an immediate schedule that enforces it.
+        """
+        # Set approval_required=True
+        self.job_model.approval_required = True
+        self.job_model.save()
+
+        # Do the stuff.
+        mock_get_worker_count.return_value = 1
+        self.add_permissions("extras.run_job")
+        device_role = DeviceRole.objects.create(name="role", slug="role")
+        job_data = {
+            "var1": "FooBar",
+            "var2": 123,
+            "var3": False,
+            "var4": device_role.pk,
+        }
+
+        data = {
+            "data": job_data,
+            "commit": True,
+            # schedule is ommitted
+        }
+
+        url = self.get_run_url()
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, self.run_success_response_status)
+
+        # Assert that we have an immediate schedule and that it matches the job_model.
+        schedule = ScheduledJob.objects.last()
+        self.assertEqual(schedule.interval, JobExecutionType.TYPE_IMMEDIATELY)
+        self.assertEqual(schedule.approval_required, self.job_model.approval_required)
         self.assertEqual(schedule.kwargs["data"]["var4"], str(device_role.pk))
 
         return (response, schedule)  # so subclasses can do additional testing
@@ -1295,12 +1342,6 @@ class JobTestVersion13(
     run_success_response_status = status.HTTP_201_CREATED
     api_version = "1.3"
 
-    def setUp(self):
-        super().setUp()
-        self.job_model = Job.objects.get_for_class_path("local/api_test_job/APITestJob")
-        self.job_model.enabled = True
-        self.job_model.validated_save()
-
     def get_run_url(self, class_path="local/api_test_job/APITestJob"):
         job_model = Job.objects.get_for_class_path(class_path)
         return reverse("extras-api:job-run", kwargs={"pk": job_model.pk})
@@ -1377,12 +1418,6 @@ class JobTestVersion12(
 
     run_success_response_status = status.HTTP_200_OK
     api_version = "1.2"
-
-    def setUp(self):
-        super().setUp()
-        job_model = Job.objects.get_for_class_path("local/api_test_job/APITestJob")
-        job_model.enabled = True
-        job_model.validated_save()
 
     def get_run_url(self, class_path="local/api_test_job/APITestJob"):
         return reverse("extras-api:job-run", kwargs={"class_path": class_path})


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1476
# What's Changed
- This will create an "immediately" executing schedule to run the job upon approval when called from the API in the event that a "schedule" is omitted from the job run payload.
 


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design