### PR TITLE
Create method for model_to_json

### DIFF
--- a/nautobot/utilities/tests/test_utils.py
+++ b/nautobot/utilities/tests/test_utils.py
@@ -10,9 +10,10 @@ from nautobot.utilities.utils import (
     get_model_from_name,
     get_route_for_model,
     get_table_for_model,
+    model_to_json,
     normalize_querydict,
 )
-from nautobot.dcim.models import Device, Site
+from nautobot.dcim.models import Device, Region, Site
 from nautobot.dcim.filters import DeviceFilterSet, SiteFilterSet
 from nautobot.dcim.forms import DeviceForm, DeviceFilterForm, SiteForm, SiteFilterForm
 from nautobot.dcim.tables import DeviceTable, SiteTable
@@ -215,3 +216,31 @@ class IsTruthyTest(TestCase):
         self.assertFalse(is_truthy("n"))
         self.assertFalse(is_truthy(0))
         self.assertFalse(is_truthy("0"))
+
+
+class ModelToJson(TestCase):
+    """
+    Validate model_to_json() utility function.
+    """
+
+    def setUp(self):
+        self.region_a = Region.objects.create(name="Region A", slug="region-a")
+        self.site1 = Site.objects.create(region=self.region_a, name="Site 1", slug="site-1")
+
+    def test_model_to_json(self):
+        site_json = model_to_json(self.site1)
+        self.assertIn("url", site_json.keys())
+        self.assertIn("url", site_json["region"].keys())
+        self.assertIn("id", site_json.keys())
+        self.assertIn("id", site_json["region"].keys())
+        self.assertEqual(site_json["slug"], "site-1")
+        self.assertEqual(site_json["region"]["slug"], "region-a")
+
+    def test_model_to_json_with_filterset(self):
+        site_json = model_to_json(self.site1, "nautobot.dcim.api.serializers.SiteSerializer")
+        self.assertIn("url", site_json.keys())
+        self.assertIn("url", site_json["region"].keys())
+        self.assertIn("id", site_json.keys())
+        self.assertIn("id", site_json["region"].keys())
+        self.assertEqual(site_json["slug"], "site-1")
+        self.assertEqual(site_json["region"]["slug"], "region-a")

--- a/nautobot/utilities/tests/test_utils.py
+++ b/nautobot/utilities/tests/test_utils.py
@@ -10,7 +10,7 @@ from nautobot.utilities.utils import (
     get_model_from_name,
     get_route_for_model,
     get_table_for_model,
-    model_to_json,
+    model_to_dict,
     normalize_querydict,
 )
 from nautobot.dcim.models import Device, Region, Site
@@ -218,17 +218,17 @@ class IsTruthyTest(TestCase):
         self.assertFalse(is_truthy("0"))
 
 
-class ModelToJson(TestCase):
+class ModelToDict(TestCase):
     """
-    Validate model_to_json() utility function.
+    Validate model_to_dict() utility function.
     """
 
     def setUp(self):
         self.region_a = Region.objects.create(name="Region A", slug="region-a")
         self.site1 = Site.objects.create(region=self.region_a, name="Site 1", slug="site-1")
 
-    def test_model_to_json(self):
-        site_json = model_to_json(self.site1)
+    def test_model_to_dict(self):
+        site_json = model_to_dict(self.site1)
         self.assertIn("url", site_json.keys())
         self.assertIn("url", site_json["region"].keys())
         self.assertIn("id", site_json.keys())
@@ -236,8 +236,8 @@ class ModelToJson(TestCase):
         self.assertEqual(site_json["slug"], "site-1")
         self.assertEqual(site_json["region"]["slug"], "region-a")
 
-    def test_model_to_json_with_filterset(self):
-        site_json = model_to_json(self.site1, "nautobot.dcim.api.serializers.SiteSerializer")
+    def test_model_to_dict_with_filterset(self):
+        site_json = model_to_dict(self.site1, "nautobot.dcim.api.serializers.SiteSerializer")
         self.assertIn("url", site_json.keys())
         self.assertIn("url", site_json["region"].keys())
         self.assertIn("id", site_json.keys())

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -188,14 +188,14 @@ def serialize_object_v2(obj):
     return data
 
 
-def model_to_json(obj, cls=None):
+def model_to_dict(obj, dotted_path=None):
     """
-    Convenience method to convert object instance to json via a serializer.
+    Convert a Django model instance to a dictionary that is JSON serialiable, leveraging a Django serializer.
     """
-    if cls:
+    if dotted_path:
         # By default serialize_object_v2 will find a serializer, this is used to send in the serializer
         # you would prefer, via a `import_string` dotted path to the serializer
-        return json.loads(JSONRenderer().render(import_string(cls)(obj, context={"request": None}).data))
+        return json.loads(JSONRenderer().render(import_string(dotted_path)(obj, context={"request": None}).data))
     return json.loads(JSONRenderer().render(serialize_object_v2(obj)))
 
 

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -5,6 +5,7 @@ import json
 from collections import OrderedDict, namedtuple
 from itertools import count, groupby
 from decimal import Decimal
+from rest_framework.renderers import JSONRenderer
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -185,6 +186,17 @@ def serialize_object_v2(obj):
         data = serialize_object(obj)
 
     return data
+
+
+def model_to_json(obj, cls=None):
+    """
+    Convenience method to convert object instance to json via a serializer.
+    """
+    if cls:
+        # By default serialize_object_v2 will find a serializer, this is used to send in the serializer
+        # you would prefer, via a `import_string` dotted path to the serializer
+        return json.loads(JSONRenderer().render(import_string(cls)(obj, context={"request": None}).data))
+    return json.loads(JSONRenderer().render(serialize_object_v2(obj)))
 
 
 def dict_to_filter_params(d, prefix=""):

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -190,7 +190,7 @@ def serialize_object_v2(obj):
 
 def model_to_dict(obj, dotted_path=None):
     """
-    Convert a Django model instance to a dictionary that is JSON serialiable, leveraging a Django serializer.
+    Convert a Django model instance to a dictionary that is JSON serializable, leveraging a Django serializer.
     """
     if dotted_path:
         # By default serialize_object_v2 will find a serializer, this is used to send in the serializer


### PR DESCRIPTION

# Closes: N/A
# What's Changed

Added a util method to convert a model object instance to json data, via a serializer. With the increased usage of jobs and plugins, accessing data via the orm is more and more likely to happen. This should help alleviate instances where developers are having to expand data themselves, instead leveraging the serializer to expand data.