### PR TITLE
Enforce JobModel database field length limits

### DIFF
--- a/nautobot/extras/constants.py
+++ b/nautobot/extras/constants.py
@@ -30,6 +30,14 @@ JOB_OVERRIDABLE_FIELDS = (
     "time_limit",
 )
 
+
+# Job field length limits
+JOB_MAX_NAME_LENGTH = 100  # TODO this should really be a more general-purpose constant, like NAME_MAX_LENGTH
+JOB_MAX_SLUG_LENGTH = 320  # 16 source, 100 GitRepository.name, 100 module_name, 100 job_class_name
+JOB_MAX_GROUPING_LENGTH = 255
+JOB_MAX_SOURCE_LENGTH = 16  # "git", "local", "plugins"
+
+
 # JobLogEntry Truncation Length
 JOB_LOG_MAX_GROUPING_LENGTH = 100
 JOB_LOG_MAX_LOG_OBJECT_LENGTH = 200

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -922,6 +922,16 @@ def refresh_git_jobs(repository_record, job_result, delete=False):
                     job_info.job_class,
                     git_repository=repository_record,
                 )
+
+                if job_model is None:
+                    job_result.log(
+                        message="Failed to create Job record; check Nautobot logs for details",
+                        grouping="jobs",
+                        level_choice=LogLevelChoices.LOG_FAILURE,
+                        logger=logger,
+                    )
+                    continue
+
                 if created:
                     message = "Created Job record"
                 else:

--- a/nautobot/extras/migrations/0024_job_data_migration.py
+++ b/nautobot/extras/migrations/0024_job_data_migration.py
@@ -1,17 +1,33 @@
 from django.db import migrations
 
 from nautobot.core.fields import slugify_dots_to_dashes
+from nautobot.extras.constants import (
+    JOB_MAX_GROUPING_LENGTH,
+    JOB_MAX_NAME_LENGTH,
+    JOB_MAX_SLUG_LENGTH,
+)
 
 
 def _create_job_model(job_model_class, class_path):
     try:
         source, module_name, job_class_name = class_path.split("/")
+        # At this point in the migrations, source = "git.RepositoryName" not just "git", so not JOB_MAX_SOURCE_LENGTH
+        if len(source) > 110:
+            print(f'Skipping Job model creation from "{class_path}" as the source is too long')
+            return None
+        if len(module_name) > JOB_MAX_NAME_LENGTH or len(module_name) > JOB_MAX_GROUPING_LENGTH:
+            print(f'Skipping Job model creation from "{class_path}" as the module_name is too long')
+            return None
+        if len(job_class_name) > JOB_MAX_NAME_LENGTH:
+            print(f'Skipping Job model creation from "{class_path}" as the job_class_name is too long')
+            return None
+
         job_model, created = job_model_class.objects.get_or_create(
             source=source,
             module_name=module_name,
             job_class_name=job_class_name,
             # AutoSlugField.slugify_function isn't applied during migrations, need to manually generate slug
-            slug=slugify_dots_to_dashes(f"{source}-{module_name}-{job_class_name}"),
+            slug=slugify_dots_to_dashes(f"{source}-{module_name}-{job_class_name}")[:JOB_MAX_SLUG_LENGTH],
             defaults={
                 "grouping": module_name,
                 "name": job_class_name,

--- a/nautobot/extras/migrations/0024_job_data_migration.py
+++ b/nautobot/extras/migrations/0024_job_data_migration.py
@@ -1,11 +1,6 @@
 from django.db import migrations
 
 from nautobot.core.fields import slugify_dots_to_dashes
-from nautobot.extras.constants import (
-    JOB_MAX_GROUPING_LENGTH,
-    JOB_MAX_NAME_LENGTH,
-    JOB_MAX_SLUG_LENGTH,
-)
 
 
 def _create_job_model(job_model_class, class_path):
@@ -15,10 +10,10 @@ def _create_job_model(job_model_class, class_path):
         if len(source) > 110:
             print(f'Skipping Job model creation from "{class_path}" as the source is too long')
             return None
-        if len(module_name) > JOB_MAX_NAME_LENGTH or len(module_name) > JOB_MAX_GROUPING_LENGTH:
+        if len(module_name) > 100:
             print(f'Skipping Job model creation from "{class_path}" as the module_name is too long')
             return None
-        if len(job_class_name) > JOB_MAX_NAME_LENGTH:
+        if len(job_class_name) > 100:
             print(f'Skipping Job model creation from "{class_path}" as the job_class_name is too long')
             return None
 
@@ -27,7 +22,7 @@ def _create_job_model(job_model_class, class_path):
             module_name=module_name,
             job_class_name=job_class_name,
             # AutoSlugField.slugify_function isn't applied during migrations, need to manually generate slug
-            slug=slugify_dots_to_dashes(f"{source}-{module_name}-{job_class_name}")[:JOB_MAX_SLUG_LENGTH],
+            slug=slugify_dots_to_dashes(f"{source}-{module_name}-{job_class_name}")[:320],
             defaults={
                 "grouping": module_name,
                 "name": job_class_name,

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -231,7 +231,8 @@ def refresh_job_models(sender, *, apps, **kwargs):
             for job_class_name, job_class in module_details["jobs"].items():
                 # TODO: catch DB error in case where multiple Jobs have the same grouping + name
                 job_model, _ = refresh_job_model_from_job_class(Job, source, job_class, git_repository=git_repository)
-                job_models.append(job_model)
+                if job_model is not None:
+                    job_models.append(job_model)
 
     for job_model in Job.objects.all():
         if job_model.installed and job_model not in job_models:

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -14,7 +14,14 @@ from django.utils.deconstruct import deconstructible
 from taggit.managers import _TaggableManager
 
 from nautobot.core.fields import slugify_dots_to_dashes
-from nautobot.extras.constants import EXTRAS_FEATURES, JOB_OVERRIDABLE_FIELDS
+from nautobot.extras.constants import (
+    EXTRAS_FEATURES,
+    JOB_MAX_GROUPING_LENGTH,
+    JOB_MAX_NAME_LENGTH,
+    JOB_MAX_SLUG_LENGTH,
+    JOB_MAX_SOURCE_LENGTH,
+    JOB_OVERRIDABLE_FIELDS,
+)
 from nautobot.extras.registry import registry
 
 
@@ -217,15 +224,54 @@ def refresh_job_model_from_job_class(job_model_class, job_source, job_class, *, 
     else:
         default_slug = slugify_dots_to_dashes(f"{job_source}-{job_class.__module__}-{job_class.__name__}")
 
+    # Unrecoverable errors
+    if len(job_source) > JOB_MAX_SOURCE_LENGTH:  # Should NEVER happen
+        logger.error(
+            'Unable to store Jobs from "%s" as Job models because the source exceeds %d characters in length!',
+            job_source,
+            JOB_MAX_SOURCE_LENGTH,
+        )
+        return (None, False)
+    if len(job_class.__module__) > JOB_MAX_NAME_LENGTH:
+        logger.error(
+            'Unable to store Jobs from module "%s" as Job models because the module exceeds %d characters in length!',
+            job_class.__module__,
+            JOB_MAX_NAME_LENGTH,
+        )
+        return (None, False)
+    if len(job_class.__name__) > JOB_MAX_NAME_LENGTH:
+        logger.error(
+            'Unable to represent Job class "%s" as a Job model because the class name exceeds %d characters in length!',
+            job_class.__name__,
+            JOB_MAX_NAME_LENGTH,
+        )
+        return (None, False)
+
+    # Recoverable errors
+    if len(job_class.grouping) > JOB_MAX_GROUPING_LENGTH:
+        logger.warning(
+            'Job class "%s" grouping "%s" exceeds %d characters in length, it will be truncated in the database.',
+            job_class.__name__,
+            job_class.grouping,
+            JOB_MAX_GROUPING_LENGTH,
+        )
+    if len(job_class.name) > JOB_MAX_NAME_LENGTH:
+        logger.warning(
+            'Job class "%s" name "%s" exceeds %d characters in length, it will be truncated in the database.',
+            job_class.__name__,
+            job_class.name,
+            JOB_MAX_NAME_LENGTH,
+        )
+
     job_model, created = job_model_class.objects.get_or_create(
-        source=job_source,
+        source=job_source[:JOB_MAX_SOURCE_LENGTH],
         git_repository=git_repository,
-        module_name=job_class.__module__,
-        job_class_name=job_class.__name__,
+        module_name=job_class.__module__[:JOB_MAX_NAME_LENGTH],
+        job_class_name=job_class.__name__[:JOB_MAX_NAME_LENGTH],
         defaults={
-            "slug": default_slug,
-            "grouping": job_class.grouping,
-            "name": job_class.name,
+            "slug": default_slug[:JOB_MAX_SLUG_LENGTH],
+            "grouping": job_class.grouping[:JOB_MAX_GROUPING_LENGTH],
+            "name": job_class.name[:JOB_MAX_NAME_LENGTH],
             "installed": True,
             "enabled": False,
         },


### PR DESCRIPTION
# Closes: #1679
# What's Changed

(`JobModel.clean()` already enforced most of these limits, but in the automated cases where we populate JobModels automatically, we use `JobModel.objects.get_or_create()` which bypasses `clean` 🤦‍♂️)

- When constructing speculative JobModel records based on existing JobResults (during initial migration):
  - don't create a record if the `source`, `module_name`, or `job_class_name` is too long to store in the DB (as truncating these would result in a lookup failure when trying to locate the associated JobClass)
  - truncate the auto-generated `slug` if it's too long
- When constructing JobModel records based on a JobClass (either at `post_migrate` time or when refreshing a `GitRepository`):
  - don't create a record if the `source`, `module_name`, or `job_class_name` is too long to store in the DB (same reason as above), and log appropriate error messages if this is the case
  - truncate auto-generated `slug`, `grouping`, and `name` if necessary, logging warning messages if this is the case