### PR TITLE
fix: "select all" box expanding to the full height

### DIFF
--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -34,6 +34,7 @@
                 {% csrf_token %}
                 <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
                 {% if table.paginator.num_pages > 1 %}
+                <div class="table-responsive">
                     <div id="select_all_box" class="hidden panel panel-default noprint">
                         <div class="panel-body">
                             <div class="checkbox-inline">
@@ -56,6 +57,7 @@
                             </div>
                         </div>
                     </div>
+                </div>
                 {% endif %}
                 {% include table_template|default:'responsive_table.html' %}
                 <div class="pull-left noprint">


### PR DESCRIPTION
# Closes: #1755
# What's Changed

This change wraps the select all  confirmation box and buttons with a responsive-table div to prevent the box from expanding to the full height of the adjacent query form.

![image](https://user-images.githubusercontent.com/358901/167141298-6a8b5db9-2d74-4b26-b690-add7a0c8af90.png)
