### PR TITLE
Use poetry-installed dependencies for final Docker image as well as dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Exclude everything by default
+*
+
+# Un-exclude specific things needed for the Docker build
+!development/nautobot_config.py
+!docker/docker-entrypoint.sh
+!docker/nautobot_config.append.py
+!docker/uwsgi.ini
+!examples
+!nautobot
+!poetry.lock
+!pyproject.toml
+!README.md
+
+# Add specific exclusions
+**/__pycache__

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
 
   container-build:
     runs-on: "ubuntu-20.04"
-    # TODO if: "github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/next')"
+    if: "github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/next')"
     needs:
       - "integration-test"
     strategy:
@@ -275,7 +275,7 @@ jobs:
       - name: "Build"
         uses: "docker/build-push-action@v2"
         with:
-          push: false  # TODO true
+          push: true
           target: final
           file: "docker/Dockerfile"
           tags: "${{ steps.dockermeta.outputs.tags }}"
@@ -305,7 +305,7 @@ jobs:
       - name: "Build Dev Containers"
         uses: "docker/build-push-action@v2"
         with:
-          push: false   # TODO true
+          push: true
           target: final-dev
           file: "docker/Dockerfile"
           tags: "${{ steps.dockerdevmeta.outputs.tags }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
 
   container-build:
     runs-on: "ubuntu-20.04"
-    if: "github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/next')"
+    # TODO if: "github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/next')"
     needs:
       - "integration-test"
     strategy:
@@ -246,6 +246,8 @@ jobs:
         uses: "actions/checkout@v2"
       - run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: "gitbranch"
+      - run: echo "##[set-output name=version;]$(egrep -m1 'file.*pyuwsgi-' poetry.lock | cut -f2 -d-)"
+        id: "pyuwsgi"
       - name: "Set up Docker Buildx"
         uses: "docker/setup-buildx-action@v1"
       - name: Login to GitHub Container Registry
@@ -273,7 +275,7 @@ jobs:
       - name: "Build"
         uses: "docker/build-push-action@v2"
         with:
-          push: true
+          push: false  # TODO true
           target: final
           file: "docker/Dockerfile"
           tags: "${{ steps.dockermeta.outputs.tags }}"
@@ -283,6 +285,7 @@ jobs:
           context: "."
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
+            PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
       - name: "Docker Dev Metadata"
         id: "dockerdevmeta"
         uses: "docker/metadata-action@v3"
@@ -302,7 +305,7 @@ jobs:
       - name: "Build Dev Containers"
         uses: "docker/build-push-action@v2"
         with:
-          push: true
+          push: false   # TODO true
           target: final-dev
           file: "docker/Dockerfile"
           tags: "${{ steps.dockerdevmeta.outputs.tags }}"
@@ -312,3 +315,4 @@ jobs:
           context: "."
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
+            PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ ARG PYUWSGI_VER
 # dependencies (intermediate build target)
 #   adds OS-level dependencies for *installing* Nautobot, its dependencies, and its development dependencies
 #   installs Poetry
-#   copies Nautobot sourcee files and packaging definition into the image
+#   copies Nautobot source files and packaging definition into the image
 #   uses Pip/Poetry to install Nautobot's Python dependencies (but *not* development dependencies or Nautobot itself)
 #   uses Poetry to build a Nautobot wheel (but not yet install it)
 #
@@ -134,6 +134,7 @@ RUN poetry install --no-root --no-ansi --extras all
 COPY development/nautobot_config.py /opt/nautobot/nautobot_config.py
 
 # Run Nautobot development server by default
+EXPOSE 8080
 CMD ["nautobot-server", "runserver", "0.0.0.0:8080", "--insecure"]
 
 ################################ Stage: dev (development environment for Nautobot core)
@@ -189,4 +190,5 @@ RUN nautobot-server init && \
     rm -f /opt/nautobot/nautobot_config.append.py
 
 # Run Nautobot server under uwsgi by default
+EXPOSE 8080 8443
 CMD ["nautobot-server", "start", "--ini", "/opt/nautobot/uwsgi.ini"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,7 +85,9 @@ RUN apt-get update && \
 # if we instead used "pip install poetry" it would install its own dependencies globally which may conflict with ours.
 # https://python-poetry.org/docs/master/#installing-with-the-official-installer
 # This also makes it so that Poetry will *not* be included in the "final" image since it's not installed to /usr/local/
-RUN curl -sSL https://install.python-poetry.org | python -
+RUN curl -sSL https://install.python-poetry.org -o /tmp/install-poetry.py && \
+    python /tmp/install-poetry.py && \
+    rm -f /tmp/install-poetry.py
 
 # Add poetry install location to the $PATH
 ENV PATH="${PATH}:/root/.local/bin"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,43 +1,41 @@
 ARG PYTHON_VER
+ARG PYUWSGI_VER
 
 ################################ Overview
 # This builds the following hierarchy of images:
 #
-# python:${PYTHON_VER}-slim
-#           |
-#           V
-#         (base) --> (install-dependencies) --> dev --> final-dev
-#           |                  |
-#           V                  V
-#         final <..... (install-nautobot)
+# python:${PYTHON_VER}-slim --> (base) --> (install) --> (install-dev) -->  dev
+#                                 |            .              |
+#                                 V            .              V
+#                               final <.........          final-dev
 #
 # base (intermediate build target; basis for all other images herein)
 #   adds OS-level packaging dependencies for *running* Nautobot
+#   installs Pip and wheel
 #
-# install-dependencies (intermediate build target)
+# install (intermediate build target)
 #   adds OS-level packaging dependencies for *installing* Nautobot, its dependencies, and its development dependencies
-#   installs Pip and Poetry
+#   installs Poetry
 #   uses Pip and Poetry to install Nautobot's Python dependencies (but *not* development dependencies)
-#   uses Poetry to build a Nautobot wheel for later use by the "install-nautobot" and "final-dev" images
+#   uses Poetry to build a Nautobot wheel
+#
+# install-dev (intermediate build target)
+#   uses Poetry to additionally install Nautobot's *development* dependencies
+#   adds files for Nautobot development server to run
+#
+# final-dev (development environment for Nautobot plugins)
+#   uses Pip to install Nautobot as a wheel
 #
 # dev (development environment for Nautobot core)
-#   uses Poetry to additionally install Nautobot's *development* dependencies
-#   uses Poetry to install Nautobot itself in editable (develop) mode
-#     (at runtime the intent is to mount the live Nautobot source over the Poetry-installed Nautobot)
-#   is capable of running Nautobot dev server
-#
-# install-nautobot (intermediate build target):
-#   uses Pip to install the Nautobot wheel previously built in "install-dependencies"
-#   creates a self-signed SSL certificate for later use by the "final" image
+#   uses Poetry to install Nautobot as editable
+#     (at runtime the requirement is to mount the live Nautobot source code to /source/; it won't run without that)
 #
 # final (production-ready environment):
 #   adds "nautobot" system user
 #   copies all installed Python packages, including Nautobot itself, from "install-nautobot"
-#   copies the self-signed SSL certificate from "install-nautobot"
+#   creates a self-signed SSL certificate
 #   sets up the system to run Nautobot in production with uwsgi
 #
-# final-dev (development environment for Nautobot plugins)
-#   as "dev", but replaces the editable install of Nautobot with a wheel-based install of Nautobot
 
 ################################ Stage: base (intermediate build target; basis for all other images herein)
 
@@ -51,7 +49,7 @@ ENV PYTHONUNBUFFERED=1 \
 # hadolint ignore=DL3005,DL3008,DL3013
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y git mime-support curl libxml2 libmariadb3 && \
+    apt-get install --no-install-recommends -y git mime-support curl libxml2 libmariadb3 openssl && \
     apt-get autoremove -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/* && \
@@ -59,9 +57,17 @@ RUN apt-get update && \
 
 HEALTHCHECK --interval=5s --timeout=5s --start-period=5s --retries=1 CMD curl --fail http://localhost:8080/health/ || exit 1
 
-################################ Stage: install-dependencies (intermediate build target)
+# Generate required dirs for later consumption
+RUN mkdir /opt/nautobot /prom_cache
 
-FROM base as install-dependencies
+# Common entrypoint for all environments
+COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+################################ Stage: install (intermediate build target)
+
+FROM base as install
+ARG PYUWSGI_VER
 
 # Modify the PATH here because otherwise poetry fails 100% of the time. WAT??
 ENV PATH="${PATH}:/root/.local/bin"
@@ -69,7 +75,7 @@ ENV PATH="${PATH}:/root/.local/bin"
 # Install development/install-time OS dependencies
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y openssl build-essential libssl-dev libxmlsec1-dev libxmlsec1-openssl pkg-config libldap-dev libsasl2-dev libmariadb-dev && \
+    apt-get install --no-install-recommends -y build-essential libssl-dev libxmlsec1-dev libxmlsec1-openssl pkg-config libldap-dev libsasl2-dev libmariadb-dev && \
     apt-get autoremove -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
@@ -90,82 +96,81 @@ RUN poetry config virtualenvs.create false && \
     poetry config installer.parallel false
 
 # Install (non-development) Python dependencies of Nautobot
-COPY pyproject.toml poetry.lock /source/
+COPY pyproject.toml poetry.lock README.md /source/
 COPY examples /source/examples
 WORKDIR /source
 # pyuwsgi doesn't support ssl so we build it from source
 # https://github.com/nautobot/nautobot/issues/193
-RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi==2.0.20 && \
+RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi==${PYUWSGI_VER} && \
     poetry install --no-root --no-dev --no-ansi --extras all
 
-# Generate required dirs for later consumption
-RUN mkdir /opt/nautobot /prom_cache
-
-# Copy nautobot source and poetry info to container to reduce cache invalidations
-COPY README.md /source/
+# Copy in the Nautobot source code to build the wheel from
 COPY nautobot /source/nautobot
 
-# Build the wheel for later use by other images
+# Build the wheel
 RUN poetry build
 
-################################ Stage: dev (development environment for Nautobot core)
-# nautobot will be installed in editable mode in /source
+################################ Stage: install-dev (intermediate build target)
 
-FROM install-dependencies as dev
+FROM install as install-dev
 
 # Install hadolint for linting Dockerfiles
 RUN curl -Lo /usr/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.0.0/hadolint-Linux-x86_64 && \
     chmod +x /usr/bin/hadolint
 
-# Used if someone wants to override the entrypoint and provision a super user
-COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
+# Install development-specific dependencies of Nautobot
+RUN poetry install --no-root --no-ansi --extras all
 
 # TODO Use nautobot init to generate the same config for all use cases
 COPY development/nautobot_config.py /opt/nautobot/nautobot_config.py
 
 # Common docker entrypoint for migrations, superuser creations, etc.
-ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nautobot-server", "runserver", "0.0.0.0:8080", "--insecure"]
 
-# Install development-specific dependencies of Nautobot as well as Nautobot itself in editable mode
-RUN poetry install --no-ansi --extras all
+################################ Stage: dev (development environment for Nautobot core)
 
-################################ Stage: install-nautobot (intermediate build target)
+FROM install-dev as dev
 
-FROM install-dependencies as install-nautobot
+RUN poetry install --no-ansi && \
+    rm -rf /source
 
-# hadolint ignore=DL3013,SC2102
-RUN for whl in /source/dist/nautobot*.whl; do pip install --no-deps --no-cache-dir ${whl}[all]; done
+################################ Stage: final-dev (development environment for Nautobot plugins)
 
-# Generate self signed ssl certificates for later use
-RUN openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj \
-    '/C=US/ST=NY/L=NYC/O=Nautobot/CN=nautobot.local' \
-    -keyout /opt/nautobot/nautobot.key -out /opt/nautobot/nautobot.crt
+FROM install-dev as final-dev
+
+RUN pip install --no-deps --no-cache-dir /source/dist/*.whl && \
+    rm -rf /source
 
 ################################ Stage: final (production-ready image)
 
 FROM base as final
 ARG PYTHON_VER
 
-# Make sure we don't run as a root user
-RUN useradd --system --shell /bin/bash --create-home --home-dir /opt/nautobot nautobot
+# Remove files added by Poetry installer
+RUN rm -rf /root/.local
 
-# Copy from install-nautobot the required python libraries and binaries
-COPY --from=install-nautobot /usr/local/lib/python${PYTHON_VER}/site-packages /usr/local/lib/python${PYTHON_VER}/site-packages
-COPY --from=install-nautobot /usr/local/bin /usr/local/bin
+# Copy from install the required python libraries and binaries
+COPY --from=install /usr/local/lib/python${PYTHON_VER}/site-packages /usr/local/lib/python${PYTHON_VER}/site-packages
+COPY --from=install /usr/local/bin /usr/local/bin
+COPY --from=install /source/dist/*.whl /tmp
 
-# Setup the entrypoint
-COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
+# Install the Nautobot wheel
+RUN pip install --no-deps --no-cache-dir /tmp/*.whl
 
-# Copy SSL certs
-COPY --from=install-nautobot /opt/nautobot/nautobot.key /opt/nautobot/nautobot.crt /opt/nautobot/
+# Generate self-signed SSL certs
+RUN openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj \
+    '/C=US/ST=NY/L=NYC/O=Nautobot/CN=nautobot.local' \
+    -keyout /opt/nautobot/nautobot.key -out /opt/nautobot/nautobot.crt
 
 # Configure uWSGI
 COPY docker/uwsgi.ini /opt/nautobot
 COPY docker/nautobot_config.append.py /opt/nautobot
 
+# Make sure we don't run as a root user
+RUN useradd --system --shell /bin/bash --create-home --home-dir /opt/nautobot nautobot
+
 # Make sure everything under /opt/nautobot and /prom_cache is owned by nautobot
-RUN mkdir /prom_cache && chown -R nautobot:nautobot /opt/nautobot /prom_cache
+RUN chown -R nautobot:nautobot /opt/nautobot /prom_cache
 
 # Set up Nautobot to run in production
 USER nautobot
@@ -176,16 +181,4 @@ RUN nautobot-server init && \
     cat /opt/nautobot/nautobot_config.append.py >> /opt/nautobot/nautobot_config.py && \
     rm -f /opt/nautobot/nautobot_config.append.py
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nautobot-server", "start", "--ini", "/opt/nautobot/uwsgi.ini"]
-
-################################ Stage: final-dev (development environment for Nautobot plugins)
-# This image will contain the development dependencies (including poetry) as well as nautobot installed
-# as a system package
-
-FROM dev as final-dev
-
-# Nautobot was installed in editable mode so reinstall as a system package (all dependencies are already there)
-# hadolint ignore=DL3013,SC2102
-RUN for whl in /source/dist/nautobot*.whl; do pip install --force-reinstall --no-deps --no-cache-dir ${whl}[all]; done && \
-    rm -rf /source

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,38 +4,42 @@ ARG PYUWSGI_VER
 ################################ Overview
 # This builds the following hierarchy of images:
 #
-# python:${PYTHON_VER}-slim --> (base) --> (install) --> (install-dev) -->  dev
-#                                 |            .              |
-#                                 V            .              V
-#                               final <.........          final-dev
+# python:${PYTHON_VER}-slim --> (base) --> (dependencies) --> (dependencies-dev) -->  dev
+#                                 |              .                    |
+#                                 V              .                    V
+#                               final <...........                final-dev
 #
 # base (intermediate build target; basis for all other images herein)
-#   adds OS-level packaging dependencies for *running* Nautobot
+#   adds OS-level dependencies for *running* Nautobot
 #   installs Pip and wheel
+#   creates required directories and adds Docker healthcheck and entrypoint script
 #
-# install (intermediate build target)
-#   adds OS-level packaging dependencies for *installing* Nautobot, its dependencies, and its development dependencies
+# dependencies (intermediate build target)
+#   adds OS-level dependencies for *installing* Nautobot, its dependencies, and its development dependencies
 #   installs Poetry
-#   uses Pip and Poetry to install Nautobot's Python dependencies (but *not* development dependencies)
-#   uses Poetry to build a Nautobot wheel
+#   copies Nautobot sourcee files and packaging definition into the image
+#   uses Pip/Poetry to install Nautobot's Python dependencies (but *not* development dependencies or Nautobot itself)
+#   uses Poetry to build a Nautobot wheel (but not yet install it)
 #
-# install-dev (intermediate build target)
+# dependencies-dev (intermediate build target)
+#   installs hadolint for validating Dockerfiles
 #   uses Poetry to additionally install Nautobot's *development* dependencies
-#   adds files for Nautobot development server to run
-#
-# final-dev (development environment for Nautobot plugins)
-#   uses Pip to install Nautobot as a wheel
+#   adds files and configuration for Nautobot development server to run
 #
 # dev (development environment for Nautobot core)
 #   uses Poetry to install Nautobot as editable
 #     (at runtime the requirement is to mount the live Nautobot source code to /source/; it won't run without that)
 #
-# final (production-ready environment):
-#   adds "nautobot" system user
-#   copies all installed Python packages, including Nautobot itself, from "install-nautobot"
-#   creates a self-signed SSL certificate
-#   sets up the system to run Nautobot in production with uwsgi
+# final-dev (development environment for Nautobot plugins)
+#   uses Pip to install Nautobot as a wheel
 #
+# final (production-ready environment):
+#   removes Poetry
+#   copies all installed Python dependencies from "dependencies"
+#   copies Nautobot wheel from "dependencies" and installs it
+#   creates a self-signed SSL certificate
+#   adds "nautobot" system user
+#   sets up the system to run Nautobot in production with uwsgi
 
 ################################ Stage: base (intermediate build target; basis for all other images herein)
 
@@ -64,13 +68,10 @@ RUN mkdir /opt/nautobot /prom_cache
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-################################ Stage: install (intermediate build target)
+################################ Stage: dependencies (intermediate build target)
 
-FROM base as install
+FROM base as dependencies
 ARG PYUWSGI_VER
-
-# Modify the PATH here because otherwise poetry fails 100% of the time. WAT??
-ENV PATH="${PATH}:/root/.local/bin"
 
 # Install development/install-time OS dependencies
 # hadolint ignore=DL3008
@@ -80,12 +81,14 @@ RUN apt-get update && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Poetry manually from GitHub because otherwise it installs its own
-# dependencies globally which may conflict with ours.
-# https://python-poetry.org/docs/#osx-linux-bashonwindows-install-instructions
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -o /tmp/install-poetry.py && \
-    python /tmp/install-poetry.py && \
-    rm -f /tmp/install-poetry.py
+# Install Poetry manually via its installer script;
+# if we instead used "pip install poetry" it would install its own dependencies globally which may conflict with ours.
+# https://python-poetry.org/docs/master/#installing-with-the-official-installer
+# This also makes it so that Poetry will *not* be included in the "final" image since it's not installed to /usr/local/
+RUN curl -sSL https://install.python-poetry.org | python -
+
+# Add poetry install location to the $PATH
+ENV PATH="${PATH}:/root/.local/bin"
 
 # Poetry shouldn't create a venv as we want global install
 # Poetry 1.1.0 added parallel installation as an option;
@@ -95,11 +98,15 @@ RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/inst
 RUN poetry config virtualenvs.create false && \
     poetry config installer.parallel false
 
-# Install (non-development) Python dependencies of Nautobot
 COPY pyproject.toml poetry.lock README.md /source/
+
+# The example_plugin is only a dev dependency, but Poetry fails to install non-dev dependencies if its source is missing
 COPY examples /source/examples
+
 WORKDIR /source
-# pyuwsgi doesn't support ssl so we build it from source
+
+# Install (non-development) Python dependencies of Nautobot
+# pyuwsgi wheel doesn't support ssl so we build it from source
 # https://github.com/nautobot/nautobot/issues/193
 RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi==${PYUWSGI_VER} && \
     poetry install --no-root --no-dev --no-ansi --extras all
@@ -110,9 +117,9 @@ COPY nautobot /source/nautobot
 # Build the wheel
 RUN poetry build
 
-################################ Stage: install-dev (intermediate build target)
+################################ Stage: dependencies-dev (intermediate build target)
 
-FROM install as install-dev
+FROM dependencies as dependencies-dev
 
 # Install hadolint for linting Dockerfiles
 RUN curl -Lo /usr/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.0.0/hadolint-Linux-x86_64 && \
@@ -124,19 +131,19 @@ RUN poetry install --no-root --no-ansi --extras all
 # TODO Use nautobot init to generate the same config for all use cases
 COPY development/nautobot_config.py /opt/nautobot/nautobot_config.py
 
-# Common docker entrypoint for migrations, superuser creations, etc.
+# Run Nautobot development server by default
 CMD ["nautobot-server", "runserver", "0.0.0.0:8080", "--insecure"]
 
 ################################ Stage: dev (development environment for Nautobot core)
 
-FROM install-dev as dev
+FROM dependencies-dev as dev
 
 RUN poetry install --no-ansi && \
     rm -rf /source
 
 ################################ Stage: final-dev (development environment for Nautobot plugins)
 
-FROM install-dev as final-dev
+FROM dependencies-dev as final-dev
 
 RUN pip install --no-deps --no-cache-dir /source/dist/*.whl && \
     rm -rf /source
@@ -146,16 +153,14 @@ RUN pip install --no-deps --no-cache-dir /source/dist/*.whl && \
 FROM base as final
 ARG PYTHON_VER
 
-# Remove files added by Poetry installer
-RUN rm -rf /root/.local
-
-# Copy from install the required python libraries and binaries
-COPY --from=install /usr/local/lib/python${PYTHON_VER}/site-packages /usr/local/lib/python${PYTHON_VER}/site-packages
-COPY --from=install /usr/local/bin /usr/local/bin
-COPY --from=install /source/dist/*.whl /tmp
+# Copy from "dependencies" the required python libraries and binaries
+COPY --from=dependencies /usr/local/lib/python${PYTHON_VER}/site-packages /usr/local/lib/python${PYTHON_VER}/site-packages
+COPY --from=dependencies /usr/local/bin /usr/local/bin
+COPY --from=dependencies /source/dist/*.whl /tmp
 
 # Install the Nautobot wheel
-RUN pip install --no-deps --no-cache-dir /tmp/*.whl
+RUN pip install --no-deps --no-cache-dir /tmp/*.whl && \
+    rm -rf /tmp/*.whl
 
 # Generate self-signed SSL certs
 RUN openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj \
@@ -181,4 +186,5 @@ RUN nautobot-server init && \
     cat /opt/nautobot/nautobot_config.append.py >> /opt/nautobot/nautobot_config.py && \
     rm -f /opt/nautobot/nautobot_config.append.py
 
+# Run Nautobot server under uwsgi by default
 CMD ["nautobot-server", "start", "--ini", "/opt/nautobot/uwsgi.ini"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,53 @@
 ARG PYTHON_VER
-################################ Stage: base
-# Install all OS package upgrades and dependencies once from which we will base other containers
+
+################################ Overview
+# This builds the following hierarchy of images:
+#
+# python:${PYTHON_VER}-slim
+#           |
+#           V
+#         (base) --> (install-dependencies) --> dev --> final-dev
+#           |                  |
+#           V                  V
+#         final <..... (install-nautobot)
+#
+# base (intermediate build target; basis for all other images herein)
+#   adds OS-level packaging dependencies for *running* Nautobot
+#
+# install-dependencies (intermediate build target)
+#   adds OS-level packaging dependencies for *installing* Nautobot, its dependencies, and its development dependencies
+#   installs Pip and Poetry
+#   uses Pip and Poetry to install Nautobot's Python dependencies (but *not* development dependencies)
+#   uses Poetry to build a Nautobot wheel for later use by the "install-nautobot" and "final-dev" images
+#
+# dev (development environment for Nautobot core)
+#   uses Poetry to additionally install Nautobot's *development* dependencies
+#   uses Poetry to install Nautobot itself in editable (develop) mode
+#     (at runtime the intent is to mount the live Nautobot source over the Poetry-installed Nautobot)
+#   is capable of running Nautobot dev server
+#
+# install-nautobot (intermediate build target):
+#   uses Pip to install the Nautobot wheel previously built in "install-dependencies"
+#   creates a self-signed SSL certificate for later use by the "final" image
+#
+# final (production-ready environment):
+#   adds "nautobot" system user
+#   copies all installed Python packages, including Nautobot itself, from "install-nautobot"
+#   copies the self-signed SSL certificate from "install-nautobot"
+#   sets up the system to run Nautobot in production with uwsgi
+#
+# final-dev (development environment for Nautobot plugins)
+#   as "dev", but replaces the editable install of Nautobot with a wheel-based install of Nautobot
+
+################################ Stage: base (intermediate build target; basis for all other images herein)
+
 FROM python:${PYTHON_VER}-slim as base
 
 ENV PYTHONUNBUFFERED=1 \
     NAUTOBOT_ROOT=/opt/nautobot \
     prometheus_multiproc_dir=/prom_cache
 
-# Install all OS package upgrades and dependencies
+# Install all OS package upgrades and dependencies needed to run Nautobot in production
 # hadolint ignore=DL3005,DL3008,DL3013
 RUN apt-get update && \
     apt-get upgrade -y && \
@@ -19,25 +59,20 @@ RUN apt-get update && \
 
 HEALTHCHECK --interval=5s --timeout=5s --start-period=5s --retries=1 CMD curl --fail http://localhost:8080/health/ || exit 1
 
-################################ Stage: dev
-# The dev container is used for development purposes but also to build the .whl for the final image
-# nautobot will be installed in editable mode in /source 
-FROM base as dev
+################################ Stage: install-dependencies (intermediate build target)
+
+FROM base as install-dependencies
 
 # Modify the PATH here because otherwise poetry fails 100% of the time. WAT??
 ENV PATH="${PATH}:/root/.local/bin"
 
-# Install development OS dependencies
+# Install development/install-time OS dependencies
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y openssl build-essential libxmlsec1-dev libxmlsec1-openssl pkg-config libldap-dev libsasl2-dev libmariadb-dev && \
+    apt-get install --no-install-recommends -y openssl build-essential libssl-dev libxmlsec1-dev libxmlsec1-openssl pkg-config libldap-dev libsasl2-dev libmariadb-dev && \
     apt-get autoremove -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
-
-# Install hadolint for linting Dockerfiles
-RUN curl -Lo /usr/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.0.0/hadolint-Linux-x86_64 && \
-    chmod +x /usr/bin/hadolint
 
 # Install Poetry manually from GitHub because otherwise it installs its own
 # dependencies globally which may conflict with ours.
@@ -54,25 +89,33 @@ RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/inst
 RUN poetry config virtualenvs.create false && \
     poetry config installer.parallel false
 
-# Keep the project source code from NAUTOBOT_ROOT
+# Install (non-development) Python dependencies of Nautobot
 COPY pyproject.toml poetry.lock /source/
 COPY examples /source/examples
 WORKDIR /source
+# pyuwsgi doesn't support ssl so we build it from source
+# https://github.com/nautobot/nautobot/issues/193
+RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi==2.0.20 && \
+    poetry install --no-root --no-dev --no-ansi --extras all
 
-# -------------------------------------------------------------------------------------
-# Install Nautobot requirements
-# -------------------------------------------------------------------------------------
-# During image build process, only Nautobot's requirements are installed.
-#
-# Local source code is mounted as volume into container. This approach does not require
-# to rebuild a container when source code change occurs.
-# -------------------------------------------------------------------------------------
-RUN poetry install --no-root --no-ansi --extras all
+# Generate required dirs for later consumption
+RUN mkdir /opt/nautobot /prom_cache
 
-# Generate required dirs and self signed ssl certificates
-RUN mkdir /opt/nautobot /prom_cache && openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj \
-    '/C=US/ST=NY/L=NYC/O=Nautobot/CN=nautobot.local' \
-    -keyout /opt/nautobot/nautobot.key -out /opt/nautobot/nautobot.crt
+# Copy nautobot source and poetry info to container to reduce cache invalidations
+COPY README.md /source/
+COPY nautobot /source/nautobot
+
+# Build the wheel for later use by other images
+RUN poetry build
+
+################################ Stage: dev (development environment for Nautobot core)
+# nautobot will be installed in editable mode in /source
+
+FROM install-dependencies as dev
+
+# Install hadolint for linting Dockerfiles
+RUN curl -Lo /usr/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.0.0/hadolint-Linux-x86_64 && \
+    chmod +x /usr/bin/hadolint
 
 # Used if someone wants to override the entrypoint and provision a super user
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
@@ -84,55 +127,47 @@ COPY development/nautobot_config.py /opt/nautobot/nautobot_config.py
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nautobot-server", "runserver", "0.0.0.0:8080", "--insecure"]
 
-# Copy nautobot source and poetry info to container to reduce cache invalidations
-COPY poetry.lock pyproject.toml README.md /source/
-COPY nautobot /source/nautobot
+# Install development-specific dependencies of Nautobot as well as Nautobot itself in editable mode
+RUN poetry install --no-ansi --extras all
 
-# Build the whl for use in the final container and install for the dev container
-RUN poetry build && \
-    poetry install --no-ansi --extras all
+################################ Stage: install-nautobot (intermediate build target)
 
-################################ Stage: cleaninstall
-# Build an image with required dependencies to pull the installation from
-FROM base as cleaninstall
-
-# hadolint ignore=DL3008
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential libssl-dev libxmlsec1-dev libxmlsec1-openssl pkg-config libldap-dev libsasl2-dev libmariadb-dev
-
-# pyuwsgi doesn't support ssl so we build it from source
-# https://github.com/nautobot/nautobot/issues/193
-RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi
-
-COPY --from=dev /source/dist/*.whl /tmp
+FROM install-dependencies as install-nautobot
 
 # hadolint ignore=DL3013,SC2102
-RUN for whl in /tmp/nautobot*.whl; do pip install --no-cache-dir ${whl}[all]; done
+RUN for whl in /source/dist/nautobot*.whl; do pip install --no-deps --no-cache-dir ${whl}[all]; done
 
-################################ Stage: final
-# This image will be the production ready image
+# Generate self signed ssl certificates for later use
+RUN openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj \
+    '/C=US/ST=NY/L=NYC/O=Nautobot/CN=nautobot.local' \
+    -keyout /opt/nautobot/nautobot.key -out /opt/nautobot/nautobot.crt
+
+################################ Stage: final (production-ready image)
+
 FROM base as final
 ARG PYTHON_VER
 
 # Make sure we don't run as a root user
 RUN useradd --system --shell /bin/bash --create-home --home-dir /opt/nautobot nautobot
 
-# Copy from base the required python libraries and binaries
-COPY --from=cleaninstall /usr/local/lib/python${PYTHON_VER}/site-packages /usr/local/lib/python${PYTHON_VER}/site-packages
-COPY --from=cleaninstall /usr/local/bin /usr/local/bin
+# Copy from install-nautobot the required python libraries and binaries
+COPY --from=install-nautobot /usr/local/lib/python${PYTHON_VER}/site-packages /usr/local/lib/python${PYTHON_VER}/site-packages
+COPY --from=install-nautobot /usr/local/bin /usr/local/bin
 
 # Setup the entrypoint
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
 
-# Copy SSL certs after the directory exists
-COPY --from=dev /opt/nautobot/nautobot.key /opt/nautobot/nautobot.crt /opt/nautobot/
+# Copy SSL certs
+COPY --from=install-nautobot /opt/nautobot/nautobot.key /opt/nautobot/nautobot.crt /opt/nautobot/
 
 # Configure uWSGI
 COPY docker/uwsgi.ini /opt/nautobot
 COPY docker/nautobot_config.append.py /opt/nautobot
 
-# Make sure everything under /opt/nautobot is owned by nautobot
+# Make sure everything under /opt/nautobot and /prom_cache is owned by nautobot
 RUN mkdir /prom_cache && chown -R nautobot:nautobot /opt/nautobot /prom_cache
 
+# Set up Nautobot to run in production
 USER nautobot
 
 WORKDIR /opt/nautobot
@@ -144,11 +179,13 @@ RUN nautobot-server init && \
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nautobot-server", "start", "--ini", "/opt/nautobot/uwsgi.ini"]
 
-################################ Stage: final-dev
+################################ Stage: final-dev (development environment for Nautobot plugins)
 # This image will contain the development dependencies (including poetry) as well as nautobot installed
 # as a system package
+
 FROM dev as final-dev
 
 # Nautobot was installed in editable mode so reinstall as a system package (all dependencies are already there)
-RUN pip install --force-reinstall --no-deps --no-cache-dir /source/dist/*.whl && \
+# hadolint ignore=DL3013,SC2102
+RUN for whl in /source/dist/nautobot*.whl; do pip install --force-reinstall --no-deps --no-cache-dir ${whl}[all]; done && \
     rm -rf /source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ psycopg2-binary = "~2.9.3"
 # Cryptographic library
 pycryptodome = "~3.13.0"
 # The uWSGI WSGI HTTP server as a Python module
+# NOTE: docker/Dockerfile hard-codes a pyuwsgi version as well, keep them in sync!
 pyuwsgi = "~2.0.20"
 # YAML parsing and rendering
 PyYAML = "~6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,6 @@ psycopg2-binary = "~2.9.3"
 # Cryptographic library
 pycryptodome = "~3.13.0"
 # The uWSGI WSGI HTTP server as a Python module
-# NOTE: docker/Dockerfile hard-codes a pyuwsgi version as well, keep them in sync!
 pyuwsgi = "~2.0.20"
 # YAML parsing and rendering
 PyYAML = "~6.0"


### PR DESCRIPTION
# Closes: #792 
# What's Changed

Revamped the way we build docker images somewhat - see added comments at the top of the Dockerfile for an overview of the new layers/images involved.

The *functional* change to the Docker build is that in the `final` image, we now use the exact versioned Python dependencies as installed by `poetry install --no-root --no-dev` (and hence enforced by `poetry.lock`) instead of the looser set of dependencies that would be automatically derived by doing `pip install nautobot.whl` alone. This guarantees that the `final`, `dev`, and `final-dev` images all have the same set of base dependencies, and the `final-dev`/`dev` images just add the additional development-only dependencies:

```diff
% diff -uw final.pip final-dev.pip
--- final.pip	2022-04-07 12:34:12.000000000 -0400
+++ final-dev.pip	2022-04-07 12:33:36.000000000 -0400
@@ -3,10 +3,12 @@
 amqp                           5.1.0
 aniso8601                      7.0.0
 asgiref                        3.5.0
+async-generator                1.10
 async-timeout                  4.0.2
 attrs                          21.4.0
 bcrypt                         3.2.0
 billiard                       3.6.4.0
+black                          22.3.0
 cached-property                1.5.2
 celery                         5.2.6
 certifi                        2021.10.8
@@ -19,6 +21,7 @@
 click-repl                     0.2.0
 coreapi                        2.3.3
 coreschema                     0.0.4
+coverage                       6.3.2
 cryptography                   36.0.2
 defusedxml                     0.7.1
 Deprecated                     1.2.13
@@ -32,6 +35,7 @@
 django-cors-headers            3.10.1
 django-cryptography            1.0
 django-db-file-storage         0.5.5
+django-debug-toolbar           3.2.4
 django-extensions              3.1.5
 django-filter                  21.1
 django-health-check            3.16.5
@@ -53,8 +57,11 @@
 drf-spectacular-sidecar        2022.4.1
 drf-yasg                       1.20.0
 ecdsa                          0.17.0
+example-plugin                 1.0.0
+flake8                         3.9.2
 funcy                          1.17
 future                         0.18.2
+ghp-import                     2.0.2
 gitdb                          4.0.9
 GitPython                      3.1.27
 graphene                       2.1.9
@@ -62,10 +69,12 @@
 graphene-django-optimizer      0.8.0
 graphql-core                   2.3.2
 graphql-relay                  2.0.1
+h11                            0.13.0
 idna                           3.3
 importlib-metadata             4.4.0
 importlib-resources            5.6.0
 inflection                     0.5.1
+invoke                         1.6.0
 isodate                        0.6.1
 itypes                         1.2.0
 Jinja2                         3.0.3
@@ -76,6 +85,11 @@
 lxml                           4.6.5
 Markdown                       3.3.6
 MarkupSafe                     2.1.1
+mccabe                         0.6.1
+mergedeep                      1.3.4
+mkdocs                         1.3.0
+mkdocs-include-markdown-plugin 3.2.3
+mypy-extensions                0.4.3
 mysqlclient                    2.1.0
 napalm                         3.3.1
 nautobot                       1.3.0b1
@@ -85,25 +99,32 @@
 netutils                       1.0.0
 ntc-templates                  3.0.0
 oauthlib                       3.2.0
+outcome                        1.1.0
 packaging                      21.3
 paramiko                       2.10.3
 passlib                        1.7.4
+pathspec                       0.9.0
 Pillow                         9.0.1
 pip                            22.0.4
+platformdirs                   2.5.1
 prometheus-client              0.13.1
 promise                        2.3
 prompt-toolkit                 3.0.29
 psycopg2-binary                2.9.3
 pyasn1                         0.4.8
 pyasn1-modules                 0.2.8
+pycodestyle                    2.7.0
 pycparser                      2.21
 pycryptodome                   3.13.0
 pyeapi                         0.8.4
+pyflakes                       2.3.1
 PyJWT                          2.3.0
 PyNaCl                         1.5.0
+pyOpenSSL                      22.0.0
 pyparsing                      3.0.7
 pyrsistent                     0.18.1
 pyserial                       3.5
+PySocks                        1.7.1
 python-crontab                 2.6.0
 python-dateutil                2.8.2
 python-jose                    3.3.0
@@ -113,6 +134,7 @@
 pytz                           2022.1
 pyuwsgi                        2.0.20
 PyYAML                         6.0
+pyyaml_env_tag                 0.1
 redis                          4.2.2
 requests                       2.27.1
 requests-oauthlib              1.3.1
@@ -122,12 +144,16 @@
 ruamel.yaml.clib               0.2.6
 Rx                             1.6.1
 scp                            0.14.4
+selenium                       4.1.3
 setuptools                     50.3.2
 singledispatch                 3.7.0
 six                            1.16.0
 smmap                          5.0.0
+sniffio                        1.2.0
 social-auth-app-django         5.0.0
 social-auth-core               4.2.0
+sortedcontainers               2.4.0
+splinter                       0.17.0
 sqlparse                       0.4.2
 svgwrite                       1.4.2
 swagger-spec-validator         2.7.4
@@ -135,14 +161,20 @@
 text-unidecode                 1.3
 textfsm                        1.1.2
 toml                           0.10.2
+tomli                          2.0.1
 transitions                    0.8.11
+trio                           0.20.0
+trio-websocket                 0.9.2
+typed-ast                      1.5.2
 typing_extensions              4.1.1
 uritemplate                    4.1.1
 urllib3                        1.26.9
 vine                           5.0.0
+watchdog                       2.1.7
 wcwidth                        0.2.5
 wheel                          0.37.1
 wrapt                          1.14.0
+wsproto                        1.1.0
 xmlsec                         1.3.12
 yamlordereddictloader          0.4.0
 zipp                           3.8.0
```