### PR TITLE
Re-Enable Parallel Poetry Install

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -297,6 +297,7 @@ jobs:
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
             PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
+            POETRY_PARALLEL=true
       - name: "Docker Dev Metadata"
         id: "dockerdevmeta"
         uses: "docker/metadata-action@v3"
@@ -328,3 +329,4 @@ jobs:
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
             PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
+            POETRY_PARALLEL=true

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -241,9 +241,7 @@ jobs:
 
   container-build:
     runs-on: "ubuntu-20.04"
-    if: "github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/next')"
-    needs:
-      - "integration-test"
+    if: "github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/bsc-parallel-poetry')"
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -7,6 +7,7 @@ on:  # yamllint disable
       - "main"
       - "develop"
       - "next"
+      - "bsc-parallel-poetry"
   workflow_call:
 
 jobs:
@@ -260,12 +261,6 @@ jobs:
         uses: "docker/setup-qemu-action@v1"
       - name: "Set up Docker Buildx"
         uses: "docker/setup-buildx-action@v1"
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Docker Metadata"
         id: "dockermeta"
         uses: "docker/metadata-action@v3"
@@ -285,7 +280,7 @@ jobs:
       - name: "Build"
         uses: "docker/build-push-action@v2"
         with:
-          push: true
+          push: false
           target: final
           file: "docker/Dockerfile"
           platforms: "linux/amd64,linux/arm64"
@@ -316,7 +311,7 @@ jobs:
       - name: "Build Dev Containers"
         uses: "docker/build-push-action@v2"
         with:
-          push: true
+          push: false
           target: final-dev
           file: "docker/Dockerfile"
           platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -7,7 +7,6 @@ on:  # yamllint disable
       - "main"
       - "develop"
       - "next"
-      - "bsc-parallel-poetry"
   workflow_call:
 
 jobs:
@@ -241,7 +240,9 @@ jobs:
 
   container-build:
     runs-on: "ubuntu-20.04"
-    if: "github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/bsc-parallel-poetry')"
+    if: "github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/next')"
+    needs:
+      - "integration-test"
     strategy:
       fail-fast: true
       matrix:
@@ -259,6 +260,12 @@ jobs:
         uses: "docker/setup-qemu-action@v1"
       - name: "Set up Docker Buildx"
         uses: "docker/setup-buildx-action@v1"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Docker Metadata"
         id: "dockermeta"
         uses: "docker/metadata-action@v3"
@@ -278,7 +285,7 @@ jobs:
       - name: "Build"
         uses: "docker/build-push-action@v2"
         with:
-          push: false
+          push: true
           target: final
           file: "docker/Dockerfile"
           platforms: "linux/amd64,linux/arm64"
@@ -309,7 +316,7 @@ jobs:
       - name: "Build Dev Containers"
         uses: "docker/build-push-action@v2"
         with:
-          push: false
+          push: true
           target: final-dev
           file: "docker/Dockerfile"
           platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -99,6 +99,7 @@ jobs:
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
             PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
+            POETRY_PARALLEL=false
       - name: "Docker Dev Metadata"
         id: "dockerdevmeta"
         uses: "docker/metadata-action@v3"
@@ -126,6 +127,7 @@ jobs:
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
             PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
+            POETRY_PARALLEL=false
 
   slack-notify:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
             PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
+            POETRY_PARALLEL=false
       - name: "Docker Dev Metadata"
         id: "dockerdevmeta"
         uses: "docker/metadata-action@v3"
@@ -134,6 +135,7 @@ jobs:
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
             PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
+            POETRY_PARALLEL=false
 
   slack-notify:
     needs:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,8 +99,7 @@ ENV PATH="${PATH}:/root/.local/bin"
 # unfortunately it seems to have some issues with installing/updating "requests" and "certifi"
 # while simultaneously atttempting to *use* those packages to install other packages.
 # For now we disable it.
-RUN poetry config virtualenvs.create false && \
-    poetry config installer.parallel false
+RUN poetry config virtualenvs.create false
 
 COPY pyproject.toml poetry.lock README.md /source/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,6 +74,7 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 FROM base as dependencies
 ARG PYUWSGI_VER
+ARG POETRY_PARALLEL
 
 # Install development/install-time OS dependencies
 # hadolint ignore=DL3008
@@ -95,7 +96,12 @@ RUN curl -sSL https://install.python-poetry.org -o /tmp/install-poetry.py && \
 ENV PATH="${PATH}:/root/.local/bin"
 
 # Poetry shouldn't create a venv as we want global install
-RUN poetry config virtualenvs.create false
+# Poetry 1.1.0 added parallel installation as an option;
+# unfortunately it seems to have some issues with installing/updating "requests" and "certifi"
+# while simultaneously atttempting to *use* those packages to install other packages.
+# This is disabled by default (safer), but can be re-enabled by setting POETRY_PARALLEL=true
+RUN poetry config virtualenvs.create false && \
+    poetry config installer.parallel ${POETRY_PARALLEL:-false}
 
 COPY pyproject.toml poetry.lock README.md /source/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,10 +95,6 @@ RUN curl -sSL https://install.python-poetry.org -o /tmp/install-poetry.py && \
 ENV PATH="${PATH}:/root/.local/bin"
 
 # Poetry shouldn't create a venv as we want global install
-# Poetry 1.1.0 added parallel installation as an option;
-# unfortunately it seems to have some issues with installing/updating "requests" and "certifi"
-# while simultaneously atttempting to *use* those packages to install other packages.
-# For now we disable it.
 RUN poetry config virtualenvs.create false
 
 COPY pyproject.toml poetry.lock README.md /source/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "1.3.2-beta.1"
+version = "1.3.2-alpha.1"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "1.3.2-alpha.1"
+version = "1.3.2-beta.1"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"

--- a/tasks.py
+++ b/tasks.py
@@ -132,9 +132,10 @@ def run_command(context, command, **kwargs):
     help={
         "force_rm": "Always remove intermediate containers.",
         "cache": "Whether to use Docker's cache when building the image. (Default: enabled)",
+        "poetry_parallel": "Enable/disable poetry to install packages in parallel. (Default: True)",
     }
 )
-def build(context, force_rm=False, cache=True):
+def build(context, force_rm=False, cache=True, poetry_parallel=True):
     """Build Nautobot docker image."""
     command = (
         "build"
@@ -146,6 +147,8 @@ def build(context, force_rm=False, cache=True):
         command += " --no-cache"
     if force_rm:
         command += " --force-rm"
+    if poetry_parallel:
+        command += " --build-arg POETRY_PARALLEL=true"
 
     print(f"Building Nautobot with Python {context.nautobot.python_ver}...")
     docker_compose(context, command)
@@ -158,6 +161,7 @@ def build(context, force_rm=False, cache=True):
         "platforms": "Comma-separated list of strings for which to build. (Default: linux/amd64)",
         "tag": "Tags to be applied to the built image. (Default: networktocode/nautobot-dev:local)",
         "target": "Build target from the Dockerfile. (Default: dev)",
+        "poetry_parallel": "Enable/disable poetry to install packages in parallel. (Default: False)",
     }
 )
 def buildx(
@@ -167,6 +171,7 @@ def buildx(
     platforms="linux/amd64",
     tag="networktocode/nautobot-dev-py3.7:local",
     target="dev",
+    poetry_parallel=False
 ):
     """Build Nautobot docker image using the experimental buildx docker functionality (multi-arch capablility)."""
     print(f"Building Nautobot with Python {context.nautobot.python_ver} for {platforms}...")
@@ -183,6 +188,8 @@ def buildx(
             f" --cache-to type=local,dest={cache_dir}/{context.nautobot.python_ver}"
             f" --cache-from type=local,src={cache_dir}/{context.nautobot.python_ver}"
         )
+    if poetry_parallel:
+        command += " --build-arg POETRY_PARALLEL=true"
 
     context.run(command, env={"PYTHON_VER": context.nautobot.python_ver})
 

--- a/tasks.py
+++ b/tasks.py
@@ -171,7 +171,7 @@ def buildx(
     platforms="linux/amd64",
     tag="networktocode/nautobot-dev-py3.7:local",
     target="dev",
-    poetry_parallel=False
+    poetry_parallel=False,
 ):
     """Build Nautobot docker image using the experimental buildx docker functionality (multi-arch capablility)."""
     print(f"Building Nautobot with Python {context.nautobot.python_ver} for {platforms}...")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

We have the statement:
```
# Poetry 1.1.0 added parallel installation as an option;
# unfortunately it seems to have some issues with installing/updating "requests" and "certifi"
# while simultaneously atttempting to *use* those packages to install other packages.
# For now we disable it.
```
in our Dockerfile and this seems to be one of the slowest parts of our CI on integration and release (ARM now making it even slower, 40+ min).

This has worked locally for me for a while so want to do some test runs removing it in CI.


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design