### PR TITLE
Configure drf-spectacular schema to more closely match drf-yasg

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -189,6 +189,13 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "Source of truth and network automation platform",
     "LICENSE": {"name": "Apache v2 License"},
     "VERSION": VERSION,
+    # For a semblance of backwards-compatibility with drf-yasg / OpenAPI 2.0, where "/api" was a common "basePath"
+    # in the schema.
+    # OpenAPI 3.0 removes "basePath" in favor of "servers", so we now declare "/api" as the server relative URL and
+    # trim it from all of the individual paths correspondingly.
+    # See also https://github.com/nautobot/nautobot-ansible/pull/135 for an example of why this is desirable.
+    "SERVERS": [{"url": "/api"}],
+    "SCHEMA_PATH_PREFIX_TRIM": True,
     # use sidecar - locally packaged UI files, not CDN
     "SWAGGER_UI_DIST": "SIDECAR",
     "SWAGGER_UI_FAVICON_HREF": "SIDECAR",


### PR DESCRIPTION
# Relates-to: https://github.com/nautobot/nautobot-ansible/pull/135
# What's Changed

Although the OpenAPI 3.0 schema is fundamentally different in its structure from OpenAPI 2.0, we can configure drf-spectacular to make it match a bit more closely in the parts that can be treated similarly. Specifically it turns out that nautobot-ansible was introspecting the schema to identify the set of valid query parameters that can be used in filtering the device/VM inventory, and our schema was just different enough to break that introspection. This set of config changes should reduce the impact to that library.

I verified that the Swagger UI still works correctly after this change.

## Nautobot 1.2:

![image](https://user-images.githubusercontent.com/5603551/164269745-ab8a6642-f95d-4748-a42c-3addcead66be.png)

![image](https://user-images.githubusercontent.com/5603551/164269848-fcad1695-146b-43c3-b326-d15b7b4e9a9a.png)

## Nautobot 1.3.1:

![image](https://user-images.githubusercontent.com/5603551/164270533-b88b1a7b-cd8f-4070-aa26-fe0eada28266.png)

(note leading `/api` on paths)

![image](https://user-images.githubusercontent.com/5603551/164270674-2f829bcc-28ae-479a-b3ec-425a58dc166d.png)

![image](https://user-images.githubusercontent.com/5603551/164270713-aea4cc10-68e7-4141-830d-9bfeb5d6a756.png)

## After this changeset:

![image](https://user-images.githubusercontent.com/5603551/164269908-e46feaf4-0af9-4b5a-a555-4a49b62371d2.png)

![image](https://user-images.githubusercontent.com/5603551/164269948-6abb9f5b-70c2-47dd-840e-e89c03fe5f4c.png)

![image](https://user-images.githubusercontent.com/5603551/164270011-e268d24b-bb3f-42b8-98aa-f2cc92ff42cd.png)
