### PR TITLE
Resolve missing menu 'General / Installed Plugins' in navbar if HIDE RESTRICTED UI is activated

### DIFF
--- a/nautobot/extras/plugins/views.py
+++ b/nautobot/extras/plugins/views.py
@@ -19,9 +19,10 @@ from nautobot.core.api.views import NautobotAPIVersionMixin
 from nautobot.utilities.forms import TableConfigForm
 from nautobot.utilities.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.extras.plugins.tables import InstalledPluginsTable
+from nautobot.utilities.views import RestrictedUIPermissionMixin
 
 
-class InstalledPluginsView(LoginRequiredMixin, View):
+class InstalledPluginsView(RestrictedUIPermissionMixin, View):
     """
     View for listing all installed plugins.
     """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1769 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
- Create `RestrictedUIPermissionMixin` permission mixin which grants access to UI if user is `staff`/`super user` or `HIDE_RESTRICTED_UI` is set to `False`
  - Implement `RestrictedUIPermissionMixin` in `InstalledPluginsView`


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design