### PR TITLE
Add some checks for "request is None"

### DIFF
--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -402,10 +402,10 @@ class DeviceViewSet(ConfigContextQuerySetMixin, StatusViewSetMixin, CustomFieldM
         """
 
         request = self.get_serializer_context()["request"]
-        if request.query_params.get("brief", False):
+        if request is not None and request.query_params.get("brief", False):
             return serializers.NestedDeviceSerializer
 
-        elif "config_context" in request.query_params.get("exclude", []):
+        elif request is not None and "config_context" in request.query_params.get("exclude", []):
             return serializers.DeviceSerializer
 
         return serializers.DeviceWithConfigContextSerializer

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -109,7 +109,7 @@ class ConfigContextQuerySetMixin:
         """
         queryset = super().get_queryset()
         request = self.get_serializer_context()["request"]
-        if self.brief or "config_context" in request.query_params.get("exclude", []):
+        if self.brief or (request is not None and "config_context" in request.query_params.get("exclude", [])):
             return queryset
         return queryset.annotate_config_context_data()
 

--- a/nautobot/virtualization/api/views.py
+++ b/nautobot/virtualization/api/views.py
@@ -84,10 +84,10 @@ class VirtualMachineViewSet(ConfigContextQuerySetMixin, StatusViewSetMixin, Cust
         """
 
         request = self.get_serializer_context()["request"]
-        if request.query_params.get("brief", False):
+        if request is not None and request.query_params.get("brief", False):
             return serializers.NestedVirtualMachineSerializer
 
-        elif "config_context" in request.query_params.get("exclude", []):
+        elif request is not None and "config_context" in request.query_params.get("exclude", []):
             return serializers.VirtualMachineSerializer
 
         return serializers.VirtualMachineWithConfigContextSerializer


### PR DESCRIPTION
# Closes: #DNE
# What's Changed

In investigating #784, GraphQL schema generation with `graph_wrap` errored out in a couple of places because we were missing logic to handle the possibility that `get_serializer_context["request"]` might be `None`. I'm not sure if the absence of this logic causes problems in any case other than graph_wrap, but it should be harmless to add in any case.