### PR TITLE
Removing incorrect default value

### DIFF
--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -203,7 +203,7 @@ A dict of additional options passed to the Celery broker transport. This is only
 
 Environment Variable: `NAUTOBOT_CELERY_BROKER_URL`
 
-Default: `'redis://localhost:6379/0'` (Inherited from `CACHES["default"]["LOCATION"]`)
+Default: `'redis://localhost:6379/0'`
 
 Celery broker URL used to tell workers where queues are located.
 
@@ -213,7 +213,7 @@ Celery broker URL used to tell workers where queues are located.
 
 Environment Variable: `NAUTOBOT_CELERY_RESULT_BACKEND`
 
-Default: `'redis://localhost:6379/0'` (Inherited from `CACHES["default"]["LOCATION"]`)
+Default: `'redis://localhost:6379/0'`
 
 Celery result backend used to tell workers where to store task results (tombstones).
 


### PR DESCRIPTION
This PR Updates the docs to remove the incorrect statement which indicates Celerey redis URLs are defaulted from CACHES, bringing docs for CELERY_* inline with other redis related variables.