### PR TITLE
Populate statuses integration only

### DIFF
--- a/nautobot/utilities/testing/integration.py
+++ b/nautobot/utilities/testing/integration.py
@@ -94,7 +94,7 @@ class SeleniumTestCase(StaticLiveServerTestCase, NautobotTestCaseMixin):
             cls.celery_worker.__enter__()
 
     def setUp(self):
-        super().setUpNautobot()
+        super().setUpNautobot(populate_status=True)
 
         self.password = "testpassword"
         self.user.set_password(self.password)

--- a/nautobot/utilities/testing/mixins.py
+++ b/nautobot/utilities/testing/mixins.py
@@ -28,10 +28,11 @@ class NautobotTestCaseMixin:
 
     user_permissions = ()
 
-    def setUpNautobot(self, client=True):
+    def setUpNautobot(self, client=True, populate_status=False):
         """Setup shared testuser, statuses and client."""
         # Re-populate status choices after database truncation by TransactionTestCase
-        populate_status_choices(apps, None)
+        if populate_status:
+            populate_status_choices(apps, None)
 
         # Create the test user and assign permissions
         self.user = User.objects.create_user(username="nautobotuser")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2150
# What's Changed
Populate_status_choices was called during every test setUp. This is only required for TransactionTestCases. Moved to a conditional.

This reduced my test time from ~45 minutes to ~22 minutes.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)