### PR TITLE
500 for circuit termination details (#1712) fixed

### DIFF
--- a/nautobot/circuits/templates/circuits/circuittermination.html
+++ b/nautobot/circuits/templates/circuits/circuittermination.html
@@ -53,7 +53,7 @@
                                 ({{ peer }})
                             {% endwith %}
                         {% else %}
-                            {% if perms.dcim.add_cable %}
+                            {% if perms.dcim.add_cable and object.site %}
                                 <div class="pull-right">
                                     <span class="dropdown">
                                         <button type="button" class="btn btn-success btn-xs dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/nautobot/circuits/templates/circuits/circuittermination.html
+++ b/nautobot/circuits/templates/circuits/circuittermination.html
@@ -12,13 +12,21 @@
     <div class="panel panel-default">
             <table class="table table-hover panel-body attr-table">
                 <tr>
-                    <td>Site</td>
-                    <td>
-                        {% if object.site.region %}
-                            <a href="{{ object.site.region.get_absolute_url }}">{{ object.site.region }}</a> /
-                        {% endif %}
-                        <a href="{% url 'dcim:site' slug=object.site.slug %}">{{ object.site }}</a>
-                    </td>
+                    {% if object.site %}
+                        <td>Site</td>
+                        <td>
+                            {% if object.site.region %}
+                                <a href="{{ object.site.region.get_absolute_url }}">{{ object.site.region }}</a> /
+                            {% endif %}
+                            <a href="{% url 'dcim:site' slug=object.site.slug %}">{{ object.site }}</a>
+                        </td>
+                    {% endif %}
+                    {% if object.provider_network %}
+                        <td>Provider Network</td>
+                        <td>
+                            <a href="{% url 'circuits:providernetwork' slug=object.provider_network.slug %}">{{ object.provider_network }}</a>
+                        </td>
+                    {% endif %}
                 </tr>
                 <tr>
                     <td>Termination</td>

--- a/nautobot/circuits/templates/circuits/circuittermination_edit.html
+++ b/nautobot/circuits/templates/circuits/circuittermination_edit.html
@@ -25,7 +25,7 @@
                     <p class="form-control-static">{{ form.term_side.value }}</p>
                 </div>
             </div>
-                {% with providernetwork_tab_active=form.initial.providernetwork %}
+                {% with providernetwork_tab_active=form.initial.provider_network %}
                     <ul class="nav nav-tabs" role="tablist">
                         <li role="presentation"{% if not providernetwork_tab_active %} class="active"{% endif %}><a href="#site" role="tab" data-toggle="tab">Site</a></li>
                         <li role="presentation"{% if providernetwork_tab_active %} class="active"{% endif %}><a href="#providernetwork" role="tab" data-toggle="tab">Provider Network</a></li>

--- a/nautobot/circuits/templates/circuits/inc/circuit_termination.html
+++ b/nautobot/circuits/templates/circuits/inc/circuit_termination.html
@@ -66,7 +66,7 @@
                             ({{ peer }})
                         {% endwith %}
                     {% else %}
-                        {% if perms.dcim.add_cable %}
+                        {% if perms.dcim.add_cable and termination.site %}
                             <div class="pull-right">
                                 <span class="dropdown">
                                     <button type="button" class="btn btn-success btn-xs dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/nautobot/circuits/tests/test_views.py
+++ b/nautobot/circuits/tests/test_views.py
@@ -1,8 +1,16 @@
 import datetime
+from django.urls import reverse
 
-from nautobot.circuits.models import Circuit, CircuitType, Provider, ProviderNetwork
+from nautobot.circuits.models import (
+    Circuit,
+    CircuitTermination,
+    CircuitTerminationSideChoices,
+    CircuitType,
+    Provider,
+    ProviderNetwork,
+)
 from nautobot.extras.models import Status
-from nautobot.utilities.testing import ViewTestCases
+from nautobot.utilities.testing import TestCase as NautobotTestCase, ViewTestCases
 
 
 class ProviderTestCase(ViewTestCases.PrimaryObjectViewTestCase):
@@ -198,3 +206,40 @@ class ProviderNetworkTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         cls.slug_test_object = "Provider Network 8"
         cls.slug_source = "name"
+
+
+class CircuitTerminationTestCase(NautobotTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user.is_superuser = True
+        self.user.save()
+
+    def test_circuit_termination_detail_200(self):
+        """
+        This tests that a circuit termination's detail page (with a provider
+        network instead of a site) returns a 200 response
+        """
+
+        # Set up the required objects:
+        provider = Provider.objects.create(name="Test Provider", slug="test-provider", asn=12345)
+        provider_network = ProviderNetwork.objects.create(
+            name="Test Provider Network",
+            slug="test-provider-network",
+            provider=provider,
+        )
+        circuit_type = CircuitType.objects.create(name="Test Circuit Type", slug="test-circuit-type")
+        active_status = Status.objects.get_for_model(Circuit).get(slug="active")
+        circuit = Circuit.objects.create(
+            cid="Test Circuit",
+            provider=provider,
+            type=circuit_type,
+            status=active_status,
+        )
+        termination = CircuitTermination.objects.create(
+            circuit=circuit, provider_network=provider_network, term_side=CircuitTerminationSideChoices.SIDE_A
+        )
+
+        # Visit the termination detail page and assert responses:
+        response = self.client.get(reverse("circuits:circuittermination", kwargs={"pk": termination.pk}))
+        self.assertEqual(200, response.status_code)
+        self.assertIn("Test Provider Network", str(response.content))

--- a/nautobot/circuits/tests/test_views.py
+++ b/nautobot/circuits/tests/test_views.py
@@ -217,7 +217,7 @@ class CircuitTerminationTestCase(NautobotTestCase):
     def test_circuit_termination_detail_200(self):
         """
         This tests that a circuit termination's detail page (with a provider
-        network instead of a site) returns a 200 response
+        network instead of a site) returns a 200 response and doesn't contain the connect menu button.
         """
 
         # Set up the required objects:
@@ -243,3 +243,4 @@ class CircuitTerminationTestCase(NautobotTestCase):
         response = self.client.get(reverse("circuits:circuittermination", kwargs={"pk": termination.pk}))
         self.assertEqual(200, response.status_code)
         self.assertIn("Test Provider Network", str(response.content))
+        self.assertNotIn("</span> Connect", str(response.content))

--- a/nautobot/circuits/tests/test_views.py
+++ b/nautobot/circuits/tests/test_views.py
@@ -244,3 +244,7 @@ class CircuitTerminationTestCase(NautobotTestCase):
         self.assertEqual(200, response.status_code)
         self.assertIn("Test Provider Network", str(response.content))
         self.assertNotIn("</span> Connect", str(response.content))
+
+        # Visit the circuit object detail page and check there is no connect button present:
+        response = self.client.get(reverse("circuits:circuit", kwargs={"pk": circuit.pk}))
+        self.assertNotIn("</span> Connect", str(response.content))

--- a/nautobot/docs/release-notes/version-1.3.md
+++ b/nautobot/docs/release-notes/version-1.3.md
@@ -155,6 +155,7 @@ As Python 3.6 has reached end-of-life, and many of Nautobot's dependencies have 
 
 - [#1263](https://github.com/nautobot/nautobot/issues/1263) - Rack device image toggle added back to detail UI.
 - [#1652](https://github.com/nautobot/nautobot/issues/1652) - Unicode now renders correctly on uses of json.dumps and yaml.dump throughout the code base.
+- [#1712](https://github.com/nautobot/nautobot/issues/1712) - Fixed circuit termination detail view getting 500 response when it's a provider network.
 - [#1755](https://github.com/nautobot/nautobot/issues/1755) - Fixed "Select All" helper widget from taking full UI height.
 - [#1761](https://github.com/nautobot/nautobot/pull/1761) - Fixed typo in upgrading documentation.
 

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -1085,7 +1085,6 @@ class ViewTestCases:
             obj_perm.save()
 
             # Bulk delete permitted objects
-
             self.assertHttpStatus(self.client.post(self._get_url("bulk_delete"), data), 302)
             self.assertEqual(self._get_queryset().count(), 0)
 

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -1085,6 +1085,7 @@ class ViewTestCases:
             obj_perm.save()
 
             # Bulk delete permitted objects
+
             self.assertHttpStatus(self.client.post(self._get_url("bulk_delete"), data), 302)
             self.assertEqual(self._get_queryset().count(), 0)
 


### PR DESCRIPTION
# Closes: #1712
# What's Changed
Circuit termination detail view no longer gets a 500 response when the termination is a provider network
# TODO
Check that there shouldn't be cable connection options if it's a provider network