### PR TITLE
Resolves #1903 - set to not populate default value if filterforms

### DIFF
--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -601,10 +601,10 @@ class CustomFieldFilterForm(forms.Form):
             field_name = "cf_{}".format(cf.name)
             if cf.type == "json":
                 self.fields[field_name] = cf.to_form_field(
-                    set_initial=True, enforce_required=False, simple_json_filter=True
+                    set_initial=False, enforce_required=False, simple_json_filter=True
                 )
             else:
-                self.fields[field_name] = cf.to_form_field(set_initial=True, enforce_required=False)
+                self.fields[field_name] = cf.to_form_field(set_initial=False, enforce_required=False)
 
 
 #


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1903 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
FilterForms no longer load with default value pre-populated.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design