### PR TITLE
update job hook docs, move to docs/models/extras

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,7 @@ nav:
         - Git Repositories: 'models/extras/gitrepository.md'
         - Health Check: 'additional-features/healthcheck.md'
         - Jobs: 'additional-features/jobs.md'
-        - Job Hooks: 'additional-features/job-hooks.md'
+        - Job Hooks: 'models/extras/jobhook.md'
         - Job Scheduling and Approvals: 'additional-features/job-scheduling-and-approvals.md'
         - NAPALM: 'additional-features/napalm.md'
         - Notes: 'models/extras/note.md'

--- a/nautobot/docs/models/extras/job.md
+++ b/nautobot/docs/models/extras/job.md
@@ -15,7 +15,7 @@ Records of this type store the following data as read-only (not modifiable via t
 * The name of the module containing the Job
 * The name of the Job class
 * Whether the job is installed presently
-* Whether the job is a [Job Hook Receiver](jobhook.md#job-hook-receivers)
+* Whether the job is a [Job Hook Receiver](../jobhook#job-hook-receivers)
 
 !!! note
     As presently implemented, after a job is uninstalled, when the database is next refreshed, the corresponding Job database record will *not* be deleted - only its `installed` flag will be set to False. This allows existing `JobResult` and `ScheduledJob` records to continue to reference the Job that they originated from.

--- a/nautobot/docs/models/extras/job.md
+++ b/nautobot/docs/models/extras/job.md
@@ -15,7 +15,7 @@ Records of this type store the following data as read-only (not modifiable via t
 * The name of the module containing the Job
 * The name of the Job class
 * Whether the job is installed presently
-* Whether the job is a [Job Hook](../../additional-features/job-hooks.md) Receiver
+* Whether the job is a [Job Hook Receiver](jobhook.md#job-hook-receivers)
 
 !!! note
     As presently implemented, after a job is uninstalled, when the database is next refreshed, the corresponding Job database record will *not* be deleted - only its `installed` flag will be set to False. This allows existing `JobResult` and `ScheduledJob` records to continue to reference the Job that they originated from.

--- a/nautobot/docs/models/extras/job.md
+++ b/nautobot/docs/models/extras/job.md
@@ -15,7 +15,7 @@ Records of this type store the following data as read-only (not modifiable via t
 * The name of the module containing the Job
 * The name of the Job class
 * Whether the job is installed presently
-* Whether the job is a [Job Hook Receiver](../jobhook#job-hook-receivers)
+* Whether the job is a [Job Hook Receiver](../jobhook/#job-hook-receivers)
 
 !!! note
     As presently implemented, after a job is uninstalled, when the database is next refreshed, the corresponding Job database record will *not* be deleted - only its `installed` flag will be set to False. This allows existing `JobResult` and `ScheduledJob` records to continue to reference the Job that they originated from.

--- a/nautobot/docs/models/extras/jobhook.md
+++ b/nautobot/docs/models/extras/jobhook.md
@@ -1,10 +1,18 @@
 # Job Hooks
 
-A Job Hook is a mechanism for automatically starting a [job](./jobs.md) when an object is changed. Job Hooks are similar to [webhooks](../models/extras/webhook.md) except that an object change event initiates a `JobHookReceiver` job instead of a web request. Job hooks are configured in the web UI under **Jobs > Job Hooks**.
+A Job Hook is a mechanism for automatically starting a [job](../../additional-features/jobs.md) when an object is changed. Job Hooks are similar to [webhooks](webhook.md) except that an object change event initiates a `JobHookReceiver` job instead of a web request. Job hooks are configured in the web UI under **Jobs > Job Hooks**.
+
+## Configuration
+
+* **Name** - A unique name for the job hook.
+* **Content type(s)** - The type or types of Nautobot object that will trigger the job hook.
+* **Job** - The [job hook receiver](#job-hook-receivers) that this job hook will run.
+* **Enabled** - If unchecked, the job hook will be inactive.
+* **Events** - A job hook may trigger on any combination of create, update, and delete events. At least one event type must be selected.
 
 ## Job Hook Receivers
 
-Job Hooks are only able to initiate a specific type of job called a **Job Hook Receiver**. These are jobs that subclass the `nautobot.extras.jobs.JobHookReceiver` class. Job hook receivers are similar to normal jobs except they are hard coded to accept only an `object_change` [variable](jobs.md#variables). Job Hook Receivers are hidden from the jobs listing UI by default but otherwise function similarly to other jobs. The `JobHookReceiver` class only implements one method called `receive_job_hook`.
+Job Hooks are only able to initiate a specific type of job called a **Job Hook Receiver**. These are jobs that subclass the `nautobot.extras.jobs.JobHookReceiver` class. Job hook receivers are similar to normal jobs except they are hard coded to accept only an `object_change` [variable](../../additional-features/jobs.md#variables). Job Hook Receivers are hidden from the jobs listing UI by default but otherwise function similarly to other jobs. The `JobHookReceiver` class only implements one method called `receive_job_hook`.
 
 !!! important
     To prevent negatively impacting system performance through an infinite loop, a change that was made by a `JobHookReceiver` job will not trigger another `JobHookReceiver` job to run.

--- a/nautobot/docs/models/extras/jobhook.md
+++ b/nautobot/docs/models/extras/jobhook.md
@@ -1,6 +1,6 @@
 # Job Hooks
 
-A Job Hook is a mechanism for automatically starting a [job](../../../additional-features/jobs) when an object is changed. Job Hooks are similar to [webhooks](../webhook) except that an object change event initiates a `JobHookReceiver` job instead of a web request. Job hooks are configured in the web UI under **Jobs > Job Hooks**.
+A Job Hook is a mechanism for automatically starting a [job](../../../additional-features/jobs/) when an object is changed. Job Hooks are similar to [webhooks](../webhook/) except that an object change event initiates a `JobHookReceiver` job instead of a web request. Job hooks are configured in the web UI under **Jobs > Job Hooks**.
 
 ## Configuration
 

--- a/nautobot/docs/models/extras/jobhook.md
+++ b/nautobot/docs/models/extras/jobhook.md
@@ -1,6 +1,6 @@
 # Job Hooks
 
-A Job Hook is a mechanism for automatically starting a [job](../../additional-features/jobs.md) when an object is changed. Job Hooks are similar to [webhooks](webhook.md) except that an object change event initiates a `JobHookReceiver` job instead of a web request. Job hooks are configured in the web UI under **Jobs > Job Hooks**.
+A Job Hook is a mechanism for automatically starting a [job](../../../additional-features/jobs) when an object is changed. Job Hooks are similar to [webhooks](../webhook) except that an object change event initiates a `JobHookReceiver` job instead of a web request. Job hooks are configured in the web UI under **Jobs > Job Hooks**.
 
 ## Configuration
 
@@ -12,7 +12,7 @@ A Job Hook is a mechanism for automatically starting a [job](../../additional-fe
 
 ## Job Hook Receivers
 
-Job Hooks are only able to initiate a specific type of job called a **Job Hook Receiver**. These are jobs that subclass the `nautobot.extras.jobs.JobHookReceiver` class. Job hook receivers are similar to normal jobs except they are hard coded to accept only an `object_change` [variable](../../additional-features/jobs.md#variables). Job Hook Receivers are hidden from the jobs listing UI by default but otherwise function similarly to other jobs. The `JobHookReceiver` class only implements one method called `receive_job_hook`.
+Job Hooks are only able to initiate a specific type of job called a **Job Hook Receiver**. These are jobs that subclass the `nautobot.extras.jobs.JobHookReceiver` class. Job hook receivers are similar to normal jobs except they are hard coded to accept only an `object_change` [variable](../../../additional-features/jobs#variables). Job Hook Receivers are hidden from the jobs listing UI by default but otherwise function similarly to other jobs. The `JobHookReceiver` class only implements one method called `receive_job_hook`.
 
 !!! important
     To prevent negatively impacting system performance through an infinite loop, a change that was made by a `JobHookReceiver` job will not trigger another `JobHookReceiver` job to run.

--- a/nautobot/docs/models/extras/jobhook.md
+++ b/nautobot/docs/models/extras/jobhook.md
@@ -12,7 +12,7 @@ A Job Hook is a mechanism for automatically starting a [job](../../../additional
 
 ## Job Hook Receivers
 
-Job Hooks are only able to initiate a specific type of job called a **Job Hook Receiver**. These are jobs that subclass the `nautobot.extras.jobs.JobHookReceiver` class. Job hook receivers are similar to normal jobs except they are hard coded to accept only an `object_change` [variable](../../../additional-features/jobs#variables). Job Hook Receivers are hidden from the jobs listing UI by default but otherwise function similarly to other jobs. The `JobHookReceiver` class only implements one method called `receive_job_hook`.
+Job Hooks are only able to initiate a specific type of job called a **Job Hook Receiver**. These are jobs that subclass the `nautobot.extras.jobs.JobHookReceiver` class. Job hook receivers are similar to normal jobs except they are hard coded to accept only an `object_change` [variable](../../../additional-features/jobs/#variables). Job Hook Receivers are hidden from the jobs listing UI by default but otherwise function similarly to other jobs. The `JobHookReceiver` class only implements one method called `receive_job_hook`.
 
 !!! important
     To prevent negatively impacting system performance through an infinite loop, a change that was made by a `JobHookReceiver` job will not trigger another `JobHookReceiver` job to run.


### PR DESCRIPTION
# Closes: #DNE
# What's Changed

- Move job hooks documentation to `nautobot/docs/models/extras/jobhook.md` so Nautobot's form can link to it with the help button
- Add configuration section to job hooks documentation

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design