### PR TITLE
Fix a few errors in the documentation about imports

### DIFF
--- a/nautobot/docs/installation/migrating-from-netbox.md
+++ b/nautobot/docs/installation/migrating-from-netbox.md
@@ -104,8 +104,8 @@ Device.objects.filter(status=DeviceStatusChoices.STATUS_PLANNED)
 Update it to this:
 
 ```python
-from extras.models import Status
-from dcim.models import Device
+from nautobot.extras.models import Status
+from nautobot.dcim.models import Device
 
 Device.objects.filter(status=Status.objects.get(slug="planned"))
 ```

--- a/nautobot/docs/models/extras/status.md
+++ b/nautobot/docs/models/extras/status.md
@@ -33,7 +33,7 @@ For Virtual Machines, if utilizing OpenStack, statuses in Nautobot could be cust
     data models of their own that implement a `status` field. Proceed at your
     own risk!
 
-Any model that is intended to have a `status` field must inherit from `extras.models.statuses.StatusModel`. This abstract model will add an `extras.models.statuses.StatusField` to the model. The abstract base will automatically assign a `related_name` for the reverse relationship back to the inheriting model's name (e.g. `devices`).o
+Any model that is intended to have a `status` field must inherit from `nautobot.extras.models.statuses.StatusModel`. This abstract model will add an `nautobot.extras.models.statuses.StatusField` to the model. The abstract base will automatically assign a `related_name` for the reverse relationship back to the inheriting model's name (e.g. `devices`).
 
 ### `StatusField` model field
 
@@ -45,25 +45,25 @@ This model field also emits its own form field to eliminate the requirement for 
 
 ### `StatusFilter` filter field
 
-Any filter that is intended to have a `status` field must inherit from `extras.filters.StatusModelFilterSetMixin`. This will add a `extras.filters.StatusFilter` to the filter, which allows filtering by the `name` of the status.
+Any filter that is intended to have a `status` field must inherit from `nautobot.extras.filters.StatusModelFilterSetMixin`. This will add a `nautobot.extras.filters.StatusFilter` to the filter, which allows filtering by the `name` of the status.
 
 ### Form fields
 
 Any model form that is intended to have a `status` field must inherit from one of three mixins, depending on the use-case:
 
-- `extras.forms.StatusFilterFormMixin` should be used to add a non-required, multiple-choice `status` filter field to UI filter forms. This multiple-choice field allows for multiple status values to be selected for filtering objects in list views in the web UI.
-- `extras.forms.StatusBulkEditFormMixin` should be used to add a non-required `status` form field to a an object's model form. This field constrains status choices eligible to the object type being edited.
+- `nautobot.extras.forms.StatusFilterFormMixin` should be used to add a non-required, multiple-choice `status` filter field to UI filter forms. This multiple-choice field allows for multiple status values to be selected for filtering objects in list views in the web UI.
+- `nautobot.extras.forms.StatusBulkEditFormMixin` should be used to add a non-required `status` form field to a an object's model form. This field constrains status choices eligible to the object type being edited.
 - FIXME: CSV import forms
 
 ### `StatusSerializerField` serializer field
 
-Any serializer that is intended to have a `status` field must inherit from `extras.api.serializers.StatusModelSerializerMixin`. This adds an `extras.api.fields.StatusSerializerField` to the serializer.
+Any serializer that is intended to have a `status` field must inherit from `nautobot.extras.api.serializers.StatusModelSerializerMixin`. This adds an `nautobot.extras.api.fields.StatusSerializerField` to the serializer.
 
 The `StatusSerializerField` is a writable slug-related choice field that allows writing to the field using the `name` value of the status (e.g. `"active"`). Writing to this field is normalized to always be converted to lowercase.
 
 ### Table field
 
-If you wish for a table to include a `status` field, your table must inherit from `extras.tables.StatusTableMixin`. This includes a `ColorColumn` on the table.
+If you wish for a table to include a `status` field, your table must inherit from `nautobot.extras.tables.StatusTableMixin`. This includes a `ColorColumn` on the table.
 
 ## Status object integrations
 
@@ -71,24 +71,24 @@ To fully integrate a model to include a `status` field, assert the following:
 
 ### Model
 
-- The model must inherit from `extras.models.statuses.StatusModel`
-- Decorate the model class with `@extras.utils.extras_features('statuses')`
+- The model must inherit from `nautobot.extras.models.statuses.StatusModel`
+- Decorate the model class with `@extras_features('statuses')` (`from nautobot.extras.utils import extras_features`)
 
 ### Forms
 
 - Generic model forms will automatically include a `StatusField`
-- Bulk edit model forms must inherit from `extras.forms.StatusBulkEditFormMixin`
-- CSV model import forms must inherit from `extras.forms.StatusModelCSVFormMixin`
-- Filter forms must inherit from `extras.forms.StatusFilterFormMixin`
+- Bulk edit model forms must inherit from `nautobot.extras.forms.StatusBulkEditFormMixin`
+- CSV model import forms must inherit from `nautobot.extras.forms.StatusModelCSVFormMixin`
+- Filter forms must inherit from `nautobot.extras.forms.StatusFilterFormMixin`
 
 ### Filters
 
-- Filtersets for your model must inherit from `extras.filters.StatusModelFilterSetMixin`
+- Filtersets for your model must inherit from `nautobot.extras.filters.StatusModelFilterSetMixin`
 
 ### Serializers
 
-- Serializers for your model must inherit from `extras.api.serializers.StatusModelSerializerMixin`
+- Serializers for your model must inherit from `nautobot.extras.api.serializers.StatusModelSerializerMixin`
 
 ### Tables
 
-- The table class for your model must inherit from `extras.tables.StatusTableMixin`
+- The table class for your model must inherit from `nautobot.extras.tables.StatusTableMixin`


### PR DESCRIPTION
# Closes: #None
# What's Changed

A couple of places in the documentation gave incorrect module imports (missing the leading `nautobot.`. This corrects those.