### PR TITLE
Simplify class inheritance of JobViewSet

### DIFF
--- a/nautobot/docs/release-notes/version-1.3.md
+++ b/nautobot/docs/release-notes/version-1.3.md
@@ -146,6 +146,8 @@ As Python 3.6 has reached end-of-life, and many of Nautobot's dependencies have 
 
 ### Changed
 
+- [#1647](https://github.com/nautobot/nautobot/pull/1647) - Changed class inheritance of JobViewSet to be simpler and more self-consistent.
+
 ### Fixed
 
 ## v1.3.0 (2022-04-18)

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -20,7 +20,6 @@ from nautobot.core.api.metadata import ContentTypeMetadata, StatusFieldMetadata
 from nautobot.core.api.views import (
     BulkDestroyModelMixin,
     BulkUpdateModelMixin,
-    ModelViewSetMixin,
     ModelViewSet,
     ReadOnlyModelViewSet,
 )
@@ -454,16 +453,13 @@ def _run_job(request, job_model, legacy_response=False):
 class JobViewSet(
     # DRF mixins:
     # note no CreateModelMixin
-    mixins.ListModelMixin,
-    mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
     mixins.DestroyModelMixin,
     # Nautobot mixins:
     BulkUpdateModelMixin,
     BulkDestroyModelMixin,
-    ModelViewSetMixin,
     # Base class
-    viewsets.GenericViewSet,
+    ReadOnlyModelViewSet,
 ):
     queryset = Job.objects.all()
     serializer_class = serializers.JobSerializer


### PR DESCRIPTION
# Closes: #DNE
# What's Changed

Another minor bit of cleanup that I identified while investigating #784. Our JobViewSet class could be simplified by inheriting from and extending `ReadOnlyModelViewSet` instead of constructing it from first principles from `viewsets.GenericViewSet`. This has the advantage of making `graph_wrap` happier, presumably because it's [explicitly looking for `ModelViewSet` and `ReadOnlyModelViewSet` subclasses](https://github.com/PaulGilmartin/graph_wrap/blob/master/graph_wrap/django_rest_framework/schema_factory.py#L44) and so was inadvertently overlooking this one.