### PR TITLE
update paginator to enforce MAX_PAGE_SIZE setting in web ui views

### DIFF
--- a/nautobot/utilities/paginator.py
+++ b/nautobot/utilities/paginator.py
@@ -12,6 +12,10 @@ class EnhancedPaginator(Paginator):
         except ValueError:
             per_page = get_settings_or_config("PAGINATE_COUNT")
 
+        max_page_size = get_settings_or_config("MAX_PAGE_SIZE")
+        if max_page_size:
+            per_page = min(per_page, max_page_size)
+
         super().__init__(object_list, per_page, **kwargs)
 
     def _get_page(self, *args, **kwargs):

--- a/nautobot/utilities/tests/test_paginator.py
+++ b/nautobot/utilities/tests/test_paginator.py
@@ -1,11 +1,14 @@
 """Test the nautobot.utilities.paginator module."""
 
 from django.contrib.auth import get_user_model
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import RequestFactory, override_settings
+from django.urls import reverse
 
 from constance.test import override_config
 
+from nautobot.dcim.models import Site
 from nautobot.utilities.paginator import get_paginate_count
+from nautobot.utilities.testing import TestCase
 
 
 class PaginatorTestCase(TestCase):
@@ -42,3 +45,34 @@ class PaginatorTestCase(TestCase):
         request = self.request_factory.get("some_paginated_view", {"per_page": 400})
         request.user = self.user
         self.assertEqual(get_paginate_count(request), 400)
+
+    @override_settings(MAX_PAGE_SIZE=10)
+    @override_settings(PAGINATE_COUNT=50)
+    def test_enforce_max_page_size(self):
+        """Request an object list view and assert that the MAX_PAGE_SIZE setting is enforced"""
+        Site.objects.bulk_create([Site(name=f"TestSite{x}") for x in range(20)])
+        url = reverse("dcim:site_list")
+        self.add_permissions("dcim.view_site")
+        self.client.force_login(self.user)
+        with self.subTest("query parameter per_page=20 returns 10 rows"):
+            response = self.client.get(url, {"per_page": 20})
+            self.assertHttpStatus(response, 200)
+            self.assertEqual(response.context["paginator"].per_page, 10)
+            self.assertEqual(len(response.context["table"].page), 10)
+        with self.subTest("query parameter per_page=5 returns 5 rows"):
+            response = self.client.get(url, {"per_page": 5})
+            self.assertHttpStatus(response, 200)
+            self.assertEqual(response.context["paginator"].per_page, 5)
+            self.assertEqual(len(response.context["table"].page), 5)
+        with self.subTest("user config per_page=200 returns 10 rows"):
+            self.user.set_config("pagination.per_page", 200, commit=True)
+            response = self.client.get(url)
+            self.assertHttpStatus(response, 200)
+            self.assertEqual(response.context["paginator"].per_page, 10)
+            self.assertEqual(len(response.context["table"].page), 10)
+        with self.subTest("global config PAGINATE_COUNT=50 returns 10 rows"):
+            self.user.clear_config("pagination.per_page", commit=True)
+            response = self.client.get(url)
+            self.assertHttpStatus(response, 200)
+            self.assertEqual(response.context["paginator"].per_page, 10)
+            self.assertEqual(len(response.context["table"].page), 10)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1739
# What's Changed

- Update `nautobot.utilities.paginator.EnhancePaginator` to enforce the `MAX_PAGE_SIZE` global setting in web ui views. This behaves the same as the API; if you request a page size greater than `MAX_PAGE_SIZE` the page size is set to `MAX_PAGE_SIZE`

NOTE: This was not added to the `get_paginate_count` method because `django_tables2.RequestConfig` overwrites the value returned from `get_paginate_count` if a `per_page` query param is included in the request


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design