### PR TITLE
add flake8 linting and black formatting settings to vscode workspace settings

### DIFF
--- a/nautobot.code-workspace
+++ b/nautobot.code-workspace
@@ -12,6 +12,7 @@
 	"settings": {
 		"editor.formatOnSave": true,
 		"python.formatting.provider": "black",
+		"python.linting.enabled": true,
 		"python.linting.flake8Enabled": true
 	},
 	"launch": {

--- a/nautobot.code-workspace
+++ b/nautobot.code-workspace
@@ -4,9 +4,34 @@
 			"path": "."
 		}
 	],
+	"extensions": {
+		"recommendations": [
+			"ms-python.python"
+		]
+	},
 	"settings": {
-		"python.linting.pylintEnabled": true,
-		"python.linting.enabled": true
+		"editor.formatOnSave": true,
+		"python.formatting.provider": "black",
+		"python.formatting.blackArgs": [
+			"--line-length",
+			"120",
+			"--target-version",
+			"py37",
+			"--target-version",
+			"py38",
+			"--target-version",
+			"py39",
+			"--target-version",
+			"py310",
+			"--include",
+			"'\\.pyi?$'",
+			"--exclude",
+			"'/(\\.eggs|\\.git|\\.hg|\\.mypy_cache|\\.tox|\\.venv|_build|buck-out|build|dist)/'"
+		],
+		"python.linting.flake8Enabled": true,
+		"python.linting.flake8Args": [
+			"--ignore=E203,E501,W503,W504"
+		]
 	},
 	"launch": {
 		"version": "0.2.0",

--- a/nautobot.code-workspace
+++ b/nautobot.code-workspace
@@ -12,26 +12,7 @@
 	"settings": {
 		"editor.formatOnSave": true,
 		"python.formatting.provider": "black",
-		"python.formatting.blackArgs": [
-			"--line-length",
-			"120",
-			"--target-version",
-			"py37",
-			"--target-version",
-			"py38",
-			"--target-version",
-			"py39",
-			"--target-version",
-			"py310",
-			"--include",
-			"'\\.pyi?$'",
-			"--exclude",
-			"'/(\\.eggs|\\.git|\\.hg|\\.mypy_cache|\\.tox|\\.venv|_build|buck-out|build|dist)/'"
-		],
-		"python.linting.flake8Enabled": true,
-		"python.linting.flake8Args": [
-			"--ignore=E203,E501,W503,W504"
-		]
+		"python.linting.flake8Enabled": true
 	},
 	"launch": {
 		"version": "0.2.0",


### PR DESCRIPTION
# Closes: #DNE
# What's Changed

- add flake8 linting and black formatting settings to vscode workspace settings
- add recommended extension `ms-python.python` required for these settings to work
- remove pylint linting setting


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design