### PR TITLE
Fix job.request removed from job instance in `v1.4.0b1`

### DIFF
--- a/nautobot/docs/release-notes/version-1.4.md
+++ b/nautobot/docs/release-notes/version-1.4.md
@@ -146,6 +146,7 @@ The `settings_and_registry` default context processor was changed to purely `set
 ### Fixed
 
 - [#2178](https://github.com/nautobot/nautobot/issues/2178) - Fixed "invalid filter" error when filtering JobResults in the UI.
+- [#2192](https://github.com/nautobot/nautobot/issues/2178) - Fixed job.request removed from job instance in `v1.4.0b1`.
 
 ## v1.4.0rc1 (2022-08-10)
 

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -129,6 +129,6 @@ def web_request_context(user, context_detail="", change_id=None):
 
     request = RequestFactory().request(SERVER_NAME="web_request_context")
     request.user = user
-    change_context = ORMChangeContext(user=request.user, context_detail=context_detail, change_id=change_id)
+    change_context = ORMChangeContext(request=request, context_detail=context_detail, change_id=change_id)
     with change_logging(change_context):
         yield request

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1149,6 +1149,9 @@ def run_job(data, request, job_result_pk, commit=True, *args, **kwargs):
     job_result.set_status(JobResultStatusChoices.STATUS_RUNNING)
     job_result.save()
 
+    # Add the current request as a property of the job
+    job.request = request
+
     def _run_job():
         """
         Core job execution task.

--- a/nautobot/extras/tests/example_jobs/test_job_hook_receiver.py
+++ b/nautobot/extras/tests/example_jobs/test_job_hook_receiver.py
@@ -6,6 +6,7 @@ class TestJobHookReceiverLog(JobHookReceiver):
     def receive_job_hook(self, change, action, changed_object):
         self.log_info(f"change: {change}")
         self.log_info(f"action: {action}")
+        self.log_info(f"request.user: {self.request.user.username}")
         self.log_success(changed_object.name)
 
 

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -650,16 +650,6 @@ class JobHookReceiverTest(TransactionTestCase):
         self.assertEqual(oc.change_context, ObjectChangeEventContextChoices.CONTEXT_JOB_HOOK)
         self.assertEqual(oc.user_id, self.user.pk)
 
-    def test_run_job(self):
-        module = "test_job_hook_receiver"
-        name = "TestJobHookReceiverLog"
-        job_result = create_job_result_and_run_job(module, name, data=self.data, commit=False)
-        log_info = JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_INFO)[:2]
-        self.assertEqual(log_info[0].message, "change: dcim | site Test Site 1 created by testuser")
-        self.assertEqual(log_info[1].message, "action: create")
-        log_success = JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_SUCCESS).first()
-        self.assertEqual(log_success.message, "Test Site 1")
-
     def test_missing_receive_job_hook_method(self):
         module = "test_job_hook_receiver"
         name = "TestJobHookReceiverFail"
@@ -667,7 +657,7 @@ class JobHookReceiverTest(TransactionTestCase):
         self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_ERRORED)
 
 
-class JobHookTest(TransactionTestCase):
+class JobHookTest(CeleryTestCase):
     """
     Test job hooks.
     """
@@ -675,26 +665,38 @@ class JobHookTest(TransactionTestCase):
     def setUp(self):
         super().setUp()
 
-        job = Job.objects.get(job_class_name="TestJobHookReceiverLog")
+        module = "test_job_hook_receiver"
+        name = "TestJobHookReceiverLog"
+        self.job_class, self.job_model = get_job_class_and_model(module, name)
         job_hook = JobHook(
             name="JobHookTest",
             type_create=True,
-            job=job,
+            job=self.job_model,
         )
         obj_type = ContentType.objects.get_for_model(Site)
         job_hook.save()
         job_hook.content_types.set([obj_type])
 
-    @mock.patch.object(JobResult, "enqueue_job")
-    def test_enqueue_job_hook(self, mock):
-        with web_request_context(self.user):
+    def test_enqueue_job_hook(self):
+        self.clear_worker()
+        with web_request_context(user=self.user):
             Site.objects.create(name="Test Job Hook Site 1")
-
-        mock.assert_called_once()
+            self.wait_on_active_tasks()
+            job_result = JobResult.objects.get(job_model=self.job_model)
+            expected_log_messages = [
+                ("info", f"change: dcim | site Test Job Hook Site 1 created by {self.user.username}"),
+                ("info", "action: create"),
+                ("info", f"request.user: {self.user.username}"),
+                ("success", "Test Job Hook Site 1"),
+            ]
+            log_messages = JobLogEntry.objects.filter(job_result=job_result).values_list("log_level", "message")
+            self.assertSequenceEqual(log_messages, expected_log_messages)
 
     @mock.patch.object(JobResult, "enqueue_job")
     def test_enqueue_job_hook_skipped(self, mock):
-        change_context = JobHookChangeContext(user=self.user)
+        request = RequestFactory().request(SERVER_NAME="job_hook_context")
+        request.user = self.user
+        change_context = JobHookChangeContext(request=request)
         with change_logging(change_context):
             Site.objects.create(name="Test Job Hook Site 2")
 

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -694,9 +694,7 @@ class JobHookTest(CeleryTestCase):
 
     @mock.patch.object(JobResult, "enqueue_job")
     def test_enqueue_job_hook_skipped(self, mock):
-        request = RequestFactory().request(SERVER_NAME="job_hook_context")
-        request.user = self.user
-        change_context = JobHookChangeContext(request=request)
+        change_context = JobHookChangeContext(user=self.user)
         with change_logging(change_context):
             Site.objects.create(name="Test Job Hook Site 2")
 


### PR DESCRIPTION
# Closes: #2192
# What's Changed

Job.request was mistakenly removed from the job instance in #2035. Re-add to job.request and add test case to test for this functionality.


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design