### PR TITLE
Fix primary IP lost after creating/updating different interface

### DIFF
--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -152,6 +152,7 @@ Just as with the UI, the `slug` can still always be explicitly set if desired.
 
 - [#1408](https://github.com/nautobot/nautobot/issues/1408) - Fixed incorrect HTML in the Devices detail views.
 - [#1467](https://github.com/nautobot/nautobot/issues/1467) - Fixed an issue where at certain browser widths the nav bar would cover the top of the page content.
+- [#1523](https://github.com/nautobot/nautobot/issues/1523) - Fixed primary IP being unset after creating/updating different interface
 - [#1548](https://github.com/nautobot/nautobot/issues/1548) - Pin Jinja2 version for mkdocs requirements to fix RTD docs builds related to API deprecation in Jinja2 >= 3.1.0
 
 ## v1.2.10 (2022-03-21)

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -731,13 +731,11 @@ class IPAddressForm(
         # If `primary_for_parent` is unset, clear the `primary_ip{version}` for the
         # Device/VirtualMachine. It will not be saved until after `IPAddress.clean()` succeeds which
         # also checks for the `_primary_ip_unset_by_form` value.
-        device_primary_ip = Device.objects.filter(
-            Q(primary_ip6=self.instance) | Q(primary_ip4=self.instance)
-        ).exists()
+        device_primary_ip = Device.objects.filter(Q(primary_ip6=self.instance) | Q(primary_ip4=self.instance)).exists()
         vm_primary_ip = VirtualMachine.objects.filter(
             Q(primary_ip6=self.instance) | Q(primary_ip4=self.instance)
         ).exists()
-        
+
         currently_primary_ip = device_primary_ip or vm_primary_ip
 
         if not primary_for_parent and self.instance._original_assigned_object is not None and currently_primary_ip:

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.db.models import Q
 
 from nautobot.dcim.models import Device, Interface, Rack, Region, Site
 from nautobot.extras.forms import (
@@ -730,7 +731,11 @@ class IPAddressForm(
         # If `primary_for_parent` is unset, clear the `primary_ip{version}` for the
         # Device/VirtualMachine. It will not be saved until after `IPAddress.clean()` succeeds which
         # also checks for the `_primary_ip_unset_by_form` value.
-        if not primary_for_parent and self.instance._original_assigned_object is not None:
+        currently_primary_ip = Device.objects.filter(
+            Q(primary_ip6=self.instance) | Q(primary_ip4=self.instance)
+        ).exists()
+
+        if not primary_for_parent and self.instance._original_assigned_object is not None and currently_primary_ip:
             self.instance._primary_ip_unset_by_form = True
 
     def save(self, *args, **kwargs):

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -731,9 +731,14 @@ class IPAddressForm(
         # If `primary_for_parent` is unset, clear the `primary_ip{version}` for the
         # Device/VirtualMachine. It will not be saved until after `IPAddress.clean()` succeeds which
         # also checks for the `_primary_ip_unset_by_form` value.
-        currently_primary_ip = Device.objects.filter(
+        device_primary_ip = Device.objects.filter(
             Q(primary_ip6=self.instance) | Q(primary_ip4=self.instance)
         ).exists()
+        vm_primary_ip = VirtualMachine.objects.filter(
+            Q(primary_ip6=self.instance) | Q(primary_ip4=self.instance)
+        ).exists()
+        
+        currently_primary_ip = device_primary_ip or vm_primary_ip
 
         if not primary_for_parent and self.instance._original_assigned_object is not None and currently_primary_ip:
             self.instance._primary_ip_unset_by_form = True

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -2,6 +2,7 @@
 
 from django.test import TestCase
 
+from nautobot.dcim.models import Device, DeviceType, DeviceRole, Interface, Manufacturer, Site
 from nautobot.extras.models.statuses import Status
 from nautobot.ipam import forms, models
 
@@ -80,3 +81,51 @@ class IPAddressFormTest(BaseNetworkFormTest, TestCase):
         form = self.form_class(data={self.field_name: "192.168.0.1/32", "status": Status.objects.get(slug="slaac")})
         self.assertFalse(form.is_valid())
         self.assertEqual("Only IPv6 addresses can be assigned SLAAC status", form.errors["status"][0])
+
+    def test_primary_ip_not_altered_if_adding_a_new_IP_to_diff_interface(self):
+        """Test primary IP of device not lost when adding new IP to diffrent interface"""
+        manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
+        devicetype = DeviceType.objects.create(model="Device Type 1", slug="device-type-1", manufacturer=manufacturer)
+        devicerole = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
+        status_active = Status.objects.get_for_model(Device).get(slug="active")
+        site = Site.objects.create(name="Site 1", slug="site-1")
+        device = Device.objects.create(
+            name="Device 1",
+            site=site,
+            device_type=devicetype,
+            device_role=devicerole,
+            status=status_active,
+        )
+        interface1 = Interface.objects.create(device=device, name="eth0")
+        interface2 = Interface.objects.create(device=device, name="eth1")
+
+        ipaddress1 = "191.168.0.5/32"
+        ipaddress2 = "192.168.0.5/32"
+
+        form1 = self.form_class(
+            data={
+                self.field_name: ipaddress1,
+                "status": Status.objects.get(slug="active"),
+                "device": device,
+                "interface": interface1,
+                "primary_for_parent": True,
+            }
+        )
+        form1.is_valid()
+        form1.save()
+
+        form2 = self.form_class(
+            data={
+                self.field_name: ipaddress2,
+                "status": Status.objects.get(slug="active"),
+                "device": device,
+                "interface": interface2,
+            }
+        )
+
+        form2.is_valid()
+        form2.save()
+
+        device.refresh_from_db()
+        # Assert primary IP was not altered
+        self.assertEqual(str(device.primary_ip4), ipaddress1)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1523 
# What's Changed
Check IPAddress was initially set to primary before performing primary_unset actions
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design