### PR TITLE
Add position and face as nullable fields to DeviceBulkEditForm

### DIFF
--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -1977,7 +1977,7 @@ class DeviceBulkEditForm(
         query_params={"manufacturer_id": "$manufacturer"},
     )
     rack = DynamicModelChoiceField(queryset=Rack.objects.all(), required=False)
-    position = forms.CharField(required=False)
+    position = forms.IntegerField(required=False)
     face = forms.ChoiceField(
         required=False,
         choices=add_blank_choice(DeviceFaceChoices),

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -1978,7 +1978,11 @@ class DeviceBulkEditForm(
     )
     rack = DynamicModelChoiceField(queryset=Rack.objects.all(), required=False)
     position = forms.CharField(required=False)
-    face = forms.CharField(required=False)
+    face = forms.ChoiceField(
+        required=False,
+        choices=add_blank_choice(DeviceFaceChoices),
+        widget=StaticSelect2(),
+    )
     rack_group = DynamicModelChoiceField(queryset=RackGroup.objects.all(), required=False)
     device_role = DynamicModelChoiceField(queryset=DeviceRole.objects.all(), required=False)
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
@@ -2003,7 +2007,6 @@ class DeviceBulkEditForm(
 
         # Disable position and face because only setting null values for these fields is needed
         self.fields["position"].disabled = True
-        self.fields["face"].disabled = True
 
 
 class DeviceFilterForm(

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -2005,7 +2005,7 @@ class DeviceBulkEditForm(
     def __init__(self, *args, **kwrags):
         super().__init__(*args, **kwrags)
 
-        # Disable position and face because only setting null values for these fields is needed
+        # Disable position because only setting null value is required
         self.fields["position"].disabled = True
 
 

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -1977,6 +1977,8 @@ class DeviceBulkEditForm(
         query_params={"manufacturer_id": "$manufacturer"},
     )
     rack = DynamicModelChoiceField(queryset=Rack.objects.all(), required=False)
+    position = forms.CharField(required=False)
+    face = forms.CharField(required=False)
     rack_group = DynamicModelChoiceField(queryset=RackGroup.objects.all(), required=False)
     device_role = DynamicModelChoiceField(queryset=DeviceRole.objects.all(), required=False)
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
@@ -1990,9 +1992,18 @@ class DeviceBulkEditForm(
             "platform",
             "serial",
             "rack",
+            "position",
+            "face",
             "rack_group",
             "secrets_group",
         ]
+
+    def __init__(self, *args, **kwrags):
+        super().__init__(*args, **kwrags)
+
+        # Disable position and face because only setting null values for these fields is needed
+        self.fields["position"].disabled = True
+        self.fields["face"].disabled = True
 
 
 class DeviceFilterForm(

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1340,6 +1340,8 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "status": statuses.get(slug="decommissioning").pk,
             "site": sites[1].pk,
             "rack": racks[1].pk,
+            "position": None,
+            "face": "",
             "secrets_group": secrets_groups[1].pk,
         }
 

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1341,7 +1341,7 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "site": sites[1].pk,
             "rack": racks[1].pk,
             "position": None,
-            "face": "",
+            "face": DeviceFaceChoices.FACE_FRONT,
             "secrets_group": secrets_groups[1].pk,
         }
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1757 
# What's Changed

- Add position and face to DeviceBulkEditForm 
- Disable both position and face fields because only setting these fields to null is required.
- Add relevant test case
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design