### PR TITLE
Fix exception raised when updating RelationshipAssociation

### DIFF
--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -614,11 +614,15 @@ class RelationshipAssociation(BaseModel):
             RelationshipTypeChoices.TYPE_MANY_TO_MANY_SYMMETRIC,
         ):
             # Either one-to-many or one-to-one, in either case don't allow multiple sources to the same destination
-            if RelationshipAssociation.objects.filter(
-                relationship=self.relationship,
-                destination_type=self.destination_type,
-                destination_id=self.destination_id,
-            ).exists():
+            if (
+                RelationshipAssociation.objects.filter(
+                    relationship=self.relationship,
+                    destination_type=self.destination_type,
+                    destination_id=self.destination_id,
+                )
+                .exclude(pk=self.pk)
+                .exists()
+            ):
                 raise ValidationError(
                     {
                         "destination": (

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -637,11 +637,15 @@ class RelationshipAssociation(BaseModel):
                 RelationshipTypeChoices.TYPE_ONE_TO_ONE_SYMMETRIC,
             ):
                 # Don't allow multiple destinations from the same source
-                if RelationshipAssociation.objects.filter(
-                    relationship=self.relationship,
-                    source_type=self.source_type,
-                    source_id=self.source_id,
-                ).exists():
+                if (
+                    RelationshipAssociation.objects.filter(
+                        relationship=self.relationship,
+                        source_type=self.source_type,
+                        source_id=self.source_id,
+                    )
+                    .exclude(pk=self.pk)
+                    .exists()
+                ):
                     raise ValidationError(
                         {
                             "source": (

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -384,6 +384,28 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         for cra in self.invalid_relationship_associations:
             cra.validated_save()
 
+    def test_exception_not_raised_when_updating_instance_with_type_o2m_or_o21(self):
+        """Validate 'Unable to create more than one relationship-association...' not raise when updating instance with
+        type one-to-one or one-to-many relationship."""
+
+        # RelationshipAssociation with type one-to-many
+        cra_1 = RelationshipAssociation(relationship=self.o2m_1, source=self.sites[0], destination=self.vlans[1])
+        cra_1.validated_save()
+
+        cra_1.source = self.sites[1]
+        cra_1.validated_save()
+
+        self.assertEqual(cra_1.source, self.sites[1])
+
+        # RelationshipAssociation with type one-to-one
+        cra_2 = RelationshipAssociation(relationship=self.o2o_1, source=self.racks[0], destination=self.sites[0])
+        cra_2.validated_save()
+
+        cra_2.source = self.racks[1]
+        cra_2.validated_save()
+
+        self.assertEqual(cra_2.source, self.racks[1])
+
     def test_clean_wrong_type(self):
         # Create with the wrong source Type
         with self.assertRaises(ValidationError) as handler:

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -384,11 +384,11 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         for cra in self.invalid_relationship_associations:
             cra.validated_save()
 
-    def test_exception_not_raised_when_updating_instance_with_type_o2m_or_o21(self):
+    def test_exception_not_raised_when_updating_instance_with_relationship_type_o2m_or_o21(self):
         """Validate 'Unable to create more than one relationship-association...' not raise when updating instance with
         type one-to-one or one-to-many relationship."""
 
-        # RelationshipAssociation with type one-to-many
+        # RelationshipAssociation with relationship type one-to-many
         cra_1 = RelationshipAssociation(relationship=self.o2m_1, source=self.sites[0], destination=self.vlans[1])
         cra_1.validated_save()
 
@@ -397,7 +397,7 @@ class RelationshipAssociationTest(RelationshipBaseTest):
 
         self.assertEqual(cra_1.source, self.sites[1])
 
-        # RelationshipAssociation with type one-to-one
+        # RelationshipAssociation with relationship type one-to-one
         cra_2 = RelationshipAssociation(relationship=self.o2o_1, source=self.racks[0], destination=self.sites[0])
         cra_2.validated_save()
 

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -397,6 +397,9 @@ class RelationshipAssociationTest(RelationshipBaseTest):
 
         self.assertEqual(cra_1.source, self.sites[1])
 
+        # Validate Exception not raised when calling .validated_save() on a RelationshipAssociation instance without making any update
+        cra_1.validated_save()
+
         # Assert Exception not raise updating source of RelationshipAssociation with one-to-one relationship type
         cra_2 = RelationshipAssociation(relationship=self.o2o_1, source=self.racks[0], destination=self.sites[0])
         cra_2.validated_save()

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -384,11 +384,11 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         for cra in self.invalid_relationship_associations:
             cra.validated_save()
 
-    def test_exception_not_raised_when_updating_instance_with_relationship_type_o2m_or_o21(self):
+    def test_exception_not_raised_when_updating_instance_with_relationship_type_o2o_or_o2m(self):
         """Validate 'Unable to create more than one relationship-association...' not raise when updating instance with
-        type one-to-one or one-to-many relationship."""
+        type one-to-one, symmetric-one-to-one, one-to-many relationship."""
 
-        # RelationshipAssociation with relationship type one-to-many
+        # Assert Exception not raise updating source of RelationshipAssociation with one-to-many relationship type
         cra_1 = RelationshipAssociation(relationship=self.o2m_1, source=self.sites[0], destination=self.vlans[1])
         cra_1.validated_save()
 
@@ -397,7 +397,7 @@ class RelationshipAssociationTest(RelationshipBaseTest):
 
         self.assertEqual(cra_1.source, self.sites[1])
 
-        # RelationshipAssociation with relationship type one-to-one
+        # Assert Exception not raise updating source of RelationshipAssociation with one-to-one relationship type
         cra_2 = RelationshipAssociation(relationship=self.o2o_1, source=self.racks[0], destination=self.sites[0])
         cra_2.validated_save()
 
@@ -405,6 +405,24 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         cra_2.validated_save()
 
         self.assertEqual(cra_2.source, self.racks[1])
+
+        # Assert Exception not raise updating destination of RelationshipAssociation with one-to-one relationship type
+        cra_3 = RelationshipAssociation(relationship=self.o2o_1, source=self.racks[2], destination=self.sites[2])
+        cra_3.validated_save()
+
+        cra_3.destination = self.sites[4]
+        cra_3.validated_save()
+
+        self.assertEqual(cra_3.destination, self.sites[4])
+
+        # Assert Exception not raise updating destination of RelationshipAssociation with symmetric-one-to-one relationship type
+        cra_4 = RelationshipAssociation(relationship=self.o2os_1, source=self.racks[0], destination=self.racks[2])
+        cra_4.validated_save()
+
+        cra_4.destination = self.racks[1]
+        cra_4.validated_save()
+
+        self.assertEqual(cra_4.destination, self.racks[1])
 
     def test_clean_wrong_type(self):
         # Create with the wrong source Type


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1771 
# What's Changed
- Fix exception raised when updating a RelationshipAssociation instance with type one-to-one or one-to-many
- Add relevant test case
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design