### PR TITLE
Fix #1898 - Browsable API is now styled like the rest of the app

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -290,7 +290,7 @@ INSTALLED_APPS = [
     "nautobot.core",
     "django.contrib.admin",  # Must be after `nautobot.core` for template overrides
     "django_celery_beat",  # Must be after `nautobot.core` for template overrides
-    "rest_framework",  # Must be after `nautobot.core` for template overrides templates
+    "rest_framework",  # Must be after `nautobot.core` for template overrides
     "db_file_storage",
     "nautobot.circuits",
     "nautobot.dcim",

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -283,14 +283,14 @@ INSTALLED_APPS = [
     "django_tables2",
     "django_prometheus",
     "mptt",
-    "rest_framework",
     "social_django",
     "taggit",
     "timezone_field",
     "nautobot.core.apps.NautobotConstanceConfig",  # overridden form of "constance" AppConfig
     "nautobot.core",
-    "django.contrib.admin",  # Needs to after `nautobot.core` to so templates can be overridden
-    "django_celery_beat",  # Needs to after `nautobot.core` to so templates can be overridden
+    "django.contrib.admin",  # Must be after `nautobot.core` for template overrides
+    "django_celery_beat",  # Must be after `nautobot.core` for template overrides
+    "rest_framework",  # Must be after `nautobot.core` for template overrides templates
     "db_file_storage",
     "nautobot.circuits",
     "nautobot.dcim",

--- a/nautobot/core/templates/base.html
+++ b/nautobot/core/templates/base.html
@@ -6,40 +6,7 @@
 <html lang="en">
 <head>
     <title>{% block title %}Home{% endblock %} - {{ settings.BRANDING_TITLE }}</title>
-    <link rel="stylesheet"
-          href="{% static 'bootstrap-3.4.1-dist/css/bootstrap.min.css' %}"
-          onerror="window.location='{% url 'media_failure' %}?filename=bootstrap-3.4.1-dist/css/bootstrap.min.css'">
-    <link rel="stylesheet"
-          href="{% static 'materialdesignicons-6.5.95/css/materialdesignicons.min.css' %}"
-          onerror="window.location='{% url 'media_failure' %}?filename=materialdesignicons-6.5.95/css/materialdesignicons.min.css'">
-    <link rel="stylesheet"
-          href="{% static 'jquery-ui-1.13.1/jquery-ui.min.css' %}"
-          onerror="window.location='{% url 'media_failure' %}?filename=jquery-ui-1.13.1/jquery-ui.min.css'">
-    <link rel="stylesheet"
-          href="{% static 'select2-4.0.13/select2.min.css' %}"
-          onerror="window.location='{% url 'media_failure' %}?filename=select2-4.0.13/select2.min.css'">
-    <link rel="stylesheet"
-          href="{% static 'select2-bootstrap-0.1.0-beta.10/select2-bootstrap.min.css' %}"
-          onerror="window.location='{% url 'media_failure' %}?filename=select2-bootstrap-0.1.0-beta.10/select2-bootstrap.min.css'">
-    <link rel="stylesheet"
-          href="{% static 'flatpickr-4.6.9/themes/light.min.css' %}"
-          onerror="window.location='{% url 'media_failure' %}?filename=flatpickr-4.6.9/themes/light.min.css'">
-    <link rel="stylesheet" id="dark-theme"
-          href="{% static 'css/dark.css' %}?v{{ settings.VERSION }}"
-          onerror="window.location='{% url 'media_failure' %}?filename=css/dark.css'" disabled="disabled" />
-    <link rel="stylesheet"
-          href="{% static 'css/base.css' %}?v{{ settings.VERSION }}"
-          onerror="window.location='{% url 'media_failure' %}?filename=css/base.css'">
-    <link rel="apple-touch-icon" sizes="180x180" href="{% custom_branding_or_static 'icon_180' 'img/nautobot_icon_180x180.png' %}">
-    <link rel="icon" type="image/png" sizes="32x32" href="{% custom_branding_or_static 'icon_32' 'img/nautobot_icon_32x32.png' %}">
-    <link rel="icon" type="image/png" sizes="16x16" href="{% custom_branding_or_static 'icon_16' 'img/nautobot_icon_16x16.png' %}">
-    <link rel="icon" type="image/png" sizes="192x192" href="{% custom_branding_or_static 'icon_192' 'img/nautobot_icon_192x192.png' %}">
-    <link rel="mask-icon" type="image/png" color="#0097ff" href="{% custom_branding_or_static 'icon_mask' 'img/nautobot_icon_monochrome.png' %}">
-    <link rel="shortcut icon" href="{% custom_branding_or_static 'favicon' 'img/favicon.ico' %}">
-    <meta name="msapplication-TileColor" content="#2d89ef">
-    <meta name="theme-color" content="#ffffff">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width">
+    {% include 'inc/media.html' %}
     {% block extra_styles %}{% endblock %}
 </head>
 <body>
@@ -74,72 +41,9 @@
             </div>
         {% endif %}
     </div>
-    <footer class="footer">
-        <div class="container-fluid">
-            <div class="row">
-                <div class="col-xs-4">
-                    <p class="text-muted">
-                        {% if settings.BRANDING_FILEPATHS.logo and settings.BRANDING_POWERED_BY_URL %}<a href="{{ settings.BRANDING_POWERED_BY_URL }}"><img src="{% static 'img/nautobot_logo.svg' %}" height="20" /> Powered</a> &middot;{% endif %}
-                        {{ settings.HOSTNAME }} (v{{ settings.VERSION }})
-                    </p>
-                </div>
-                <div class="col-xs-4 text-center">
-                    <p class="text-muted">{% now 'Y-m-d H:i:s T' %}</p>
-                </div>
-                <div class="col-xs-4 text-right noprint">
-                    <p class="text-muted">
-                        <a href="#theme_modal" data-toggle="modal" data-target="#theme_modal" id="btn-theme-modal"><i class="mdi mdi-theme-light-dark text-primary"></i>Theme</a> &middot;
-                        <i class="mdi mdi-book-open-page-variant text-primary"></i>
-                        {% if settings.BRANDING_URLS.docs %}
-                            <a href="{{ settings.BRANDING_URLS.docs }}">Docs</a>
-                        {% else %}
-                            <a href="{% static 'docs/index.html' %}">Docs</a>
-                        {% endif %}
-                        &middot;
-                        <i class="mdi mdi-cloud-braces text-primary"></i> <a href="{% url 'api_docs' %}">API</a> &middot;
-                        <i class="mdi mdi-graphql text-primary"></i> <a href="{% url 'graphql' %}">GraphQL</a> &middot;
-                        <i class="mdi mdi-xml text-primary"></i> <a href="{{ settings.BRANDING_URLS.code }}">Code</a> &middot;
-                        <i class="mdi mdi-lifebuoy text-primary"></i> <a href="{{ settings.BRANDING_URLS.help }}">Help</a>
-                    </p>
-                </div>
-            </div>
-        </div>
-    </footer>
 {% include 'modals/modal_theme.html' with name='theme'%}
-<script src="{% static 'js/theme.js' %}"></script>
-<script src="{% static 'jquery/jquery-3.6.0.min.js' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=jquery/jquery-3.6.0.min.js'"></script>
-<script src="{% static 'jquery-ui-1.13.1/jquery-ui.min.js' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=jquery-ui-1.13.1/jquery-ui.min.js'"></script>
-<script src="{% static 'bootstrap-3.4.1-dist/js/bootstrap.min.js' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=bootstrap-3.4.1-dist/js/bootstrap.min.js'"></script>
-<script src="{% static 'select2-4.0.13/select2.min.js' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=select2-4.0.13/select2.min.js'"></script>
-<script src="{% static 'clipboard.js-2.0.9/clipboard.min.js' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=clipboard.js-2.0.9/clipboard.min.js'"></script>
-<script src="{% static 'flatpickr-4.6.9/flatpickr.min.js' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=flatpickr-4.6.9/flatpickr.min.js'"></script>
-<script src="{% static 'js/forms.js' %}?v{{ settings.VERSION }}"
-        onerror="window.location='{% url 'media_failure' %}?filename=js/forms.js'"></script>
-<script type="text/javascript">
-    var nautobot_api_path = "{% url 'api-root' %}";
-    var nautobot_csrf_token = "{{ csrf_token }}";
-    var loading = $(".loading");
-    $(document).ajaxStart(function() {
-        loading.show();
-    }).ajaxStop(function() {
-        loading.hide();
-    });
-    /*
-    this fixes the navbar blocking the main UI from being seen
-    https://github.com/nautobot/nautobot/issues/1467
-    */
-    let setBodyPaddingTop = () => {
-        document.querySelector('body').style.paddingTop = `${parseInt(window.getComputedStyle(document.querySelector('.navbar')).height)+10}px`
-    }
-    window.addEventListener("resize", setBodyPaddingTop);
-    window.addEventListener("load", setBodyPaddingTop);
-</script>
+    {% include 'inc/footer.html' %}
+    {% include 'inc/javascript.html' %}
 {% block javascript %}{% endblock %}
 </body>
 </html>

--- a/nautobot/core/templates/base.html
+++ b/nautobot/core/templates/base.html
@@ -41,7 +41,7 @@
             </div>
         {% endif %}
     </div>
-{% include 'modals/modal_theme.html' with name='theme'%}
+    {% include 'modals/modal_theme.html' with name='theme'%}
     {% include 'inc/footer.html' %}
     {% include 'inc/javascript.html' %}
 {% block javascript %}{% endblock %}

--- a/nautobot/core/templates/inc/footer.html
+++ b/nautobot/core/templates/inc/footer.html
@@ -16,9 +16,10 @@
                 </div>
                 <div class="col-xs-4 text-right noprint">
                     <p class="text-muted">
+                        <a href="#theme_modal" data-toggle="modal" data-target="#theme_modal" id="btn-theme-modal"><i class="mdi mdi-theme-light-dark text-primary"></i>Theme</a> &middot;
                         <i class="mdi mdi-book-open-page-variant text-primary"></i>
                         {% if settings.BRANDING_URLS.docs %}
-                             <a href="{{ settings.BRANDING_URLS.docs }}">Docs</a>
+                            <a href="{{ settings.BRANDING_URLS.docs }}">Docs</a>
                         {% else %}
                             <a href="{% static 'docs/index.html' %}">Docs</a>
                         {% endif %}

--- a/nautobot/core/templates/inc/footer.html
+++ b/nautobot/core/templates/inc/footer.html
@@ -1,0 +1,34 @@
+{% load static %}
+{% load helpers %}
+{% load plugins %}
+
+    <footer class="footer">
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-xs-4">
+                    <p class="text-muted">
+                        {% if settings.BRANDING_FILEPATHS.logo and settings.BRANDING_POWERED_BY_URL %}<a href="{{ settings.BRANDING_POWERED_BY_URL }}"><img src="{% static 'img/nautobot_logo.svg' %}" height="20" /> Powered</a> &middot;{% endif %}
+                        {{ settings.HOSTNAME }} (v{{ settings.VERSION }})
+                    </p>
+                </div>
+                <div class="col-xs-4 text-center">
+                    <p class="text-muted">{% now 'Y-m-d H:i:s T' %}</p>
+                </div>
+                <div class="col-xs-4 text-right noprint">
+                    <p class="text-muted">
+                        <i class="mdi mdi-book-open-page-variant text-primary"></i>
+                        {% if settings.BRANDING_URLS.docs %}
+                             <a href="{{ settings.BRANDING_URLS.docs }}">Docs</a>
+                        {% else %}
+                            <a href="{% static 'docs/index.html' %}">Docs</a>
+                        {% endif %}
+                        &middot;
+                        <i class="mdi mdi-cloud-braces text-primary"></i> <a href="{% url 'api_docs' %}">API</a> &middot;
+                        <i class="mdi mdi-graphql text-primary"></i> <a href="{% url 'graphql' %}">GraphQL</a> &middot;
+                        <i class="mdi mdi-xml text-primary"></i> <a href="{{ settings.BRANDING_URLS.code }}">Code</a> &middot;
+                        <i class="mdi mdi-lifebuoy text-primary"></i> <a href="{{ settings.BRANDING_URLS.help }}">Help</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </footer>

--- a/nautobot/core/templates/inc/javascript.html
+++ b/nautobot/core/templates/inc/javascript.html
@@ -2,6 +2,7 @@
 {% load plugins %}
 {% load static %}
 
+<script src="{% static 'js/theme.js' %}"></script>
 <script src="{% static 'jquery/jquery-3.6.0.min.js' %}"
         onerror="window.location='{% url 'media_failure' %}?filename=jquery/jquery-3.6.0.min.js'"></script>
 <script src="{% static 'jquery-ui-1.13.1/jquery-ui.min.js' %}"

--- a/nautobot/core/templates/inc/javascript.html
+++ b/nautobot/core/templates/inc/javascript.html
@@ -1,0 +1,37 @@
+{% load helpers %}
+{% load plugins %}
+{% load static %}
+
+<script src="{% static 'jquery/jquery-3.6.0.min.js' %}"
+        onerror="window.location='{% url 'media_failure' %}?filename=jquery/jquery-3.6.0.min.js'"></script>
+<script src="{% static 'jquery-ui-1.13.1/jquery-ui.min.js' %}"
+        onerror="window.location='{% url 'media_failure' %}?filename=jquery-ui-1.13.1/jquery-ui.min.js'"></script>
+<script src="{% static 'bootstrap-3.4.1-dist/js/bootstrap.min.js' %}"
+        onerror="window.location='{% url 'media_failure' %}?filename=bootstrap-3.4.1-dist/js/bootstrap.min.js'"></script>
+<script src="{% static 'select2-4.0.13/select2.min.js' %}"
+        onerror="window.location='{% url 'media_failure' %}?filename=select2-4.0.13/select2.min.js'"></script>
+<script src="{% static 'clipboard.js-2.0.9/clipboard.min.js' %}"
+        onerror="window.location='{% url 'media_failure' %}?filename=clipboard.js-2.0.9/clipboard.min.js'"></script>
+<script src="{% static 'flatpickr-4.6.9/flatpickr.min.js' %}"
+        onerror="window.location='{% url 'media_failure' %}?filename=flatpickr-4.6.9/flatpickr.min.js'"></script>
+<script src="{% static 'js/forms.js' %}?v{{ settings.VERSION }}"
+        onerror="window.location='{% url 'media_failure' %}?filename=js/forms.js'"></script>
+<script type="text/javascript">
+    var nautobot_api_path = "{% url 'api-root' %}";
+    var nautobot_csrf_token = "{{ csrf_token }}";
+    var loading = $(".loading");
+    $(document).ajaxStart(function() {
+        loading.show();
+    }).ajaxStop(function() {
+        loading.hide();
+    });
+    /*
+    this fixes the navbar blocking the main UI from being seen
+    https://github.com/nautobot/nautobot/issues/1467
+    */
+    let setBodyPaddingTop = () => {
+        document.querySelector('body').style.paddingTop = `${parseInt(window.getComputedStyle(document.querySelector('.navbar')).height)+10}px`
+    }
+    window.addEventListener("resize", setBodyPaddingTop);
+    window.addEventListener("load", setBodyPaddingTop);
+</script>

--- a/nautobot/core/templates/inc/media.html
+++ b/nautobot/core/templates/inc/media.html
@@ -1,0 +1,35 @@
+{% load static %}
+{% load helpers %}
+{% load plugins %}
+
+    <link rel="stylesheet"
+          href="{% static 'bootstrap-3.4.1-dist/css/bootstrap.min.css' %}"
+          onerror="window.location='{% url 'media_failure' %}?filename=bootstrap-3.4.1-dist/css/bootstrap.min.css'">
+    <link rel="stylesheet"
+          href="{% static 'materialdesignicons-6.5.95/css/materialdesignicons.min.css' %}"
+          onerror="window.location='{% url 'media_failure' %}?filename=materialdesignicons-6.5.95/css/materialdesignicons.min.css'">
+    <link rel="stylesheet"
+          href="{% static 'jquery-ui-1.13.1/jquery-ui.min.css' %}"
+          onerror="window.location='{% url 'media_failure' %}?filename=jquery-ui-1.13.1/jquery-ui.min.css'">
+    <link rel="stylesheet"
+          href="{% static 'select2-4.0.13/select2.min.css' %}"
+          onerror="window.location='{% url 'media_failure' %}?filename=select2-4.0.13/select2.min.css'">
+    <link rel="stylesheet"
+          href="{% static 'select2-bootstrap-0.1.0-beta.10/select2-bootstrap.min.css' %}"
+          onerror="window.location='{% url 'media_failure' %}?filename=select2-bootstrap-0.1.0-beta.10/select2-bootstrap.min.css'">
+    <link rel="stylesheet"
+          href="{% static 'flatpickr-4.6.9/themes/light.min.css' %}"
+          onerror="window.location='{% url 'media_failure' %}?filename=flatpickr-4.6.9/themes/light.min.css'">
+    <link rel="stylesheet"
+          href="{% static 'css/base.css' %}?v{{ settings.VERSION }}"
+          onerror="window.location='{% url 'media_failure' %}?filename=css/base.css'">
+    <link rel="apple-touch-icon" sizes="180x180" href="{% custom_branding_or_static 'icon_180' 'img/nautobot_icon_180x180.png' %}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{% custom_branding_or_static 'icon_32' 'img/nautobot_icon_32x32.png' %}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{% custom_branding_or_static 'icon_16' 'img/nautobot_icon_16x16.png' %}">
+    <link rel="icon" type="image/png" sizes="192x192" href="{% custom_branding_or_static 'icon_192' 'img/nautobot_icon_192x192.png' %}">
+    <link rel="mask-icon" type="image/png" color="#0097ff" href="{% custom_branding_or_static 'icon_mask' 'img/nautobot_icon_monochrome.png' %}">
+    <link rel="shortcut icon" href="{% custom_branding_or_static 'favicon' 'img/favicon.ico' %}">
+    <meta name="msapplication-TileColor" content="#2d89ef">
+    <meta name="theme-color" content="#ffffff">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width">

--- a/nautobot/core/templates/inc/media.html
+++ b/nautobot/core/templates/inc/media.html
@@ -20,6 +20,9 @@
     <link rel="stylesheet"
           href="{% static 'flatpickr-4.6.9/themes/light.min.css' %}"
           onerror="window.location='{% url 'media_failure' %}?filename=flatpickr-4.6.9/themes/light.min.css'">
+    <link rel="stylesheet" id="dark-theme"
+          href="{% static 'css/dark.css' %}?v{{ settings.VERSION }}"
+          onerror="window.location='{% url 'media_failure' %}?filename=css/dark.css'" disabled="disabled" />
     <link rel="stylesheet"
           href="{% static 'css/base.css' %}?v{{ settings.VERSION }}"
           onerror="window.location='{% url 'media_failure' %}?filename=css/base.css'">

--- a/nautobot/core/templates/rest_framework/api.html
+++ b/nautobot/core/templates/rest_framework/api.html
@@ -1,27 +1,21 @@
 {% extends 'rest_framework/base.html' %}
+{% load helpers %}
+{% load plugins %}
 {% load static %}
 
 {% block bootstrap_theme %}
-    <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.4.1-dist/css/bootstrap.min.css' %}"/>
-    <link rel="stylesheet"
-          href="{% static 'materialdesignicons-6.5.95/css/materialdesignicons.min.css' %}"
-          onerror="window.location='{% url 'media_failure' %}?filename=materialdesignicons-6.5.95/css/materialdesignicons.min.css'">
-    <link rel="stylesheet"
-          href="{% static 'jquery-ui-1.13.1/jquery-ui.min.css' %}"
-          onerror="window.location='{% url 'media_failure' %}?filename=jquery-ui-1.13.1/jquery-ui.min.css'">
-    <link rel="stylesheet"
-          href="{% static 'css/base.css' %}?v{{ settings.VERSION }}"
-          onerror="window.location='{% url 'media_failure' %}?filename=css/base.css'">
-    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'img/nautobot_icon_180x180.png' %}">
-    <link rel="icon" type="image/png" sizes="32x32" href="{% static 'img/nautobot_icon_32x32.png' %}">
-    <link rel="icon" type="image/png" sizes="16x16" href="{% static 'img/nautobot_icon_16x16.png' %}">
-    <link rel="icon" type="image/png" href="{% static 'img/nautobot_icon_192x192.png' %}" sizes="192x192">
-    <link rel="mask-icon" href="{% static 'img/nautobot_icon_monochrome.svg' %}" color="#0097ff">
-    <link rel="shortcut icon" href="{% static 'img/favicon.ico' %}">
-    <meta name="msapplication-TileColor" content="#2d89ef">
-    <meta name="theme-color" content="#ffffff">
-{% endblock %}
+    {% include 'inc/media.html' %}
+{% endblock bootstrap_theme %}
 
 {% block navbar %}
     {% include 'inc/nav_menu.html' %}
-{% endblock %}
+{% endblock navbar %}
+
+{% block body %}
+    {{ block.super }}
+    {% include 'inc/footer.html' %}
+{% endblock body %}
+
+{% block script %}
+    {% include 'inc/javascript.html' %}
+{% endblock script %}


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1898
# What's Changed
- The entry for `rest_framework` within `nautobot.core.settings.INSTALLED_APPS` was moved below `nautobot.core` so that the template can be properly overloaded
- Three new include templates in `nautobot/core/templates/inc` have been added and `base.html` has been updated to include these templates
  - `footer.html` - The `<footer>` tag from `base.html`
  - `javascript.html` - The `<script>` tags from `base.html`
  - `media.html` - The `<link>` and `<meta>` header tags from `base.html`
- Finally, `nautobot/core/templates/rest_framework/api.html` has been updated to include the same templates to assert uniform UI for the browsable API.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design