### PR TITLE
Handle NoReverseMatch exception when related views for action_buttons don't exist

### DIFF
--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -189,11 +189,13 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
     def validate_action_buttons(self):
         """Verify actions in self.action_buttons are valid view actions. Raise exception if not valid"""
 
-        # export is excluded because it's not a view
+        # ignore_actions are excluded because they are not view actions
+        ignore_actions = ["export", "delete"]
+
         invalid_actions = [
             action
             for action in self.action_buttons
-            if action != "export" and validated_viewname(self.queryset.model, action) is None
+            if action not in ignore_actions and validated_viewname(self.queryset.model, action) is None
         ]
         if invalid_actions:
             raise NoReverseMatch(f"Path for {', '.join(invalid_actions)} views are missing")

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -194,7 +194,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
             if validated_viewname(self.queryset.model, action_button) is None
         ]
         if invalid_buttons:
-            raise NoReverseMatch(f"path for {', '.join(invalid_buttons)} views are missing")
+            raise NoReverseMatch(f"Path for {', '.join(invalid_buttons)} views are missing")
 
     def get(self, request):
 

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -190,7 +190,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
         """Verify actions in self.action_buttons are valid view actions. Raise exception if not valid"""
 
         # ignore_actions are excluded because they are not view actions
-        ignore_actions = ["export", "delete"]
+        ignore_actions = ("export",)
 
         invalid_actions = [
             action

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -188,13 +188,15 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
 
     def validate_action_buttons(self):
         """Verify actions in self.action_buttons are valid view actions. Raise exception if not valid"""
-        invalid_buttons = [
-            action_button
-            for action_button in self.action_buttons
-            if validated_viewname(self.queryset.model, action_button) is None
+
+        # export is excluded because it's not a view
+        invalid_actions = [
+            action
+            for action in self.action_buttons
+            if action != "export" and validated_viewname(self.queryset.model, action) is None
         ]
-        if invalid_buttons:
-            raise NoReverseMatch(f"Path for {', '.join(invalid_buttons)} views are missing")
+        if invalid_actions:
+            raise NoReverseMatch(f"Path for {', '.join(invalid_actions)} views are missing")
 
     def get(self, request):
 

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1212,7 +1212,7 @@ class ScheduledJobListView(generic.ObjectListView):
     table = tables.ScheduledJobTable
     filterset = filters.ScheduledJobFilterSet
     filterset_form = forms.ScheduledJobFilterForm
-    action_buttons = ("delete",)
+    action_buttons = ()
 
 
 class ScheduledJobBulkDeleteView(generic.BulkDeleteView):
@@ -1583,7 +1583,6 @@ class SecretsGroupListView(generic.ObjectListView):
     table = tables.SecretsGroupTable
     action_buttons = (
         "add",
-        "delete",
     )
 
 

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1581,9 +1581,7 @@ class SecretsGroupListView(generic.ObjectListView):
     filterset = filters.SecretsGroupFilterSet
     filterset_form = forms.SecretsGroupFilterForm
     table = tables.SecretsGroupTable
-    action_buttons = (
-        "add",
-    )
+    action_buttons = ("add",)
 
 
 class SecretsGroupView(generic.ObjectView):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1427 
# What's Changed
- Create a `validate_action_buttons` method in `ObjectListView`, which returns only valid view actions and alerts user of invalid view actions using Django messages framework
- Remove `delete` from all `action_buttons` because its an invalid view action

### Before
<img width="943" alt="Screenshot 2022-05-24 at 11 25 17 PM" src="https://user-images.githubusercontent.com/94907097/170142156-db569598-159b-4156-afb5-6ac4106c9fa9.png">

### After
<img width="1482" alt="Screenshot 2022-05-25 at 4 27 33 PM" src="https://user-images.githubusercontent.com/94907097/170300216-65a3a49c-e6a5-4541-857e-cb9dbe78f11e.png">




<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design