### PR TITLE
Persist active page when viewing live updating JobResult log entries

### DIFF
--- a/nautobot/extras/templates/django_ajax_tables/ajax_wrapper.html
+++ b/nautobot/extras/templates/django_ajax_tables/ajax_wrapper.html
@@ -18,8 +18,6 @@ Ref: https://github.com/nautobot/nautobot/issues/1289
                     // Store the query string in sessiong storage.
                     window.sessionStorage.setItem("job_results_current_page", new_querystring);
                     update_{{ ajax_divname }}(new_querystring, url);
-                    let qs = window.sessionStorage.getItem("job_results_current_page");
-                    console.log("SRC query= " + qs);
                 };
             }
         }
@@ -43,7 +41,7 @@ Ref: https://github.com/nautobot/nautobot/issues/1289
         xhr.send();
     }
 
-    // Remove any previous session data for storing curreng page.
+    // Remove any previous session data for storing current page. Session storage is unique per tab but not per page load.
     window.sessionStorage.removeItem("job_results_current_page");
     // Call update_ for the first time.
     update_{{ ajax_divname }}('', "{{ ajax_tableurl }}");

--- a/nautobot/extras/templates/django_ajax_tables/ajax_wrapper.html
+++ b/nautobot/extras/templates/django_ajax_tables/ajax_wrapper.html
@@ -1,0 +1,50 @@
+<!--
+This is a fork of `ajax_wrapper.html` from `django-ajax-tables` plugin core. It has been updated to store the current query string in session storage so that it may be passed along to persist current page in the log table while a job is running.
+
+Ref: https://github.com/nautobot/nautobot/issues/1289
+-->
+
+<div id="{{ ajax_divname }}"></div>
+
+<script type='text/javascript'>
+
+    function _replace_links_{{ ajax_divname }}(url, elements) {
+        for (var x = 0; x < elements.length; x++) {
+            var links = elements[x].getElementsByTagName('A');
+            for (var y = 0; y < links.length; y++) {
+                let new_querystring = links[y].getAttribute('href');
+                links[y].onclick = function(e) {
+                    e.preventDefault();
+                    // Store the query string in sessiong storage.
+                    window.sessionStorage.setItem("job_results_current_page", new_querystring);
+                    update_{{ ajax_divname }}(new_querystring, url);
+                    let qs = window.sessionStorage.getItem("job_results_current_page");
+                    console.log("SRC query= " + qs);
+                };
+            }
+        }
+    };
+
+    function update_{{ ajax_divname }}(querystring = '', url = "{{ ajax_tableurl }}") {
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState == XMLHttpRequest.DONE ) {
+                if (xhr.status == 200) {
+                    var div = document.getElementById('{{ ajax_divname }}');
+
+                    div.innerHTML = xhr.responseText;
+
+                    _replace_links_{{ ajax_divname }}(url, div.getElementsByTagName('TH'));
+                    _replace_links_{{ ajax_divname }}(url, div.getElementsByClassName('pagination'));
+                }
+            }
+        };
+        xhr.open('GET', url + querystring, true);
+        xhr.send();
+    }
+
+    // Remove any previous session data for storing curreng page.
+    window.sessionStorage.removeItem("job_results_current_page");
+    // Call update_ for the first time.
+    update_{{ ajax_divname }}('', "{{ ajax_tableurl }}");
+</script>

--- a/nautobot/extras/templates/django_ajax_tables/ajax_wrapper.html
+++ b/nautobot/extras/templates/django_ajax_tables/ajax_wrapper.html
@@ -1,5 +1,7 @@
 <!--
-This is a fork of `ajax_wrapper.html` from `django-ajax-tables` plugin core. It has been updated to store the current query string in session storage so that it may be passed along to persist current page in the log table while a job is running.
+This is a fork of `ajax_wrapper.html` from `django-ajax-tables` plugin core. It has been updated to
+store the current query string in session storage so that it may be passed along to persist current
+page in the log table while a job is running.
 
 Ref: https://github.com/nautobot/nautobot/issues/1289
 -->
@@ -8,6 +10,8 @@ Ref: https://github.com/nautobot/nautobot/issues/1289
 
 <script type='text/javascript'>
 
+    var session_key = "ajax_table_current_page";
+
     function _replace_links_{{ ajax_divname }}(url, elements) {
         for (var x = 0; x < elements.length; x++) {
             var links = elements[x].getElementsByTagName('A');
@@ -15,8 +19,8 @@ Ref: https://github.com/nautobot/nautobot/issues/1289
                 let new_querystring = links[y].getAttribute('href');
                 links[y].onclick = function(e) {
                     e.preventDefault();
-                    // Store the query string in sessiong storage.
-                    window.sessionStorage.setItem("job_results_current_page", new_querystring);
+                    // Store the query string in session storage.
+                    window.sessionStorage.setItem(session_key, new_querystring);
                     update_{{ ajax_divname }}(new_querystring, url);
                 };
             }
@@ -41,8 +45,9 @@ Ref: https://github.com/nautobot/nautobot/issues/1289
         xhr.send();
     }
 
-    // Remove any previous session data for storing current page. Session storage is unique per tab but not per page load.
-    window.sessionStorage.removeItem("job_results_current_page");
+    // Remove any previous session data for storing current page. Session storage is unique per tab
+    // but not per page load.
+    window.sessionStorage.removeItem(session_key);
     // Call update_ for the first time.
     update_{{ ajax_divname }}('', "{{ ajax_tableurl }}");
 </script>

--- a/nautobot/project-static/js/job_result.js
+++ b/nautobot/project-static/js/job_result.js
@@ -1,6 +1,7 @@
 var url = nautobot_api_path + "extras/job-results/";
 var timeout = 1000;
 var terminal_statuses = ['completed', 'failed', 'errored'];
+var session_key = "ajax_table_current_page";
 
 function updatePendingStatusLabel(status) {
     // Updates "Status" label in "Summary of Results" table in JobResult detail view.
@@ -25,7 +26,7 @@ function updatePendingStatusLabel(status) {
 function updateLogTable(result_id) {
     // Calls `update_log_table` to refresh the jobs table from the `/log-table/` endpoint
     // Grab the query string from session storage and pass it through to the log table.
-    let qs = window.sessionStorage.getItem("job_results_current_page");
+    let qs = window.sessionStorage.getItem(session_key) || "";
     update_log_table(qs, '/extras/job-results/' + result_id + '/log-table/');
 }
 
@@ -47,11 +48,11 @@ $(document).ready(function(){
                     updateLogTable(pending_result_id);
 
                     /// Should reload the page yet?
-                    let reload_page = window.sessionStorage.getItem("job_results_current_page") == null;
+                    let reload_page = window.sessionStorage.getItem(session_key) == null;
 
                     // If there is a terminal status, refresh the page and clear session storage.
                     if (terminal_statuses.includes(data.status.value)) {
-                        window.sessionStorage.removeItem("job_results_current_page");
+                        window.sessionStorage.removeItem(session_key);
                         reload_page && window.location.reload();
                     }
                     // Otherwise call myself again after `timeout`.

--- a/nautobot/project-static/js/job_result.js
+++ b/nautobot/project-static/js/job_result.js
@@ -51,8 +51,8 @@ $(document).ready(function(){
 
                     // If there is a terminal status, refresh the page and clear session storage.
                     if (terminal_statuses.includes(data.status.value)) {
-                        reload_page && window.location.reload();
                         window.sessionStorage.removeItem("job_results_current_page");
+                        reload_page && window.location.reload();
                     }
                     // Otherwise call myself again after `timeout`.
                     else {

--- a/nautobot/project-static/js/job_result.js
+++ b/nautobot/project-static/js/job_result.js
@@ -24,7 +24,9 @@ function updatePendingStatusLabel(status) {
 
 function updateLogTable(result_id) {
     // Calls `update_log_table` to refresh the jobs table from the `/log-table/` endpoint
-    update_log_table('', '/extras/job-results/' + result_id + '/log-table/');
+    // Grab the query string from session storage and pass it through to the log table.
+    let qs = window.sessionStorage.getItem("job_results_current_page");
+    update_log_table(qs, '/extras/job-results/' + result_id + '/log-table/');
 }
 
 $(document).ready(function(){
@@ -44,9 +46,13 @@ $(document).ready(function(){
                     // Update the job logs table
                     updateLogTable(pending_result_id);
 
-                    // If there is a terminal status, refresh the page.
+                    /// Should reload the page yet?
+                    let reload_page = window.sessionStorage.getItem("job_results_current_page") == null;
+
+                    // If there is a terminal status, refresh the page and clear session storage.
                     if (terminal_statuses.includes(data.status.value)) {
-                        window.location.reload();
+                        reload_page && window.location.reload();
+                        window.sessionStorage.removeItem("job_results_current_page");
                     }
                     // Otherwise call myself again after `timeout`.
                     else {


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1289 
# What's Changed
- This forks `ajax_wrapper.html` template file from `django-ajax-tables` plugin core, updating it to store the current query string in session storage so that it may be passed along to persist current page in the log table while a job is running.
- `job_result.js` was updated to retreive this stored session variable and pass it along to the `update_log_table()` JS function
  - Additionally, the session variable is cleared after the job has completed and only reloads the page if it never needed to clear the session variable

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design