### PR TITLE
Fix `get_return_url` for Plugin Reverse URLs

### DIFF
--- a/nautobot/extras/tests/integration/test_plugins.py
+++ b/nautobot/extras/tests/integration/test_plugins.py
@@ -122,3 +122,27 @@ class PluginWebhookTest(SeleniumTestCase):
         with open(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_with_body"), "r") as f:
             self.assertEqual(json.loads(f.read()), {"message": "created"})
         os.remove(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_with_body"))
+
+
+class PluginReturnUrlTestCase(SeleniumTestCase):
+    """
+    Integration tests for the CustomField and CustomFieldChoice models.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user.is_superuser = True
+        self.user.save()
+        self.login(self.user.username, self.password)
+
+    def test_plugin_return_url(self):
+        """This test ensures that plugins return url for new objects is the list view."""
+        self.browser.visit(f'{self.live_server_url}{reverse("plugins:example_plugin:examplemodel_add")}')
+
+        form = self.browser.find_by_tag("form")
+
+        # Check that the Cancel button is a link to the examplemodel_list view.
+        element = form.first.links.find_by_text("Cancel").first
+        self.assertEqual(
+            element["href"], f'{self.live_server_url}{reverse("plugins:example_plugin:examplemodel_list")}'
+        )

--- a/nautobot/utilities/views.py
+++ b/nautobot/utilities/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.mixins import AccessMixin
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
@@ -124,7 +125,8 @@ class GetReturnURLMixin:
         if hasattr(self, "queryset"):
             model_opts = self.queryset.model._meta
             try:
-                return reverse(f"{model_opts.app_label}:{model_opts.model_name}_list")
+                prefix = "plugins:" if model_opts.app_label in settings.PLUGINS else ""
+                return reverse(f"{prefix}{model_opts.app_label}:{model_opts.model_name}_list")
             except NoReverseMatch:
                 pass
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #473
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
This solves the issue of plugins unable to utilize the
GetReturnURLMixin by prefixing the url with "plugins:"
if the App comes from a plugin.

![image](https://user-images.githubusercontent.com/17092348/164782850-576be305-1dc3-48a6-aa61-72d176f42506.png)

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design