### PR TITLE
Expand on `query_params` for ObjectVar in the documentation

### DIFF
--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -304,7 +304,7 @@ device = ObjectVar(
 )
 ```
 
-Multiple values can be specified by assigning a list to the dictionary key. It is also possible to reference the value of other fields in the form by prepending a dollar sign (`$`) to the variable's name. You can even traverse the model relationships this way (note the single underscore in the example - `tenant_region_id`).
+Multiple values can be specified by assigning a list to the dictionary key. It is also possible to reference the value of other fields in the form by prepending a dollar sign (`$`) to the variable's name. The keys you can use in this dictionary are the same ones that are available in the REST API - as an example it is also possible to filter the `Site` `ObjectVar` for its `tenant_group_id`.
 
 ```python
 region = ObjectVar(
@@ -317,7 +317,7 @@ site = ObjectVar(
     model=Site,
     query_params={
         'region_id': '$region',
-        'tenant_region_id': '$tenant_group'
+        'tenant_group_id': '$tenant_group'
     }
 )
 ```

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -281,7 +281,7 @@ A particular object within Nautobot. Each ObjectVar must specify a particular mo
 
 * `model` - The model class
 * `display_field` - The name of the REST API object field to display in the selection list (default: `'display'`)
-* `query_params` - A dictionary of query parameters to use when retrieving available options (optional)
+* `query_params` - A dictionary of REST API query parameters to use when retrieving available options (optional)
 * `null_option` - A label representing a "null" or empty choice (optional)
 
 The `display_field` argument is useful in cases where using the `display` API field is not desired for referencing the object. For example, when displaying a list of IP Addresses, you might want to use the `dns_name` field:
@@ -304,16 +304,20 @@ device = ObjectVar(
 )
 ```
 
-Multiple values can be specified by assigning a list to the dictionary key. It is also possible to reference the value of other fields in the form by prepending a dollar sign (`$`) to the variable's name.
+Multiple values can be specified by assigning a list to the dictionary key. It is also possible to reference the value of other fields in the form by prepending a dollar sign (`$`) to the variable's name. You can even traverse the model relationships this way (note the single underscore in the example - `tenant_region_id`).
 
 ```python
 region = ObjectVar(
     model=Region
 )
+tenant_group = ObjectVar(
+    model=TenantGroup
+)
 site = ObjectVar(
     model=Site,
     query_params={
-        'region_id': '$region'
+        'region_id': '$region',
+        'tenant_region_id': '$tenant_group'
     }
 )
 ```


### PR DESCRIPTION
# Closes: DNE
# What's Changed

Expand on `query_params` for `ObjectVar` in the documentation, clarify that its syntax is composed of REST API parameters rather than ORM ones.