### PR TITLE
Fixed CablePath not found error when disconnects/delete action performed on a cable

### DIFF
--- a/nautobot/dcim/signals.py
+++ b/nautobot/dcim/signals.py
@@ -2,7 +2,7 @@ import logging
 
 from cacheops import invalidate_obj
 from django.contrib.contenttypes.models import ContentType
-from django.db.models.signals import post_save, post_delete, pre_delete
+from django.db.models.signals import post_save, pre_delete
 from django.db import transaction
 from django.dispatch import receiver
 
@@ -157,7 +157,7 @@ def update_connected_endpoints(instance, created, raw=False, **kwargs):
             rebuild_paths(instance)
 
 
-@receiver(post_delete, sender=Cable)
+@receiver(pre_delete, sender=Cable)
 def nullify_connected_endpoints(instance, **kwargs):
     """
     When a Cable is deleted, check for and update its two connected endpoints

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -2156,6 +2156,7 @@ class CableTestCase(
         }
 
     def test_delete_a_cable_which_has_a_peer_connection(self):
+        """Test for https://github.com/nautobot/nautobot/issues/1694."""
         self.add_permissions("dcim.delete_cable")
 
         site = Site.objects.first()

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -2204,12 +2204,16 @@ class CableTestCase(
         cable_path_1 = CablePath.objects.filter(
             Q(origin_type=termination_ct, origin_id=circuit_terminations[0].pk)
             | Q(origin_type=interface_ct, origin_id=interfaces[0].pk)
+            | Q(destination_type=termination_ct, destination_id=circuit_terminations[0].pk)
+            | Q(destination_type=interface_ct, destination_id=interfaces[0].pk)
         )
         self.assertFalse(cable_path_1.exists())
 
         cable_path_2 = CablePath.objects.filter(
             Q(origin_type=termination_ct, origin_id=circuit_terminations[1].pk)
             | Q(origin_type=interface_ct, origin_id=interfaces[1].pk)
+            | Q(destination_type=termination_ct, destination_id=circuit_terminations[1].pk)
+            | Q(destination_type=interface_ct, destination_id=interfaces[1].pk)
         )
         self.assertTrue(cable_path_2.exists())
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1694 
# What's Changed
## Problem
Previously disconnecting/deleting this `Cable` triggers `post_delete`  signal.
```python
@receiver(post_delete, sender=Cable)
def nullify_connected_endpoints(instance, **kwargs):
    """
    When a Cable is deleted, check for and update its two connected endpoints
    """
    logger = logging.getLogger("nautobot.dcim.cable")

    # Disassociate the Cable from its termination points
    if instance.termination_a is not None:
        logger.debug(f"Nullifying termination A for cable {instance}")
        instance.termination_a.cable = None
        instance.termination_a._cable_peer = None
        instance.termination_a.save()
    if instance.termination_b is not None:
        logger.debug(f"Nullifying termination B for cable {instance}")
        instance.termination_b.cable = None
        instance.termination_b._cable_peer = None
        instance.termination_b.save()
     ...

```
then `instance.termination_a.save()` triggers `CircuitTermination` `post_save` signal
```python
@receiver(post_save, sender=CircuitTermination)
def update_connected_terminations(instance, **kwargs):
    """
    When a CircuitTermination has been modified, update the Cable Paths if the Circuit Termination has a peer.
    """
    peer = instance.get_peer_termination()
    # Check if Circuit Termination has a peer
    if peer:
        rebuild_paths_circuits(peer)
```
`rebuild_paths_circuits(peer)` attempts to rebuild a list of `CablePath` by deleting and recreating it. The problem with this is it might get a `Path` in which `origin.cable` is the `Cable` that just got deleted and then ends up not recreating that `CablePath`.
```python
def rebuild_paths_circuits(obj):
    """
    Rebuild all CablePaths which traverse, begin or end with the specified node.
    """
    termination_type = ContentType.objects.get_for_model(CircuitTermination)

    cable_paths = CablePath.objects.filter(
        Q(path__contains=obj)
        | Q(destination_type=termination_type, destination_id=obj.pk)
        | Q(origin_type=termination_type, origin_id=obj.pk)
    )

    with transaction.atomic():
        for cp in cable_paths:
            invalidate_obj(cp.origin)
            cp.delete()
            # Prevent looping back to rebuild_paths during the atomic transaction.
            create_cablepath(cp.origin, rebuild=False)

```

## Solution
Changing `Cable` `post_delete`  signal to `pre_delete`, makes sure all deleted `CablePath` gets recreated because the `Cable` is yet to be deleted at the time this action is performed : **ref**:`rebuild_paths_circuits(peer) `



# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design