### PR TITLE
Add tags to location form

### DIFF
--- a/nautobot/dcim/filters.py
+++ b/nautobot/dcim/filters.py
@@ -321,7 +321,7 @@ class LocationFilterSet(NautobotFilterSet, StatusModelFilterSetMixin, TenancyFil
         field_name="location_type__content_types",
         choices=FeatureQuery("locations").get_choices,
     )
-    tags = TagFilter()
+    tag = TagFilter()
 
     class Meta:
         model = Location

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -483,7 +483,7 @@ class LocationForm(NautobotModelForm, TenancyForm):
             "tenant_group",
             "tenant",
             "description",
-            "tags",
+            "tag",
         ]
 
 

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -483,7 +483,7 @@ class LocationForm(NautobotModelForm, TenancyForm):
             "tenant_group",
             "tenant",
             "description",
-            "tag",
+            "tags",
         ]
 
 

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -473,7 +473,7 @@ class LocationForm(NautobotModelForm, TenancyForm):
 
     class Meta:
         model = Location
-        fields = ["location_type", "parent", "site", "name", "slug", "status", "tenant_group", "tenant", "description"]
+        fields = ["location_type", "parent", "site", "name", "slug", "status", "tenant_group", "tenant", "description", "tags"]
 
 
 class LocationBulkEditForm(TagsBulkEditFormMixin, StatusModelBulkEditFormMixin, NautobotBulkEditForm):

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -473,7 +473,18 @@ class LocationForm(NautobotModelForm, TenancyForm):
 
     class Meta:
         model = Location
-        fields = ["location_type", "parent", "site", "name", "slug", "status", "tenant_group", "tenant", "description", "tags"]
+        fields = [
+            "location_type",
+            "parent",
+            "site",
+            "name",
+            "slug",
+            "status",
+            "tenant_group",
+            "tenant",
+            "description",
+            "tags",
+        ]
 
 
 class LocationBulkEditForm(TagsBulkEditFormMixin, StatusModelBulkEditFormMixin, NautobotBulkEditForm):

--- a/nautobot/dcim/templates/dcim/location_edit.html
+++ b/nautobot/dcim/templates/dcim/location_edit.html
@@ -21,4 +21,5 @@
             {% render_field form.tenant %}
         </div>
     </div>
+    {% include 'inc/extras_features_edit_form_fields.html' %}
 {% endblock form %}

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -82,6 +82,8 @@ from .base import (
 from .mixins import (
     CustomFieldModelBulkEditFormMixin,
     CustomFieldModelFormMixin,
+    NoteModelBulkEditFormMixin,
+    NoteModelFormMixin,
     RelationshipModelFormMixin,
 )
 
@@ -203,7 +205,7 @@ class ComputedFieldFilterForm(BootstrapMixin, forms.Form):
 #
 
 
-class ConfigContextForm(BootstrapMixin, forms.ModelForm):
+class ConfigContextForm(BootstrapMixin, NoteModelFormMixin, forms.ModelForm):
     regions = DynamicModelMultipleChoiceField(queryset=Region.objects.all(), required=False)
     sites = DynamicModelMultipleChoiceField(queryset=Site.objects.all(), required=False)
     locations = DynamicModelMultipleChoiceField(queryset=Location.objects.all(), required=False)
@@ -240,7 +242,7 @@ class ConfigContextForm(BootstrapMixin, forms.ModelForm):
         )
 
 
-class ConfigContextBulkEditForm(BootstrapMixin, BulkEditForm):
+class ConfigContextBulkEditForm(BootstrapMixin, NoteModelBulkEditFormMixin, BulkEditForm):
     pk = forms.ModelMultipleChoiceField(queryset=ConfigContext.objects.all(), widget=forms.MultipleHiddenInput)
     schema = DynamicModelChoiceField(queryset=ConfigContextSchema.objects.all(), required=False)
     weight = forms.IntegerField(required=False, min_value=0)

--- a/nautobot/extras/templates/extras/configcontext_edit.html
+++ b/nautobot/extras/templates/extras/configcontext_edit.html
@@ -34,4 +34,15 @@
             {% render_field form.data %}
         </div>
     </div>
+    {% comment %}
+    We don't use 'inc/extras_features_edit_form_fields.html' because it would add a second,
+    and incorrect, "Tags" field to the form. Currently config-contexts don't support custom-fields or relationships,
+    but they do support notes.
+    {% endcomment %}
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Notes</strong></div>
+        <div class="panel-body">
+            {% render_field form.object_note %}
+        </div>
+    </div>
 {% endblock %}

--- a/nautobot/extras/templates/extras/configcontextschema_edit.html
+++ b/nautobot/extras/templates/extras/configcontextschema_edit.html
@@ -16,4 +16,5 @@
             {% render_field form.data_schema %}
         </div>
     </div>
+    {% include 'inc/extras_features_edit_form_fields.html' %}
 {% endblock %}


### PR DESCRIPTION
# Closes: #DNS
# What's Changed
A keen eyed customer noted that tags was missing from the Location form. 

Additional/related fixes added by @glennmatthews:

- Location tag filter name of `tags` was correct with how we want to do things moving forward, but there's existing code (notably the implementation of `TagColumn`) that expects this filter to be named `tag` as it is (incorrectly) named in all other existing filters. So sadly I changed it to `tag`.
- Added missing include in `location_edit.html` so that tags/custom fields/relationships/notes show up in this form.
- A cursory search found that the same include was missing for `configcontextschema_edit.html`, and that the forms for ConfigContext were missing the Notes mixins.

# TODO
N/A