### PR TITLE
More error handling for RelationshipAssociations

### DIFF
--- a/nautobot/docs/release-notes/version-1.3.md
+++ b/nautobot/docs/release-notes/version-1.3.md
@@ -148,6 +148,8 @@ As Python 3.6 has reached end-of-life, and many of Nautobot's dependencies have 
 
 ### Fixed
 
+- [#1278](https://github.com/nautobot/nautobot/issues/1278) - Fixed several different errors that could be raised when working with RelationshipAssociations.
+
 ## v1.3.0 (2022-04-18)
 
 ### Added

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -671,10 +671,10 @@ class RelationshipAssociationTable(BaseTable):
     actions = ButtonsColumn(RelationshipAssociation, buttons=("delete",))
 
     source_type = tables.Column()
-    source = tables.Column(linkify=True, orderable=False)
+    source = tables.Column(linkify=True, orderable=False, accessor="get_source")
 
     destination_type = tables.Column()
-    destination = tables.Column(linkify=True, orderable=False)
+    destination = tables.Column(linkify=True, orderable=False, accessor="get_destination")
 
     class Meta(BaseTable.Meta):
         model = RelationshipAssociation


### PR DESCRIPTION
# Closes #1278 
# What's Changed

- In `get_relationships_data()`, if a related object doesn't implement `get_absolute_url()`, log a warning and set `url` to None instead of raising an AttributeError.
- In the case where a RelationshipAssociation references an object whose model class is not available (e.g. a RelationshipAssociation to a plugin-defined model class, where the plugin is no longer installed), fix various cases where interacting with the RelationshipAssociation would raise an exception. (In the longer term, it would be nice to have something like #16 provide the ability to automatically clean up stale relationship-associations when a plugin is deregistered.)
    - `str()` method
    - `get_peer()` method
    - `clean()` method
    - rendering of `RelationshipAssociationTable`
- Add tests for `str()`, `get_peer()` and `get_relationships_data()`