### PR TITLE
Change prefetch for Device API view to nat_outside_list.

### DIFF
--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -382,9 +382,9 @@ class DeviceViewSet(ConfigContextQuerySetMixin, StatusViewSetMixin, CustomFieldM
         "site",
         "rack",
         "parent_bay",
+        "primary_ip4__nat_outside_list",
+        "primary_ip6__nat_outside_list",
         "virtual_chassis__master",
-        "primary_ip4__nat_outside",
-        "primary_ip6__nat_outside",
         "tags",
         "status",
     )

--- a/nautobot/virtualization/templates/virtualization/virtualmachine.html
+++ b/nautobot/virtualization/templates/virtualization/virtualmachine.html
@@ -76,8 +76,8 @@
                             <a href="{% url 'ipam:ipaddress' pk=object.primary_ip4.pk %}">{{ object.primary_ip4.address.ip }}</a>
                             {% if object.primary_ip4.nat_inside %}
                                 <span>(NAT for {{ object.primary_ip4.nat_inside.address.ip }})</span>
-                            {% elif object.primary_ip4.nat_outside %}
-                                <span>(NAT: {{ object.primary_ip4.nat_outside.address.ip }})</span>
+                            {% elif object.primary_ip4.nat_outside_list.exists %}
+                                <span>(NAT: {% for nat in object.primary_ip4.nat_outside_list.all %}{{ nat }}{% if not forloop.last %}, {% endif %}{% endfor %})</span>
                             {% endif %}
                         {% else %}
                             <span class="text-muted">&mdash;</span>
@@ -91,8 +91,8 @@
                             <a href="{% url 'ipam:ipaddress' pk=object.primary_ip6.pk %}">{{ object.primary_ip6.address.ip }}</a>
                             {% if object.primary_ip6.nat_inside %}
                                 <span>(NAT for {{ object.primary_ip6.nat_inside.address.ip }})</span>
-                            {% elif object.primary_ip6.nat_outside %}
-                                <span>(NAT: {{ object.primary_ip6.nat_outside.address.ip }})</span>
+                            {% elif object.primary_ip6.nat_outside_list.exists %}
+                                <span>(NAT: {% for nat in object.primary_ip6.nat_outside_list.all %}{{ nat }}{% if not forloop.last %}, {% endif %}{% endfor %})</span>
                             {% endif %}
                         {% else %}
                             <span class="text-muted">&mdash;</span>


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1662
# What's Changed
Modified the prefetch_related to fetch nat_outside_list rather than the nat_outside property that cannot be prefetched due to it not stored within the DB.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->