### PR TITLE
Hanlin unable to navigate away from rack changelog #1850

### DIFF
--- a/nautobot/dcim/templates/dcim/rack.html
+++ b/nautobot/dcim/templates/dcim/rack.html
@@ -339,5 +339,6 @@
 {% endblock content_right_page %}
 
 {% block javascript %}
+    {{block.super}}
     <script src="{% static 'js/rack_elevations.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock javascript %}

--- a/nautobot/ipam/homepage.py
+++ b/nautobot/ipam/homepage.py
@@ -12,7 +12,7 @@ layout = (
                 link="ipam:vrf_list",
                 model=VRF,
                 description="Virtual routing and forwarding tables",
-                permissions=["circuits.view_vrf"],
+                permissions=["ipam.view_vrf"],
                 weight=100,
             ),
             HomePageItem(

--- a/nautobot/ipam/homepage.py
+++ b/nautobot/ipam/homepage.py
@@ -12,7 +12,7 @@ layout = (
                 link="ipam:vrf_list",
                 model=VRF,
                 description="Virtual routing and forwarding tables",
-                permissions=["ipam.view_vrf"],
+                permissions=["circuits.view_vrf"],
                 weight=100,
             ),
             HomePageItem(


### PR DESCRIPTION
# Closes: #1850
# What's Changed
Added {{block.super}} to negate the override from the js block in rack.html. This change fixed the issue of unable to navigate away from rack changelog tab.