### PR TITLE
Fix footer italics for theme button

### DIFF
--- a/nautobot/core/templates/admin/base.html
+++ b/nautobot/core/templates/admin/base.html
@@ -169,7 +169,7 @@
                 </div>
                 <div class="col-xs-4 text-right noprint">
                     <p class="text-muted">
-                        <a href="#theme_modal" data-toggle="modal" data-target="#theme_modal" id="btn-theme-modal"><i class="mdi mdi-theme-light-dark text-primary">Theme</i></a> &middot;
+                        <a href="#theme_modal" data-toggle="modal" data-target="#theme_modal" id="btn-theme-modal"><i class="mdi mdi-theme-light-dark text-primary"></i>Theme</a> &middot;
                         <i class="mdi mdi-book-open-page-variant text-primary"></i>
                         {% if settings.BRANDING_URLS.docs %}
                             <a href="{{ settings.BRANDING_URLS.docs }}">Docs</a>

--- a/nautobot/core/templates/base.html
+++ b/nautobot/core/templates/base.html
@@ -88,7 +88,7 @@
                 </div>
                 <div class="col-xs-4 text-right noprint">
                     <p class="text-muted">
-                        <a href="#theme_modal" data-toggle="modal" data-target="#theme_modal" id="btn-theme-modal"><i class="mdi mdi-theme-light-dark text-primary">Theme</i></a> &middot;
+                        <a href="#theme_modal" data-toggle="modal" data-target="#theme_modal" id="btn-theme-modal"><i class="mdi mdi-theme-light-dark text-primary"></i>Theme</a> &middot;
                         <i class="mdi mdi-book-open-page-variant text-primary"></i>
                         {% if settings.BRANDING_URLS.docs %}
                             <a href="{{ settings.BRANDING_URLS.docs }}">Docs</a>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1815 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
In my recent Dark Mode PR, I accidentally left the word "Theme" italicized due to the incorrect positioning of the closing `</i>` tag.  This removes the Italicized styling from the word "Theme".


