### PR TITLE
Assert that if `untagged_vlan` is set, that `mode` must also be set on `[VM]Interface` objects

### DIFF
--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -499,11 +499,12 @@ class BaseInterface(RelationshipModel):
     class Meta:
         abstract = True
 
-    def save(self, *args, **kwargs):
-
+    def clean(self):
         # Remove untagged VLAN assignment for non-802.1Q interfaces
-        if not self.mode:
-            self.untagged_vlan = None
+        if not self.mode and self.untagged_vlan is not None:
+            raise ValidationError({"untagged_vlan": "Mode must be set when specifiying unagged_vlan"})
+
+    def save(self, *args, **kwargs):
 
         # Only "tagged" interfaces may have tagged VLANs assigned. ("tagged all" implies all VLANs are assigned.)
         if self.present_in_database and self.mode != InterfaceModeChoices.MODE_TAGGED:

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -1489,6 +1489,28 @@ class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
             },
         ]
 
+    def test_untagged_vlan_requires_mode(self):
+        """Test that when an `untagged_vlan` is specified, `mode` is also set."""
+        self.add_permissions("dcim.add_interface")
+
+        vlan = VLAN.objects.first()
+        device = Device.objects.first()
+
+        # This will fail.
+        data = {
+            "device": device.pk,
+            "name": "expected-to-fail",
+            "type": InterfaceTypeChoices.TYPE_VIRTUAL,
+            "untagged_vlan": vlan.pk,
+        }
+
+        url = self._get_list_url()
+        self.assertHttpStatus(self.client.post(url, data, format="json", **self.header), status.HTTP_400_BAD_REQUEST)
+
+        # Now let's add mode and it will work.
+        data["mode"] = InterfaceModeChoices.MODE_ACCESS
+        self.assertHttpStatus(self.client.post(url, data, format="json", **self.header), status.HTTP_201_CREATED)
+
 
 class FrontPortTest(APIViewTestCases.APIViewTestCase):
     model = FrontPort

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -355,7 +355,7 @@ $(document).ready(function() {
     if( $('select#id_mode').length > 0 ) {
         $('select#id_mode').on('change', function () {
             if ($(this).val() == '') {
-                $('select#id_untagged_vlan').val();
+                $('select#id_untagged_vlan').val('');
                 $('select#id_untagged_vlan').trigger('change');
                 $('select#id_tagged_vlans').val([]);
                 $('select#id_tagged_vlans').trigger('change');

--- a/nautobot/virtualization/tests/test_api.py
+++ b/nautobot/virtualization/tests/test_api.py
@@ -326,3 +326,24 @@ class VMInterfaceTest(APIViewTestCases.APIViewTestCase):
                 "untagged_vlan": vlans[2].pk,
             },
         ]
+
+    def test_untagged_vlan_requires_mode(self):
+        """Test that when an `untagged_vlan` is specified, `mode` is also set."""
+        self.add_permissions("virtualization.add_vminterface")
+
+        vlan = VLAN.objects.first()
+        virtual_machine = VirtualMachine.objects.first()
+
+        # This will fail.
+        data = {
+            "virtual_machine": virtual_machine.pk,
+            "name": "expected-to-fail",
+            "untagged_vlan": vlan.pk,
+        }
+
+        url = self._get_list_url()
+        self.assertHttpStatus(self.client.post(url, data, format="json", **self.header), status.HTTP_400_BAD_REQUEST)
+
+        # Now let's add mode and it will work.
+        data["mode"] = InterfaceModeChoices.MODE_ACCESS
+        self.assertHttpStatus(self.client.post(url, data, format="json", **self.header), status.HTTP_201_CREATED)


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #895 
# What's Changed
- `BaseInterface.save()` no longer explicitly unsets `untagged_vlan` if `mode` is not set
  - This logic was moved from `BaseInterface.save()` to `BaseInterface.clean()` and instead of unsetting `untagged_vlan` a `ValidationError` is now raised
- The UI form code in `forms.js` for handling display toggle of the `untagged_vlan` field if `mode` is set will now clear `untagged_vlan` value when `mode` is unset
- The `validate()` methods for `VMInterfaceSerializer` and `InterfaceSerializer` will now bubble up the `ValidationError` raised from `BaseInterface.clean()`

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design