### PR TITLE
filter panel UI, add button to expand/collapse the search panel

### DIFF
--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -7,6 +7,7 @@
 <div class="pull-right noprint">
     {% block buttons %}{% endblock %}
     {% if request.user.is_authenticated and table_config_form %}
+        <button type="button" class="btn btn-default" data-toggle="collapse" data-target="#FilterPanel" title="Configure table"><i class="mdi mdi-filter"></i> Filters</button>
         <button type="button" class="btn btn-default" data-toggle="modal" data-target="#ObjectTable_config" title="Configure table"><i class="mdi mdi-cog"></i> Configure</button>
     {% endif %}
     {% if permissions.add and 'add' in action_buttons %}
@@ -23,7 +24,7 @@
 <div class="row">
     <div class="col-md-12">
         {% if filter_form %}
-            <div class="col-md-3 pull-right right-side-panel noprint">
+            <div id=FilterPanel class="col-md-3 pull-right right-side-panel collapse in noprint">
                 {% include 'inc/search_panel.html' %}
                 {% block sidebar %}{% endblock %}
             </div>

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="pull-right noprint">
     {% block buttons %}{% endblock %}
-    {% if request.user.is_authenticated and filter_form %}
+    {% if filter_form %}
         <button type="button" class="btn btn-default" data-toggle="collapse" data-target="#SearchPanel" title="Configure table"><i class="mdi mdi-filter"></i> Filters</button>
     {% endif %}
     {% if request.user.is_authenticated and table_config_form %}

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -6,8 +6,10 @@
 {% block content %}
 <div class="pull-right noprint">
     {% block buttons %}{% endblock %}
+    {% if request.user.is_authenticated and filter_form %}
+        <button type="button" class="btn btn-default" data-toggle="collapse" data-target="#SearchPanel" title="Configure table"><i class="mdi mdi-filter"></i> Filters</button>
+    {% endif %}
     {% if request.user.is_authenticated and table_config_form %}
-        <button type="button" class="btn btn-default" data-toggle="collapse" data-target="#FilterPanel" title="Configure table"><i class="mdi mdi-filter"></i> Filters</button>
         <button type="button" class="btn btn-default" data-toggle="modal" data-target="#ObjectTable_config" title="Configure table"><i class="mdi mdi-cog"></i> Configure</button>
     {% endif %}
     {% if permissions.add and 'add' in action_buttons %}
@@ -24,7 +26,7 @@
 <div class="row">
     <div class="col-md-12">
         {% if filter_form %}
-            <div id=FilterPanel class="col-md-3 pull-right right-side-panel collapse in noprint">
+            <div id=SearchPanel class="col-md-3 pull-right right-side-panel collapse in noprint">
                 {% include 'inc/search_panel.html' %}
                 {% block sidebar %}{% endblock %}
             </div>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2185
# Add a filter button that collapses and expands the search panel. This button only appears if { filter_form } context has been provided.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Desig
![image1](https://user-images.githubusercontent.com/57967713/184219765-1dc07e4f-e668-48bf-9bbc-be24c608c0d9.jpg)
![image2](https://user-images.githubusercontent.com/57967713/184219768-1f8a0d9c-5e57-43cc-a849-d583b351250f.jpg)
