### PR TITLE
A couple of fixes to dynamic groups detail display

### DIFF
--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -365,7 +365,7 @@ DESCENDANTS_LINK = """
         {% endfor %}
     {% endif %}
 {% endfor %}
-<a href="{{ record.get_absolute_url }}">{{ record.slug }}</a>
+<a href="{{ record.get_absolute_url }}">{{ record.name }}</a>
 """
 
 
@@ -407,7 +407,7 @@ ANCESTORS_LINK = """
         {% endfor %}
     {% endif %}
 {% endfor %}
-<a href="{{ record.get_absolute_url }}">{{ record.slug }}</a>
+<a href="{{ record.get_absolute_url }}">{{ record.name }}</a>
 """
 
 

--- a/nautobot/utilities/tests/test_utils.py
+++ b/nautobot/utilities/tests/test_utils.py
@@ -262,20 +262,57 @@ class PrettyPrintQueryTest(TestCase):
             Q(site__slug__in=["ams01", "ang01"]),
         ]
         results = [
-            "(((site__slug='ams01' OR site__slug='ang01') AND (NOT status__slug='active')) OR status__slug='planned')",
-            "((site__slug='ams01' OR site__slug='ang01') AND (NOT status__slug='active'))",
-            "(site__slug='ams01' OR site__slug='ang01')",
-            "(site__slug='ang01' AND (NOT status__slug='active'))",
-            "(site__slug='ams01' AND status__slug='planned')",
-            "(site__slug='ang01')",
-            "(status__id=12345)",
-            "(site__slug__in=['ams01', 'ang01'])",
+            """\
+(
+  (
+    (
+      site__slug='ams01' OR site__slug='ang01'
+    ) AND (
+      NOT (status__slug='active')
+    )
+  ) OR status__slug='planned'
+)""",
+            """\
+(
+  (
+    site__slug='ams01' OR site__slug='ang01'
+  ) AND (
+    NOT (status__slug='active')
+  )
+)""",
+            """\
+(
+  site__slug='ams01' OR site__slug='ang01'
+)""",
+            """\
+(
+  site__slug='ang01' AND (
+    NOT (status__slug='active')
+  )
+)""",
+            """\
+(
+  site__slug='ams01' AND status__slug='planned'
+)""",
+            """\
+(
+  site__slug='ang01'
+)""",
+            """\
+(
+  status__id=12345
+)""",
+            """\
+(
+  site__slug__in=['ams01', 'ang01']
+)""",
         ]
 
         tests = zip(queries, results)
 
         for query, expected in tests:
-            self.assertEqual(pretty_print_query(query), expected)
+            with self.subTest(query=query):
+                self.assertEqual(pretty_print_query(query), expected)
 
 
 class SlugifyFunctionsTest(TestCase):

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -625,13 +625,33 @@ def pretty_print_query(query):
     """
     Given a `Q` object, display it in a more human-readable format.
 
-    :param query:
-        Q instance
+    Args:
+        query (Q): Query to display.
+
+    Returns:
+        str: Pretty-printed query logic
+
+    Example:
+        >>> print(pretty_print_query(Q))
+        (
+          site__slug='ams01' OR site__slug='bkk01' OR (
+            site__slug='can01' AND status__slug='active'
+          ) OR (
+            site__slug='del01' AND (
+              NOT (site__slug='del01' AND status__slug='decommissioning')
+            )
+          )
+        )
     """
 
-    def pretty_str(self, node=None):
+    def pretty_str(self, node=None, depth=0):
         """Improvement to default `Node.__str__` with a more human-readable style."""
-        template = "(NOT %s)" if self.negated else "(%s)"
+        template = f"(\n{'  ' * (depth + 1)}"
+        if self.negated:
+            template += "NOT (%s)"
+        else:
+            template += "%s"
+        template += f"\n{'  ' * depth})"
         children = []
 
         # If we don't have a node, we are the node!
@@ -642,7 +662,7 @@ def pretty_print_query(query):
         for child in node.children:
             # Trust that we can stringify the child if it is a Node instance.
             if isinstance(child, Node):
-                children.append(pretty_str(child))
+                children.append(pretty_str(child, depth=depth + 1))
             # If a 2-tuple, stringify to key=value
             else:
                 key, value = child


### PR DESCRIPTION
# Closes: #DNE
# What's Changed

1. In dynamic groups detail page, the "ancestors" and "descendants" tables have a column labeled "Name" but these columns were displaying the related group's slug instead of its name. Fixed this.
2. When nested groups are present, displaying the entire query logic on a single line results in a lengthy horizontal scroll to see the whole thing. I've adjusted the `pretty_print_query` implementation to add some line breaks for readability.

![image](https://user-images.githubusercontent.com/5603551/184420971-8024973a-e626-47b0-a2a0-17a004b15aa3.png)
