### PR TITLE
Catch RuntimeError in jobs view when trying to run a job.

### DIFF
--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -950,7 +950,12 @@ class JobView(ObjectPermissionRequiredMixin, View):
     def get(self, request, class_path=None, slug=None):
         job_model = self._get_job_model_or_404(class_path, slug)
 
-        job_form = job_model.job_class().as_form(initial=normalize_querydict(request.GET))
+        try:
+            job_form = job_model.job_class().as_form(initial=normalize_querydict(request.GET))
+        except RuntimeError as err:
+            messages.error(request, f"Unable to run or schedule '{job_model}': {err}")
+            return redirect("extras:job_list")
+
         schedule_form = forms.JobScheduleForm(initial=normalize_querydict(request.GET))
 
         return render(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1563
# What's Changed
- For Jobs that has not been properly uninstalled, such as when a plugin was removed but the content-types were not purged, catch the exception and print a pretty error in the UI.
- If the Job form cannot be generated this will prevent the job from being displayed/executed confusingly in the UI and also prevent a 500 error.

<img width="1477" alt="image" src="https://user-images.githubusercontent.com/138052/160940521-f36c98bf-9216-4f0c-91ca-8b2b44bf960e.png">

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design