### PR TITLE
Fix up relationship-association API test issue

### DIFF
--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -132,8 +132,10 @@ class StatusModelSerializerMixin(BaseModelSerializer):
         """
         Get the list of valid status values for this serializer.
 
-        May be necessary to use with settings.SPECTACULAR_SETTINGS["ENUM_NAME_OVERRIDES"] at some point if
-        we ever end up with multiple serializers whose default set of status choices are identical.
+        In the case where multiple serializers have the same set of status choices, it's necessary to set
+        settings.SPECTACULAR_SETTINGS["ENUM_NAME_OVERRIDES"] for at least one of the matching serializers,
+        or else drf-spectacular will report:
+        'enum naming encountered a non-optimally resolvable collision for fields named "status"'
         """
         return list(cls().fields["status"].get_choices().keys())
 

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -2314,6 +2314,7 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
     def setUpTestData(cls):
         cls.site_type = ContentType.objects.get_for_model(Site)
         cls.device_type = ContentType.objects.get_for_model(Device)
+        cls.status_active = Status.objects.get(slug="active")
 
         cls.relationship = Relationship(
             name="Devices found elsewhere",
@@ -2324,18 +2325,42 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
         )
         cls.relationship.validated_save()
         cls.sites = (
-            Site.objects.create(name="Empty Site", slug="empty"),
-            Site.objects.create(name="Occupied Site", slug="occupied"),
-            Site.objects.create(name="Another Empty Site", slug="another-empty"),
+            Site.objects.create(name="Empty Site", slug="empty", status=cls.status_active),
+            Site.objects.create(name="Occupied Site", slug="occupied", status=cls.status_active),
+            Site.objects.create(name="Another Empty Site", slug="another-empty", status=cls.status_active),
         )
         manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
         devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="Device Type 1", slug="device-type-1")
         devicerole = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
         cls.devices = (
-            Device.objects.create(name="Device 1", device_type=devicetype, device_role=devicerole, site=cls.sites[1]),
-            Device.objects.create(name="Device 2", device_type=devicetype, device_role=devicerole, site=cls.sites[1]),
-            Device.objects.create(name="Device 3", device_type=devicetype, device_role=devicerole, site=cls.sites[1]),
-            Device.objects.create(name="Device 4", device_type=devicetype, device_role=devicerole, site=cls.sites[1]),
+            Device.objects.create(
+                name="Device 1",
+                device_type=devicetype,
+                device_role=devicerole,
+                site=cls.sites[1],
+                status=cls.status_active,
+            ),
+            Device.objects.create(
+                name="Device 2",
+                device_type=devicetype,
+                device_role=devicerole,
+                site=cls.sites[1],
+                status=cls.status_active,
+            ),
+            Device.objects.create(
+                name="Device 3",
+                device_type=devicetype,
+                device_role=devicerole,
+                site=cls.sites[1],
+                status=cls.status_active,
+            ),
+            Device.objects.create(
+                name="Device 4",
+                device_type=devicetype,
+                device_role=devicerole,
+                site=cls.sites[1],
+                status=cls.status_active,
+            ),
         )
 
         cls.associations = (
@@ -2538,11 +2563,7 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
         with self.subTest("Round-trip of same relationships data is a no-op"):
             response = self.client.patch(
                 url,
-                {
-                    # TODO: omitting status here results in a 400 error "This field cannot be blank". Seems like a bug?
-                    "status": "planned",
-                    "relationships": initial_response.data["relationships"],
-                },
+                {"relationships": initial_response.data["relationships"]},
                 format="json",
                 **self.header,
             )
@@ -2554,7 +2575,7 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
         with self.subTest("Omitting relationships data entirely is valid"):
             response = self.client.patch(
                 url,
-                {"status": "planned"},  # TODO: see above
+                {},
                 format="json",
                 **self.header,
             )
@@ -2566,10 +2587,7 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
         with self.subTest("Error handling: nonexistent relationship"):
             response = self.client.patch(
                 url,
-                {
-                    "status": "planned",  # TODO: see above
-                    "relationships": {"nonexistent-relationship": {"peer": {"objects": []}}},
-                },
+                {"relationships": {"nonexistent-relationship": {"peer": {"objects": []}}}},
                 format="json",
                 **self.header,
             )
@@ -2591,10 +2609,7 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
             )
             response = self.client.patch(
                 url,
-                {
-                    "status": "planned",  # TODO: see above
-                    "relationships": {"device-to-device": {"peer": {"objects": []}}},
-                },
+                {"relationships": {"device-to-device": {"peer": {"objects": []}}}},
                 format="json",
                 **self.header,
             )
@@ -2609,10 +2624,7 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
         with self.subTest("Error handling: wrong relationship side"):
             response = self.client.patch(
                 url,
-                {
-                    "status": "planned",  # TODO: see above
-                    "relationships": {self.relationship.slug: {"source": {"objects": []}}},
-                },
+                {"relationships": {self.relationship.slug: {"source": {"objects": []}}}},
                 format="json",
                 **self.header,
             )
@@ -2629,7 +2641,6 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
             response = self.client.patch(
                 url,
                 {
-                    "status": "planned",  # TODO: see above
                     "relationships": {
                         self.relationship.slug: {
                             "destination": {


### PR DESCRIPTION
# Closes: #DNE
# What's Changed

Just a bit of code cleanup to address an issue in the RelationshipAssociation REST API test that I had worked around while implementing tests for #2092. I'd thought at the time that it was a potential bug in the REST API (requiring PATCH requests on `/api/dcim/site/` to always include `status` as a field) but it turned out to be much simpler - another case where we were creating objects via the ORM in the test case setup and not actually specifying all object attributes that should be required. (tagging #1034 here). Ensuring that the Site objects we create during setup actually *have* a `status` value at creation time makes it so that we don't need to specify a status on subsequent PATCH requests.