### PR TITLE
Closes issue #1838

### DIFF
--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -292,7 +292,7 @@ class Job(PrimaryModel):
     @property
     def latest_result(self):
         if self._latest_result is None:
-            self._latest_result = self.results.last()
+            self._latest_result = self.results.first()
         return self._latest_result
 
     @property

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -352,8 +352,8 @@ class JobTest(TransactionTestCase):
         """
         Job test to see if the latest_result property is indeed returning the most recent job result
         """
-        module = "test_latest_property"
-        name = "TestLatestProperty"
+        module = "test_pass"
+        name = "TestPass"
         job_result = create_job_result_and_run_job(module, name, commit=False)
         self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
         job = Job.objects.get(id=job_result.job_id)

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -354,11 +354,14 @@ class JobTest(TransactionTestCase):
         """
         module = "test_pass"
         name = "TestPass"
-        job_result = create_job_result_and_run_job(module, name, commit=False)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
+        job_result_1 = create_job_result_and_run_job(module, name, commit=False)
+        self.assertEqual(job_result_1.status, JobResultStatusChoices.STATUS_COMPLETED)
+        job_result_2 = create_job_result_and_run_job(module, name, commit=False)
+        self.assertEqual(job_result_2.status, JobResultStatusChoices.STATUS_COMPLETED)
         job_class, job_model = get_job_class_and_model(module, name)
-        latest_job_result = job_model.results.first()
-        self.assertEqual(job_result.completed, latest_job_result.completed)
+        self.assertGreaterEqual(job_model.results.count(), 2)
+        latest_job_result = job_model.latest_result()
+        self.assertEqual(job_result_2.completed, latest_job_result.completed)
 
 
 class JobFileUploadTest(TransactionTestCase):

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -348,6 +348,18 @@ class JobTest(TransactionTestCase):
         ).first()
         self.assertIn("Data should be a dictionary", log_failure.message)
 
+    def test_job_latest_result_property(self):
+        """
+        Job test to see if the latest_result property is indeed returning the most recent job result
+        """
+        module = "test_latest_property"
+        name = "TestLatestProperty"
+        job_result = create_job_result_and_run_job(module, name, commit=False)
+        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
+        job = Job.objects.get(id=job_result.job_id)
+        latest_job_result = job.results.first()
+        self.assertEqual(job_result.completed, latest_job_result.completed)
+
 
 class JobFileUploadTest(TransactionTestCase):
     """Test a job that uploads/deletes files."""

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -356,8 +356,8 @@ class JobTest(TransactionTestCase):
         name = "TestPass"
         job_result = create_job_result_and_run_job(module, name, commit=False)
         self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
-        job = Job.objects.get(id=job_result.job_id)
-        latest_job_result = job.results.first()
+        job_class, job_model = get_job_class_and_model(module, name)
+        latest_job_result = job_model.results.first()
         self.assertEqual(job_result.completed, latest_job_result.completed)
 
 

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -360,7 +360,7 @@ class JobTest(TransactionTestCase):
         self.assertEqual(job_result_2.status, JobResultStatusChoices.STATUS_COMPLETED)
         job_class, job_model = get_job_class_and_model(module, name)
         self.assertGreaterEqual(job_model.results.count(), 2)
-        latest_job_result = job_model.latest_result()
+        latest_job_result = job_model.latest_result
         self.assertEqual(job_result_2.completed, latest_job_result.completed)
 
 


### PR DESCRIPTION
replaced self.results.last() with self.results.first() to show the latest test job result in extras/jobs.py

Should fix issue in https://github.com/nautobot/nautobot/issues/1838