### PR TITLE
add windows development section to development/getting-started docs

### DIFF
--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -115,7 +115,7 @@ Getting started with Nautobot development is pretty straightforward, and should 
 
 ### Windows Development
 
-Local development on Windows Subsystem for Linux (WSL) is not currently supported. When developing locally on Windows, we recommended
+Local development on Windows Subsystem for Linux (WSL) is not currently supported. When developing locally on Windows, we recommend
 using a virtual machine running an [officially supported operating system](../../installation/#installing-nautobot-dependencies).
 
 ### Docker Compose Workflow

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -113,6 +113,11 @@ $ ln -s ../../scripts/git-hooks/pre-commit
 
 Getting started with Nautobot development is pretty straightforward, and should feel very familiar to anyone with Django development experience. We can recommend either a [Docker Compose workflow](#docker-compose-workflow) (if you don't want to install dependencies such as PostgreSQL and Redis directly onto your system) or a [Python virtual environment workflow](#python-virtual-environment-workflow).
 
+### Windows Development
+
+Local development on Windows Subsystem for Linux (WSL) is not currently supported. When developing locally on Windows, we recommended
+using a virtual machine running an [officially supported operating system](../../installation/#installing-nautobot-dependencies).
+
 ### Docker Compose Workflow
 
 This workflow uses [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/) and assumes that you have them installed.


### PR DESCRIPTION
# Closes: DNE
# What's Changed

Add section to let developers know that Nautobot development in WSL is a bad idea. I put this in its own subsection so that it stands out, it could get lost if it's in a tip or note block.

![image](https://user-images.githubusercontent.com/75227981/170117991-1941be6c-6946-4869-aaf2-1255354f6d9a.png)


# TODO
