### PR TITLE
Clarify messaging in API for rack position occupied.

### DIFF
--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -804,7 +804,11 @@ class DeviceSerializer(TaggedObjectSerializer, StatusModelSerializerMixin, Custo
 
         # Validate uniqueness of (rack, position, face) since we omitted the automatically-created validator from Meta.
         if data.get("rack") and data.get("position") and data.get("face"):
-            validator = UniqueTogetherValidator(queryset=Device.objects.all(), fields=("rack", "position", "face"))
+            validator = UniqueTogetherValidator(
+                queryset=Device.objects.all(),
+                fields=("rack", "position", "face"),
+                message=f"The position and face is already occupied on this rack. {UniqueTogetherValidator.message}",
+            )
             validator(data, self)
 
         # Enforce model validation


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #386
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
- Added "The position and face is already occupied on this rack." to message outputted by `UniqueTogetherValidator` for `DeviceSerializer`.

<img width="1298" alt="image" src="https://user-images.githubusercontent.com/31187/178593416-e4497a91-ef46-4a6a-b417-e2d3b1404577.png">


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- NA Unit, Integration Tests
- NA Documentation Updates (when adding/changing features)
- NA Example Plugin Updates (when adding/changing features)
- NA Outline Remaining Work, Constraints from Design