### PR TITLE
Removed incorrect parameter "scheduled_job.user"

### DIFF
--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -938,7 +938,6 @@ class JobApprovalRequestView(ContentTypePermissionRequiredMixin, View):
                 run_job,
                 job.class_path,
                 job_content_type,
-                scheduled_job.user,
                 request.user,
                 data=job_class.serialize_data(initial),
                 request=copy_safe_request(request),


### PR DESCRIPTION
# Closes: #1475 
# What's Changed
This removes the incorrect parameter `scheduled_job.user`.
`request.user` is the correct user instance to pass.