### PR TITLE
Handle case on object detail views where a relationship-association involves a non-installed model

### DIFF
--- a/examples/example_plugin/example_plugin/forms.py
+++ b/examples/example_plugin/example_plugin/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 
+from nautobot.extras.forms import NautobotModelForm
 from nautobot.utilities.forms import (
     BootstrapMixin,
     BulkEditForm,
@@ -16,7 +17,7 @@ class ExamplePluginConfigForm(BootstrapMixin, forms.Form):
     maximum_velocity = forms.IntegerField(help_text="Meters per second")
 
 
-class ExampleModelForm(BootstrapMixin, forms.ModelForm):
+class ExampleModelForm(NautobotModelForm):
     """Generic create/update form for `ExampleModel` objects."""
 
     class Meta:
@@ -52,7 +53,7 @@ class ExampleModelBulkEditForm(BootstrapMixin, BulkEditForm):
         nullable_fields = []
 
 
-class AnotherExampleModelForm(BootstrapMixin, forms.ModelForm):
+class AnotherExampleModelForm(NautobotModelForm):
     """Generic create/update form for `AnotherExampleModel` objects."""
 
     class Meta:

--- a/examples/example_plugin/example_plugin/models.py
+++ b/examples/example_plugin/example_plugin/models.py
@@ -6,9 +6,13 @@ from nautobot.extras.utils import extras_features
 
 
 @extras_features(
+    "custom_fields",
     "custom_links",
+    "custom_validators",
     "dynamic_groups",
+    "export_templates",
     "graphql",
+    "relationships",
     "webhooks",
 )
 class ExampleModel(OrganizationalModel):
@@ -35,7 +39,12 @@ class ExampleModel(OrganizationalModel):
 
 @extras_features(
     "custom_fields",
+    "custom_validators",
     "dynamic_groups",
+    "export_templates",
+    # "graphql", Not specified here as we have a custom type for this model, see example_plugin.graphql.types
+    "relationships",
+    "webhooks",
 )
 class AnotherExampleModel(OrganizationalModel):
     name = models.CharField(max_length=20)

--- a/nautobot/core/templates/inc/relationships_table_rows.html
+++ b/nautobot/core/templates/inc/relationships_table_rows.html
@@ -13,10 +13,19 @@
                     <td>
                         <a href="{% url 'extras:relationshipassociation_list' %}?relationship={{relationship.slug}}&{{side}}_id={{object.id}}">
                             {{ value.queryset.count }}
-                            {% if value.queryset.count > 1 %}
-                                {{ value.peer_type.model_class|meta:"verbose_name_plural" }}
+                            {% comment %}
+                            If peer_type is a plugin model that has subsequently been uninstalled,
+                            peer_type.model_class will be None and we can't access its Meta.
+                            https://github.com/nautobot/nautobot/issues/2077
+                            {% endcomment %}
+                            {% if value.peer_type.model_class is not None %}
+                                {% if value.queryset.count > 1 %}
+                                    {{ value.peer_type.model_class|meta:"verbose_name_plural" }}
+                                {% else %}
+                                    {{ value.peer_type.model_class|meta:"verbose_name" }}
+                                {% endif %}
                             {% else %}
-                                {{ value.peer_type.model_class|meta:"verbose_name" }}
+                                {{ value.peer_type }}(s)
                             {% endif %}
                         </a>
                     </td>

--- a/nautobot/docs/release-notes/version-1.3.md
+++ b/nautobot/docs/release-notes/version-1.3.md
@@ -167,6 +167,7 @@ As Python 3.6 has reached end-of-life, and many of Nautobot's dependencies have 
 - [#2036](https://github.com/nautobot/nautobot/pull/2036) - Fixed outdated UI navigation references in documentation.
 - [#2039](https://github.com/nautobot/nautobot/issues/2039) - Fixed IntegerVar with default set to 0 on Job evaluating to False.
 - [#2057](https://github.com/nautobot/nautobot/issues/2057) - Fixed RIR changelog route being in VRF name prefix.
+- [#2077](https://github.com/nautobot/nautobot/issues/2077) - Fixed an error when viewing object detail pages after uninstalling a plugin but still having RelationshipAssociations involving the plugin's models.
 
 ## v1.3.8 (2022-07-11)
 

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -656,10 +656,10 @@ class RelationshipAssociationTable(BaseTable):
     actions = ButtonsColumn(RelationshipAssociation, buttons=("delete",))
 
     source_type = tables.Column()
-    source = tables.Column(linkify=True, orderable=False, accessor="get_source")
+    source = tables.Column(linkify=True, orderable=False, accessor="get_source", default="unknown")
 
     destination_type = tables.Column()
-    destination = tables.Column(linkify=True, orderable=False, accessor="get_destination")
+    destination = tables.Column(linkify=True, orderable=False, accessor="get_destination", default="unknown")
 
     class Meta(BaseTable.Meta):
         model = RelationshipAssociation


### PR DESCRIPTION
# Closes: #2077
# What's Changed

- Add check in `relationships_table_rows.html` template to confirm that the related content-type actually has an associated model class, and have appropriate default behavior if not, instead of throwing an exception.
- Add missing standard extras_features to the example-plugin models.
- Change edit forms for example-plugin models to use NautobotModelForm, allowing specification of custom fields and relationship-associations when editing these models.
   - Add integration test for page rendering in this case
- In the case where a RelationshipAssociation involves an object of a missing/invalid content-type, change the table column so it displays "unknown" for the related object instead of "—"

# Screenshots

After enabling the example plugin, defining a Relationship and RelationshipAssociation between Region and ExampleModel, then disabling the example plugin:

![image](https://user-images.githubusercontent.com/5603551/180028520-2834212b-6323-4bd8-b563-34ddaa428947.png)

![image](https://user-images.githubusercontent.com/5603551/180028594-9fedf87a-a611-4394-b044-fd686eb52838.png)

# TODO
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design