### PR TITLE
Passing the redis password to Sentinel

### DIFF
--- a/nautobot/docs/additional-features/caching.md
+++ b/nautobot/docs/additional-features/caching.md
@@ -135,7 +135,7 @@ Example:
 ```python
 CACHEOPS_REDIS = False
 CACHEOPS_SENTINEL = {
-    "db": 0,
+    "db": 1,
     "locations": [
         ("mysentinel.redis.example.com", 26379),
         ("othersentinel.redis.example.com", 26379),

--- a/nautobot/extras/health_checks.py
+++ b/nautobot/extras/health_checks.py
@@ -41,7 +41,12 @@ class RedisBackend(BaseHealthCheckBackend):
         # if Sentinel is enabled we need to check Redis using Sentinel
         if self.sentinel_url is not None:
             try:
-                sentinel = Sentinel(self.sentinel_url["locations"], socket_timeout=self.sentinel_url["socket_timeout"])
+                sentinel = Sentinel(
+                    self.sentinel_url["locations"],
+                    password=self.sentinel_url["password"],
+                    sentinel_kwargs=self.sentinel_url["sentinel_kwargs"],
+                    socket_timeout=self.sentinel_url["socket_timeout"],
+                )
                 with sentinel.master_for(self.sentinel_url["service_name"], db=self.sentinel_url["db"]) as master:
                     master.ping()
             except (ConnectionRefusedError, exceptions.ConnectionError, exceptions.TimeoutError) as e:

--- a/nautobot/extras/health_checks.py
+++ b/nautobot/extras/health_checks.py
@@ -43,9 +43,9 @@ class RedisBackend(BaseHealthCheckBackend):
             try:
                 sentinel = Sentinel(
                     self.sentinel_url["locations"],
-                    password=self.sentinel_url["password"],
-                    sentinel_kwargs=self.sentinel_url["sentinel_kwargs"],
-                    socket_timeout=self.sentinel_url["socket_timeout"],
+                    password=self.sentinel_url.get("password", None),
+                    sentinel_kwargs=self.sentinel_url.get("sentinel_kwargs", None),
+                    socket_timeout=self.sentinel_url.get("socket_timeout", None),
                 )
                 with sentinel.master_for(self.sentinel_url["service_name"], db=self.sentinel_url["db"]) as master:
                     master.ping()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1682 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

This PR passes the redis password to the Sentinel object for healthchecks.  When creating the sentinel object you must pass both the redis password and sentinel password (provided in sentinel_kwargs), these are typically the same but not always.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design