### PR TITLE
Fix URL generation for relationships nested API

### DIFF
--- a/nautobot/extras/api/relationships.py
+++ b/nautobot/extras/api/relationships.py
@@ -2,10 +2,10 @@ import logging
 
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
-from django.urls import reverse
 from drf_spectacular.utils import extend_schema_field
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.fields import JSONField
+from rest_framework.reverse import reverse
 from rest_framework.serializers import ValidationError
 
 from nautobot.core.api import ValidatedModelSerializer
@@ -110,7 +110,11 @@ class RelationshipsDataField(JSONField):
                     relationship.slug,
                     {
                         "id": str(relationship.id),
-                        "url": reverse("extras-api:relationship-detail", kwargs={"pk": relationship.id}),
+                        "url": reverse(
+                            "extras-api:relationship-detail",
+                            kwargs={"pk": relationship.id},
+                            request=self.parent.context.get("request"),
+                        ),
                         "name": relationship.name,
                         "type": relationship.type,
                     },

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -2068,7 +2068,10 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase):
             {
                 self.relationships[0].slug: {
                     "id": str(self.relationships[0].pk),
-                    "url": reverse("extras-api:relationship-detail", kwargs={"pk": self.relationships[0].pk}),
+                    "url": (
+                        "http://testserver"
+                        + reverse("extras-api:relationship-detail", kwargs={"pk": self.relationships[0].pk})
+                    ),
                     "name": self.relationships[0].name,
                     "type": self.relationships[0].type,
                     "peer": {
@@ -2079,7 +2082,10 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase):
                 },
                 self.relationships[1].slug: {
                     "id": str(self.relationships[1].pk),
-                    "url": reverse("extras-api:relationship-detail", kwargs={"pk": self.relationships[1].pk}),
+                    "url": (
+                        "http://testserver"
+                        + reverse("extras-api:relationship-detail", kwargs={"pk": self.relationships[1].pk})
+                    ),
                     "name": self.relationships[1].name,
                     "type": self.relationships[1].type,
                     "destination": {
@@ -2095,7 +2101,10 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase):
                 },
                 self.relationships[2].slug: {
                     "id": str(self.relationships[2].pk),
-                    "url": reverse("extras-api:relationship-detail", kwargs={"pk": self.relationships[2].pk}),
+                    "url": (
+                        "http://testserver"
+                        + reverse("extras-api:relationship-detail", kwargs={"pk": self.relationships[2].pk})
+                    ),
                     "name": self.relationships[2].name,
                     "type": self.relationships[2].type,
                     "destination": {
@@ -2374,7 +2383,10 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
             {
                 self.relationship.slug: {
                     "id": str(self.relationship.pk),
-                    "url": reverse("extras-api:relationship-detail", kwargs={"pk": self.relationship.pk}),
+                    "url": (
+                        "http://testserver"
+                        + reverse("extras-api:relationship-detail", kwargs={"pk": self.relationship.pk})
+                    ),
                     "name": self.relationship.name,
                     "type": "many-to-many",
                     "destination": {


### PR DESCRIPTION
# Closes: DNE
# What's Changed

Fix URL generation for nested relationships data in the REST API so that it includes the full path like other url fields.

Before:

```json
            "relationships": {
                "sites-vrfs": {
                    "id": "6736bd25-27cf-4200-a0cf-054eeeb10555",
                    "url": "/api/extras/relationships/6736bd25-27cf-4200-a0cf-054eeeb10555/",   <----<<
                    "name": "Site's VRFs",
                    "type": "many-to-many",
                    "destination": {
                        "label": "Related VRFs",
                        "object_type": "ipam.vrf",
                        "objects": [
                            {
                                "id": "9641b4af-6ab4-4c99-9df2-1e019ed3e546",
                                "url": "http://localhost:8080/api/ipam/vrfs/9641b4af-6ab4-4c99-9df2-1e019ed3e546/",
                                "name": "Red",
                                "rd": null,
                                "display": "Red"
                            }
                        ]
                    }
                }
            }
```

After:

```json
            "relationships": {
                "sites-vrfs": {
                    "id": "6736bd25-27cf-4200-a0cf-054eeeb10555",
                    "url": "http://localhost:8080/api/extras/relationships/6736bd25-27cf-4200-a0cf-054eeeb10555/",  <------<<
                    "name": "Site's VRFs",
                    "type": "many-to-many",
                    "destination": {
                        "label": "Related VRFs",
                        "object_type": "ipam.vrf",
                        "objects": [
                            {
                                "id": "9641b4af-6ab4-4c99-9df2-1e019ed3e546",
                                "url": "http://localhost:8080/api/ipam/vrfs/9641b4af-6ab4-4c99-9df2-1e019ed3e546/",
                                "name": "Red",
                                "rd": null,
                                "display": "Red"
                            }
                        ]
                    }
                }
            }
```