### PR TITLE
Honor `has_sensitive_variables` when storing kwargs for re-run, Fix immediate job schedule in API

### DIFF
--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -508,7 +508,7 @@ def _run_job(request, job_model, legacy_response=False):
     if job_model.has_sensitive_variables:
         if request.data.get("schedule") and request.data["schedule"]["interval"] != JobExecutionType.TYPE_IMMEDIATELY:
             raise ValidationError(
-                {"schedule": {"interval": ["Unable to schedule job: Job has sensitive input variables"]}}
+                {"schedule": {"interval": ["Unable to schedule job: Job may have sensitive input variables"]}}
             )
 
     job_class = job_model.job_class
@@ -545,6 +545,13 @@ def _run_job(request, job_model, legacy_response=False):
     # executes immediately.
     if schedule_data is None and job_model.approval_required:
         schedule_data = {"interval": JobExecutionType.TYPE_IMMEDIATELY}
+
+    elif (
+        schedule_data
+        and schedule_data["interval"] == JobExecutionType.TYPE_IMMEDIATELY
+        and not job_model.approval_required
+    ):
+        schedule_data = None
 
     # Try to create a ScheduledJob, or...
     if schedule_data:

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -546,6 +546,7 @@ def _run_job(request, job_model, legacy_response=False):
     if schedule_data is None and job_model.approval_required:
         schedule_data = {"interval": JobExecutionType.TYPE_IMMEDIATELY}
 
+    # Skip creating a ScheduledJob when job can be executed immediately
     elif (
         schedule_data
         and schedule_data["interval"] == JobExecutionType.TYPE_IMMEDIATELY

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -100,6 +100,7 @@ class BaseJob:
         - approval_required (bool)
         - soft_time_limit (int)
         - time_limit (int)
+        - has_sensitive_variables (bool)
         """
 
         pass

--- a/nautobot/extras/templates/extras/job.html
+++ b/nautobot/extras/templates/extras/job.html
@@ -67,7 +67,7 @@
                                     <div class="panel-footer">
                                         <span class="help-block">
                                             <i class="mdi mdi-information-outline"></i>
-                                            This job has sensitive variables and can only be executed immediately.
+                                            This job may have sensitive variables and can only be executed immediately. This can be changed in the Job edit view to set `has_sensitive_variables` to `False` if appropriate.
                                         </span>
                                     </div>
                                 {% endif %}

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1787,7 +1787,7 @@ class JobTestVersion13(
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data["has_sensitive_variables"][0],
-            "A job that may have sensitive variables cannot also be marked as requiring approval",
+            "A job with sensitive variables cannot also be marked as requiring approval",
         )
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1765,7 +1765,7 @@ class JobTestVersion13(
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data["approval_required"][0],
-            "A job that may have sensitive variables cannot also be marked as requiring approval",
+            "A job with sensitive variables cannot also be marked as requiring approval",
         )
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1437,7 +1437,7 @@ class JobAPIRunTestMixin:
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data["schedule"]["interval"][0],
-            "Unable to schedule job: Job may have sensitive input variables.",
+            "Unable to schedule job: Job may have sensitive input variables",
         )
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1437,7 +1437,7 @@ class JobAPIRunTestMixin:
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data["schedule"]["interval"][0],
-            "Unable to schedule job: Job has sensitive input variables",
+            "Unable to schedule job: Job may have sensitive input variables.",
         )
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
@@ -1462,6 +1462,9 @@ class JobAPIRunTestMixin:
         url = self.get_run_url()
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, self.run_success_response_status)
+
+        job_result = JobResult.objects.last()
+        self.assertEqual(job_result.job_kwargs, None)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     @mock.patch("nautobot.extras.api.views.get_worker_count")
@@ -1762,7 +1765,7 @@ class JobTestVersion13(
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data["approval_required"][0],
-            "A job with sensitive variables cannot also be marked as requiring approval",
+            "A job that may have sensitive variables cannot also be marked as requiring approval",
         )
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
@@ -1784,7 +1787,7 @@ class JobTestVersion13(
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data["has_sensitive_variables"][0],
-            "A job with sensitive variables cannot also be marked as requiring approval",
+            "A job that may have sensitive variables cannot also be marked as requiring approval",
         )
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])

--- a/nautobot/extras/tests/test_forms.py
+++ b/nautobot/extras/tests/test_forms.py
@@ -1089,5 +1089,5 @@ class JobEditFormTestCase(TestCase):
         error_msg = json.loads(form.errors.as_json())
         self.assertEqual(
             error_msg["approval_required"][0]["message"],
-            "A job with sensitive variables cannot be marked as requiring approval",
+            "A job that may have sensitive variables cannot be marked as requiring approval",
         )

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -831,7 +831,7 @@ class JobModelTest(TestCase):
             ).clean()
         self.assertEqual(
             handler.exception.message_dict["approval_required"][0],
-            "A job with sensitive variables cannot be marked as requiring approval",
+            "A job that may have sensitive variables cannot be marked as requiring approval",
         )
 
 

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -1777,7 +1777,7 @@ class JobTestCase(
             self.assertHttpStatus(response, 200, msg=self.run_urls[1])
 
             content = extract_page_body(response.content.decode(response.charset))
-            self.assertIn("Unable to schedule job: Job has sensitive input variables.", content)
+            self.assertIn("Unable to schedule job: Job may have sensitive input variables.", content)
 
 
 # TODO: Convert to StandardTestCases.Views

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1089,7 +1089,7 @@ class JobView(ObjectPermissionRequiredMixin, View):
         elif not job_model.enabled:
             messages.error(request, "Unable to run or schedule job: Job is not enabled to be run.")
         elif job_model.has_sensitive_variables and request.POST["_schedule_type"] != JobExecutionType.TYPE_IMMEDIATELY:
-            messages.error(request, "Unable to schedule job: Job has sensitive input variables.")
+            messages.error(request, "Unable to schedule job: Job may have sensitive input variables.")
         elif job_form is not None and job_form.is_valid() and schedule_form.is_valid():
             # Run the job. A new JobResult is created.
             commit = job_form.cleaned_data.pop("_commit")


### PR DESCRIPTION
Close #2184
Close #1845

# What's Changed

* Honor `has_sensitive_variables` when storing kwargs for re-run
* Update Job class docstring
* Add test for not storing kwargs on rerun for sensitive variable jobs
* Fix "Unable to schedule job with job interval 'immediately' from API"
* Update job sensitive variables messaging

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- NA Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- NA Documentation Updates (when adding/changing features)
- NA Example Plugin Updates (when adding/changing features)
- NA Outline Remaining Work, Constraints from Design