### PR TITLE
fix napalm enable password optional arg for eos driver

### DIFF
--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -502,7 +502,12 @@ class DeviceViewSet(ConfigContextQuerySetMixin, StatusViewSetMixin, CustomFieldM
         # Get NAPALM enable-secret from the device if present
         if device.secrets_group:
             try:
-                optional_args["secret"] = device.secrets_group.get_secret_value(
+                # Work around inconsistent enable password arg in NAPALM drivers
+                enable_password_arg = "secret"
+                if device.platform.napalm_driver.lower() == "eos":
+                    enable_password_arg = "enable_password"
+
+                optional_args[enable_password_arg] = device.secrets_group.get_secret_value(
                     SecretsGroupAccessTypeChoices.TYPE_GENERIC,
                     SecretsGroupSecretTypeChoices.TYPE_SECRET,
                     obj=device,


### PR DESCRIPTION
# Closes: #1290
# What's Changed

- NAPALM eos driver uses optional_arg `enable_password` for eos driver instead of the `secret` arg used by ios and nxos_ssh. Set the correct optional arg for devices using eos driver

## BEFORE: dcim/devices napalm endpoint returns an error

![image](https://user-images.githubusercontent.com/75227981/169846615-40de0a95-fe53-4ef5-b5f7-32a5e71102f6.png)

## AFTER: dcim/devices napalm endpoint returns expected device data

![image](https://user-images.githubusercontent.com/75227981/169846641-d8b2beeb-7f30-4dd4-90fe-05430a7237d8.png)

# TODO
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- N/A Unit, Integration Tests
- N/A Documentation Updates (when adding/changing features)
- N/A Example Plugin Updates (when adding/changing features)
- N/A Outline Remaining Work, Constraints from Design