### PR TITLE
Provide additional utilities for job testing.

### DIFF
--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -553,36 +553,87 @@ Provision of user input (`data` values) via the CLI is not supported at this tim
 
 Jobs are Python code and can be tested as such, usually via [Django unit-test features](https://docs.djangoproject.com/en/stable/topics/testing/). That said, there are a few useful tricks specific to testing Jobs.
 
-While individual methods within your Job can and should be tested in isolation, you'll likely also want to test the entire execution of the Job. The simplest way to do so is via calling the `nautobot.extras.jobs.run_job()` method, as this is the same function used to execute a Job via Nautobot's Celery worker process. As part of your test, you can call `run_job` directly rather than enqueuing it for the worker to handle; this is simpler and generally quite sufficient for testing.
+While individual methods within your Job can and should be tested in isolation, you'll likely also want to test the entire execution of the Job. Nautobot 1.3 introduced a couple of changes to the way Jobs are handled. As a consequence, the recommended job testing approach also differs between 1.2.x and 1.3.x and later.
 
-Because of the way `run_job()` works, which is somewhat complex behind the scenes, there are a few things you'll need to do in your test code:
+### 1.3.x and later
 
-1. Inherit from `django.test.TransactionTestCase` instead of `django.test.TestCase`. (Refer to the [Django documentation](https://docs.djangoproject.com/en/stable/topics/testing/tools/#provided-test-case-classes) if you're interested in the differences between these classes.)
-2. Set your test class's `databases` attribute to `("default", "job_logs")`. (`job_logs` is a proxy connection to the same (`default`) database that's used exclusively for Job logging.)
+The simplest way to test the entire execution of Jobs from 1.3 on is via calling the `nautobot.utilities.testing.run_job_for_testing()` method, which is a helper wrapper around the `run_job` function used to execute a Job via Nautobot's Celery worker process.
 
-!!! tip
-    Additionally, *if your test case needs to be backwards-compatible with test execution against Nautobot 1.2.x*, you should add the following block to your test module:
+Because of the way `run_job_for_testing` and more specifically `run_job()` works, which is somewhat complex behind the scenes, you need to inherit from `nautobot.utilities.testing.TransactionTestCase` instead of `django.test.TestCase` (Refer to the [Django documentation](https://docs.djangoproject.com/en/stable/topics/testing/tools/#provided-test-case-classes) if you're interested in the differences between these classes - `TransactionTestCase` from Nautobot is a small wrapper around Django's `TransactionTestCase`).
 
-        from django.conf import settings
+### 1.2.x
 
-        if "job_logs" in settings.DATABASES:
-            settings.DATABASES["job_logs"] = settings.DATABASES["job_logs"].copy()
-            settings.DATABASES["job_logs"]["TEST"] = {"MIRROR": "default"}
+If your test case needs to be backwards-compatible with test execution against Nautobot 1.2.x, you need to handle a couple more things manually:
 
-    This code isn't *needed* in Nautobot 1.3.x and later, as the `"job_logs"` database will already be set up correctly for testability, but it also won't hurt anything to include.
+- Set up the `"job_logs"` database correctly for testability
+  ```
+  from django.conf import settings
+
+  if "job_logs" in settings.DATABASES:
+      settings.DATABASES["job_logs"] = settings.DATABASES["job_logs"].copy()
+      settings.DATABASES["job_logs"]["TEST"] = {"MIRROR": "default"}
+  ```
+- Replicate the behavior of `run_job_for_testing` manually so that your test execution most closely resembles the way the celery worker would run the test and set up the `databases` field on the test class correctly
+  ```python
+  import uuid
+
+  from django.contrib.auth import get_user_model
+  from django.contrib.contenttypes.models import ContentType
+  
+  from nautobot.extras.context_managers import web_request_context
+  from nautobot.extras.jobs import run_job
+  from nautobot.extras.models import JobResult, Job
+
+  def run_job_for_testing(job, data=None, commit=True, username="test-user"):
+      if data is None:
+        data = {}
+      user_model = get_user_model()
+      user, _ = user_model.objects.get_or_create(username=username, is_superuser=True, password="password")
+      job_result = JobResult.objects.create(
+          name=job.class_path,
+          obj_type=ContentType.objects.get_for_model(Job),
+          user=user,
+          job_id=uuid.uuid4(),
+      )
+      with web_request_context(user=user) as request:
+          run_job(data=data, request=request, commit=commit, job_result_pk=job_result.pk)
+      return job_result
+  ```
+- Re-create the default Statuses on `setUp` in your test classes, because `django.test.TransactionTestCase` truncates them on every `tearDown`
+  ```python
+  from django.apps import apps
+  from django.conf import settings
+  from django.test import TransactionTestCase
+
+  from nautobot.extras.management import populate_status_choices
+
+  class MyJobTestCase(TransactionTestCase):
+    # 'job_logs' is a proxy connection to the same (default) database that's used exclusively for Job logging
+    if "job_logs" in settings.DATABASES:
+        databases = ("default", "job_logs")
+
+    def setUp(self):
+        super().setUp()
+        populate_status_choices(apps, None)
+  ```
+
+---
 
 A simple example of a Job test case that's implemented to be backwards-compatible with Nautobot 1.2.x might look like the following:
 
 ```python
 import uuid
 
+from django.apps import apps
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import TransactionTestCase
 
-from nautobot.extras.jobs import run_job
+from nautobot.extras.context_managers import web_request_context
+from nautobot.extras.jobs import run_job 
+from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Job, JobResult, JobLogEntry
-
 
 if "job_logs" in settings.DATABASES:
     settings.DATABASES["job_logs"] = settings.DATABASES["job_logs"].copy()
@@ -590,20 +641,25 @@ if "job_logs" in settings.DATABASES:
 
 
 class MyJobTestCase(TransactionTestCase):
-    if "job_logs" in settings.DATABASES:
-        databases = ("default", "job_logs")
 
+    def setUp(self):
+        super().setUp()
+        populate_status_choices(apps, None)
+    
     def test_my_job(self):
         # Testing of Job "MyJob" in file "my_job_file.py" in $JOBS_ROOT
         job = Job.objects.get(job_class_name="MyJob", module_name="my_job_file", source="local")
         # or, job = Job.objects.get_for_class_path("local/my_job_file/MyJob")
+        user_model = get_user_model()
+        user, _ = user_model.objects.get_or_create(username="test-user", is_superuser=True, password="password")
         job_result = JobResult.objects.create(
             name=job.class_path,
             obj_type=ContentType.objects.get(app_label="extras", model="job"),
-            job_model=job,
+            user=user,
             job_id=uuid.uuid4(),
         )
-        run_job(data={"my_variable": "my_value"}, request=None, commit=False, job_result_pk=job_result.pk)
+        with web_request_context(user=user) as request:
+            run_job(data={"my_variable": "my_value"}, request=request, commit=False, job_result_pk=job_result.pk)
 
         # Since we ran with commit=False, any database changes made by the job won't persist,
         # but we can still inspect the logs created by running the job

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -566,6 +566,7 @@ Because of the way `run_job_for_testing` and more specifically `run_job()` works
 If your test case needs to be backwards-compatible with test execution against Nautobot 1.2.x, you need to handle a couple more things manually:
 
 Set up the `"job_logs"` database correctly for testing:
+
 ```python
 from django.conf import settings
 
@@ -573,7 +574,9 @@ if "job_logs" in settings.DATABASES:
     settings.DATABASES["job_logs"] = settings.DATABASES["job_logs"].copy()
     settings.DATABASES["job_logs"]["TEST"] = {"MIRROR": "default"}
   ```
+
 Replicate the behavior of `run_job_for_testing` manually so that your test execution most closely resembles the way the celery worker would run the test:
+
 ```python
 import uuid
 from django.contrib.auth import get_user_model
@@ -599,7 +602,9 @@ def run_job_for_testing(job, data=None, commit=True, username="test-user"):
         run_job(data=data, request=request, commit=commit, job_result_pk=job_result.pk)
     return job_result
 ```
+
 Setup the `databases` field on the test class correctly, and re-create the default Statuses on `setUp` in your test classes, because `django.test.TransactionTestCase` truncates them on every `tearDown`:
+
 ```python
 from django.apps import apps
 from django.conf import settings

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -553,61 +553,61 @@ Provision of user input (`data` values) via the CLI is not supported at this tim
 
 Jobs are Python code and can be tested as such, usually via [Django unit-test features](https://docs.djangoproject.com/en/stable/topics/testing/). That said, there are a few useful tricks specific to testing Jobs.
 
-While individual methods within your Job can and should be tested in isolation, you'll likely also want to test the entire execution of the Job. Nautobot 1.3 introduced a couple of changes to the way Jobs are handled. As a consequence, the recommended job testing approach also differs between 1.2.x and 1.3.x and later.
+While individual methods within your Job can and should be tested in isolation, you'll likely also want to test the entire execution of the Job. Nautobot 1.3 introduced a few enhancements to make this simpler to do, but it's also quite possible to test under Nautobot 1.2 with a bit more effort.
 
-### 1.3.x and later
+### Nautobot 1.3 and later
 
 The simplest way to test the entire execution of Jobs from 1.3 on is via calling the `nautobot.utilities.testing.run_job_for_testing()` method, which is a helper wrapper around the `run_job` function used to execute a Job via Nautobot's Celery worker process.
 
 Because of the way `run_job_for_testing` and more specifically `run_job()` works, which is somewhat complex behind the scenes, you need to inherit from `nautobot.utilities.testing.TransactionTestCase` instead of `django.test.TestCase` (Refer to the [Django documentation](https://docs.djangoproject.com/en/stable/topics/testing/tools/#provided-test-case-classes) if you're interested in the differences between these classes - `TransactionTestCase` from Nautobot is a small wrapper around Django's `TransactionTestCase`).
 
-### 1.2.x
+### Nautobot 1.2
 
 If your test case needs to be backwards-compatible with test execution against Nautobot 1.2.x, you need to handle a couple more things manually:
 
-- Set up the `"job_logs"` database correctly for testing:
-  ```python
-  from django.conf import settings
+Set up the `"job_logs"` database correctly for testing:
+```python
+from django.conf import settings
 
-  if "job_logs" in settings.DATABASES:
-      settings.DATABASES["job_logs"] = settings.DATABASES["job_logs"].copy()
-      settings.DATABASES["job_logs"]["TEST"] = {"MIRROR": "default"}
+if "job_logs" in settings.DATABASES:
+    settings.DATABASES["job_logs"] = settings.DATABASES["job_logs"].copy()
+    settings.DATABASES["job_logs"]["TEST"] = {"MIRROR": "default"}
   ```
-- Replicate the behavior of `run_job_for_testing` manually so that your test execution most closely resembles the way the celery worker would run the test:
-  ```python
-  import uuid
+Replicate the behavior of `run_job_for_testing` manually so that your test execution most closely resembles the way the celery worker would run the test:
+```python
+import uuid
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 
-  from django.contrib.auth import get_user_model
-  from django.contrib.contenttypes.models import ContentType
-  
-  from nautobot.extras.context_managers import web_request_context
-  from nautobot.extras.jobs import run_job
-  from nautobot.extras.models import JobResult, Job
+from nautobot.extras.context_managers import web_request_context
+from nautobot.extras.jobs import run_job
+from nautobot.extras.models import JobResult, Job
 
-  def run_job_for_testing(job, data=None, commit=True, username="test-user"):
-      if data is None:
+def run_job_for_testing(job, data=None, commit=True, username="test-user"):
+    if data is None:
         data = {}
-      user_model = get_user_model()
-      user, _ = user_model.objects.get_or_create(username=username, is_superuser=True, password="password")
-      job_result = JobResult.objects.create(
-          name=job.class_path,
-          obj_type=ContentType.objects.get_for_model(Job),
-          user=user,
-          job_id=uuid.uuid4(),
-      )
-      with web_request_context(user=user) as request:
-          run_job(data=data, request=request, commit=commit, job_result_pk=job_result.pk)
-      return job_result
-  ```
-- Setup the `databases` field on the test class correctly, and re-create the default Statuses on `setUp` in your test classes, because `django.test.TransactionTestCase` truncates them on every `tearDown`:
-  ```python
-  from django.apps import apps
-  from django.conf import settings
-  from django.test import TransactionTestCase
+    user_model = get_user_model()
+    user, _ = user_model.objects.get_or_create(username=username, is_superuser=True, password="password")
+    job_result = JobResult.objects.create(
+        name=job.class_path,
+        obj_type=ContentType.objects.get_for_model(Job),
+        user=user,
+        job_model=job,
+        job_id=uuid.uuid4(),
+    )
+    with web_request_context(user=user) as request:
+        run_job(data=data, request=request, commit=commit, job_result_pk=job_result.pk)
+    return job_result
+```
+Setup the `databases` field on the test class correctly, and re-create the default Statuses on `setUp` in your test classes, because `django.test.TransactionTestCase` truncates them on every `tearDown`:
+```python
+from django.apps import apps
+from django.conf import settings
+from django.test import TransactionTestCase
 
-  from nautobot.extras.management import populate_status_choices
+from nautobot.extras.management import populate_status_choices
 
-  class MyJobTestCase(TransactionTestCase):
+class MyJobTestCase(TransactionTestCase):
     # 'job_logs' is a proxy connection to the same (default) database that's used exclusively for Job logging
     if "job_logs" in settings.DATABASES:
         databases = ("default", "job_logs")
@@ -615,27 +615,18 @@ If your test case needs to be backwards-compatible with test execution against N
     def setUp(self):
         super().setUp()
         populate_status_choices(apps, None)
-  ```
+```
 
 ---
 
 A simple example of a Job test case for 1.3.x and forward might look like the following:
 
 ```python
-from django.apps import apps
-from django.test import TransactionTestCase
-
-from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import Job, JobLogEntry
-from nautobot.utilities.testing import run_job_for_testing
+from nautobot.utilities.testing import run_job_for_testing, TransactionTestCase
 
 
 class MyJobTestCase(TransactionTestCase):
-
-    def setUp(self):
-        super().setUp()
-        populate_status_choices(apps, None)
-    
     def test_my_job(self):
         # Testing of Job "MyJob" in file "my_job_file.py" in $JOBS_ROOT
         job = Job.objects.get(job_class_name="MyJob", module_name="my_job_file", source="local")

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -582,6 +582,9 @@ class MyJobTestCase(TransactionTestCase):
             self.assertEqual(log_entry.message, "...")
 ```
 
+!!! tip
+    For more advanced examples (such as testing jobs executed with `commit=True`, for example) refer to the Nautobot source code, specifically `nautobot/extras/tests/test_jobs.py`.
+
 ### Nautobot 1.2
 
 If your test case needs to be backwards-compatible with test execution against Nautobot 1.2.x, you need to handle a couple more things manually:
@@ -594,7 +597,7 @@ from django.conf import settings
 if "job_logs" in settings.DATABASES:
     settings.DATABASES["job_logs"] = settings.DATABASES["job_logs"].copy()
     settings.DATABASES["job_logs"]["TEST"] = {"MIRROR": "default"}
- ```
+```
 
 Replicate the behavior of `run_job_for_testing` manually so that your test execution most closely resembles the way the celery worker would run the test:
 
@@ -641,9 +644,6 @@ class MyJobTestCase(TransactionTestCase):
         super().setUp()
         populate_status_choices(apps, None)
 ```
-
-!!! tip
-    For more advanced examples (such as testing jobs executed with `commit=True`, for example) refer to the Nautobot source code, specifically `nautobot/extras/tests/test_jobs.py`.
 
 ## Example Jobs
 

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -15,8 +15,7 @@ from nautobot.extras.choices import JobResultStatusChoices, LogLevelChoices
 from nautobot.extras.jobs import get_job, run_job
 from nautobot.extras.models import FileProxy, Job, JobResult, Status, CustomField
 from nautobot.extras.models.models import JobLogEntry
-from nautobot.utilities.testing import CeleryTestCase, TransactionTestCase
-
+from nautobot.utilities.testing import CeleryTestCase, TransactionTestCase, run_job_for_testing
 
 # Use the proper swappable User model
 User = get_user_model()
@@ -37,15 +36,7 @@ def create_job_result_and_run_job(module, name, *, data=None, commit=True, reque
     if data is None:
         data = {}
     job_class, job_model = get_job_class_and_model(module, name)
-    job_content_type = ContentType.objects.get(app_label="extras", model="job")
-    job_result = JobResult.objects.create(
-        name=job_model.class_path,
-        obj_type=job_content_type,
-        job_model=job_model,
-        user=None,
-        job_id=uuid.uuid4(),
-    )
-    run_job(data=data, request=request, commit=commit, job_result_pk=job_result.pk)
+    job_result = run_job_for_testing(job=job_class, data=data, commit=commit, request=request)
     job_result.refresh_from_db()
     return job_result
 

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -7,13 +7,12 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
 from django.test.client import RequestFactory
 
 from nautobot.dcim.models import DeviceRole, Site
 from nautobot.extras.choices import JobResultStatusChoices, LogLevelChoices
-from nautobot.extras.jobs import get_job, run_job
-from nautobot.extras.models import FileProxy, Job, JobResult, Status, CustomField
+from nautobot.extras.jobs import get_job
+from nautobot.extras.models import FileProxy, Job, Status, CustomField
 from nautobot.extras.models.models import JobLogEntry
 from nautobot.utilities.testing import CeleryTestCase, TransactionTestCase, run_job_for_testing
 
@@ -32,7 +31,7 @@ def get_job_class_and_model(module, name):
 
 
 def create_job_result_and_run_job(module, name, *, data=None, commit=True, request=None):
-    """Test helper function to call get_job_class_and_model() then create a JobResult and call run_job()."""
+    """Test helper function to call get_job_class_and_model() then and call run_job_for_testing()."""
     if data is None:
         data = {}
     job_class, job_model = get_job_class_and_model(module, name)

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -2,6 +2,7 @@ import json
 from io import StringIO
 import uuid
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
@@ -11,8 +12,8 @@ from django.test.client import RequestFactory
 
 from nautobot.dcim.models import DeviceRole, Site
 from nautobot.extras.choices import JobResultStatusChoices, LogLevelChoices
-from nautobot.extras.jobs import get_job
-from nautobot.extras.models import FileProxy, Job, Status, CustomField
+from nautobot.extras.jobs import get_job, run_job
+from nautobot.extras.models import FileProxy, Job, Status, CustomField, JobResult
 from nautobot.extras.models.models import JobLogEntry
 from nautobot.utilities.testing import CeleryTestCase, TransactionTestCase, run_job_for_testing
 
@@ -73,6 +74,28 @@ class JobTest(TransactionTestCase):
             "or equal to the soft time limit of 10.0 seconds. "
             "This job will fail silently after 5.0 seconds.",
         )
+
+    def test_job_pass_with_run_job_directly(self):
+        """
+        Job test with pass result calling run_job directly in order to test for backwards stability of its API.
+
+        Because calling run_job directly used to be the best practice for testing jobs, we want to ensure that calling
+        it still works even if we ever change the run_job call in the run_job_for_testing wrapper.
+        """
+        module = "test_pass"
+        name = "TestPass"
+        job_class, job_model = get_job_class_and_model(module, name)
+        job_content_type = ContentType.objects.get(app_label="extras", model="job")
+        job_result = JobResult.objects.create(
+            name=job_model.class_path,
+            obj_type=job_content_type,
+            job_model=job_model,
+            user=None,
+            job_id=uuid.uuid4(),
+        )
+        run_job(data={}, request=None, commit=False, job_result_pk=job_result.pk)
+        job_result = create_job_result_and_run_job(module, name, commit=False)
+        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
 
     def test_job_pass(self):
         """

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -35,7 +35,7 @@ def create_job_result_and_run_job(module, name, *, data=None, commit=True, reque
     if data is None:
         data = {}
     job_class, job_model = get_job_class_and_model(module, name)
-    job_result = run_job_for_testing(job=job_class, data=data, commit=commit, request=request)
+    job_result = run_job_for_testing(job=job_model, data=data, commit=commit, request=request)
     job_result.refresh_from_db()
     return job_result
 

--- a/nautobot/utilities/testing/__init__.py
+++ b/nautobot/utilities/testing/__init__.py
@@ -1,9 +1,18 @@
 import time
+import uuid
 
 from celery.contrib.testing.worker import start_worker
+from django.apps import apps
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.test import tag, TransactionTestCase as _TransactionTestCase
 
 from nautobot.core.celery import app
+from nautobot.extras.context_managers import web_request_context
+from nautobot.extras.jobs import run_job
+from nautobot.extras.management import populate_status_choices
+from nautobot.extras.models import JobResult, Job
 
 from .api import APITestCase, APIViewTestCases
 from .utils import (
@@ -35,11 +44,42 @@ __all__ = (
 )
 
 
+def run_job_for_testing(job, data=None, commit=True, username="test-user"):
+    """Provide a common interface to run Nautobot jobs as part of unit tests."""
+    if data is None:
+        data = {}
+    user_model = get_user_model()
+    user, _ = user_model.objects.get_or_create(username=username, is_superuser=True, password="password")
+    job_result = JobResult.objects.create(
+        name=job.class_path,
+        obj_type=ContentType.objects.get_for_model(Job),
+        user=user,
+        job_id=uuid.uuid4(),
+    )
+    with web_request_context(user=user) as request:
+        run_job(data=data, request=request, commit=commit, job_result_pk=job_result.pk)
+    return job_result
+
+
 @tag("unit")
 class TransactionTestCase(_TransactionTestCase):
     """
     Base test case class using the TransactionTestCase for unit testing
     """
+
+    # 'job_logs' is a proxy connection to the same (default) database that's used exclusively for Job logging
+    if "job_logs" in settings.DATABASES:
+        databases = ("default", "job_logs")
+
+    def setUp(self):
+        """Provide a clean, post-migration state before each test case.
+
+        django.test.TransactionTestCase truncates the database after each test runs. We need at least the default
+        statuses present in the database in order to run tests."""
+        super().setUp()
+
+        # Re-populate status choices after database truncation by TransactionTestCase
+        populate_status_choices(apps, None)
 
 
 class CeleryTestCase(TransactionTestCase):

--- a/nautobot/utilities/testing/__init__.py
+++ b/nautobot/utilities/testing/__init__.py
@@ -42,7 +42,7 @@ __all__ = (
     "ModelTestCase",
     "ModelViewTestCase",
     "ViewTestCases",
-    "run_job_for_testing"
+    "run_job_for_testing",
 )
 
 

--- a/nautobot/utilities/testing/__init__.py
+++ b/nautobot/utilities/testing/__init__.py
@@ -67,8 +67,10 @@ def run_job_for_testing(job, data=None, commit=True, username="test-user", reque
     if request and request.user:
         user_instance = request.user
     else:
-        user_model = get_user_model()
-        user_instance, _ = user_model.objects.get_or_create(username=username, is_superuser=True, password="password")
+        User = get_user_model()
+        user_instance, _ = User.objects.get_or_create(
+            username=username, defaults={"is_superuser": True, "password": "password"}
+        )
     job_result = JobResult.objects.create(
         name=job.class_path,
         obj_type=ContentType.objects.get_for_model(Job),
@@ -94,10 +96,6 @@ class TransactionTestCase(_TransactionTestCase):
     """
     Base test case class using the TransactionTestCase for unit testing
     """
-
-    # 'job_logs' is a proxy connection to the same (default) database that's used exclusively for Job logging
-    if "job_logs" in settings.DATABASES:
-        databases = ("default", "job_logs")
 
     def setUp(self):
         """Provide a clean, post-migration state before each test case.

--- a/nautobot/utilities/testing/__init__.py
+++ b/nautobot/utilities/testing/__init__.py
@@ -41,6 +41,7 @@ __all__ = (
     "ModelTestCase",
     "ModelViewTestCase",
     "ViewTestCases",
+    "run_job_for_testing"
 )
 
 

--- a/nautobot/utilities/testing/__init__.py
+++ b/nautobot/utilities/testing/__init__.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 
 from celery.contrib.testing.worker import start_worker
 from django.apps import apps
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import tag, TransactionTestCase as _TransactionTestCase


### PR DESCRIPTION
# What's Changed

- Expand `nautobot.utilities.testing.TransactionTestCase` to automatically re-populate statuses after `django.test.TransactionTestCase` truncates the database
- Provide a `run_job_for_testing` wrapper around `run_job` to allow for easier job testing
- Elaborate upon these changes in the "Testing Jobs" section of the docs

# Questions

- Should I provide unit testing for `run_job_for_testing`?
- Should we (perhaps optionally) call `cacheops.invalidate_all()` in `TransactionTestCase.setUp()`?
- I raised this PR against `next` because I am changing a doc section that is not present in `develop` - let me know if this should be done another way 
- Should we use a different method than `populate_status_choices` to prepare to re-create future default objects that aren't statuses?

# TODO
- [x] Explanation of Change(s)
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design