### PR TITLE
Use static templatetag for drf-spectacular-sidecar files

### DIFF
--- a/nautobot/core/templates/swagger_ui.html
+++ b/nautobot/core/templates/swagger_ui.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block title %}{{ title | default:"Swagger" }}{% endblock title %}
 
 {% block extra_styles %}
-    <link rel="stylesheet" href="{{ dist }}/swagger-ui.css">
+    <link rel="stylesheet" href="{% static 'drf_spectacular_sidecar/swagger-ui-dist/swagger-ui.css' %}">
     <style>
       /* Manual styling inherited from drf-spectacular */
       html { box-sizing: border-box; overflow-y: scroll; }
@@ -20,8 +21,8 @@
 {% endblock content %}
 
 {% block javascript %}
-    <script src="{{ dist }}/swagger-ui-bundle.js"></script>
-    <script src="{{ dist }}/swagger-ui-standalone-preset.js"></script>
+    <script src="{% static 'drf_spectacular_sidecar/swagger-ui-dist/swagger-ui-bundle.js' %}"></script>
+    <script src="{% static 'drf_spectacular_sidecar/swagger-ui-dist/swagger-ui-standalone-preset.js' %}"></script>
     {% if script_url %}
     <script src="{{ script_url }}"></script>
     {% else %}


### PR DESCRIPTION
# Closes: #N/A
# What's Changed

Work around for https://github.com/tfranzel/drf-spectacular/issues/718. Since we already have a custom page template for the Swagger UI view, and we know that in Nautobot's case we always are using drf-spectacular-sidecar, we can directly use the `static` templatetag, bypassing drf-spectacular's currently more-flexible (since it can use CDNs as well as drf-spectacular-sidecar) but less-robust (because it doesn't handle STATICFILES_STORAGE yet) calculation of the paths to the relevant static files.