### PR TITLE
fix none choice not showing on filter form after search

### DIFF
--- a/nautobot/utilities/forms/widgets.py
+++ b/nautobot/utilities/forms/widgets.py
@@ -169,7 +169,7 @@ class APISelect(SelectWithDisabled):
         # 3. if both value and choices are iterable
         if (
             self.attrs.get("data-null-option")
-            and isinstance(value, Iterable)
+            and isinstance(value, (list, tuple))
             and "null" in value
             and isinstance(self.choices, Iterable)
         ):

--- a/nautobot/utilities/forms/widgets.py
+++ b/nautobot/utilities/forms/widgets.py
@@ -163,7 +163,7 @@ class APISelectMultiple(APISelect, forms.SelectMultiple):
 
     def get_context(self, name, value, attrs):
 
-        # This adds None options to DynamicModelMultipleChoiceField selected choices
+        # This adds null options to DynamicModelMultipleChoiceField selected choices
         # example <select ..>
         #           <option .. selected value="null">None</option>
         #           <option .. selected value="1234-455...">Rack 001</option>

--- a/nautobot/utilities/forms/widgets.py
+++ b/nautobot/utilities/forms/widgets.py
@@ -169,7 +169,7 @@ class APISelectMultiple(APISelect, forms.SelectMultiple):
         #           <option .. selected value="1234-455...">Rack 001</option>
         #           <option .. value="1234-455...">Rack 002</option>
         #          </select>
-        # Prepend None choice to self.choices if
+        # Prepend null choice to self.choices if
         # 1. form field allow null_option e.g. DynamicModelMultipleChoiceField(..., null_option="None"..)
         # 2. if null is part of url query parameter for name(field_name) i.e. http://.../?rack_id=null
         # 3. if both value and choices are iterable

--- a/nautobot/utilities/forms/widgets.py
+++ b/nautobot/utilities/forms/widgets.py
@@ -155,13 +155,6 @@ class APISelect(SelectWithDisabled):
 
         self.attrs[key] = json.dumps(values, ensure_ascii=False)
 
-
-class APISelectMultiple(APISelect, forms.SelectMultiple):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.attrs["data-multiple"] = 1
-
     def get_context(self, name, value, attrs):
 
         # This adds null options to DynamicModelMultipleChoiceField selected choices
@@ -198,6 +191,13 @@ class APISelectMultiple(APISelect, forms.SelectMultiple):
             self.choices = choices
 
         return super().get_context(name, value, attrs)
+
+
+class APISelectMultiple(APISelect, forms.SelectMultiple):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.attrs["data-multiple"] = 1
 
 
 class DatePicker(forms.TextInput):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1524 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

### First Search
<img width="1393" alt="Screenshot 2022-05-26 at 11 37 01 PM" src="https://user-images.githubusercontent.com/94907097/170591486-3c36ab8e-73f4-4853-bb05-bdde760f25b9.png">

### Subsequent Search
**Before**:  Only values` != None` where retained and None missing from Rack filter field
<img width="1409" alt="Screenshot 2022-05-26 at 11 38 50 PM" src="https://user-images.githubusercontent.com/94907097/170591618-4f94ad03-1327-4ffb-a301-f841762e43fc.png">


**After**
<img width="1410" alt="Screenshot 2022-05-26 at 11 37 59 PM" src="https://user-images.githubusercontent.com/94907097/170591654-a3e0a8d3-c7ff-499c-9da2-8618f6d80137.png">




# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design