### PR TITLE
Closes #2131: Fix various issues with the available-ips/prefixes API …

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -220,6 +220,7 @@ SPECTACULAR_SETTINGS = {
         "PowerPortTypeChoices": "nautobot.dcim.choices.PowerPortTypeChoices",
         "RackTypeChoices": "nautobot.dcim.choices.RackTypeChoices",
         "RelationshipTypeChoices": "nautobot.extras.choices.RelationshipTypeChoices",
+        "IPAddressStatusChoices": "nautobot.ipam.choices.IPAddressStatusChoices",
     },
 }
 

--- a/nautobot/ipam/api/serializers.py
+++ b/nautobot/ipam/api/serializers.py
@@ -19,7 +19,13 @@ from nautobot.extras.api.serializers import (
     StatusModelSerializerMixin,
     TaggedObjectSerializer,
 )
-from nautobot.ipam.choices import IPAddressFamilyChoices, IPAddressRoleChoices, ServiceProtocolChoices
+from nautobot.ipam.choices import (
+    IPAddressFamilyChoices,
+    IPAddressRoleChoices,
+    IPAddressStatusChoices,
+    PrefixStatusChoices,
+    ServiceProtocolChoices,
+)
 from nautobot.ipam import constants
 from nautobot.ipam.models import (
     Aggregate,
@@ -336,9 +342,15 @@ class PrefixSerializer(TaggedObjectSerializer, StatusModelSerializerMixin, Custo
         opt_in_fields = ["computed_fields"]
 
 
-class PrefixLengthSerializer(serializers.Serializer):
-
+class AvailablePrefixRequestSerializer(serializers.Serializer):
     prefix_length = serializers.IntegerField()
+    status = ChoiceField(choices=PrefixStatusChoices)
+
+    class Meta:
+        model = Prefix
+        fields = [
+            "status",
+        ]
 
     def to_internal_value(self, data):
         requested_prefix = data.get("prefix_length")
@@ -442,6 +454,16 @@ class IPAddressSerializer(TaggedObjectSerializer, StatusModelSerializerMixin, Cu
 # 2.0 TODO: Remove in 2.0. Used to serialize against pre-1.3 behavior (nat_inside was one-to-one)
 class IPAddressSerializerLegacy(IPAddressSerializer):
     nat_outside = NestedIPAddressSerializer(read_only=True)
+
+
+class AvailableIPAddressRequestSerializer(StatusModelSerializerMixin):
+    status = ChoiceField(choices=IPAddressStatusChoices)
+
+    class Meta:
+        model = IPAddress
+        fields = [
+            "status",
+        ]
 
 
 class AvailableIPSerializer(serializers.Serializer):


### PR DESCRIPTION
…calls and related OpenAPI specification

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2131 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

The `available-ips` and `available-prefixes` API calls as well as their associated OpenAPI specification have been slightly reworked to match or implement missing behavior.

## GET /available-ips/

* Pagination is now implemented using the OptionalLimitOffsetPagination paginator, including offset which was previously missing
* Response returns the results nested in a pagination structure.

## POST /available-ips/

* The status field is now documented in the OpenAPI specification
* The OpenAPI specification now refers properly to the response as a single IPAddress unpaginated object, rather than a paginated AvailableIPAddress list

## GET /available-prefixes/

* Pagination is now implemented using the OptionalLimitOffsetPagination paginator, including offset which was previously missing
* Response returns the results nested in a pagination structure.

## POST /available-prefixes/

* The status field is now documented in the OpenAPI specification

The only changes I've hidden behind API version 1.4 are the pagination structure, as the rest are either internal behavior changes, implementing fields already mentioned in the specification, or specification changes to match the actual API behavior.

I pondered whether it was better to keep the GET results as is, decided API consistency was more desirable in the long run, but feel free to disagree.

One remaining caveat is bulk address and prefix creation. The API actually allows this, but I have no idea how to document a SingleOrList pattern in OpenAPI requests and responses with the way things are written. The easiest way would have been to use lists everywhere, especially accounting for clients using strongly typed languages, but it would be yet another breaking change.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Outline Remaining Work, Constraints from Design