### PR TITLE
<WIP> Temp solution, made group show up in admin site

### DIFF
--- a/nautobot/core/authentication.py
+++ b/nautobot/core/authentication.py
@@ -47,9 +47,11 @@ class ObjectPermissionBackend(ModelBackend):
         return perms
 
     def has_perm(self, user_obj, perm, obj=None):
-
         if perm == "is_staff":
             return user_obj.is_active and (user_obj.obj.is_staff or user_obj.is_superuser)
+
+        if "users" in perm and "admingroup" in perm:
+            perm = perm.replace("users", "auth").replace("admingroup", "group")
 
         app_label, action, model_name = resolve_permission(perm)
 

--- a/nautobot/core/authentication.py
+++ b/nautobot/core/authentication.py
@@ -50,10 +50,10 @@ class ObjectPermissionBackend(ModelBackend):
         if perm == "is_staff":
             return user_obj.is_active and (user_obj.obj.is_staff or user_obj.is_superuser)
 
-        if "users" in perm and "admingroup" in perm:
-            perm = perm.replace("users", "auth").replace("admingroup", "group")
-
         app_label, action, model_name = resolve_permission(perm)
+
+        if app_label == "users" and model_name == "admingroup":
+            perm = perm.replace("users", "auth").replace("admingroup", "group")
 
         # Superusers implicitly have all permissions
         if user_obj.is_active and user_obj.is_superuser:


### PR DESCRIPTION
When a staff user is assigned permissions to view, change, add `**auth > group** `objects, `user_obj.get_all_permissions()` looks like this.
<img width="1303" alt="Screen Shot 2022-07-08 at 10 17 57 PM" src="https://user-images.githubusercontent.com/46973263/178087945-800f5911-0319-4aa4-8223-55b0b804f3d0.png">
When `has_perm()` goes through the permissions that pertains to `**auth > group** ` and check if the user has them, it checks intead `users.view_admingroup, users.add_admingroup`, etc.
<img width="355" alt="Screen Shot 2022-07-08 at 10 20 04 PM" src="https://user-images.githubusercontent.com/46973263/178087993-90e8e013-69fd-4ff3-8fee-69b19c0e28cf.png">
The current solution works.
<img width="1366" alt="Screen Shot 2022-07-08 at 10 24 53 PM" src="https://user-images.githubusercontent.com/46973263/178088108-853d75ee-93a2-4564-95eb-5f0af0570339.png">

