### PR TITLE
Add bulk methods to schema.method_mapping to avoid drf-spectacular warnings

### DIFF
--- a/nautobot/core/api/schema.py
+++ b/nautobot/core/api/schema.py
@@ -21,6 +21,20 @@ class NautobotAutoSchema(AutoSchema):
 
     custom_actions = ["bulk_update", "bulk_partial_update", "bulk_destroy"]
 
+    # Primarily, method_mapping is used to map HTTP method verbs to viewset method names,
+    # which doesn't account for the fact that with our custom actions there are multiple viewset methods per verb,
+    # hence why we have to override get_operation_id() below.
+    # Secondarily, drf-spectacular uses method_mapping.values() to identify which methods are view methods,
+    # so need to make sure these methods are represented as values in the mapping even if not under the actual verbs.
+    method_mapping = AutoSchema.method_mapping.copy()
+    method_mapping.update(
+        {
+            "_put": "bulk_update",
+            "_patch": "bulk_partial_update",
+            "_delete": "bulk_destroy",
+        }
+    )
+
     def get_operation_id(self):
         """Extend the base method to handle Nautobot's REST API bulk operations.
 


### PR DESCRIPTION
# Closes: #DNE
# What's Changed

I noticed that with #1505 and #1420, drf-spectacular schema generation was logging a few warnings, e.g. https://github.com/nautobot/nautobot/runs/5990786743?check_suite_focus=true:

```
Warning #0: @extend_schema_view argument "bulk_update" was not found on view TagViewSet. method override for "bulk_update" will be ignored.
Warning #1: @extend_schema_view argument "bulk_partial_update" was not found on view TagViewSet. method override for "bulk_partial_update" will be ignored.
Warning #2: @extend_schema_view argument "bulk_update" was not found on view IPAddressViewSet. method override for "bulk_update" will be ignored.
Warning #3: @extend_schema_view argument "bulk_partial_update" was not found on view IPAddressViewSet. method override for "bulk_partial_update" will be ignored.
```

Oddly, these were not causing `nautobot-server spectacular --fail-on-warn` to report a failure, which seems like a bug in drf-spectacular to me. Nonetheless, they should be addressed.

I tracked this down to drf-spectacular's [`get_view_method_names`](https://github.com/tfranzel/drf-spectacular/blob/master/drf_spectacular/drainage.py#L119) function, which detects the available view methods on a given ViewSet as follows:

```python
    return [
        item for item in dir(view) if callable(getattr(view, item)) and (
            item in view.http_method_names
            or item in schema.method_mapping.values()
            or item == 'list'
            or hasattr(getattr(view, item), 'mapping')
        )
    ]
```

1. `view.http_method_names` is just a list of HTTP verbs (e.g. `["get", "put", "patch", "post", "delete"]`) so our bulk API methods don't appear in this listing
2. `schema.method_mapping` maps HTTP verbs to method names; because our bulk API methods use the same verbs as the standard detail-view API methods (e.g. `PUT` is for both `update` and `bulk_update`) our bulk methods don't appear in the default method_mapping.
3. Special-case handling for the `list` endpoint (i.e. bulk `GET`) - it'd be nice if this were extensible without monkey-patching this function, but it isn't.
4. Existence of a `mapping` attribute on the method itself - this is how one-off custom API endpoints get detected; DRF adds a `mapping` to any method with the `@action` decorator, but because our bulk methods aren't distinct endpoints but rather custom verbs on the standard list endpoint, this doesn't detect those.

The best fix I could come up, given this logic, with was a bit of a kludge on `schema.method_mapping` - since this function looks at `values` rather than `keys` of this method, even though the keys (verbs) are non-unique for our custom methods, we can register them under some other keys (I chose `_put`, `_patch`, `_delete`) just to make sure they're present in `values`. This appears to resolve the warnings.