### PR TITLE
Can't Mix Range, Update Types

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,7 @@
       "groupName": "Problematic Minor Updates",
       "matchBaseBranches": ["next"],
       "matchPackageNames": ["graphene-django-optimizer", "django-timezone-field"],
-      "matchUpdateTypes": ["major", "minor"],
-      "rangeStrategy": "update-lockfile"
+      "matchUpdateTypes": ["major", "minor"]
     },
     {
       "description": "Require dashboard approval for major updates for django-taggit.",
@@ -26,8 +25,7 @@
       "groupName": "Problematic Major Updates",
       "matchBaseBranches": ["next"],
       "matchPackageNames": ["django-taggit"],
-      "matchUpdateTypes": ["major"],
-      "rangeStrategy": "update-lockfile"
+      "matchUpdateTypes": ["major"]
     },
     {
       "description": "Group updates to next cut down on PR noise.",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1987 
# What's Changed
From #1987

> Location: `renovate.json`
Error type: The renovate configuration file contains some invalid settings
Message: `packageRules[0]: packageRules cannot combine both matchUpdateTypes and rangeStrategy. Rule: {"description":["Require dashboard approval for non-patch updates to graphene-django-optimizer and django-timezone-field."],"dependencyDashboardApproval":true,"groupName":"Problematic Minor Updates","matchBaseBranches":["next"],"matchPackageNames":["graphene-django-optimizer","django-timezone-field"],"matchUpdateTypes":["major","minor"],"rangeStrategy":"update-lockfile"}, packageRules[1]: packageRules cannot combine both matchUpdateTypes and rangeStrategy. Rule: {"description":["Require dashboard approval for major updates for django-taggit."],"dependencyDashboardApproval":true,"groupName":"Problematic Major Updates","matchBaseBranches":["next"],"matchPackageNames":["django-taggit"],"matchUpdateTypes":["major"],"rangeStrategy":"update-lockfile"}`


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design