### PR TITLE
fix prefix utilization over 100 percent (#1428)

### DIFF
--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -704,11 +704,10 @@ class Prefix(PrimaryModel, StatusModel):
             return UtilizationData(numerator=child_prefixes.size, denominator=self.prefix.size)
 
         else:
-            # Compile an IPSet to avoid counting duplicate IPs
-            child_count = netaddr.IPSet([ip.address.ip for ip in self.get_child_ips()]).size
             prefix_size = self.prefix.size
             if self.prefix.version == 4 and self.prefix.prefixlen < 31 and not self.is_pool:
                 prefix_size -= 2
+            child_count = prefix_size - self.get_available_ips().size
             return UtilizationData(numerator=child_count, denominator=prefix_size)
 
 

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -318,6 +318,10 @@ class TestPrefix(TestCase):
             # Create 32 IPAddresses within the Prefix
             [IPAddress(address=netaddr.IPNetwork("10.0.0.{}/24".format(i))) for i in range(1, 33)]
         )
+        # Create IPAddress objects for network and broadcast addresses
+        IPAddress.objects.bulk_create(
+            (IPAddress(address=netaddr.IPNetwork("10.0.0.0/32")), IPAddress(address=netaddr.IPNetwork("10.0.0.255/32")))
+        )
         self.assertEqual(prefix.get_utilization(), (32, 254))
 
     #


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1428
# What's Changed

IPv4 prefixes larger than /31 will no longer count the network and broadcast addresses in utilization calculations. Does not apply to prefixes that are containers or pools.

## Test Prefix

![image](https://user-images.githubusercontent.com/75227981/169593812-459b1566-c68c-4893-bced-786ea228f418.png)

## Before

![image](https://user-images.githubusercontent.com/75227981/169594298-d3b0a18b-f7d7-428a-b306-4298d01efb8d.png)

## After

![image](https://user-images.githubusercontent.com/75227981/169594517-1b6c6bcc-03fa-4aff-b508-d482b5a70eb4.png)

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design