### PR TITLE
Dynamic Group of Groups: Add draggable child groups, recompute and hide weight.

### DIFF
--- a/nautobot/extras/forms.py
+++ b/nautobot/extras/forms.py
@@ -888,6 +888,7 @@ BaseDynamicGroupMembershipFormSet = inlineformset_factory(
     fk_name="parent_group",
     widgets={
         "operator": StaticSelect2,
+        "weight": forms.HiddenInput(),
     },
 )
 

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -304,7 +304,6 @@ class DynamicGroupMembershipTable(DynamicGroupTable):
             "members",
             "filter",
             "operator",
-            "weight",
             "description",
             "actions",
         )

--- a/nautobot/extras/templates/extras/dynamicgroup_edit.html
+++ b/nautobot/extras/templates/extras/dynamicgroup_edit.html
@@ -62,6 +62,7 @@
                                 {% if forloop.first %}
                                     <thead>
                                         <tr>
+                                            <th>Sort</th>
                                             {% for field in child_form.visible_fields %}
                                                 <th>{{ field.label|capfirst }}</th>
                                             {% endfor %}
@@ -69,6 +70,7 @@
                                     </thead>
                                 {% endif %}
                                 <tr class="formset_row-{{ children.prefix }}">
+                                    <td><i class="mdi mdi-drag-horizontal drag-handler"></i></td>
                                     {% for field in child_form.visible_fields %}
                                         <td>
                                             {% if forloop.first %}
@@ -111,6 +113,35 @@
         prefix: '{{ children.prefix }}',
         formCssClass: 'dynamic-formset-{{ children.prefix }}',
         added: jsify_form
+    });
+
+    // Function that takes a Dynamic Group children form and recomputes the weights.
+    function update_weights(children_form){
+        let w = 10;
+        $(children_form).find('.formset_row-{{ children.prefix }}').each((i, el) => {
+            contains_value = $(el).find("select[name$='-group'], select[name$='-operator']").map((idx, sel) => {
+                return ($(sel).val().length > 0)
+            }).toArray().some(x => x === true)
+
+            if(contains_value) {
+                $(el).find("*[name$='-weight']").val(w);
+                w+=10;
+            }
+        })
+    }
+
+    // Make the children form formset rows draggable and hook to re-weight on drag complete.
+    $('#children-form').sortable({
+        handle: '.drag-handler',
+        items: '.formset_row-{{ children.prefix }}',
+        update: ( e, ui ) => {
+            update_weights(e.target)
+        }
+    });
+
+    // Instead of re-weight on every input change, just do it before we submit the form.
+    $('form.form').submit((e) => {
+        $(e.target).find('#children-form').each((i, cf) => { update_weights(cf) });
     });
 </script>
 {% endblock javascript %}

--- a/nautobot/extras/templates/extras/dynamicgroup_edit.html
+++ b/nautobot/extras/templates/extras/dynamicgroup_edit.html
@@ -119,12 +119,14 @@
     function update_weights(children_form){
         let w = 10;
         $(children_form).find('.formset_row-{{ children.prefix }}').each((i, el) => {
-            contains_value = $(el).find("select[name$='-group'], select[name$='-operator']").map((idx, sel) => {
+            let contains_value = $(el).find("select[name$='-group'], select[name$='-operator']").map((idx, sel) => {
                 return ($(sel).val().length > 0)
             }).toArray().some(x => x === true)
 
+            let weight_input = $(el).find("*[name$='-weight']")
+            weight_input.val("")
             if(contains_value) {
-                $(el).find("*[name$='-weight']").val(w);
+                weight_input.val(w);
                 w+=10;
             }
         })

--- a/nautobot/extras/templates/extras/dynamicgroup_edit.html
+++ b/nautobot/extras/templates/extras/dynamicgroup_edit.html
@@ -62,7 +62,7 @@
                                 {% if forloop.first %}
                                     <thead>
                                         <tr>
-                                            <th>Sort</th>
+                                            <th>Weight</th>
                                             {% for field in child_form.visible_fields %}
                                                 <th>{{ field.label|capfirst }}</th>
                                             {% endfor %}
@@ -119,15 +119,28 @@
     function update_weights(children_form){
         let w = 10;
         $(children_form).find('.formset_row-{{ children.prefix }}').each((i, el) => {
-            let contains_value = $(el).find("select[name$='-group'], select[name$='-operator']").map((idx, sel) => {
-                return ($(sel).val().length > 0)
-            }).toArray().some(x => x === true)
+
+            // A child is considered "weight-able" if any of the settable values contains a value
+            // If a user is in the middle of setting a group we want to consider it for weight
+            // We also want to remove the weight if it's empty to not throw a field value error on a hidden field
+            //
+            // el = child row
+            // sel = a select element either specifying the child group or operator
+            //         we don't need to worry about which one we are looking at, just if it has a value
+            let contains_value = $(el).find("select[name$='-group'], select[name$='-operator']") // Get any select element in this row ending in -group or -operator
+                .toArray() // Convert to Array to access .some() method
+                .some((x) => { return ($(x).val().length > 0) === true }) // Evaluate if any element in this row has a value length over 0
+                // .some(fn(x)) will return a true/false if any item in the array return true when passed into the evaluator function
+
+
 
             let weight_input = $(el).find("*[name$='-weight']")
-            weight_input.val("")
+            weight_input.val("") // Reset the value to start clean always
             if(contains_value) {
-                weight_input.val(w);
-                w+=10;
+                weight_input.val(w); // Set a weight
+                w += 10; // Following current convention by allowing space between children to aid in API interface.
+                         //   If someone wants to add a child later via the API they can insert a child between children without
+                         //   having to re-weight all children following first.
             }
         })
     }


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
- Add dragging and re-weighting to Dynamic Group of Groups memberships


**Drag to Re-Weight**

https://user-images.githubusercontent.com/31187/179160540-bc9face5-8d3d-4d13-859d-a5dfba84c8a9.mov

**Ignores Empty Rows**

https://user-images.githubusercontent.com/31187/179161313-12f5bcee-772f-4b5e-a018-7f01c2c89ed2.mov

**



# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- NA Unit, Integration Tests
- NA Documentation Updates (when adding/changing features)
- NA Example Plugin Updates (when adding/changing features)
- NA Outline Remaining Work, Constraints from Design