### PR TITLE
Revise #1588 commit to use `example_plugin` vs. `dummy_plugin`

### DIFF
--- a/nautobot/docs/release-notes/version-1.2.md
+++ b/nautobot/docs/release-notes/version-1.2.md
@@ -150,7 +150,8 @@ Just as with the UI, the `slug` can still always be explicitly set if desired.
 
 ### Changed
 
-- [#1536](https://github.com/nautobot/nautobot/pull/1536) - Removed the ServiceUnavailable exception when no primary_ip is available for a device, as other connection options available.
+- [#1536](https://github.com/nautobot/nautobot/pull/1536) - Removed the ServiceUnavailable exception when no `primary_ip` is available for a device, but other connection options are available.
+- [#1581](https://github.com/nautobot/nautobot/issues/1581) - Changed MultipleChoiceJSONField to accept choices as a callable, fixing Datasource Contents provided by plugins are not accepted as valid choice by REST API.
 - [#1584](https://github.com/nautobot/nautobot/issues/1584) - Replaced links in docs to celeryproject.org with celeryq.dev
 
 ### Fixed

--- a/nautobot/extras/api/fields.py
+++ b/nautobot/extras/api/fields.py
@@ -1,10 +1,18 @@
 from collections import OrderedDict
 
+from django.forms.fields import CallableChoiceIterator
 from rest_framework import serializers
 
 
 class MultipleChoiceJSONField(serializers.MultipleChoiceField):
     """A MultipleChoiceField that renders the received value as a JSON-compatible list rather than a set."""
+
+    def __init__(self, **kwargs):
+        """Overload default choices handling to also accept a callable."""
+        choices = kwargs.get("choices")
+        if callable(choices):
+            kwargs["choices"] = CallableChoiceIterator(choices)
+        super().__init__(**kwargs)
 
     def to_internal_value(self, data):
         set_value = super().to_internal_value(data)

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -477,7 +477,7 @@ class GitRepositorySerializer(CustomFieldModelSerializer):
     secrets_group = NestedSecretsGroupSerializer(required=False, allow_null=True)
 
     provided_contents = MultipleChoiceJSONField(
-        choices=get_datasource_content_choices("extras.gitrepository"),
+        choices=lambda: get_datasource_content_choices("extras.gitrepository"),
         allow_blank=True,
         required=False,
     )

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -759,7 +759,7 @@ class GitRepositoryTest(APIViewTestCases.APIViewTestCase):
             "name": "plugin_test",
             "slug": "plugin-test",
             "remote_url": "https://localhost/plugin-test",
-            "provided_contents": ["dummy_plugin.textfile"],
+            "provided_contents": ["example_plugin.textfile"],
         }
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -750,6 +750,21 @@ class GitRepositoryTest(APIViewTestCases.APIViewTestCase):
         response = self.client.post(url, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
+    def test_create_with_plugin_provided_contents(self):
+        """Test that `provided_contents` published by a plugin works."""
+        self.add_permissions("extras.add_gitrepository")
+        self.add_permissions("extras.change_gitrepository")
+        url = self._get_list_url()
+        data = {
+            "name": "plugin_test",
+            "slug": "plugin-test",
+            "remote_url": "https://localhost/plugin-test",
+            "provided_contents": ["dummy_plugin.textfile"],
+        }
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(list(response.data["provided_contents"]), data["provided_contents"])
+
 
 class GraphQLQueryTest(APIViewTestCases.APIViewTestCase):
     model = GraphQLQuery


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: n/a
# What's Changed

This updates the fix provided to `develop` branch in #1588 to to be compatible with `next` branch by renaming `dummy_plugin` to `example_plugin` in the test code.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design