### PR TITLE
Add get_changelog_url Method to Objects that Support Changelogs

### DIFF
--- a/nautobot/core/templates/generic/object_detail.html
+++ b/nautobot/core/templates/generic/object_detail.html
@@ -86,9 +86,9 @@
             </li>
         {% endif %}
         {% if perms.extras.view_objectchange %}
-            {% if active_tab != 'changelog' and changelog_url or active_tab == 'changelog' %}
+            {% if active_tab != 'changelog' and object.get_changelog_url or active_tab == 'changelog' %}
                 <li role="presentation"{% if active_tab == 'changelog' %} class="active"{% endif %}>
-                    <a href="{{ changelog_url }}">Change Log</a>
+                    <a href="{{ object.get_changelog_url }}">Change Log</a>
                 </li>
             {% endif %}
         {% endif %}

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -84,6 +84,9 @@ class ObjectView(ObjectPermissionRequiredMixin, View):
             "active_tab": request.GET.get("tab", "main"),
         }
 
+    # TODO: Remove this method in 2.0. Can be retrieved from instance itself now
+    # instance.get_changelog_url()
+    # Only available on models that support changelogs
     def get_changelog_url(self, instance):
         """Return the changelog URL for a given instance."""
         meta = self.queryset.model._meta
@@ -123,7 +126,7 @@ class ObjectView(ObjectPermissionRequiredMixin, View):
                 "object": instance,
                 "verbose_name": self.queryset.model._meta.verbose_name,
                 "verbose_name_plural": self.queryset.model._meta.verbose_name_plural,
-                "changelog_url": self.get_changelog_url(instance),
+                "changelog_url": instance.get_changelog_url(),  # TODO: Remove in 2.0. This information can be retrieved from the object itself now.
                 **self.get_extra_context(request, instance),
             },
         )

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -23,6 +23,7 @@ from django.views.generic import View
 from django_tables2 import RequestConfig
 
 from nautobot.extras.models import CustomField, ExportTemplate
+from nautobot.extras.models.change_logging import ChangeLoggedModel
 from nautobot.utilities.error_handlers import handle_protectederror
 from nautobot.utilities.exceptions import AbortTransaction
 from nautobot.utilities.forms import (
@@ -119,6 +120,11 @@ class ObjectView(ObjectPermissionRequiredMixin, View):
         """
         instance = get_object_or_404(self.queryset, **kwargs)
 
+        changelog_url = None
+
+        if isinstance(instance, ChangeLoggedModel):
+            changelog_url = instance.get_changelog_url()
+
         return render(
             request,
             self.get_template_name(),
@@ -126,7 +132,7 @@ class ObjectView(ObjectPermissionRequiredMixin, View):
                 "object": instance,
                 "verbose_name": self.queryset.model._meta.verbose_name,
                 "verbose_name_plural": self.queryset.model._meta.verbose_name_plural,
-                "changelog_url": instance.get_changelog_url(),  # TODO: Remove in 2.0. This information can be retrieved from the object itself now.
+                "changelog_url": changelog_url,  # TODO: Remove in 2.0. This information can be retrieved from the object itself now.
                 **self.get_extra_context(request, instance),
             },
         )

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -376,6 +376,11 @@ class CustomField(BaseModel, ChangeLoggedModel):
                 {"default": f"The specified default value ({self.default}) is not listed as an available choice."}
             )
 
+    def get_changelog_url(self):
+        """Overloaded from ChangeLoggedModel.get_changelog_url as custom fields route on name, not PK or slug."""
+        route = "extras:customfield_changelog"
+        return reverse(route, kwargs={"name": getattr(self, "name")})
+
     def to_form_field(self, set_initial=True, enforce_required=True, for_csv_import=False, simple_json_filter=False):
         """
         Return a form field suitable for setting a CustomField's value for an object.

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -379,7 +379,7 @@ class CustomField(BaseModel, ChangeLoggedModel):
     def get_changelog_url(self):
         """Overloaded from ChangeLoggedModel.get_changelog_url as custom fields route on name, not PK or slug."""
         route = "extras:customfield_changelog"
-        return reverse(route, kwargs={"name": getattr(self, "name")})
+        return reverse(route, kwargs={"name": self.name})
 
     def to_form_field(self, set_initial=True, enforce_required=True, for_csv_import=False, simple_json_filter=False):
         """

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -344,14 +344,6 @@ class CustomFieldListView(generic.ObjectListView):
 class CustomFieldView(generic.ObjectView):
     queryset = CustomField.objects.all()
 
-    # TODO: Remove this method in 2.0. Can be retrieved from instance itself now
-    # instance.get_changelog_url()
-    # Only available on models that support changelogs
-    def get_changelog_url(self, instance):
-        """Return the changelog URL."""
-        route = "extras:customfield_changelog"
-        return reverse(route, kwargs={"name": getattr(instance, "name")})
-
 
 class CustomFieldEditView(generic.ObjectEditView):
     queryset = CustomField.objects.all()

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -344,6 +344,9 @@ class CustomFieldListView(generic.ObjectListView):
 class CustomFieldView(generic.ObjectView):
     queryset = CustomField.objects.all()
 
+    # TODO: Remove this method in 2.0. Can be retrieved from instance itself now
+    # instance.get_changelog_url()
+    # Only available on models that support changelogs
     def get_changelog_url(self, instance):
         """Return the changelog URL."""
         route = "extras:customfield_changelog"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
In working with @smk4664 on #1984 it was discovered that more than just the model object is needed to be passed down in context to render the tabs.

Just like we have the `get_absolute_url` method on objects in aiding to reverse resolve the URL to the object, this adds the `get_changelog_url` method to objects that inherit from `ChangeLoggedModel`.

This will eventually eliminate the need for `changelog_url` to be passed down in the view context but is kept for now for backwards compatibility. It is no longer used in the views as the template itself has been updated to reference `object.get_changelog_url`. Existing methods are also kept for the time being.

`CustomField` models must override this as they key on the name of the Custom Field instead of `pk` or `slug` all other models use (_cough_ lets move that to `slug` _cough_).

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- NA Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [?] Documentation Updates (when adding/changing features)
- [?] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design