### PR TITLE
Augment `MultipleChoiceJSONField` to accept `choices` as a callable

### DIFF
--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -148,6 +148,8 @@ Just as with the UI, the `slug` can still always be explicitly set if desired.
 
 ### Changed
 
+- [#1581](https://github.com/nautobot/nautobot/issues/1581) - Changed MultipleChoiceJSONField to accept choices as a callable, fixing Datasource Contents provided by plugins are not accepted as valid choice by REST API.
+
 ### Fixed
 
 - [#1408](https://github.com/nautobot/nautobot/issues/1408) - Fixed incorrect HTML in the Devices detail views.

--- a/nautobot/extras/api/fields.py
+++ b/nautobot/extras/api/fields.py
@@ -1,10 +1,18 @@
 from collections import OrderedDict
 
+from django.forms.fields import CallableChoiceIterator
 from rest_framework import serializers
 
 
 class MultipleChoiceJSONField(serializers.MultipleChoiceField):
     """A MultipleChoiceField that renders the received value as a JSON-compatible list rather than a set."""
+
+    def __init__(self, **kwargs):
+        """Overload default choices handling to also accept a callable."""
+        choices = kwargs.get("choices")
+        if callable(choices):
+            kwargs["choices"] = CallableChoiceIterator(choices)
+        super().__init__(**kwargs)
 
     def to_internal_value(self, data):
         set_value = super().to_internal_value(data)

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -447,7 +447,7 @@ class GitRepositorySerializer(CustomFieldModelSerializer):
     secrets_group = NestedSecretsGroupSerializer(required=False, allow_null=True)
 
     provided_contents = MultipleChoiceJSONField(
-        choices=get_datasource_content_choices("extras.gitrepository"),
+        choices=lambda: get_datasource_content_choices("extras.gitrepository"),
         allow_blank=True,
         required=False,
     )

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -661,6 +661,28 @@ class GitRepositoryTest(APIViewTestCases.APIViewTestCase):
         response = self.client.post(url, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
+    @skipIf(
+        "dummy_plugin" not in settings.PLUGINS,
+        "dummy_plugin not in settings.PLUGINS",
+    )
+    def test_create_with_plugin_provided_contents(self):
+        """Test that `provided_contents` published by a plugin works."""
+        self.add_permissions("extras.add_gitrepository")
+        self.add_permissions("extras.change_gitrepository")
+        url = self._get_list_url()
+        data = {
+            "name": "plugin_test",
+            "slug": "plugin-test",
+            "remote_url": "https://localhost/plugin-test",
+            "provided_contents": ["dummy_plugin.textfile"],
+        }
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        # FIXME(jathan): Figure out why response.data is coming back as a set and requires being
+        # cast to a list??
+        self.assertEqual(list(response.data["provided_contents"]), data["provided_contents"])
+
 
 class GraphQLQueryTest(APIViewTestCases.APIViewTestCase):
     model = GraphQLQuery

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -661,11 +661,6 @@ class GitRepositoryTest(APIViewTestCases.APIViewTestCase):
         response = self.client.post(url, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
-    @skipIf(
-        "dummy_plugin" not in settings.PLUGINS,
-        "dummy_plugin not in settings.PLUGINS",
-    )
     def test_create_with_plugin_provided_contents(self):
         """Test that `provided_contents` published by a plugin works."""
         self.add_permissions("extras.add_gitrepository")
@@ -679,8 +674,6 @@ class GitRepositoryTest(APIViewTestCases.APIViewTestCase):
         }
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        # FIXME(jathan): Figure out why response.data is coming back as a set and requires being
-        # cast to a list??
         self.assertEqual(list(response.data["provided_contents"]), data["provided_contents"])
 
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1581
# What's Changed
- Augmented `MultipleChoiceJSONField` to accept `choices` as a callable
- I realize this is only stopgap for this field, but it is also the only use case at this time for a serializer field to accept a dynamic list of `choices`
- This makes it so that the `GitRepositorySerializer.provided_contents` field choices are updated dynamically vs. only on initial source code evaluation.

It's now pointing to a `lambda` and accessing `.choices` will display that the choices do in fact update dynamically:

```python
In [13]: GitRepositorySerializer._declared_fields["provided_contents"]
Out[13]: MultipleChoiceJSONField(allow_blank=True, choices=<function GitRepositorySerializer.<lambda>>, required=False)

In [14]: GitRepositorySerializer._declared_fields["provided_contents"].choices
Out[14]:
OrderedDict([('extras.configcontext', 'config contexts'),
             ('extras.configcontextschema', 'config context schemas'),
             ('extras.exporttemplate', 'export templates'),
             ('extras.job', 'jobs'),
             ('nautobot_golden_config.backupconfigs', 'backup configs'),
             ('nautobot_golden_config.intendedconfigs', 'intended configs'),
             ('nautobot_golden_config.jinjatemplate', 'jinja templates')])

```
# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design