### PR TITLE
Remove Empty Nautobot Service Definition Postgres Compose File

### DIFF
--- a/development/docker-compose.postgres.yml
+++ b/development/docker-compose.postgres.yml
@@ -1,7 +1,6 @@
 ---
 version: "3.4"
 services:
-  nautobot:
   db:
     image: postgres:13
     env_file:

--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -153,6 +153,7 @@ Just as with the UI, the `slug` can still always be explicitly set if desired.
 - [#1408](https://github.com/nautobot/nautobot/issues/1408) - Fixed incorrect HTML in the Devices detail views.
 - [#1467](https://github.com/nautobot/nautobot/issues/1467) - Fixed an issue where at certain browser widths the nav bar would cover the top of the page content.
 - [#1548](https://github.com/nautobot/nautobot/issues/1548) - Pin Jinja2 version for mkdocs requirements to fix RTD docs builds related to API deprecation in Jinja2 >= 3.1.0
+- [#1583](https://github.com/nautobot/nautobot/issues/1583) - Fixed Nautobot service definition in PostgreSQL-backed development environment.
 
 ## v1.2.10 (2022-03-21)
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1583
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Removed the `nautobot:` empty service definition in `development/docker-compose.postgres.yml`. This was causing `invoke` commands to fail with error: `services.nautobot must be a mapping`.

## Before:
```sh
➜ invoke build                                                                                        
Building Nautobot with Python 3.7...
Running docker-compose command "build --build-arg PYTHON_VER=3.7"
services.nautobot must be a mapping
```

## After:
```sh
➜ invoke build                                                                                        
Building Nautobot with Python 3.7...
Running docker-compose command "build --build-arg PYTHON_VER=3.7"
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 32B done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.0s
...
```

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- ~Unit, Integration Tests~
- ~Documentation Updates (when adding/changing features)~
- ~Example Plugin Updates (when adding/changing features)~
- ~Outline Remaining Work, Constraints from Design~