### PR TITLE
Add ability to sepecify uWSGI buffer size via environment variable

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -84,6 +84,10 @@ if [ "$NAUTOBOT_UWSGI_LISTEN" ]; then
   sed -i "s@.*listen = .*\$@listen = $NAUTOBOT_UWSGI_LISTEN@" /opt/nautobot/uwsgi.ini
 fi
 
+if [ "$NAUTOBOT_UWSGI_BUFFER_SIZE" ]; then
+  sed -i "s@.*buffer-size = .*\$@buffer-size = $NAUTOBOT_UWSGI_BUFFER_SIZE@" /opt/nautobot/uwsgi.ini
+fi
+
 # Launch whatever is passed by docker
 # (i.e. the RUN instruction in the Dockerfile)
 #

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -50,3 +50,7 @@ listen = 128
 ; If using subdirectory hosting e.g. example.com/nautobot, you must uncomment this line. Otherwise you'll get double paths e.g. example.com/nautobot/nautobot/.
 ; See: https://uwsgi-docs.readthedocs.io/en/latest/Changelog-2.0.11.html#fixpathinfo-routing-action
 ; route-run = fixpathinfo:
+
+; For larger installations, certain API calls (example: Relationships, GraphQL) can have a length of query parameters that go over uWSGI default limit.
+; Setting the buffer size to larger than default (4096) can have an impact on memory utilization, but can be set as high as the header limit of 65535.
+buffer-size = 4096

--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -138,6 +138,20 @@ If [`NAUTOBOT_CREATE_SUPERUSER`](#nautobot_create_superuser) is true, `NAUTOBOT_
 
 The docker container uses [uWSGI](https://uwsgi-docs.readthedocs.io/) to serve Nautobot.  A default configuration is [provided](https://github.com/nautobot/nautobot/blob/main/docker/uwsgi.ini), and can be overridden by injecting a new `uwsgi.ini` file at `/opt/nautobot/uwsgi.ini`.  There are a couple of environment variables provided to override some uWSGI defaults:
 
+#### `NAUTOBOT_UWSGI_BUFFER_SIZE`
+
+_Added in version 1.3.9_ <!-- markdownlint-disable-line MD036 -->
+
+Default: `4096`
+
+Max: `65535`
+
+The max size of non-body request payload, roughly the size of request headers for uWSGI. Request headers that might contain lengthy query parameters, for example GraphQL or Relationship filtered lookups, might go well over this limit. Increasing this limit will have an impact on running memory usage. please see [the uWSGI documentation](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?highlight=buffer-size#buffer-size) for more information.
+
+This can also be overridden by appending `-b DESIRED_BUFFER_SIZE`, ex: `-b 8192`, to the entry command in all Nautobot containers running uWSGI if you are on a release before `1.3.9`.
+
+---
+
 #### `NAUTOBOT_UWSGI_LISTEN`
 
 Default: `128`

--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -146,7 +146,7 @@ Default: `4096`
 
 Max: `65535`
 
-The max size of non-body request payload, roughly the size of request headers for uWSGI. Request headers that might contain lengthy query parameters, for example GraphQL or Relationship filtered lookups, might go well over this limit. Increasing this limit will have an impact on running memory usage. please see [the uWSGI documentation](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?highlight=buffer-size#buffer-size) for more information.
+The max size of non-body request payload, roughly the size of request headers for uWSGI. Request headers that might contain lengthy query parameters, for example GraphQL or Relationship filtered lookups, might go well over this limit. Increasing this limit will have an impact on running memory usage. Please see [the uWSGI documentation](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?highlight=buffer-size#buffer-size) for more information.
 
 This can also be overridden by appending `-b DESIRED_BUFFER_SIZE`, ex: `-b 8192`, to the entry command in all Nautobot containers running uWSGI if you are on a release before `1.3.9`.
 

--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -146,7 +146,7 @@ Default: `4096`
 
 Max: `65535`
 
-The max size of non-body request payload, roughly the size of request headers for uWSGI. Request headers that might contain lengthy query parameters, for example GraphQL or Relationship filtered lookups, might go well over this limit. Increasing this limit will have an impact on running memory usage. Please see [the uWSGI documentation](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?highlight=buffer-size#buffer-size) for more information.
+The max size of non-body request payload, roughly the size of request headers for uWSGI. Request headers that might contain lengthy query parameters, for example GraphQL or Relationship filtered lookups, might go well over the default limit. Increasing this limit will have an impact on running memory usage. Please see [the uWSGI documentation](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?highlight=buffer-size#buffer-size) for more information.
 
 This can also be overridden by appending `-b DESIRED_BUFFER_SIZE`, ex: `-b 8192`, to the entry command in all Nautobot containers running uWSGI if you are on a release before `1.3.9`.
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1595
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
* Added `sed` override for uWSGI `buffer-size` limit via `$NAUTOBOT_UWSGI_BUFFER_SIZE`
* Extended default `buffer-size` into `docker/uwsgi.ini` to better expose value and simplify `sed` operation
* Updated Docker documentation to include new `NAUTOBOT_UWSGI_BUFFER_SIZE` variable

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- NA Attached Screenshots, Payload Example
- NA Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- NA Example Plugin Updates (when adding/changing features)
- NA Outline Remaining Work, Constraints from Design