### PR TITLE
Fixes RTD links

### DIFF
--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -136,7 +136,7 @@ If [`NAUTOBOT_CREATE_SUPERUSER`](#nautobot_create_superuser) is true, `NAUTOBOT_
 
 ### uWSGI
 
-The docker container uses [uWSGI](https://uwsgi-docs.readthedocs.io/) to serve Nautobot.  A default configuration is [provided](/docker/uwsgi.ini), and can be overridden by injecting a new `uwsgi.ini` file at `/opt/nautobot/uwsgi.ini`.  There are a couple of environment variables provided to override some uWSGI defaults:
+The docker container uses [uWSGI](https://uwsgi-docs.readthedocs.io/) to serve Nautobot.  A default configuration is [provided](https://github.com/nautobot/nautobot/blob/main/docker/uwsgi.ini), and can be overridden by injecting a new `uwsgi.ini` file at `/opt/nautobot/uwsgi.ini`.  There are a couple of environment variables provided to override some uWSGI defaults:
 
 #### `NAUTOBOT_UWSGI_LISTEN`
 
@@ -191,7 +191,7 @@ COPY nautobot_config.py /opt/nautobot/nautobot_config.py
 
 ## Building the Image
 
-If you have a [development environment](/development/getting-started/#setting-up-your-development-environment) you can use invoke to build the docker images.  By default `invoke build` will build the development containers:
+If you have a [development environment](../development/getting-started/#setting-up-your-development-environment) you can use invoke to build the docker images.  By default `invoke build` will build the development containers:
 
 ```no-highlight
 $ invoke build


### PR DESCRIPTION
This fixes a few links on the readthedocs docker page.

The link in [the uWSGI section](https://nautobot.readthedocs.io/en/stable/docker/#uwsgi) is trying to point to a file that lives in the github repository:
```
A default configuration is [provided](/docker/uwsgi.ini),
```

The link in [the Building the Image section](https://nautobot.readthedocs.io/en/stable/docker/#building-the-image) references an absolute path instead of a relative one:
```
If you have a [development environment](/development/getting-started/#setting-up-your-development-environment) you can use invoke to build the docker images.
```