### PR TITLE
change SlugOrPKMultipleChoiceFilter to NaturalKeyOrPKMultipleChoiceFilter

### DIFF
--- a/nautobot/dcim/filters.py
+++ b/nautobot/dcim/filters.py
@@ -22,7 +22,7 @@ from nautobot.utilities.filters import (
     NameSlugSearchFilterSet,
     RelatedMembershipBooleanFilter,
     SearchFilter,
-    SlugOrPKMultipleChoiceFilter,
+    NaturalKeyOrPKMultipleChoiceFilter,
     TagFilter,
     TreeNodeMultipleChoiceFilter,
 )
@@ -125,7 +125,7 @@ class RegionFilterSet(NautobotFilterSet, NameSlugSearchFilterSet):
         to_field_name="slug",
         label="Parent region (slug)",
     )
-    children = SlugOrPKMultipleChoiceFilter(
+    children = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=Region.objects.all(),
         label="Children (slug or ID)",
     )
@@ -133,7 +133,7 @@ class RegionFilterSet(NautobotFilterSet, NameSlugSearchFilterSet):
         field_name="children",
         label="Has children",
     )
-    sites = SlugOrPKMultipleChoiceFilter(
+    sites = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=Site.objects.all(),
         label="Site (slug or ID)",
     )
@@ -197,7 +197,7 @@ class SiteFilterSet(NautobotFilterSet, TenancyFilterSet, StatusModelFilterSetMix
         field_name="powerpanel",
         label="Has power panels",
     )
-    rack_groups = SlugOrPKMultipleChoiceFilter(
+    rack_groups = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=RackGroup.objects.all(),
         label="Rack groups (slug or ID)",
     )
@@ -213,7 +213,7 @@ class SiteFilterSet(NautobotFilterSet, TenancyFilterSet, StatusModelFilterSetMix
         field_name="prefixes",
         label="Has prefixes",
     )
-    vlan_groups = SlugOrPKMultipleChoiceFilter(
+    vlan_groups = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=VLANGroup.objects.all(),
         label="Vlan groups (slug or ID)",
     )
@@ -296,7 +296,7 @@ class RackGroupFilterSet(NautobotFilterSet, NameSlugSearchFilterSet):
         to_field_name="slug",
         label="Parent (slug)",
     )
-    children = SlugOrPKMultipleChoiceFilter(
+    children = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=RackGroup.objects.all(),
         label="Children (slug or ID)",
     )
@@ -670,7 +670,7 @@ class DeviceTypeComponentFilterSet(NameSlugSearchFilterSet, CustomFieldModelFilt
         field_name="device_type_id",
         label="Device type (ID)",
     )
-    device_type = SlugOrPKMultipleChoiceFilter(
+    device_type = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=DeviceType.objects.all(),
         label="Device type (slug or ID)",
     )

--- a/nautobot/docs/development/best-practices.md
+++ b/nautobot/docs/development/best-practices.md
@@ -115,14 +115,21 @@ class UserFilter(NautobotFilterSet):
 ```
 
 - For foreign-key related fields on **new core models for v1.4 or later:**
-    - The field **must** be shadowed utilizing a hybrid `SlugOrPKMultipleChoiceFilter` which will automatically try to lookup by UUID or `slug` depending on the value of the incoming argument (e.g. UUID string vs. slug string).
-    - In default settings for filtersets, when not using `SlugOrPKMultipleChoiceFilter`, `provider` would be a `pk` (UUID) field, whereas using `SlugOrPKMultipleChoiceFilter` will automatically support both input values for `slug` or `pk`.
+    - The field **must** be shadowed utilizing a hybrid `NaturalKeyOrPKMultipleChoiceFilter` which will automatically try to lookup by UUID or `slug` depending on the value of the incoming argument (e.g. UUID string vs. slug string).
+    - Fields that use `name` instead of `slug` can set the `natural_key` argument on `NaturalKeyOrPKMultipleChoiceFilter`.
+    - In default settings for filtersets, when not using `NaturalKeyOrPKMultipleChoiceFilter`, `provider` would be a `pk` (UUID) field, whereas using `NaturalKeyOrPKMultipleChoiceFilter` will automatically support both input values for `slug` or `pk`.
     - New filtersets should follow this direction vs. propagating the need to continue to overload the default foreign-key filter and define an additional `_id` filter on each new filterset. *We know that most existing FilterSets aren't following this pattern, and we plan to change that in a major release.*
     - Using the previous field (`provider`) as an example, it would look something like this:
 
 ```python
-    from nautobot.utilities.filters import SlugOrPKMultipleChoiceFilter
-    provider = SlugOrPKMultipleChoiceFilter(
+    from nautobot.utilities.filters import NaturalKeyOrPKMultipleChoiceFilter
+    provider = NaturalKeyOrPKMultipleChoiceFilter(
+        queryset=Provider.objects.all(),
+        label="Provider (slug or ID)",
+    )
+    # optionally use the natural_key argument to set the field to name instead of slug
+    provider = NaturalKeyOrPKMultipleChoiceFilter(
+        natural_key="name",
         queryset=Provider.objects.all(),
         label="Provider (slug or ID)",
     )

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -20,7 +20,7 @@ from nautobot.utilities.constants import (
     FILTER_NUMERIC_BASED_LOOKUP_MAP,
     FILTER_TREENODE_NEGATION_LOOKUP_MAP,
 )
-from nautobot.utilities.forms.fields import SlugOrPKMultipleChoiceField
+from nautobot.utilities.forms.fields import MultiMatchModelMultipleChoiceField
 
 from taggit.managers import TaggableManager
 
@@ -418,12 +418,14 @@ class MappedPredicatesFilterMixin:
         return qs.distinct()
 
 
-class SlugOrPKMultipleChoiceFilter(django_filters.ModelMultipleChoiceFilter):
+class NaturalKeyOrPKMultipleChoiceFilter(django_filters.ModelMultipleChoiceFilter):
     """
-    Filter that supports filtering on the `pk` or the `slug` of a foreign-key related field.
+    Filter that supports filtering on values matching the `pk` field and another
+    field of a foreign-key related object. The desired field is set using the `natural_key`
+    keyword argument on filter initialization (defaults to `slug`).
     """
 
-    field_class = SlugOrPKMultipleChoiceField
+    field_class = MultiMatchModelMultipleChoiceField
 
 
 class SearchFilter(MappedPredicatesFilterMixin, django_filters.CharFilter):

--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -669,11 +669,16 @@ class NumericArrayField(SimpleArrayField):
         return super().to_python(value)
 
 
-class SlugOrPKMultipleChoiceField(django_filters.fields.ModelMultipleChoiceField):
+class MultiMatchModelMultipleChoiceField(django_filters.fields.ModelMultipleChoiceField):
     """
-    Field to support matching an object's `pk` or `slug` field depending on the value
-    supplied. Raises ValidationError if neither field matches.
+    Filter field to support matching on the PK or supplied `natural_key` fields. `natural_key`
+    defaults to `slug` if not provided. Raises ValidationError if none of the fields match the
+    requested value.
     """
+
+    def __init__(self, *args, **kwargs):
+        self.natural_key = kwargs.pop("natural_key", "slug")
+        super().__init__(*args, **kwargs)
 
     def _check_values(self, values):
         """
@@ -701,7 +706,7 @@ class SlugOrPKMultipleChoiceField(django_filters.fields.ModelMultipleChoiceField
                 query |= Q(pk=item)
             except (ValueError, TypeError):
                 pass
-            query |= Q(slug=str(item))
+            query |= Q(**{self.natural_key: str(item)})
             qs = self.queryset.filter(query)
             if not qs.exists():
                 raise ValidationError(
@@ -709,6 +714,6 @@ class SlugOrPKMultipleChoiceField(django_filters.fields.ModelMultipleChoiceField
                     code="invalid_choice",
                     params={"value": item},
                 )
-        query = Q(pk__in=pk_values) | Q(slug__in=values)
+        query = Q(pk__in=pk_values) | Q(**{f"{self.natural_key}__in": values})
         qs = self.queryset.filter(query)
         return qs

--- a/nautobot/utilities/tests/test_forms.py
+++ b/nautobot/utilities/tests/test_forms.py
@@ -15,7 +15,7 @@ from nautobot.utilities.forms.fields import (
     CSVDataField,
     DynamicModelMultipleChoiceField,
     JSONField,
-    SlugOrPKMultipleChoiceField,
+    MultiMatchModelMultipleChoiceField,
 )
 from nautobot.utilities.forms.utils import (
     expand_alphanumeric_pattern,
@@ -584,9 +584,9 @@ class JSONFieldTest(NautobotTestCase):
         self.assertEqual('"I am UTF-8! 😀"', JSONField().prepare_value("I am UTF-8! 😀"))
 
 
-class SlugOrPKMultipleChoiceFieldTest(TestCase):
+class MultiMatchModelMultipleChoiceFieldTest(TestCase):
     def test_clean(self):
-        field = SlugOrPKMultipleChoiceField(queryset=VLANGroup.objects.all())
+        field = MultiMatchModelMultipleChoiceField(queryset=VLANGroup.objects.all())
         vlan_groups = (
             VLANGroup.objects.create(name="VLAN Group 1", slug="vlan-group-1"),
             VLANGroup.objects.create(name="VLAN Group 2", slug="vlan-group-2"),


### PR DESCRIPTION
# Related to: #1729
# What's Changed
- Change SlugOrPKMultipleChoiceFilter to support setting the key name for related objects that have no `slug` field
- Rename filter to reflect new functionality

Example:
```python
    from nautobot.utilities.filters import NaturalKeyOrPKMultipleChoiceFilter
    provider = NaturalKeyOrPKMultipleChoiceFilter(
        queryset=Provider.objects.all(),
        label="Provider (slug or ID)",
    )
    # optionally use the natural_key argument to set the field to name instead of slug
    provider = NaturalKeyOrPKMultipleChoiceFilter(
        natural_key="name",
        queryset=Provider.objects.all(),
        label="Provider (slug or ID)",
    )
```


# TODO

- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design