### PR TITLE
Fixes #2039 - Default job values with 0 evaulate false

### DIFF
--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -608,7 +608,7 @@ class ScriptVariable:
             self.field_attrs["label"] = label
         if description:
             self.field_attrs["help_text"] = description
-        if default:
+        if default is not None:
             self.field_attrs["initial"] = default
         if widget:
             self.field_attrs["widget"] = widget

--- a/nautobot/extras/tests/example_jobs/test_field_default.py
+++ b/nautobot/extras/tests/example_jobs/test_field_default.py
@@ -1,0 +1,13 @@
+from nautobot.extras.jobs import IntegerVar, Job
+
+
+class TestFieldDefault(Job):
+    """My job demo."""
+
+    var_int = IntegerVar(default=0, min_value=0, max_value=3600, description="Test default of 0 Falsey")
+    var_int_no_default = IntegerVar(required=False, min_value=0, max_value=3600, description="Test default without default")
+
+    class Meta:
+        """Metaclass attrs."""
+
+        field_order = ["var_int", "var_int_no_default"]

--- a/nautobot/extras/tests/example_jobs/test_field_default.py
+++ b/nautobot/extras/tests/example_jobs/test_field_default.py
@@ -5,7 +5,9 @@ class TestFieldDefault(Job):
     """My job demo."""
 
     var_int = IntegerVar(default=0, min_value=0, max_value=3600, description="Test default of 0 Falsey")
-    var_int_no_default = IntegerVar(required=False, min_value=0, max_value=3600, description="Test default without default")
+    var_int_no_default = IntegerVar(
+        required=False, min_value=0, max_value=3600, description="Test default without default"
+    )
 
     class Meta:
         """Metaclass attrs."""

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -3,8 +3,17 @@ import uuid
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
-
-from nautobot.dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Platform, Rack, Region, Site
+from nautobot.dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Interface,
+    Manufacturer,
+    Platform,
+    Rack,
+    Region,
+    Site,
+)
 from nautobot.extras.choices import (
     ObjectChangeActionChoices,
     SecretsGroupAccessTypeChoices,
@@ -24,8 +33,8 @@ from nautobot.extras.filters import (
     RelationshipAssociationFilterSet,
     RelationshipFilterSet,
     SecretFilterSet,
-    SecretsGroupFilterSet,
     SecretsGroupAssociationFilterSet,
+    SecretsGroupFilterSet,
     StatusFilterSet,
     TagFilterSet,
     WebhookFilterSet,
@@ -50,11 +59,10 @@ from nautobot.extras.models import (
     Tag,
     Webhook,
 )
-from nautobot.ipam.models import IPAddress, VLAN
+from nautobot.ipam.models import VLAN, IPAddress
 from nautobot.tenancy.models import Tenant, TenantGroup
 from nautobot.utilities.choices import ColorChoices
 from nautobot.virtualization.models import Cluster, ClusterGroup, ClusterType
-
 
 # Use the proper swappable User model
 User = get_user_model()
@@ -602,13 +610,13 @@ class JobFilterSetTestCase(TestCase):
 
     def test_installed(self):
         params = {"installed": True}
-        # 31 local jobs and 3 plugin jobs
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 34)
+        # 32 local jobs and 3 plugin jobs
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 35)
 
     def test_enabled(self):
         params = {"enabled": False}
-        # 31 local jobs and 3 plugin jobs
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 34)
+        # 32 local jobs and 3 plugin jobs
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 35)
 
     def test_commit_default(self):
         params = {"commit_default": False}

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -59,7 +59,7 @@ from nautobot.extras.models import (
     Tag,
     Webhook,
 )
-from nautobot.ipam.models import VLAN, IPAddress
+from nautobot.ipam.models import IPAddress, VLAN
 from nautobot.tenancy.models import Tenant, TenantGroup
 from nautobot.utilities.choices import ColorChoices
 from nautobot.virtualization.models import Cluster, ClusterGroup, ClusterType

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -122,6 +122,29 @@ class JobTest(TransactionTestCase):
         job_result = create_job_result_and_run_job(module, name, commit=False)
         self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_ERRORED)
 
+    def test_field_default(self):
+        """
+        Job test with field that is a default value that is falsey.
+        https://github.com/nautobot/nautobot/issues/2039
+        """
+        module = "test_field_default"
+        name = "TestFieldDefault"
+        job_class = get_job(f"local/{module}/{name}")
+        form = job_class().as_form()
+
+        self.assertHTMLEqual(
+            form.as_table(),
+            """<tr><th><label for="id_var_int">Var int:</label></th><td>
+<input class="form-control form-control" id="id_var_int" max="3600" name="var_int" placeholder="None" required type="number" value="0">
+<br><span class="helptext">Test default of 0 Falsey</span></td></tr>
+<tr><th><label for="id_var_int_no_default">Var int no default:</label></th><td>
+<input class="form-control form-control" id="id_var_int_no_default" max="3600" name="var_int_no_default" placeholder="None" type="number">
+<br><span class="helptext">Test default without default</span></td></tr>
+<tr><th><label for="id__commit">Commit changes:</label></th><td>
+<input checked id="id__commit" name="_commit" placeholder="Commit changes" type="checkbox">
+<br><span class="helptext">Commit changes to the database (uncheck for a dry-run)</span></td></tr>""",
+        )
+
     def test_field_order(self):
         """
         Job test with field order.
@@ -350,19 +373,6 @@ class JobTest(TransactionTestCase):
             grouping="initialization", log_level=LogLevelChoices.LOG_FAILURE
         ).first()
         self.assertIn("Data should be a dictionary", log_failure.message)
-
-    def test_job_data_with_falsey_value(self):
-        """
-        Test a default value of 0 as an input.
-        https://github.com/nautobot/nautobot/issues/2039
-        """
-        module = "test_integer_default"
-        name = "TestIntegerDefault"
-        data = {"timer": 0}
-
-        job_result = create_job_result_and_run_job(module, name, data=data, commit=False)
-        self.assertEqual(job_result.data.get("timer"), 0)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_COMPLETED)
 
     def test_job_latest_result_property(self):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2039 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Fixes the default job value to allow the IntegerVar to be a 0 and not evaluate to false.