### PR TITLE
Redirect home page to login page when HIDE_RESTRICTED_UI is set and user is logged out

### DIFF
--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -514,7 +514,7 @@ When set to `True`, users with limited permissions will only be able to see item
     As of Nautobot 1.2.0, if you do not set a value for this setting in your `nautobot_config.py`, it can be configured dynamically by an admin user via the Nautobot Admin UI. If you do have a value for this setting in `nautobot_config.py`, it will override any dynamically configured value.
 
 !!! note
-    As of Nautobot 1.3.10, when this settings is set to `True`, logged out users will be redirected to the login page when navigating to the Nautobot home page.
+    As of Nautobot 1.3.10, when this setting is set to `True`, logged out users will be redirected to the login page when navigating to the Nautobot home page.
 
 ---
 

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -742,6 +742,8 @@ Default: `[25, 50, 100, 250, 500, 1000]`
 
 The options displayed in the web interface dropdown to limit the number of objects per page. For proper user experience, this list should include the [`PAGINATE_COUNT`](#paginate_count) and [`MAX_PAGE_SIZE`](#max_page_size) values as options.
 
+---
+
 ## PAGINATE_COUNT
 
 Default: `50`

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -11,7 +11,7 @@ As of Nautobot 1.2.0, it is now possible to configure a number of settings via t
 * [HIDE_RESTRICTED_UI](#hide_restricted_ui)
 * [MAX_PAGE_SIZE](#max_page_size)
 * [PAGINATE_COUNT](#paginate_count)
-* PER_PAGE_DEFAULTS
+* [PER_PAGE_DEFAULTS](#per_page_defaults)
 * [PREFER_IPV4](#prefer_ipv4)
 * [RACK_ELEVATION_DEFAULT_UNIT_HEIGHT](#rack_elevation_default_unit_height)
 * [RACK_ELEVATION_DEFAULT_UNIT_WIDTH](#rack_elevation_default_unit_width)
@@ -508,10 +508,13 @@ By default, all custom fields in GraphQL will be prefixed with `cf`. A custom fi
 
 Default: `False`
 
-When set to `True`, users with limited permissions will only be able to see items in the UI they have access too.
+When set to `True`, users with limited permissions will only be able to see items in the UI they have access to.
 
 !!! tip
     As of Nautobot 1.2.0, if you do not set a value for this setting in your `nautobot_config.py`, it can be configured dynamically by an admin user via the Nautobot Admin UI. If you do have a value for this setting in `nautobot_config.py`, it will override any dynamically configured value.
+
+!!! note
+    As of Nautobot 1.3.10, when this settings is set to `True`, logged out users will be redirected to the login page when navigating to the Nautobot home page.
 
 ---
 
@@ -732,6 +735,12 @@ This setting is used internally in the core settings to provide default location
     Do not override `NAUTOBOT_ROOT` in your `nautobot_config.py`. It will not work as expected. If you need to customize this setting, please always set the `NAUTOBOT_ROOT` environment variable.
 
 ---
+
+## PER_PAGE_DEFAULTS
+
+Default: `[25, 50, 100, 250, 500, 1000]`
+
+The options displayed in the web interface dropdown to limit the number of objects per page. For proper user experience, this list should include the [`PAGINATE_COUNT`](#paginate_count) and [`MAX_PAGE_SIZE`](#max_page_size) values as options.
 
 ## PAGINATE_COUNT
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2114 
# What's Changed

- Redirect home page view to login page when user is logged out and `HIDE_RESTRICTED_UI` is set to `True`
- Update documentation
- Documentation fixes


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design