### PR TITLE
hide search bar if user is not auth and hide_restricted_ui is True

### DIFF
--- a/nautobot/core/templates/home.html
+++ b/nautobot/core/templates/home.html
@@ -15,7 +15,9 @@
 
 
 {% block content %}
-    {% include 'search_form.html' %}
+    {% if request.user.is_authenticated or not "HIDE_RESTRICTED_UI"|settings_or_config %}
+        {% include 'search_form.html' %}
+    {% endif %}
     <div class="row">
         <div class="col-sm-12">
             <div class="homepage_column" style="columns: 4 360px">

--- a/nautobot/core/templates/inc/nav_menu.html
+++ b/nautobot/core/templates/inc/nav_menu.html
@@ -107,16 +107,18 @@
                     {% endif %}
                 {% endif %}
             </ul>
-            <form action="{% url 'search' %}" method="get" class="navbar-form navbar-right" id="navbar_search" role="search">
-                <div class="input-group">
-                    <input type="text" name="q" class="form-control" placeholder="Search">
-                    <span class="input-group-btn">
-                        <button type="submit" class="btn btn-primary">
-                            <i class="mdi mdi-magnify"></i>
-                        </button>
-                    </span>
-                </div>
-            </form>
+            {% if request.user.is_authenticated or not "HIDE_RESTRICTED_UI"|settings_or_config %}
+                <form action="{% url 'search' %}" method="get" class="navbar-form navbar-right" id="navbar_search" role="search">
+                    <div class="input-group">
+                        <input type="text" name="q" class="form-control" placeholder="Search">
+                        <span class="input-group-btn">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="mdi mdi-magnify"></i>
+                            </button>
+                        </span>
+                    </div>
+                </form>
+            {% endif %}
         </div>
     </div>
 </nav>

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -1,3 +1,4 @@
+import re
 import urllib.parse
 
 from django.conf import settings
@@ -24,6 +25,59 @@ class HomeViewTestCase(TestCase):
 
         response = self.client.get("{}?{}".format(url, urllib.parse.urlencode(params)))
         self.assertHttpStatus(response, 200)
+
+    def make_request(self):
+        url = reverse("home")
+        response = self.client.get(url)
+
+        # Search bar in nav
+        nav_search_bar_pattern = re.compile(
+            '<nav.*<form action="/search/" method="get" class="navbar-form navbar-right" id="navbar_search" role="search">.*</form>.*</nav>'
+        )
+        nav_search_bar_result = nav_search_bar_pattern.search(
+            response.content.decode(response.charset).replace("\n", "")
+        )
+
+        # Global search bar in body/container-fluid wrapper
+        body_search_bar_pattern = re.compile(
+            '<div class="container-fluid wrapper">.*<form action="/search/" method="get" class="form-inline">.*</form>.*</div>'
+        )
+        body_search_bar_result = body_search_bar_pattern.search(
+            response.content.decode(response.charset).replace("\n", "")
+        )
+
+        return nav_search_bar_result, body_search_bar_result
+
+    @override_settings(HIDE_RESTRICTED_UI=True)
+    def test_search_bar_not_visible_if_user_not_authenticated_and_hide_restricted_ui_True(self):
+        self.client.logout()
+
+        nav_search_bar_result, body_search_bar_result = self.make_request()
+
+        self.assertIsNone(nav_search_bar_result)
+        self.assertIsNone(body_search_bar_result)
+
+    @override_settings(HIDE_RESTRICTED_UI=False)
+    def test_search_bar_visible_if_user_authenticated_and_hide_restricted_ui_True(self):
+        nav_search_bar_result, body_search_bar_result = self.make_request()
+
+        self.assertIsNotNone(nav_search_bar_result)
+        self.assertIsNotNone(body_search_bar_result)
+
+    @override_settings(HIDE_RESTRICTED_UI=False)
+    def test_search_bar_visible_if_hide_restricted_ui_False(self):
+        # Assert if user is authenticated
+        nav_search_bar_result, body_search_bar_result = self.make_request()
+
+        self.assertIsNotNone(nav_search_bar_result)
+        self.assertIsNotNone(body_search_bar_result)
+
+        # Assert if user is logout
+        self.client.logout()
+        nav_search_bar_result, body_search_bar_result = self.make_request()
+
+        self.assertIsNotNone(nav_search_bar_result)
+        self.assertIsNotNone(body_search_bar_result)
 
 
 class ForceScriptNameTestcase(TestCase):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1645 
Hide search bar in nav and body if user is not authenticated and `HIDE_RESTRICTED_UI=True`
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design