### PR TITLE
fix ObjectChange missing user object when making changes through API

### DIFF
--- a/nautobot/core/middleware.py
+++ b/nautobot/core/middleware.py
@@ -92,6 +92,7 @@ class ObjectChangeMiddleware(object):
         except Resolver404:
             change_context_detail = ""
 
+        # Pass request rather than user here because at this point in the request handling logic, request.user may not have been set yet
         change_context = WebChangeContext(request=request, context_detail=change_context_detail)
 
         # Process the request with change logging enabled

--- a/nautobot/core/middleware.py
+++ b/nautobot/core/middleware.py
@@ -92,7 +92,7 @@ class ObjectChangeMiddleware(object):
         except Resolver404:
             change_context_detail = ""
 
-        change_context = WebChangeContext(request, context_detail=change_context_detail)
+        change_context = WebChangeContext(request=request, context_detail=change_context_detail)
 
         # Process the request with change logging enabled
         with change_logging(change_context):

--- a/nautobot/core/middleware.py
+++ b/nautobot/core/middleware.py
@@ -92,7 +92,7 @@ class ObjectChangeMiddleware(object):
         except Resolver404:
             change_context_detail = ""
 
-        change_context = WebChangeContext(request.user, context_detail=change_context_detail)
+        change_context = WebChangeContext(request, context_detail=change_context_detail)
 
         # Process the request with change logging enabled
         with change_logging(change_context):

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 
 from django.contrib.auth import get_user_model
 from django.db.models.signals import m2m_changed, pre_delete, post_save
+from django.test.client import RequestFactory
 
 from nautobot.extras.choices import ObjectChangeEventContextChoices
 from nautobot.extras.signals import _handle_changed_object, _handle_deleted_object
@@ -16,14 +17,14 @@ class ChangeContext:
     one will be generated to relate any changes to this transaction. Convenience
     classes are provided for each context.
 
-    :param user: User object
+    :param request: WSGIRequest object
     :param context: Context of the transaction, must match a choice in nautobot.extras.choices.ObjectChangeEventContextChoices
     :param context_detail: Optional extra details about the transaction (ex: the plugin name that initiated the change)
-    :param id: Optional uuid object to uniquely identify the transaction
+    :param id: Optional uuid object to uniquely identify the transaction. One will be generated if not supplied
     """
 
-    def __init__(self, user, context=None, context_detail="", id=None):
-        self.user = user
+    def __init__(self, request, context=None, context_detail="", id=None):
+        self.request = request
 
         if context is not None:
             self.context = context
@@ -88,7 +89,7 @@ def change_logging(change_context):
 
 
 @contextmanager
-def web_request_context(user, context_detail=""):
+def web_request_context(user, context_detail="", id=None):
     """
     Emulate the context of an HTTP request, which provides functions like change logging and webhook processing
     in response to data changes. This context manager is for use with low level utility tooling, such as the
@@ -106,11 +107,14 @@ def web_request_context(user, context_detail=""):
 
     :param user: User object
     :param context_detail: Optional extra details about the transaction (ex: the plugin name that initiated the change)
+    :param id: Optional uuid object to uniquely identify the transaction. One will be generated if not supplied
     """
 
     if not isinstance(user, get_user_model()):
         raise TypeError("The user object must be an instance of nautobot.users.models.User")
 
-    change_context = ORMChangeContext(user, context_detail=context_detail)
+    request = RequestFactory().request(SERVER_NAME="web_request_context")
+    request.user = user
+    change_context = ORMChangeContext(request, context_detail=context_detail, id=id)
     with change_logging(change_context):
-        yield
+        yield request

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -118,7 +118,7 @@ def web_request_context(user, context_detail="", change_id=None):
 
     :param user: User object
     :param context_detail: Optional extra details about the transaction (ex: the plugin name that initiated the change)
-    :param id: Optional uuid object to uniquely identify the transaction. One will be generated if not supplied
+    :param change_id: Optional uuid object to uniquely identify the transaction. One will be generated if not supplied
     """
 
     if not isinstance(user, get_user_model()):

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -21,7 +21,7 @@ class ChangeContext:
     :param request: WSGIRequest object to retrieve user from django rest framework after authentication is performed
     :param context: Context of the transaction, must match a choice in nautobot.extras.choices.ObjectChangeEventContextChoices
     :param context_detail: Optional extra details about the transaction (ex: the plugin name that initiated the change)
-    :param id: Optional uuid object to uniquely identify the transaction. One will be generated if not supplied
+    :param change_id: Optional uuid object to uniquely identify the transaction. One will be generated if not supplied
     """
 
     def __init__(self, user=None, request=None, context=None, context_detail="", change_id=None):

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -29,7 +29,10 @@ class ChangeContext:
         self.user = user
 
         if self.request is None and self.user is None:
-            raise TypeError("At least one keyword argument required: user or request")
+            raise TypeError("Either user or request must be provided")
+
+        if self.request is not None and self.user is not None:
+            raise TypeError("Request and user cannot be used together")
 
         if context is not None:
             self.context = context

--- a/nautobot/extras/datasources/registry.py
+++ b/nautobot/extras/datasources/registry.py
@@ -36,7 +36,7 @@ def refresh_datasource_content(model_name, record, request, job_result, delete=F
     job_result.log(f"Refreshing data provided by {record}...", level_choice=LogLevelChoices.LOG_INFO)
     job_result.save()
     if request:
-        change_context = JobChangeContext(request.user)
+        change_context = JobChangeContext(request)
         with change_logging(change_context):
             for entry in get_datasource_contents(model_name):
                 job_result.log(f"Refreshing {entry.name}...", level_choice=LogLevelChoices.LOG_INFO)

--- a/nautobot/extras/datasources/registry.py
+++ b/nautobot/extras/datasources/registry.py
@@ -36,7 +36,7 @@ def refresh_datasource_content(model_name, record, request, job_result, delete=F
     job_result.log(f"Refreshing data provided by {record}...", level_choice=LogLevelChoices.LOG_INFO)
     job_result.save()
     if request:
-        change_context = JobChangeContext(request)
+        change_context = JobChangeContext(user=request.user)
         with change_logging(change_context):
             for entry in get_datasource_contents(model_name):
                 job_result.log(f"Refreshing {entry.name}...", level_choice=LogLevelChoices.LOG_INFO)

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1217,7 +1217,7 @@ def run_job(data, request, job_result_pk, commit=True, *args, **kwargs):
     # process change logs, webhooks, etc.
     if commit:
         context_class = JobHookChangeContext if job_model.is_job_hook_receiver else JobChangeContext
-        change_context = context_class(request.user, id=request.id, context_detail=job_model.slug)
+        change_context = context_class(request, context_detail=job_model.slug)
         with change_logging(change_context):
             _run_job()
     else:
@@ -1274,7 +1274,6 @@ def enqueue_job_hooks(object_change):
         job_content_type = get_job_content_type()
         job_model = job_hook.job
         request = RequestFactory().request(SERVER_NAME="job_hook")
-        request.id = object_change.request_id
         request.user = object_change.user
         JobResult.enqueue_job(
             run_job,

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1217,7 +1217,7 @@ def run_job(data, request, job_result_pk, commit=True, *args, **kwargs):
     # process change logs, webhooks, etc.
     if commit:
         context_class = JobHookChangeContext if job_model.is_job_hook_receiver else JobChangeContext
-        change_context = context_class(request, context_detail=job_model.slug)
+        change_context = context_class(user=request.user, context_detail=job_model.slug)
         with change_logging(change_context):
             _run_job()
     else:

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -69,15 +69,15 @@ def _handle_changed_object(change_context, sender, instance, **kwargs):
             related_changes = ObjectChange.objects.filter(
                 changed_object_type=ContentType.objects.get_for_model(instance),
                 changed_object_id=instance.pk,
-                request_id=change_context.id,
+                request_id=change_context.change_id,
             )
             m2m_changes = instance.to_objectchange(action)
             related_changes.update(object_data=m2m_changes.object_data, object_data_v2=m2m_changes.object_data_v2)
             objectchange = related_changes.first() if related_changes.exists() else None
         else:
             objectchange = instance.to_objectchange(action)
-            objectchange.user = _get_user_if_authenticated(change_context.request.user, objectchange)
-            objectchange.request_id = change_context.id
+            objectchange.user = _get_user_if_authenticated(change_context.get_user(), objectchange)
+            objectchange.request_id = change_context.change_id
             objectchange.change_context = change_context.context
             objectchange.change_context_detail = change_context.context_detail
             objectchange.save()
@@ -87,7 +87,7 @@ def _handle_changed_object(change_context, sender, instance, **kwargs):
             enqueue_job_hooks(objectchange)
 
     # Enqueue webhooks
-    enqueue_webhooks(instance, change_context.request.user, change_context.id, action)
+    enqueue_webhooks(instance, change_context.get_user(), change_context.change_id, action)
 
     # Increment metric counters
     if action == ObjectChangeActionChoices.ACTION_CREATE:
@@ -111,8 +111,8 @@ def _handle_deleted_object(change_context, sender, instance, **kwargs):
     # Record an ObjectChange if applicable
     if hasattr(instance, "to_objectchange"):
         objectchange = instance.to_objectchange(ObjectChangeActionChoices.ACTION_DELETE)
-        objectchange.user = _get_user_if_authenticated(change_context.request.user, objectchange)
-        objectchange.request_id = change_context.id
+        objectchange.user = _get_user_if_authenticated(change_context.get_user(), objectchange)
+        objectchange.request_id = change_context.change_id
         objectchange.change_context = change_context.context
         objectchange.change_context_detail = change_context.context_detail
         objectchange.save()
@@ -121,7 +121,9 @@ def _handle_deleted_object(change_context, sender, instance, **kwargs):
         enqueue_job_hooks(objectchange)
 
     # Enqueue webhooks
-    enqueue_webhooks(instance, change_context.request.user, change_context.id, ObjectChangeActionChoices.ACTION_DELETE)
+    enqueue_webhooks(
+        instance, change_context.get_user(), change_context.change_id, ObjectChangeActionChoices.ACTION_DELETE
+    )
 
     # Increment metric counters
     model_deletes.labels(instance._meta.model_name).inc()

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -76,7 +76,7 @@ def _handle_changed_object(change_context, sender, instance, **kwargs):
             objectchange = related_changes.first() if related_changes.exists() else None
         else:
             objectchange = instance.to_objectchange(action)
-            objectchange.user = _get_user_if_authenticated(change_context.user, objectchange)
+            objectchange.user = _get_user_if_authenticated(change_context.request.user, objectchange)
             objectchange.request_id = change_context.id
             objectchange.change_context = change_context.context
             objectchange.change_context_detail = change_context.context_detail
@@ -87,7 +87,7 @@ def _handle_changed_object(change_context, sender, instance, **kwargs):
             enqueue_job_hooks(objectchange)
 
     # Enqueue webhooks
-    enqueue_webhooks(instance, change_context.user, change_context.id, action)
+    enqueue_webhooks(instance, change_context.request.user, change_context.id, action)
 
     # Increment metric counters
     if action == ObjectChangeActionChoices.ACTION_CREATE:
@@ -111,7 +111,7 @@ def _handle_deleted_object(change_context, sender, instance, **kwargs):
     # Record an ObjectChange if applicable
     if hasattr(instance, "to_objectchange"):
         objectchange = instance.to_objectchange(ObjectChangeActionChoices.ACTION_DELETE)
-        objectchange.user = _get_user_if_authenticated(change_context.user, objectchange)
+        objectchange.user = _get_user_if_authenticated(change_context.request.user, objectchange)
         objectchange.request_id = change_context.id
         objectchange.change_context = change_context.context
         objectchange.change_context_detail = change_context.context_detail
@@ -121,7 +121,7 @@ def _handle_deleted_object(change_context, sender, instance, **kwargs):
         enqueue_job_hooks(objectchange)
 
     # Enqueue webhooks
-    enqueue_webhooks(instance, change_context.user, change_context.id, ObjectChangeActionChoices.ACTION_DELETE)
+    enqueue_webhooks(instance, change_context.request.user, change_context.id, ObjectChangeActionChoices.ACTION_DELETE)
 
     # Increment metric counters
     model_deletes.labels(instance._meta.model_name).inc()

--- a/nautobot/extras/tests/test_changelog.py
+++ b/nautobot/extras/tests/test_changelog.py
@@ -395,6 +395,7 @@ class ChangeLogAPITest(APITestCase):
         self.assertEqual(oc.user_id, self.user.pk)
 
     def test_m2m_change(self):
+        """Test that ManyToMany change only generates a single ObjectChange instance"""
         cluster_type = ClusterType.objects.create(name="test_cluster_type")
         cluster = Cluster.objects.create(name="test_cluster", type=cluster_type)
         vm_statuses = Status.objects.get_for_model(VirtualMachine)

--- a/nautobot/extras/tests/test_changelog.py
+++ b/nautobot/extras/tests/test_changelog.py
@@ -7,10 +7,12 @@ from nautobot.core.graphql import execute_query
 from nautobot.dcim.models import Site
 from nautobot.extras.choices import CustomFieldTypeChoices, ObjectChangeActionChoices, ObjectChangeEventContextChoices
 from nautobot.extras.models import CustomField, CustomFieldChoice, ObjectChange, Status, Tag
+from nautobot.ipam.models import VLAN
 from nautobot.utilities.testing import APITestCase
 from nautobot.utilities.testing.utils import post_data
 from nautobot.utilities.testing.views import ModelViewTestCase
 from nautobot.utilities.utils import get_changes_for_model
+from nautobot.virtualization.models import Cluster, ClusterType, VMInterface, VirtualMachine
 
 
 class ChangeLogViewTest(ModelViewTestCase):
@@ -59,15 +61,13 @@ class ChangeLogViewTest(ModelViewTestCase):
         # Verify the creation of a new ObjectChange record
         site = Site.objects.get(name="Test Site 1")
         # First OC is the creation; second is the tags update
-        oc = ObjectChange.objects.get(
-            changed_object_type=ContentType.objects.get_for_model(Site),
-            changed_object_id=site.pk,
-        )
+        oc = get_changes_for_model(site).first()
         self.assertEqual(oc.changed_object, site)
         self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_CREATE)
         self.assertEqual(oc.object_data["custom_fields"]["my_field"], form_data["cf_my_field"])
         self.assertEqual(oc.object_data["custom_fields"]["my_field_select"], form_data["cf_my_field_select"])
         self.assertEqual(oc.object_data["tags"], ["Tag 1", "Tag 2"])
+        self.assertEqual(oc.user_id, self.user.pk)
 
     def test_update_object(self):
         site = Site(
@@ -107,6 +107,7 @@ class ChangeLogViewTest(ModelViewTestCase):
             form_data["cf_my_field_select"],
         )
         self.assertEqual(oc.object_data["tags"], ["Tag 3"])
+        self.assertEqual(oc.user_id, self.user.pk)
 
     def test_delete_object(self):
         site = Site(
@@ -133,6 +134,7 @@ class ChangeLogViewTest(ModelViewTestCase):
         self.assertEqual(oc.object_data["custom_fields"]["my_field"], "ABC")
         self.assertEqual(oc.object_data["custom_fields"]["my_field_select"], "Bar")
         self.assertEqual(oc.object_data["tags"], ["Tag 1", "Tag 2"])
+        self.assertEqual(oc.user_id, self.user.pk)
 
     def test_change_context(self):
         form_data = {
@@ -151,12 +153,10 @@ class ChangeLogViewTest(ModelViewTestCase):
 
         # Verify the creation of a new ObjectChange record
         site = Site.objects.get(name="Test Site 1")
-        oc = ObjectChange.objects.get(
-            changed_object_type=ContentType.objects.get_for_model(Site),
-            changed_object_id=site.pk,
-        )
+        oc = get_changes_for_model(site).first()
         self.assertEqual(oc.change_context, ObjectChangeEventContextChoices.CONTEXT_WEB)
         self.assertEqual(oc.change_context_detail, "dcim:site_add")
+        self.assertEqual(oc.user_id, self.user.pk)
 
 
 class ChangeLogAPITest(APITestCase):
@@ -214,14 +214,12 @@ class ChangeLogAPITest(APITestCase):
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
 
         site = Site.objects.get(pk=response.data["id"])
-        oc = ObjectChange.objects.get(
-            changed_object_type=ContentType.objects.get_for_model(Site),
-            changed_object_id=site.pk,
-        )
+        oc = get_changes_for_model(site).first()
         self.assertEqual(oc.changed_object, site)
         self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_CREATE)
         self.assertEqual(oc.object_data["custom_fields"], data["custom_fields"])
         self.assertEqual(oc.object_data["tags"], ["Tag 1", "Tag 2"])
+        self.assertEqual(oc.user_id, self.user.pk)
 
     def test_update_object(self):
         """Test PUT with changelogs."""
@@ -249,14 +247,12 @@ class ChangeLogAPITest(APITestCase):
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
         site = Site.objects.get(pk=response.data["id"])
-        oc = ObjectChange.objects.get(
-            changed_object_type=ContentType.objects.get_for_model(Site),
-            changed_object_id=site.pk,
-        )
+        oc = get_changes_for_model(site).first()
         self.assertEqual(oc.changed_object, site)
         self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_UPDATE)
         self.assertEqual(oc.object_data["custom_fields"], data["custom_fields"])
         self.assertEqual(oc.object_data["tags"], ["Tag 3"])
+        self.assertEqual(oc.user_id, self.user.pk)
 
     def test_partial_update_object(self):
         """Test PATCH with changelogs."""
@@ -292,6 +288,7 @@ class ChangeLogAPITest(APITestCase):
         self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_UPDATE)
         self.assertEqual(oc.object_data["custom_fields"], site.custom_field_data)
         self.assertEqual(oc.object_data["tags"], ["Tag 3"])
+        self.assertEqual(oc.user_id, self.user.pk)
 
     def test_delete_object(self):
         site = Site(
@@ -317,6 +314,7 @@ class ChangeLogAPITest(APITestCase):
         self.assertEqual(oc.object_data["custom_fields"]["my_field"], "ABC")
         self.assertEqual(oc.object_data["custom_fields"]["my_field_select"], "Bar")
         self.assertEqual(oc.object_data["tags"], ["Tag 1", "Tag 2"])
+        self.assertEqual(oc.user_id, self.user.pk)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_get_graphql_object(self):
@@ -391,9 +389,39 @@ class ChangeLogAPITest(APITestCase):
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
 
         site = Site.objects.get(pk=response.data["id"])
-        oc = ObjectChange.objects.get(
-            changed_object_type=ContentType.objects.get_for_model(Site),
-            changed_object_id=site.pk,
-        )
+        oc = get_changes_for_model(site).first()
         self.assertEqual(oc.change_context, ObjectChangeEventContextChoices.CONTEXT_WEB)
         self.assertEqual(oc.change_context_detail, "dcim-api:site-list")
+        self.assertEqual(oc.user_id, self.user.pk)
+
+    def test_m2m_change(self):
+        cluster_type = ClusterType.objects.create(name="test_cluster_type")
+        cluster = Cluster.objects.create(name="test_cluster", type=cluster_type)
+        vm_statuses = Status.objects.get_for_model(VirtualMachine)
+        vm = VirtualMachine.objects.create(
+            name="test_vm",
+            cluster=cluster,
+            status=vm_statuses.get(slug="active"),
+        )
+        vminterface_statuses = Status.objects.get_for_model(VirtualMachine)
+        vm_interface = VMInterface.objects.create(
+            name="vm interface 1",
+            virtual_machine=vm,
+            status=vminterface_statuses.get(slug="active"),
+        )
+        vlan_statuses = Status.objects.get_for_model(VLAN)
+        tagged_vlan = VLAN.objects.create(vid=100, name="Vlan100", status=vlan_statuses.get(slug="active"))
+
+        payload = {"tagged_vlans": [str(tagged_vlan.pk)], "description": "test vm interface m2m change"}
+        self.assertEqual(ObjectChange.objects.count(), 0)
+        self.add_permissions("virtualization.change_vminterface", "ipam.change_vlan")
+        url = reverse("virtualization-api:vminterface-detail", kwargs={"pk": vm_interface.pk})
+        response = self.client.patch(url, payload, format="json", **self.header)
+        vm_interface.refresh_from_db()
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        oc = get_changes_for_model(vm_interface).first()
+        self.assertEqual(ObjectChange.objects.count(), 1)
+        self.assertEqual(oc.user_id, self.user.pk)
+        self.assertEqual(vm_interface.description, "test vm interface m2m change")
+        self.assertSequenceEqual(list(vm_interface.tagged_vlans.all()), [tagged_vlan])

--- a/nautobot/extras/tests/test_context_managers.py
+++ b/nautobot/extras/tests/test_context_managers.py
@@ -57,7 +57,7 @@ class WebRequestContextTestCase(TestCase):
 
     def test_change_log_context(self):
 
-        with web_request_context(self.user, "test_change_log_context"):
+        with web_request_context(self.user, context_detail="test_change_log_context"):
             site = Site(name="Test Site 1")
             site.save()
 

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -8,7 +8,6 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.handlers.wsgi import WSGIRequest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import override_settings
@@ -686,9 +685,7 @@ class JobHookTest(TransactionTestCase):
 
     @mock.patch.object(JobResult, "enqueue_job")
     def test_enqueue_job_hook_skipped(self, mock):
-        request = mock.MagicMock(spec=WSGIRequest)
-        request.user = self.user
-        change_context = JobHookChangeContext(request)
+        change_context = JobHookChangeContext(user=self.user)
         with change_logging(change_context):
             Site.objects.create(name="Test Job Hook Site 2")
 

--- a/nautobot/extras/tests/test_webhooks.py
+++ b/nautobot/extras/tests/test_webhooks.py
@@ -13,7 +13,7 @@ from nautobot.dcim.api.serializers import SiteSerializer
 from nautobot.dcim.models import Site
 from nautobot.dcim.models.sites import Region
 from nautobot.extras.choices import ObjectChangeActionChoices
-from nautobot.extras.context_managers import ORMChangeContext, change_logging
+from nautobot.extras.context_managers import web_request_context
 from nautobot.extras.models import Webhook
 from nautobot.extras.models.statuses import Status
 from nautobot.extras.tasks import process_webhook
@@ -101,9 +101,7 @@ class WebhookTest(APITestCase):
         with patch.object(Session, "send", mock_send):
             self.client.force_login(self.user)
 
-            change_context = ORMChangeContext(self.user, id=request_id)
-
-            with change_logging(change_context):
+            with web_request_context(self.user, id=request_id):
                 site = Site(name="Site 1", slug="site-1", status=self.active_status, region=self.region_one)
                 site.save()
 
@@ -123,11 +121,12 @@ class WebhookTest(APITestCase):
                     ObjectChangeActionChoices.ACTION_CREATE,
                     timestamp,
                     self.user.username,
-                    change_context.id,
+                    request_id,
                     snapshots,
                 )
 
     def test_webhooks_snapshot_on_create(self):
+        request_id = uuid.uuid4()
         webhook = Webhook.objects.get(type_create=True)
         timestamp = str(timezone.now())
 
@@ -148,10 +147,7 @@ class WebhookTest(APITestCase):
 
         # Patch the Session object with our mock_send() method, then process the webhook for sending
         with patch.object(Session, "send", mock_send):
-
-            change_context = ORMChangeContext(self.user)
-
-            with change_logging(change_context):
+            with web_request_context(self.user, id=request_id):
                 site = Site(name="Site 1", slug="site-1")
                 site.save()
 
@@ -166,11 +162,12 @@ class WebhookTest(APITestCase):
                     ObjectChangeActionChoices.ACTION_CREATE,
                     timestamp,
                     self.user.username,
-                    change_context.id,
+                    request_id,
                     snapshots,
                 )
 
     def test_webhooks_snapshot_on_delete(self):
+        request_id = uuid.uuid4()
         webhook = Webhook.objects.get(type_create=True)
         timestamp = str(timezone.now())
 
@@ -191,10 +188,7 @@ class WebhookTest(APITestCase):
 
         # Patch the Session object with our mock_send() method, then process the webhook for sending
         with patch.object(Session, "send", mock_send):
-
-            change_context = ORMChangeContext(self.user)
-
-            with change_logging(change_context):
+            with web_request_context(self.user, id=request_id):
                 site = Site(name="Site 1", slug="site-1")
                 site.save()
 
@@ -213,7 +207,7 @@ class WebhookTest(APITestCase):
                     ObjectChangeActionChoices.ACTION_CREATE,
                     timestamp,
                     self.user.username,
-                    change_context.id,
+                    request_id,
                     snapshots,
                 )
 
@@ -224,6 +218,7 @@ class WebhookTest(APITestCase):
 
         get_serializer_for_model.side_effect = get_serializer
 
+        request_id = uuid.uuid4()
         webhook = Webhook.objects.get(type_create=True)
         timestamp = str(timezone.now())
 
@@ -249,9 +244,7 @@ class WebhookTest(APITestCase):
         with patch.object(Session, "send", mock_send):
             self.client.force_login(self.user)
 
-            change_context = ORMChangeContext(self.user)
-
-            with change_logging(change_context):
+            with web_request_context(self.user, id=request_id):
                 site = Site(name="Site 1", slug="site-1", status=self.active_status, region=self.region_one)
                 site.save()
 
@@ -271,7 +264,7 @@ class WebhookTest(APITestCase):
                     ObjectChangeActionChoices.ACTION_CREATE,
                     timestamp,
                     self.user.username,
-                    change_context.id,
+                    request_id,
                     snapshots,
                 )
 

--- a/nautobot/extras/tests/test_webhooks.py
+++ b/nautobot/extras/tests/test_webhooks.py
@@ -101,7 +101,7 @@ class WebhookTest(APITestCase):
         with patch.object(Session, "send", mock_send):
             self.client.force_login(self.user)
 
-            with web_request_context(self.user, id=request_id):
+            with web_request_context(self.user, change_id=request_id):
                 site = Site(name="Site 1", slug="site-1", status=self.active_status, region=self.region_one)
                 site.save()
 
@@ -147,7 +147,7 @@ class WebhookTest(APITestCase):
 
         # Patch the Session object with our mock_send() method, then process the webhook for sending
         with patch.object(Session, "send", mock_send):
-            with web_request_context(self.user, id=request_id):
+            with web_request_context(self.user, change_id=request_id):
                 site = Site(name="Site 1", slug="site-1")
                 site.save()
 
@@ -188,7 +188,7 @@ class WebhookTest(APITestCase):
 
         # Patch the Session object with our mock_send() method, then process the webhook for sending
         with patch.object(Session, "send", mock_send):
-            with web_request_context(self.user, id=request_id):
+            with web_request_context(self.user, change_id=request_id):
                 site = Site(name="Site 1", slug="site-1")
                 site.save()
 
@@ -244,7 +244,7 @@ class WebhookTest(APITestCase):
         with patch.object(Session, "send", mock_send):
             self.client.force_login(self.user)
 
-            with web_request_context(self.user, id=request_id):
+            with web_request_context(self.user, change_id=request_id):
                 site = Site(name="Site 1", slug="site-1", status=self.active_status, region=self.region_one)
                 site.save()
 


### PR DESCRIPTION
# Closes: #2157
# What's Changed

- Fix bug in change logging middleware where changes made through the API with token authentication aren't probably storing the user object of the user associated with the token.
- Store `request` object instead of `User` object so that we can retrieve the user after django rest framework has authenticated the user.


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design