### PR TITLE
Fixed nested OneToOne fields in GraphQL queries

### DIFF
--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -4,7 +4,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models.fields.reverse_related import ManyToOneRel
+from django.db.models.fields.reverse_related import ManyToOneRel, OneToOneRel
 
 import graphene
 from graphene.types import generic
@@ -179,7 +179,8 @@ def extend_schema_type_filter(schema_type, model):
     """
     for field in model._meta.get_fields():
         # Check attribute is a ManyToOne field
-        if not isinstance(field, ManyToOneRel):
+        # OneToOneRel is a subclass or ManyToOneRel, but we don't want to treat is as a list
+        if not isinstance(field, ManyToOneRel) or isinstance(field, OneToOneRel):
             continue
         child_schema_type = registry["graphql_types"].get(field.related_model._meta.label_lower)
         if child_schema_type:

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -179,7 +179,7 @@ def extend_schema_type_filter(schema_type, model):
     """
     for field in model._meta.get_fields():
         # Check attribute is a ManyToOne field
-        # OneToOneRel is a subclass or ManyToOneRel, but we don't want to treat is as a list
+        # OneToOneRel is a subclass of ManyToOneRel, but we don't want to treat is as a list
         if not isinstance(field, ManyToOneRel) or isinstance(field, OneToOneRel):
             continue
         child_schema_type = registry["graphql_types"].get(field.related_model._meta.label_lower)

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1343,3 +1343,27 @@ query {
         self.assertIsInstance(result.data, dict, result)
         self.assertIsInstance(result.data["device_types"], list, result)
         self.assertEqual(result.data["device_types"][0]["model"], self.devicetype.model, result)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_query_with_nested_onetoone(self):
+        """Test that querying a nested OneToOne field works as expected"""
+        query = """
+        query ($device_id: ID!) {
+            device(id: $device_id) {
+                interfaces {
+                    ip_addresses {
+                        primary_ip4_for {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+        """
+        # set device1.primary_ip4
+        self.device1.primary_ip4 = self.ipaddr1
+        self.device1.save()
+        result = self.execute_query(query, variables={"device_id": str(self.device1.id)})
+        self.assertNotIn("error", str(result))
+        self.assertIn(f"'interfaces': [{{'ip_addresses':"
+                      f" [{{'primary_ip4_for': {{'id': '{self.device1.id}'}}", str(result))

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1366,5 +1366,5 @@ query {
         result = self.execute_query(query, variables={"device_id": str(self.device1.id)})
         self.assertNotIn("error", str(result))
         self.assertIn(
-            f"'interfaces': [{{'ip_addresses':" f" [{{'primary_ip4_for': {{'id': '{self.device1.id}'}}", str(result)
+            f"'interfaces': [{{'ip_addresses': [{{'primary_ip4_for': {{'id': '{self.device1.id}'}}", str(result)
         )

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1365,6 +1365,5 @@ query {
         self.device1.save()
         result = self.execute_query(query, variables={"device_id": str(self.device1.id)})
         self.assertNotIn("error", str(result))
-        self.assertIn(
-            f"'interfaces': [{{'ip_addresses': [{{'primary_ip4_for': {{'id': '{self.device1.id}'}}", str(result.data)
-        )
+        expected_interfaces_first = {"ip_addresses": [{"primary_ip4_for": {"id": str(self.device1.id)}}]}
+        self.assertEqual(result.data["device"]["interfaces"][0], expected_interfaces_first)

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1365,5 +1365,6 @@ query {
         self.device1.save()
         result = self.execute_query(query, variables={"device_id": str(self.device1.id)})
         self.assertNotIn("error", str(result))
-        self.assertIn(f"'interfaces': [{{'ip_addresses':"
-                      f" [{{'primary_ip4_for': {{'id': '{self.device1.id}'}}", str(result))
+        self.assertIn(
+            f"'interfaces': [{{'ip_addresses':" f" [{{'primary_ip4_for': {{'id': '{self.device1.id}'}}", str(result)
+        )

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1366,5 +1366,5 @@ query {
         result = self.execute_query(query, variables={"device_id": str(self.device1.id)})
         self.assertNotIn("error", str(result))
         self.assertIn(
-            f"'interfaces': [{{'ip_addresses': [{{'primary_ip4_for': {{'id': '{self.device1.id}'}}", str(result)
+            f"'interfaces': [{{'ip_addresses': [{{'primary_ip4_for': {{'id': '{self.device1.id}'}}", str(result.data)
         )


### PR DESCRIPTION
# Closes: #1313 
# What's Changed
OneToOneRel fields were previously being treated as a list (as they were being handled as ManyToOneRel types). They're now not being treated as a list.