### PR TITLE
Fix performance of device/vm with config-contexts

### DIFF
--- a/nautobot/docs/release-notes/version-1.3.md
+++ b/nautobot/docs/release-notes/version-1.3.md
@@ -154,6 +154,7 @@ As Python 3.6 has reached end-of-life, and many of Nautobot's dependencies have 
 ### Fixed
 
 - [#1263](https://github.com/nautobot/nautobot/issues/1263) - Rack device image toggle added back to detail UI.
+- [#1449](https://github.com/nautobot/nautobot/issues/1449) - Fixed a performance bug in `/api/dcim/devices/` and `/api/virtualization/virtual-machines/` relating to configuration contexts.
 - [#1652](https://github.com/nautobot/nautobot/issues/1652) - Unicode now renders correctly on uses of json.dumps and yaml.dump throughout the code base.
 - [#1712](https://github.com/nautobot/nautobot/issues/1712) - Fixed circuit termination detail view getting 500 response when it's a provider network.
 - [#1755](https://github.com/nautobot/nautobot/issues/1755) - Fixed "Select All" helper widget from taking full UI height.

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -207,12 +207,24 @@ class ConfigContextTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(rendered_context["bar"], 456)
         self.assertEqual(rendered_context["baz"], 789)
 
+        # Test API response as well
+        self.add_permissions("dcim.view_device")
+        device_url = reverse("dcim-api:device-detail", kwargs={"pk": device.pk})
+        response = self.client.get(device_url, **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertIn("config_context", response.data)
+        self.assertEqual(response.data["config_context"], {"foo": 123, "bar": 456, "baz": 789}, response.data)
+
         # Add another context specific to the site
         configcontext4 = ConfigContext(name="Config Context 4", data={"site_data": "ABC"})
         configcontext4.save()
         configcontext4.sites.add(site)
         rendered_context = device.get_config_context()
         self.assertEqual(rendered_context["site_data"], "ABC")
+        response = self.client.get(device_url, **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertIn("config_context", response.data)
+        self.assertEqual(response.data["config_context"]["site_data"], "ABC", response.data["config_context"])
 
         # Override one of the default contexts
         configcontext5 = ConfigContext(name="Config Context 5", weight=2000, data={"foo": 999})
@@ -220,6 +232,10 @@ class ConfigContextTest(APIViewTestCases.APIViewTestCase):
         configcontext5.sites.add(site)
         rendered_context = device.get_config_context()
         self.assertEqual(rendered_context["foo"], 999)
+        response = self.client.get(device_url, **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertIn("config_context", response.data)
+        self.assertEqual(response.data["config_context"]["foo"], 999, response.data["config_context"])
 
         # Add a context which does NOT match our device and ensure it does not apply
         site2 = Site.objects.create(name="Site 2", slug="site-2")
@@ -228,6 +244,10 @@ class ConfigContextTest(APIViewTestCases.APIViewTestCase):
         configcontext6.sites.add(site2)
         rendered_context = device.get_config_context()
         self.assertEqual(rendered_context["bar"], 456)
+        response = self.client.get(device_url, **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertIn("config_context", response.data)
+        self.assertEqual(response.data["config_context"]["bar"], 456, response.data["config_context"])
 
     def test_schema_validation_pass(self):
         """


### PR DESCRIPTION
# Closes: #1449 
# What's Changed

Performance of device/virtual-machine list endpoints regressed substantially due to removal of postgres-specific annotation-using code in #217. This adds appropriate logic back in (credit to @lampwins) that should work correctly in both postgres and mysql.

Without this fix, using curl to retrieve 1000 devices from mysql in nautobot (local dev instance):

```
8:19.27 total
```

With this fix, same conditions:

```
0:34.214 total
```

# TODO
- [x] I need to take another look at #217 as I think there may be a few other changes made in that PR that can be reverted, but wanted to get this out for initial review.
- [x] Verify that test coverage of config contexts is sufficient for UI and REST API as well (I just ran `test_models.py`).