### PR TITLE
Fix JobLogEntry Migration failure caused to log_object exceeding 200 characters

### DIFF
--- a/nautobot/extras/migrations/0018_joblog_data_migration.py
+++ b/nautobot/extras/migrations/0018_joblog_data_migration.py
@@ -2,8 +2,11 @@ from collections import OrderedDict
 from django.db import migrations
 
 from nautobot.extras.choices import LogLevelChoices
-from nautobot.extras.constants import JOB_LOG_MAX_ABSOLUTE_URL_LENGTH, JOB_LOG_MAX_LOG_OBJECT_LENGTH, \
-    JOB_LOG_MAX_GROUPING_LENGTH
+from nautobot.extras.constants import (
+    JOB_LOG_MAX_ABSOLUTE_URL_LENGTH,
+    JOB_LOG_MAX_LOG_OBJECT_LENGTH,
+    JOB_LOG_MAX_GROUPING_LENGTH,
+)
 
 """
 This is the loose structure that we are trying to extract logs from (or restore to in case of reverse):

--- a/nautobot/extras/migrations/0018_joblog_data_migration.py
+++ b/nautobot/extras/migrations/0018_joblog_data_migration.py
@@ -2,7 +2,8 @@ from collections import OrderedDict
 from django.db import migrations
 
 from nautobot.extras.choices import LogLevelChoices
-
+from nautobot.extras.constants import JOB_LOG_MAX_ABSOLUTE_URL_LENGTH, JOB_LOG_MAX_LOG_OBJECT_LENGTH, \
+    JOB_LOG_MAX_GROUPING_LENGTH
 
 """
 This is the loose structure that we are trying to extract logs from (or restore to in case of reverse):
@@ -68,7 +69,7 @@ def migrate_params(apps, schema_editor):
                             # Due to Netbox Report API, the log_object sometimes stores the message.
                             # If both the log message and log url are missing, we assume this is a message.
                             entry = JobLogEntry(
-                                grouping=key,
+                                grouping=key[:JOB_LOG_MAX_GROUPING_LENGTH],
                                 job_result=job_result,
                                 created=log[0],
                                 log_level=log[1],
@@ -76,12 +77,12 @@ def migrate_params(apps, schema_editor):
                             )
                         else:
                             entry = JobLogEntry(
-                                grouping=key,
+                                grouping=key[:JOB_LOG_MAX_GROUPING_LENGTH],
                                 job_result=job_result,
                                 created=log[0],
                                 log_level=log[1],
-                                log_object=log[2],
-                                absolute_url=log[3],
+                                log_object=log[2][:JOB_LOG_MAX_LOG_OBJECT_LENGTH] if log[2] else None,
+                                absolute_url=log[3][:JOB_LOG_MAX_ABSOLUTE_URL_LENGTH] if log[3] else None,
                                 message=log[4],
                             )
                         entry.save()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1504 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Truncate `grouping`, `log_object` and `absolute_url` in 0018_joblog_data_migration


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design