### PR TITLE
Remove RQ worker container from docker-compose development environment

### DIFF
--- a/development/docker-compose.build.yml
+++ b/development/docker-compose.build.yml
@@ -14,7 +14,5 @@ services:
         - "curl"
         - "-fk"
         - "https://localhost:8443/health/"
-  worker:
-    image: "networktocode/nautobot-py${PYTHON_VER}:local"
   celery_worker:
     image: "networktocode/nautobot-py${PYTHON_VER}:local"

--- a/development/docker-compose.debug.yml
+++ b/development/docker-compose.debug.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ./nautobot_config.py:/opt/nautobot/nautobot_config.py
       - ../:/source
-  worker:
+  celery_worker:
     volumes:
       - ./nautobot_config.py:/opt/nautobot/nautobot_config.py
       - ../:/source

--- a/development/docker-compose.dev.yml
+++ b/development/docker-compose.dev.yml
@@ -9,10 +9,6 @@ services:
     volumes:
       - ./nautobot_config.py:/opt/nautobot/nautobot_config.py
       - ../:/source
-  worker:
-    volumes:
-      - ./nautobot_config.py:/opt/nautobot/nautobot_config.py
-      - ../:/source
   celery_worker:
     volumes:
       - ./nautobot_config.py:/opt/nautobot/nautobot_config.py

--- a/development/docker-compose.mysql.yml
+++ b/development/docker-compose.mysql.yml
@@ -4,9 +4,6 @@ services:
   nautobot:
     environment:
       - "NAUTOBOT_DB_ENGINE=django.db.backends.mysql"
-  worker:
-    environment:
-      - "NAUTOBOT_DB_ENGINE=django.db.backends.mysql"
   celery_worker:
     environment:
       - "NAUTOBOT_DB_ENGINE=django.db.backends.mysql"

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -28,20 +28,6 @@ services:
         - "curl"
         - "-f"
         - "http://localhost:8080/health/"
-  worker:
-    image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
-    entrypoint: "nautobot-server rqworker"
-    healthcheck:
-      interval: 60s
-      timeout: 30s
-      start_period: 5s
-      retries: 3
-      test: ["CMD", "nautobot-server", "health_check"]
-    depends_on:
-      - nautobot
-    env_file:
-      - ./dev.env
-    tty: true
   celery_worker:
     image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
     entrypoint: "nautobot-server celery worker -l INFO"

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -88,10 +88,6 @@ if not TESTING:
                 "handlers": ["verbose_console" if DEBUG else "normal_console"],
                 "level": LOG_LEVEL,
             },
-            "rq.worker": {
-                "handlers": ["verbose_console" if DEBUG else "normal_console"],
-                "level": LOG_LEVEL,
-            },
         },
     }
 

--- a/docker/nautobot_config.append.py
+++ b/docker/nautobot_config.append.py
@@ -25,9 +25,5 @@ LOGGING = {
             "handlers": ["normal_console"],
             "level": LOG_LEVEL,
         },
-        "rq.worker": {
-            "handlers": ["normal_console"],
-            "level": LOG_LEVEL,
-        },
     },
 }

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -380,6 +380,7 @@ class StatusView(NautobotAPIVersionMixin, APIView):
                     "nautobot-version": {"type": "string"},
                     "plugins": {"type": "object"},
                     "python-version": {"type": "string"},
+                    # 2.0 TODO: remove rq-workers-running property
                     "rq-workers-running": {"type": "integer"},
                     "celery-workers-running": {"type": "integer"},
                 },
@@ -417,6 +418,7 @@ class StatusView(NautobotAPIVersionMixin, APIView):
                 "nautobot-version": settings.VERSION,
                 "plugins": plugins,
                 "python-version": platform.python_version(),
+                # 2.0 TODO: remove rq-workers-running
                 "rq-workers-running": RQWorker.count(get_rq_connection("default")),
                 "celery-workers-running": worker_count,
             }

--- a/nautobot/docs/development/docker-compose-advanced-use-cases.md
+++ b/nautobot/docs/development/docker-compose-advanced-use-cases.md
@@ -108,6 +108,32 @@ nautobot:
 
 Then `invoke stop` (if you previously had the docker environment running with Postgres) and `invoke start` and you should now be running with MySQL.
 
+### Running an RQ worker
+
+By default the Docker development environment no longer includes an RQ worker container, as RQ support in Nautobot is deprecated and will be removed entirely in a future release. If you need to run an RQ worker, you can set up `invoke.yml` as described above with the following `docker-compose.override.yml`:
+
+```yaml
+---
+services:
+  rq_worker:
+    image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
+    entrypoint: "nautobot-server rqworker"
+    healthcheck:
+      interval: 60s
+      timeout: 30s
+      start_period: 5s
+      retries: 3
+      test: ["CMD", "nautobot-server", "health_check"]
+    depends_on:
+      - nautobot
+    env_file:
+      - ./dev.env
+    tty: true
+    volumes:
+      - ./nautobot_config.py:/opt/nautobot/nautobot_config.py
+      - ../:/source
+```
+
 ## Microsoft Visual Studio Code Integration
 
 For users of Microsoft Visual Studio Code, several files are included to ease development and integrate with the [VS Code Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). The following related files are found relative to the root of the project:

--- a/nautobot/docs/installation/services.md
+++ b/nautobot/docs/installation/services.md
@@ -27,7 +27,7 @@ $ nautobot-server celery --help
 ```
 
 !!! important
-    Prior to version 1.1.0, Nautobot utilized RQ as the primary background task worker. As of Nautobot 1.1.0, RQ is now *deprecated*. RQ and the `@job` decorator for custom tasks are still supported for now, but users should [migrate the primary worker to Celery](#migrating-to-celery-from-rq) and then [run RQ concurrently with the Celery worker](#concurrent-celery-and-rq-nautobot-workers). RQ and the `@job` decorator will no longer be documented, and support for RQ will be removed in a future release.
+    Prior to version 1.1.0, Nautobot utilized RQ as the primary background task worker. As of Nautobot 1.1.0, RQ is now *deprecated*. RQ and the `@job` decorator for custom tasks are still supported for now, but users should [migrate the primary worker to Celery](#migrating-to-celery-from-rq) and then, *only if still required*, [run RQ concurrently with the Celery worker](#concurrent-celery-and-rq-nautobot-workers). RQ and the `@job` decorator will no longer be documented, and support for RQ will be removed in a future release.
 
 ## Configuration
 
@@ -138,7 +138,7 @@ WantedBy=multi-user.target
 ### Nautobot Background Services
 
 !!! note
-    Prior to version 1.1.0, Nautobot utilized RQ as the primary background task worker. As of Nautobot 1.1.0, RQ is now *deprecated* and has been replaced with Celery. RQ will still work, but will be removed in a future release. Please [migrate your deployment to utilize Celery as documented below](#migrating-to-celery-from-rq).
+    Prior to version 1.1.0, Nautobot utilized RQ as the primary background task worker. As of Nautobot 1.1.0, RQ is now *deprecated* and has been replaced with Celery. RQ can still be used by plugins for now, but will be removed in a future release. Please [migrate your deployment to utilize Celery as documented below](#migrating-to-celery-from-rq).
 
 Next, we will setup the `systemd` units for the Celery worker and Celery Beat scheduler.
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -918,7 +918,7 @@ def _get_job_source_paths():
                 continue
 
             try:
-                # In the case where we have multiple Nautobot instances, or multiple RQ worker instances,
+                # In the case where we have multiple Nautobot instances, or multiple worker instances,
                 # they are not required to share a common filesystem; therefore, we may need to refresh our local clone
                 # of the Git repository to ensure that it is in sync with the latest repository clone from any instance.
                 ensure_git_repository(

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -138,7 +138,7 @@ class GitRepository(PrimaryModel):
         def on_commit_callback():
             if self.__initial_slug and self.slug != self.__initial_slug:
                 # Rename any previously existing repo directory to the new slug.
-                # TODO: In a distributed Nautobot deployment, each Django instance and/or RQ worker instance may
+                # TODO: In a distributed Nautobot deployment, each Django instance and/or worker instance may
                 # have its own clone of this repository on its own local filesystem; we need some way to ensure
                 # that all such clones are renamed.
                 # For now we just rename the one that we have locally and rely on other methods

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -251,7 +251,7 @@ class Job(PrimaryModel):
                     logger.warning("Job %s %s has no associated Git repository", self.module_name, self.job_class_name)
                     return None
                 try:
-                    # In the case where we have multiple Nautobot instances, or multiple RQ worker instances,
+                    # In the case where we have multiple Nautobot instances, or multiple worker instances,
                     # they are not required to share a common filesystem; therefore, we may need to refresh our local
                     # clone of the Git repository to ensure that it is in sync with the latest repository clone
                     # from any instance.

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -188,7 +188,7 @@ def git_repository_pre_delete(instance, **kwargs):
         job_result.set_status(JobResultStatusChoices.STATUS_COMPLETED)
     job_result.save()
 
-    # TODO: In a distributed Nautobot deployment, each Django instance and/or RQ worker instance may have its own clone
+    # TODO: In a distributed Nautobot deployment, each Django instance and/or worker instance may have its own clone
     # of this repository; we need some way to ensure that all such clones are deleted.
     # For now we just delete the one that we have locally and rely on other methods (notably get_jobs())
     # to clean up other clones as they're encountered.


### PR DESCRIPTION
# Closes: #2002 
# What's Changed

- Remove RQ worker container from docker-compose development environment
- Remove `rq.worker` logging configuration
- Document how to re-add rq_worker container using docker-compose.override.yml (note, I haven't tested this, but it *should* work)