### PR TITLE
Job testing enhancements.

### DIFF
--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -564,6 +564,8 @@ The simplest way to test the entire execution of Jobs from 1.3.3 on is via calli
 
 Because of the way `run_job_for_testing` and more specifically `run_job()` works, which is somewhat complex behind the scenes, you need to inherit from `nautobot.utilities.testing.TransactionTestCase` instead of `django.test.TestCase` (Refer to the [Django documentation](https://docs.djangoproject.com/en/stable/topics/testing/tools/#provided-test-case-classes) if you're interested in the differences between these classes - `TransactionTestCase` from Nautobot is a small wrapper around Django's `TransactionTestCase`).
 
+When using `TransactionTestCase` (whether from Django or from Nautobot) each tests runs on a completely empty database. Furthermore, Nautobot requires new jobs to be enabled before they can run. Therefore, we need to make sure the job is enabled before each run which `run_job_for_testing` handles for us.
+
 A simple example of a Job test case for 1.3.3 and forward might look like the following:
 
 ```python
@@ -576,9 +578,6 @@ class MyJobTestCase(TransactionTestCase):
         # Testing of Job "MyJob" in file "my_job_file.py" in $JOBS_ROOT
         job = Job.objects.get(job_class_name="MyJob", module_name="my_job_file", source="local")
         # or, job = Job.objects.get_for_class_path("local/my_job_file/MyJob")
-        # As tests run on a clean database each time, we need to make sure the job is enabled
-        job.enabled = True
-        job.validated_save()
         job_result = run_job_for_testing(job, data={}, commit=False)
 
         # Since we ran with commit=False, any database changes made by the job won't persist,

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -576,6 +576,9 @@ class MyJobTestCase(TransactionTestCase):
         # Testing of Job "MyJob" in file "my_job_file.py" in $JOBS_ROOT
         job = Job.objects.get(job_class_name="MyJob", module_name="my_job_file", source="local")
         # or, job = Job.objects.get_for_class_path("local/my_job_file/MyJob")
+        # As tests run on a clean database each time, we need to make sure the job is enabled
+        job.enabled = True
+        job.validated_save()
         job_result = run_job_for_testing(job, data={}, commit=False)
 
         # Since we ran with commit=False, any database changes made by the job won't persist,

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -24,12 +24,10 @@ User = get_user_model()
 
 
 def get_job_class_and_model(module, name):
-    """Test helper function to look up a job class and job model and ensure the latter is enabled."""
+    """Test helper function to look up a job class and job model."""
     class_path = f"local/{module}/{name}"
     job_class = get_job(class_path)
     job_model = Job.objects.get_for_class_path(class_path)
-    job_model.enabled = True
-    job_model.validated_save()
     return (job_class, job_model)
 
 
@@ -87,6 +85,8 @@ class JobTest(TransactionTestCase):
         module = "test_pass"
         name = "TestPass"
         job_class, job_model = get_job_class_and_model(module, name)
+        job_model.enabled = True
+        job_model.validated_save()
         job_content_type = ContentType.objects.get(app_label="extras", model="job")
         job_result = JobResult.objects.create(
             name=job_model.class_path,
@@ -455,6 +455,8 @@ class RunJobManagementCommandTest(CeleryTestCase):
         module = "test_pass"
         name = "TestPass"
         job_class, job_model = get_job_class_and_model(module, name)
+        job_model.enabled = True
+        job_model.validated_save()
 
         out, err = self.run_command(job_model.class_path)
         self.assertIn(f"Running {job_model.class_path}...", out)
@@ -472,6 +474,8 @@ class RunJobManagementCommandTest(CeleryTestCase):
         module = "test_modify_db"
         name = "TestModifyDB"
         job_class, job_model = get_job_class_and_model(module, name)
+        job_model.enabled = True
+        job_model.validated_save()
 
         out, err = self.run_command(job_model.class_path)
         self.assertIn(f"Running {job_model.class_path}...", out)
@@ -492,6 +496,8 @@ class RunJobManagementCommandTest(CeleryTestCase):
         module = "test_modify_db"
         name = "TestModifyDB"
         job_class, job_model = get_job_class_and_model(module, name)
+        job_model.enabled = True
+        job_model.validated_save()
         with self.assertRaises(CommandError):
             self.run_command("--commit", job_model.class_path)
 
@@ -500,6 +506,8 @@ class RunJobManagementCommandTest(CeleryTestCase):
         module = "test_modify_db"
         name = "TestModifyDB"
         job_class, job_model = get_job_class_and_model(module, name)
+        job_model.enabled = True
+        job_model.validated_save()
         with self.assertRaises(CommandError):
             self.run_command("--commit", "--username", "nosuchuser", job_model.class_path)
 
@@ -510,6 +518,8 @@ class RunJobManagementCommandTest(CeleryTestCase):
         module = "test_modify_db"
         name = "TestModifyDB"
         job_class, job_model = get_job_class_and_model(module, name)
+        job_model.enabled = True
+        job_model.validated_save()
 
         out, err = self.run_command("--commit", "--username", "test_user", job_model.class_path)
         self.assertIn(f"Running {job_model.class_path}...", out)

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -24,10 +24,12 @@ User = get_user_model()
 
 
 def get_job_class_and_model(module, name):
-    """Test helper function to look up a job class and job model."""
+    """Test helper function to look up a job class and job model and ensure the latter is enabled."""
     class_path = f"local/{module}/{name}"
     job_class = get_job(class_path)
     job_model = Job.objects.get_for_class_path(class_path)
+    job_model.enabled = True
+    job_model.validated_save()
     return (job_class, job_model)
 
 
@@ -455,8 +457,6 @@ class RunJobManagementCommandTest(CeleryTestCase):
         module = "test_pass"
         name = "TestPass"
         job_class, job_model = get_job_class_and_model(module, name)
-        job_model.enabled = True
-        job_model.validated_save()
 
         out, err = self.run_command(job_model.class_path)
         self.assertIn(f"Running {job_model.class_path}...", out)
@@ -474,8 +474,6 @@ class RunJobManagementCommandTest(CeleryTestCase):
         module = "test_modify_db"
         name = "TestModifyDB"
         job_class, job_model = get_job_class_and_model(module, name)
-        job_model.enabled = True
-        job_model.validated_save()
 
         out, err = self.run_command(job_model.class_path)
         self.assertIn(f"Running {job_model.class_path}...", out)
@@ -496,8 +494,6 @@ class RunJobManagementCommandTest(CeleryTestCase):
         module = "test_modify_db"
         name = "TestModifyDB"
         job_class, job_model = get_job_class_and_model(module, name)
-        job_model.enabled = True
-        job_model.validated_save()
         with self.assertRaises(CommandError):
             self.run_command("--commit", job_model.class_path)
 
@@ -506,8 +502,6 @@ class RunJobManagementCommandTest(CeleryTestCase):
         module = "test_modify_db"
         name = "TestModifyDB"
         job_class, job_model = get_job_class_and_model(module, name)
-        job_model.enabled = True
-        job_model.validated_save()
         with self.assertRaises(CommandError):
             self.run_command("--commit", "--username", "nosuchuser", job_model.class_path)
 
@@ -518,8 +512,6 @@ class RunJobManagementCommandTest(CeleryTestCase):
         module = "test_modify_db"
         name = "TestModifyDB"
         job_class, job_model = get_job_class_and_model(module, name)
-        job_model.enabled = True
-        job_model.validated_save()
 
         out, err = self.run_command("--commit", "--username", "test_user", job_model.class_path)
         self.assertIn(f"Running {job_model.class_path}...", out)

--- a/nautobot/utilities/testing/__init__.py
+++ b/nautobot/utilities/testing/__init__.py
@@ -62,6 +62,11 @@ def run_job_for_testing(job, data=None, commit=True, username="test-user", reque
     if data is None:
         data = {}
 
+    # Enable the job if it wasn't enabled before
+    if not job.enabled:
+        job.enabled = True
+        job.validated_save()
+
     # If the request has a user, ignore the username argument and use that user.
     if request and request.user:
         user_instance = request.user

--- a/nautobot/utilities/testing/__init__.py
+++ b/nautobot/utilities/testing/__init__.py
@@ -96,6 +96,9 @@ class TransactionTestCase(_TransactionTestCase):
     Base test case class using the TransactionTestCase for unit testing
     """
 
+    # 'job_logs' is a proxy connection to the same (default) database that's used exclusively for Job logging
+    databases = ("default", "job_logs")
+
     def setUp(self):
         """Provide a clean, post-migration state before each test case.
 


### PR DESCRIPTION
# Closes: #1763
# What's Changed

- Add a note in the job testing documentation about enabling jobs
- Add `databases = ("default", "job_logs")` to `nautobot.utilities.testing.TransactionTestCase`