### PR TITLE
Solved customfield default value not showing up upon device creation

### DIFF
--- a/nautobot/dcim/models/device_component_templates.py
+++ b/nautobot/dcim/models/device_component_templates.py
@@ -86,9 +86,10 @@ class ComponentTemplateModel(BaseModel, CustomFieldModel, RelationshipModel):
         Helper method to self.instantiate().
         """
         content_type = ContentType.objects.get_for_model(model)
-        fields = CustomField.objects.filter(pk=content_type.pk)
+        fields = CustomField.objects.filter(content_types=content_type)
         for field in fields:
             self._custom_field_data.setdefault(field.name, field.default)
+            print(field.name, field.default)
             self.save()
         return model(device=device, name=self.name, label=self.label, description=self.description, _custom_field_data=self._custom_field_data, **kwargs)
 

--- a/nautobot/dcim/models/device_component_templates.py
+++ b/nautobot/dcim/models/device_component_templates.py
@@ -15,7 +15,7 @@ from nautobot.dcim.choices import (
 
 from nautobot.core.models import BaseModel
 from nautobot.dcim.constants import REARPORT_POSITIONS_MAX, REARPORT_POSITIONS_MIN
-from nautobot.extras.models import CustomFieldModel, ObjectChange, RelationshipModel, CustomField
+from nautobot.extras.models import CustomField, CustomFieldModel, ObjectChange, RelationshipModel
 from nautobot.extras.utils import extras_features
 from nautobot.utilities.fields import NaturalOrderingField
 from nautobot.utilities.ordering import naturalize_interface

--- a/nautobot/dcim/models/device_component_templates.py
+++ b/nautobot/dcim/models/device_component_templates.py
@@ -85,18 +85,18 @@ class ComponentTemplateModel(BaseModel, CustomFieldModel, RelationshipModel):
         """
         Helper method to self.instantiate().
         """
-        record = {}
+        custom_field_data = {}
         content_type = ContentType.objects.get_for_model(model)
         fields = CustomField.objects.filter(content_types=content_type)
         for field in fields:
-            record[field.name] = field.default
+            custom_field_data[field.name] = field.default
 
         return model(
             device=device,
             name=self.name,
             label=self.label,
             description=self.description,
-            _custom_field_data=record,
+            _custom_field_data=custom_field_data,
             **kwargs,
         )
 
@@ -263,7 +263,12 @@ class InterfaceTemplate(ComponentTemplateModel):
         unique_together = ("device_type", "name")
 
     def instantiate(self, device):
-        return self.instantiate_model(model=Interface, device=device, type=self.type, mgmt_only=self.mgmt_only)
+        return self.instantiate_model(
+            model=Interface,
+            device=device,
+            type=self.type,
+            mgmt_only=self.mgmt_only,
+        )
 
 
 @extras_features(

--- a/nautobot/dcim/models/device_component_templates.py
+++ b/nautobot/dcim/models/device_component_templates.py
@@ -91,7 +91,14 @@ class ComponentTemplateModel(BaseModel, CustomFieldModel, RelationshipModel):
             self._custom_field_data.setdefault(field.name, field.default)
             print(field.name, field.default)
             self.save()
-        return model(device=device, name=self.name, label=self.label, description=self.description, _custom_field_data=self._custom_field_data, **kwargs)
+        return model(
+            device=device,
+            name=self.name,
+            label=self.label,
+            description=self.description,
+            _custom_field_data=self._custom_field_data,
+            **kwargs,
+        )
 
 
 @extras_features(

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -62,13 +62,13 @@ class InterfaceTemplateCustomFieldTestCase(TestCase):
         interface_templates = [
             InterfaceTemplate.objects.create(
                 device_type=device_type,
-                name="Template_1",
+                name="Template 1",
                 type=InterfaceTypeChoices.TYPE_1GE_FIXED,
                 mgmt_only=True,
             ),
             InterfaceTemplate.objects.create(
                 device_type=device_type,
-                name="Template_2",
+                name="Template 2",
                 type=InterfaceTypeChoices.TYPE_1GE_FIXED,
                 mgmt_only=True,
             ),
@@ -78,7 +78,7 @@ class InterfaceTemplateCustomFieldTestCase(TestCase):
             device_type=device_type,
             device_role=device_role,
             status=statuses[0],
-            name="Device_01",
+            name="Test Device",
             site=site,
         )
         interfaces = Interface.objects.bulk_create(

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -8,7 +8,6 @@ from nautobot.dcim.choices import (
     PowerOutletFeedLegChoices,
     InterfaceTypeChoices,
     PortTypeChoices,
-    SiteStatusChoices,
 )
 from nautobot.dcim.models import (
     Cable,
@@ -49,7 +48,7 @@ class InterfaceTemplateCustomFieldTestCase(TestCase):
         Check that all _custom_field_data is present and all customfields are filled with the correct default values.
         """
         statuses = Status.objects.get_for_model(Device)
-        site = Site.objects.create(name="Site 1", slug="site-1", status=SiteStatusChoices.STATUS_ACTIVE)
+        site = Site.objects.create(name="Site 1", slug="site-1")
         manufacturer = Manufacturer.objects.create(name="Acme", slug="acme")
         device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1", color="ff0000")
         custom_field_1 = CustomField.objects.create(

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -58,7 +58,7 @@ class InterfaceTemplateCustomFieldTestCase(TestCase):
             type=CustomFieldTypeChoices.TYPE_TEXT, name="field_3", default="value_3"
         )
         custom_field_3.content_types.set([ContentType.objects.get_for_model(Interface)])
-
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="FrameForwarder 2048", slug="ff2048")
         interface_templates = [
             InterfaceTemplate.objects.create(
                 device_type=device_type,
@@ -73,7 +73,6 @@ class InterfaceTemplateCustomFieldTestCase(TestCase):
                 mgmt_only=True,
             ),
         ]
-        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="FrameForwarder 2048", slug="ff2048")
         device_type.interfacetemplates.set(interface_templates)
         device = Device.objects.create(
             device_type=device_type,

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -36,8 +36,8 @@ from nautobot.extras.models.customfields import CustomField
 from nautobot.tenancy.models import Tenant
 from nautobot.extras.choices import CustomFieldTypeChoices
 
-class InterfaceTemplateCustomFieldTestCase(TestCase):
 
+class InterfaceTemplateCustomFieldTestCase(TestCase):
     def test_instantiate_model(self):
         """
         Check that all _custom_field_data is present and all customfields are filled with the correct default values.
@@ -46,11 +46,17 @@ class InterfaceTemplateCustomFieldTestCase(TestCase):
         site = Site.objects.create(name="Site 1", slug="site-1")
         manufacturer = Manufacturer.objects.create(name="Acme", slug="acme")
         device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1", color="ff0000")
-        custom_field_1 = CustomField.objects.create(type=CustomFieldTypeChoices.TYPE_TEXT, name="field_1", default="value_1")
+        custom_field_1 = CustomField.objects.create(
+            type=CustomFieldTypeChoices.TYPE_TEXT, name="field_1", default="value_1"
+        )
         custom_field_1.content_types.set([ContentType.objects.get_for_model(Interface)])
-        custom_field_2 = CustomField.objects.create(type=CustomFieldTypeChoices.TYPE_TEXT, name="field_2", default="value_2")
+        custom_field_2 = CustomField.objects.create(
+            type=CustomFieldTypeChoices.TYPE_TEXT, name="field_2", default="value_2"
+        )
         custom_field_2.content_types.set([ContentType.objects.get_for_model(Interface)])
-        custom_field_3 = CustomField.objects.create(type=CustomFieldTypeChoices.TYPE_TEXT, name="field_3", default="value_3")
+        custom_field_3 = CustomField.objects.create(
+            type=CustomFieldTypeChoices.TYPE_TEXT, name="field_3", default="value_3"
+        )
         custom_field_3.content_types.set([ContentType.objects.get_for_model(Interface)])
 
         interface_templates = [
@@ -60,7 +66,7 @@ class InterfaceTemplateCustomFieldTestCase(TestCase):
                 type=InterfaceTypeChoices.TYPE_1GE_FIXED,
                 mgmt_only=True,
             ),
-             InterfaceTemplate.objects.create(
+            InterfaceTemplate.objects.create(
                 device_type=device_type,
                 name="Template_2",
                 type=InterfaceTypeChoices.TYPE_1GE_FIXED,
@@ -76,13 +82,16 @@ class InterfaceTemplateCustomFieldTestCase(TestCase):
             name="Device_01",
             site=site,
         )
-        interfaces = Interface.objects.bulk_create([template.instantiate(device) for template in device_type.interfacetemplates.all()])
+        interfaces = Interface.objects.bulk_create(
+            [template.instantiate(device) for template in device_type.interfacetemplates.all()]
+        )
         self.assertEqual(Interface.objects.get(pk=interfaces[0].pk, device=device).cf["field_1"], "value_1")
         self.assertEqual(Interface.objects.get(pk=interfaces[0].pk, device=device).cf["field_2"], "value_2")
         self.assertEqual(Interface.objects.get(pk=interfaces[0].pk, device=device).cf["field_3"], "value_3")
         self.assertEqual(Interface.objects.get(pk=interfaces[1].pk, device=device).cf["field_1"], "value_1")
         self.assertEqual(Interface.objects.get(pk=interfaces[1].pk, device=device).cf["field_2"], "value_2")
         self.assertEqual(Interface.objects.get(pk=interfaces[1].pk, device=device).cf["field_3"], "value_3")
+
 
 class RackGroupTestCase(TestCase):
     def test_change_rackgroup_site(self):

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -5,9 +5,9 @@ from django.contrib.contenttypes.models import ContentType
 from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, Provider, ProviderNetwork
 from nautobot.dcim.choices import (
     DeviceFaceChoices,
-    PowerOutletFeedLegChoices,
     InterfaceTypeChoices,
     PortTypeChoices,
+    PowerOutletFeedLegChoices,
 )
 from nautobot.dcim.models import (
     Cable,
@@ -36,10 +36,9 @@ from nautobot.dcim.models import (
     RearPortTemplate,
     Site,
 )
-from nautobot.extras.models import Status
-from nautobot.extras.models.customfields import CustomField
-from nautobot.tenancy.models import Tenant
 from nautobot.extras.choices import CustomFieldTypeChoices
+from nautobot.extras.models import CustomField, Status
+from nautobot.tenancy.models import Tenant
 
 
 class InterfaceTemplateCustomFieldTestCase(TestCase):
@@ -51,18 +50,13 @@ class InterfaceTemplateCustomFieldTestCase(TestCase):
         site = Site.objects.create(name="Site 1", slug="site-1")
         manufacturer = Manufacturer.objects.create(name="Acme", slug="acme")
         device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1", color="ff0000")
-        custom_field_1 = CustomField.objects.create(
-            type=CustomFieldTypeChoices.TYPE_TEXT, name="field_1", default="value_1"
-        )
-        custom_field_1.content_types.set([ContentType.objects.get_for_model(Interface)])
-        custom_field_2 = CustomField.objects.create(
-            type=CustomFieldTypeChoices.TYPE_TEXT, name="field_2", default="value_2"
-        )
-        custom_field_2.content_types.set([ContentType.objects.get_for_model(Interface)])
-        custom_field_3 = CustomField.objects.create(
-            type=CustomFieldTypeChoices.TYPE_TEXT, name="field_3", default="value_3"
-        )
-        custom_field_3.content_types.set([ContentType.objects.get_for_model(Interface)])
+        custom_fields = [
+            CustomField.objects.create(type=CustomFieldTypeChoices.TYPE_TEXT, name="field_1", default="value_1"),
+            CustomField.objects.create(type=CustomFieldTypeChoices.TYPE_TEXT, name="field_2", default="value_2"),
+            CustomField.objects.create(type=CustomFieldTypeChoices.TYPE_TEXT, name="field_3", default="value_3"),
+        ]
+        for custom_field in custom_fields:
+            custom_field.content_types.set([ContentType.objects.get_for_model(Interface)])
         device_type = DeviceType.objects.create(manufacturer=manufacturer, model="FrameForwarder 2048", slug="ff2048")
         interface_template_1 = InterfaceTemplate.objects.create(
             device_type=device_type,


### PR DESCRIPTION
The steps to reproduce the error now creates a device with default_values populated on the custom_fields. However, there are still some bugs to work out.
<img width="1148" alt="Screen Shot 2022-06-13 at 10 26 30 PM" src="https://user-images.githubusercontent.com/46973263/17348052
<img width="1215" alt="Screen Shot 2022-06-13 at 10 28 54 PM" src="https://user-images.githubusercontent.com/46973263/173480705-0f74e3c3-969a-437f-9501-b6d1f68b7579.png">
5-8d41dcd7-05f0-4a48-96cb-adb4cefd9238.png">

