### PR TITLE
fixed unbound local error by initializing template variable before conditional logic statements

### DIFF
--- a/nautobot/utilities/tables.py
+++ b/nautobot/utilities/tables.py
@@ -365,11 +365,11 @@ class CustomFieldColumn(tables.Column):
         if value is None:
             return self.default
 
+        template = ""
         if self.customfield.type == CustomFieldTypeChoices.TYPE_BOOLEAN:
             template = render_boolean(value)
         elif self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
             if value:
-                template = ""
                 for v in value:
                     template += format_html('<span class="label label-default">{}</span> ', v)
         elif self.customfield.type == CustomFieldTypeChoices.TYPE_SELECT:


### PR DESCRIPTION
I didnt really get the unbound local error when following the steps to reproduce. But looking at the code, if `value = None` and the `CustomFieldTypeChoice` is `Type.Multiselect,` `template` variable does not get initialized