### PR TITLE
Git proxy configuration

### DIFF
--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -532,8 +532,9 @@ HTTP_PROXIES = {
     When using Git repositories within Nautobot the Python library `GitPython` needs extra proxy configuration:
 
 ```bash
-git config --global http.proxy http://10.10.1.10:3128
-git con
+git config --global http.proxy http://192.0.2.1:3128
+git config --global https.proxy http://192.0.2.1:3128
+```
 
 ---
 

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -528,6 +528,13 @@ HTTP_PROXIES = {
 }
 ```
 
+!!! note
+    When using Git repositories within Nautobot the Python library `GitPython` needs extra proxy configuration:
+
+```bash
+git config --global http.proxy http://10.10.1.10:3128
+git con
+
 ---
 
 ## INTERNAL_IPS


### PR DESCRIPTION
# Closes: #1796
# What's Changed
Additional comment about proxy configuration to get `GitPython` (Git) working within Nautobot.