### PR TITLE
Add sanitize() function and use it when logging from a Job

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -107,7 +107,7 @@ SOCIAL_AUTH_BACKEND_PREFIX = "social_core.backends"
 SANITIZER_PATTERNS = [
     # General removal of username-like and password-like tokens
     (re.compile(r"(https?://)?\S+\s*@", re.IGNORECASE), r"\1{replacement}@"),
-    (re.compile(r"(username|user|password|passwd|pwd)(\s*i?s?\s*:?\s*)?\S+", re.IGNORECASE), r"\1\2{replacement}"),
+    (re.compile(r"(username|password|passwd|pwd)(\s*i?s?\s*:?\s*)?\S+", re.IGNORECASE), r"\1\2{replacement}"),
 ]
 
 # Storage

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import re
 
 from django.contrib.messages import constants as messages
 import django.forms
@@ -101,6 +102,13 @@ REMOTE_AUTH_HEADER = "HTTP_REMOTE_USER"
 SOCIAL_AUTH_POSTGRES_JSONFIELD = False
 # Nautobot related - May be overridden if using custom social auth backend
 SOCIAL_AUTH_BACKEND_PREFIX = "social_core.backends"
+
+# Job log entry sanitization and similar
+SANITIZER_PATTERNS = [
+    # General removal of username-like and password-like tokens
+    (re.compile(r"(https?://)?\S+\s*@", re.IGNORECASE), r"\1{replacement}@"),
+    (re.compile(r"(username|user|password|passwd|pwd)(\s*i?s?\s*:?\s*)?\S+", re.IGNORECASE), r"\1\2{replacement}"),
+]
 
 # Storage
 STORAGE_BACKEND = None

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -405,6 +405,9 @@ It is advised to log a message for each object that is evaluated so that the res
 Markdown rendering is supported for log messages.
 
 !!! note
+    As a security measure, the `message` passed to any of these methods will be passed through the `nautobot.utilities.logging.sanitize()` function in an attempt to strip out information such as usernames/passwords that should not be saved to the logs. This is of course best-effort only, and Job authors should take pains to ensure that such information is not passed to the logging APIs in the first place. The set of redaction rules used by the `sanitize()` function can be configured as [settings.SANITIZER_PATTERNS](../configuration/optional-settings.md#sanitizer_patterns).
+
+!!! note
     Using `self.log_failure()`, in addition to recording a log message, will flag the overall job as failed, but it will **not** stop the execution of the job, nor will it result in an automatic rollback of any database changes made by the job. To end a job early, you can use a Python `raise` or `return` as appropriate. Raising `nautobot.utilities.exceptions.AbortTransaction` will ensure that any database changes are rolled back as part of the process of ending the job.
 
 ### Accessing Request Data

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -815,6 +815,21 @@ This parameter defines the URL of the repository that will be checked periodical
 
 ---
 
+## SANITIZER_PATTERNS
+
+Default:
+
+```python
+[
+    (re.compile(r"(https?://)?\S+\s*@", re.IGNORECASE), r"\1{replacement}@"),
+    (re.compile(r"(username|user|password|passwd|pwd)(\s*i?s?\s*:?\s*)?\S+", re.IGNORECASE), r"\1\2{replacement}"),
+]
+```
+
+List of (regular expression, replacement pattern) tuples used by the `nautobot.utilities.logging.sanitize()` function. As of Nautobot 1.3.4 this function is used primarily for sanitization of Job log entries, but it may be used in other scopes in the future.
+
+---
+
 ## SESSION_COOKIE_AGE
 
 Default: `1209600` (2 weeks, in seconds)

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -822,7 +822,7 @@ Default:
 ```python
 [
     (re.compile(r"(https?://)?\S+\s*@", re.IGNORECASE), r"\1{replacement}@"),
-    (re.compile(r"(username|user|password|passwd|pwd)(\s*i?s?\s*:?\s*)?\S+", re.IGNORECASE), r"\1\2{replacement}"),
+    (re.compile(r"(username|password|passwd|pwd)(\s*i?s?\s*:?\s*)?\S+", re.IGNORECASE), r"\1\2{replacement}"),
 ]
 ```
 

--- a/nautobot/docs/release-notes/version-1.3.md
+++ b/nautobot/docs/release-notes/version-1.3.md
@@ -148,6 +148,10 @@ As Python 3.6 has reached end-of-life, and many of Nautobot's dependencies have 
 
 ### Fixed
 
+### Security
+
+- [#1715](https://github.com/nautobot/nautobot/issues/1715) - Add [`SANITIZER_PATTERNS` optional setting](../configuration/optional-settings.md#sanitizer_patterns) and `nautobot.utilities.logging.sanitize` function and use it for redaction of Job log entries.
+
 ## v1.3.3 (2022-05-02)
 
 ### Added

--- a/nautobot/extras/tests/example_jobs/test_log_redaction.py
+++ b/nautobot/extras/tests/example_jobs/test_log_redaction.py
@@ -1,0 +1,14 @@
+from nautobot.extras.jobs import Job
+
+
+class TestLogRedaction(Job):
+    class Meta:
+        description = "Test redaction of logs"
+
+    def run(self, data, commit):
+        self.log_debug("The secret is supersecret123")
+        self.log_info(message="The secret is supersecret123")
+        self.log_success(message="The secret is supersecret123")
+        self.log_warning(message="The secret is supersecret123")
+        # Disabled as we don't want the job to fail
+        # self.log_failure(message="The secret is supersecret123")

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -531,13 +531,13 @@ class JobFilterSetTestCase(TestCase):
 
     def test_installed(self):
         params = {"installed": True}
-        # 30 local jobs and 3 plugin jobs
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 33)
+        # 31 local jobs and 3 plugin jobs
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 34)
 
     def test_enabled(self):
         params = {"enabled": False}
-        # 30 local jobs and 3 plugin jobs
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 33)
+        # 31 local jobs and 3 plugin jobs
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 34)
 
     def test_commit_default(self):
         params = {"commit_default": False}

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -1,5 +1,6 @@
 import json
 from io import StringIO
+import re
 import uuid
 
 from django.contrib.contenttypes.models import ContentType
@@ -8,6 +9,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from django.test.client import RequestFactory
 
 from nautobot.dcim.models import DeviceRole, Site
@@ -245,6 +247,24 @@ class JobTest(TransactionTestCase):
         # Assert stuff
         self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
         self.assertEqual(form_data, job_result_data)
+
+    @override_settings(
+        SANITIZER_PATTERNS=(
+            (re.compile(r"secret is \S+"), "secret is {replacement}"),
+        ),
+    )
+    def test_log_redaction(self):
+        """
+        Test that an attempt is made at log redaction.
+        """
+        module = "test_log_redaction"
+        name = "TestLogRedaction"
+        job_result = create_job_result_and_run_job(module, name, data=None, commit=True, request=self.request)
+
+        logs = JobLogEntry.objects.filter(job_result=job_result, grouping="run")
+        self.assertGreater(logs.count(), 0)
+        for log in logs:
+            self.assertEqual(log.message, "The secret is (redacted)")
 
     def test_object_vars(self):
         """

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -249,7 +249,7 @@ class JobTest(TransactionTestCase):
         self.assertEqual(form_data, job_result_data)
 
     @override_settings(
-        SANITIZER_PATTERNS=((re.compile(r"secret is \S+"), "secret is {replacement}"),),
+        SANITIZER_PATTERNS=((re.compile(r"(secret is )\S+"), "\1{replacement}"),),
     )
     def test_log_redaction(self):
         """

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -249,9 +249,7 @@ class JobTest(TransactionTestCase):
         self.assertEqual(form_data, job_result_data)
 
     @override_settings(
-        SANITIZER_PATTERNS=(
-            (re.compile(r"secret is \S+"), "secret is {replacement}"),
-        ),
+        SANITIZER_PATTERNS=((re.compile(r"secret is \S+"), "secret is {replacement}"),),
     )
     def test_log_redaction(self):
         """

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -249,7 +249,7 @@ class JobTest(TransactionTestCase):
         self.assertEqual(form_data, job_result_data)
 
     @override_settings(
-        SANITIZER_PATTERNS=((re.compile(r"(secret is )\S+"), "\1{replacement}"),),
+        SANITIZER_PATTERNS=((re.compile(r"(secret is )\S+"), r"\1{replacement}"),),
     )
     def test_log_redaction(self):
         """

--- a/nautobot/utilities/__init__.py
+++ b/nautobot/utilities/__init__.py
@@ -1,1 +1,3 @@
+from nautobot.utilities import checks
+
 default_app_config = "nautobot.utilities.apps.UtilitiesConfig"

--- a/nautobot/utilities/__init__.py
+++ b/nautobot/utilities/__init__.py
@@ -1,3 +1,6 @@
 from nautobot.utilities import checks
 
 default_app_config = "nautobot.utilities.apps.UtilitiesConfig"
+
+
+__all__ = ("checks",)

--- a/nautobot/utilities/checks.py
+++ b/nautobot/utilities/checks.py
@@ -1,0 +1,40 @@
+import re
+
+from django.conf import settings
+from django.core.checks import register, Error, Tags
+
+
+@register(Tags.security)
+def check_sanitizer_patterns(app_configs, **kwargs):
+    errors = []
+    for entry in settings.SANITIZER_PATTERNS:
+        if (
+            not isinstance(entry, (tuple, list))
+            or len(entry) != 2
+            or not isinstance(entry[0], re.Pattern)
+            or not isinstance(entry[1], str)
+        ):
+            errors.append(
+                Error(
+                    "Invalid entry in settings.SANITIZER_PATTERNS",
+                    hint="Each entry must be a list or tuple of (compiled regexp, replacement string)",
+                    obj=entry,
+                    id="nautobot.utilities.E001",
+                )
+            )
+            continue
+
+        sanitizer, repl = entry
+        try:
+            sanitizer.sub(repl.format(replacement="(REDACTED)"), "Hello world!")
+        except re.error as exc:
+            errors.append(
+                Error(
+                    f"Entry in settings.SANITIZER_PATTERNS not usable for sanitization",
+                    hint=str(exc),
+                    obj=entry,
+                    id="nautobot.utilities.E002",
+                )
+            )
+
+    return errors

--- a/nautobot/utilities/checks.py
+++ b/nautobot/utilities/checks.py
@@ -30,7 +30,7 @@ def check_sanitizer_patterns(app_configs, **kwargs):
         except re.error as exc:
             errors.append(
                 Error(
-                    f"Entry in settings.SANITIZER_PATTERNS not usable for sanitization",
+                    "Entry in settings.SANITIZER_PATTERNS not usable for sanitization",
                     hint=str(exc),
                     obj=entry,
                     id="nautobot.utilities.E002",

--- a/nautobot/utilities/logging.py
+++ b/nautobot/utilities/logging.py
@@ -23,7 +23,7 @@ def sanitize(string, replacement="(redacted)"):
     for sanitizer, repl in settings.SANITIZER_PATTERNS:
         try:
             string = sanitizer.sub(repl.format(replacement=replacement), string)
-        except re.error as exc:
+        except re.error:
             logger.error('Error in string sanitization using "%s"', sanitizer)
 
     return string

--- a/nautobot/utilities/logging.py
+++ b/nautobot/utilities/logging.py
@@ -1,0 +1,29 @@
+"""Utilities for working with log messages and similar features."""
+
+import logging
+import re
+
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def sanitize(string, replacement="(redacted)"):
+    """
+    Make an attempt at stripping potentially-sensitive information from the given string.
+
+    Obviously this will never be 100% foolproof but we can at least try.
+
+    Uses settings.SANITIZER_PATTERNS as the list of (regexp, repl) tuples to apply.
+    """
+    # Don't allow regex match groups to be referenced in the replacement string!
+    assert not re.search(r"\\\d|\\g<\d+>", replacement)
+
+    for sanitizer, repl in settings.SANITIZER_PATTERNS:
+        try:
+            string = sanitizer.sub(repl.format(replacement=replacement), string)
+        except re.error as exc:
+            logger.error('Error in string sanitization using "%s"', sanitizer)
+
+    return string

--- a/nautobot/utilities/tests/test_logging.py
+++ b/nautobot/utilities/tests/test_logging.py
@@ -1,0 +1,31 @@
+from nautobot.utilities.logging import sanitize
+from nautobot.utilities.testing import TestCase
+
+
+class LoggingUtilitiesTest(TestCase):
+
+    DIRTY_CLEAN = (
+        # should match first default pattern
+        ("http://user:password@localhost", "http://(redacted)@localhost"),
+        ("HTTPS://:password@EXAMPLE.COM", "HTTPS://(redacted)@EXAMPLE.COM"),
+        # should match second default pattern
+        ("username myusername, password mypassword", "username (redacted) password (redacted)"),
+        ("Username: me Password: you", "Username: (redacted) Password: (redacted)"),
+        ("My username is someuser", "My username is (redacted)"),
+        ("My password is: supersecret!123", "My password is: (redacted)"),
+        # both patterns need to be applied together
+        (
+            "I use username FOO and password BAR to log in as https://FOO:BAR@example.com",
+            "I use username (redacted) and password (redacted) to log in as https://(redacted)@example.com",
+        ),
+    )
+
+    def test_sanitize_default_coverage(self):
+        """Test that the default sanitizer patterns cover a variety of cases."""
+        for dirty, clean in self.DIRTY_CLEAN:
+            self.assertEqual(sanitize(dirty), clean)
+
+    def test_sanitize_idempotent(self):
+        """Test that sanitizing the same string repeatedly doesn't cascade oddly."""
+        for dirty, clean in self.DIRTY_CLEAN:
+            self.assertEqual(sanitize(sanitize(dirty)), clean)


### PR DESCRIPTION
# Closes: #1715 
# What's Changed

- Add `nautobot.utilities.logging.sanitize()` function, which takes a list of `(regexp, replacement)` tuples from `settings.SANITIZER_PATTERNS` (new config key) and applies them to the provided string.
- Update `JobResult.log()` so that it applies `sanitize()` to the provided message.
  - The typical call chain is `Job.log_debug() (etc) -> Job._log() -> JobResult.log() -> JobLogEntry().save()`, so I arguably could have added `sanitize()` at any other point in the chain, but this seemed like the most reasonable to me.
- Add testing
- Add Django checks to make sure `SANITIZER_PATTERNS` is correctly defined.

# TODO

- [x] Explanation of Change(s)
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
