### PR TITLE
JobResultFilterForm use MultipleChoiceField for status to match MultipleChoiceFilter

### DIFF
--- a/nautobot/docs/release-notes/version-1.4.md
+++ b/nautobot/docs/release-notes/version-1.4.md
@@ -134,6 +134,12 @@ A new configuration setting, [`STRICT_FILTERING`](../configuration/optional-sett
 
 The `settings_and_registry` default context processor was changed to purely `settings` - the (large) Nautobot application registry dictionary is no longer provided as part of the render context for all templates by default. Added a new `registry` template tag that can be invoked by specific templates to provide this variable where needed.
 
+## v1.4.0 (2022-MM-DD)
+
+### Fixed
+
+- [#2178](https://github.com/nautobot/nautobot/issues/2178) - Fixed "invalid filter" error when filtering JobResults in the UI.
+
 ## v1.4.0rc1 (2022-08-10)
 
 ### Added

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -949,10 +949,10 @@ class JobResultFilterForm(BootstrapMixin, forms.Form):
             api_url="/api/users/users/",
         ),
     )
-    status = forms.ChoiceField(
-        choices=add_blank_choice(JobResultStatusChoices),
+    status = forms.MultipleChoiceField(
+        choices=JobResultStatusChoices,
         required=False,
-        widget=StaticSelect2(),
+        widget=StaticSelect2Multiple(),
     )
 
 


### PR DESCRIPTION
# Closes: #2178 
# What's Changed

`JobResultFilterSet.status` is a `MultipleChoiceFilter`, but `JobResultFilterForm.status` was a `ChoiceField`; this mismatch made it so that an empty selection in the form caused an error in the filter with the new `STRICT_FILTERING` default in 1.4. Changing the FilterForm to use a `MultipleChoiceField` fixes the issue.