### PR TITLE
UI parts for job `has_sensitive_variables` 2184 (WIP)

### DIFF
--- a/nautobot/extras/templates/extras/jobresult.html
+++ b/nautobot/extras/templates/extras/jobresult.html
@@ -35,9 +35,13 @@
     {{ block.super }}
      {% if perms.extras.run_job %}
         {% if result.job_model and result.job_kwargs %}
-        <a href="{% url 'extras:job_run' slug=result.job_model.slug %}?kwargs_from_job_result={{ result.pk }}"
+        <a href="{% url 'extras:job_run' slug=result.job_model.slug %}{% if not result.job_model.job_class.has_sensitive_variables %}?kwargs_from_job_result={{ result.pk }}{% endif %}"
            class="btn btn-info">
-            <span class="mdi mdi-repeat" aria-hidden="true"></span> Re-Run
+            {% if not result.job_model.job_class.has_sensitive_variables %}
+                <span class="mdi mdi-repeat" aria-hidden="true"></span> Re-Run
+            {% else %}
+                <span class="mdi mdi-play" aria-hidden="true"></span> Run
+            {% endif %}
         </a>
         {% endif %}
     {% endif %}
@@ -73,28 +77,35 @@
 
 {% block extra_tab_content %}
     <div role="tabpanel" class="tab-pane" id="json">
-        <div class="row">
-            <div class="col-md-6">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <strong>Job Inputs</strong>
+        {% if not result.job_model.job_class.has_sensitive_variables %}
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <strong>Job Inputs</strong>
+                        </div>
+                        <div class="panel-body">
+                            {% include 'extras/inc/json_data.html' with data=result.job_kwargs format="json" %}
+                        </div>
                     </div>
-                    <div class="panel-body">
-                        {% include 'extras/inc/json_data.html' with data=result.job_kwargs format="json" %}
+                </div>
+                <div class="col-md-6">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <strong>Output Data</strong>
+                        </div>
+                        <div class="panel-body">
+                            {% include 'extras/inc/json_data.html' with data=result.data format="json" %}
+                        </div>
                     </div>
                 </div>
             </div>
-            <div class="col-md-6">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <strong>Output Data</strong>
-                    </div>
-                    <div class="panel-body">
-                        {% include 'extras/inc/json_data.html' with data=result.data format="json" %}
-                    </div>
-                </div>
+        {% else %}
+            <div class="alert alert-warning text-center" role="alert">
+                <h4><i class="mdi mdi-alert"></i> Job Data Not saved</h4>
+                <p>This job is marked as having sensitive variables, so its data has not been saved to the database.</p>
             </div>
-        </div>
+        {% endif %}
     </div>
     {% if result.data.output %}
         <div role="tabpanel" class="tab-pane" id="output">

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1163,6 +1163,7 @@ class JobView(ObjectPermissionRequiredMixin, View):
                     data=job_model.job_class.serialize_data(job_form.cleaned_data),
                     request=copy_safe_request(request),
                     commit=commit,
+                    has_sensitive_variables=getattr(job_model.job_class, "has_sensitive_variables", False),
                 )
 
                 return redirect("extras:job_jobresult", pk=job_result.pk)


### PR DESCRIPTION
# Closes: #2184 
# What's Changed
So far, if a job is marked as has_sensitive_variables:
- It can only "Run" and not re-run
- kwargs/data aren't saved to the database in enqueue_job
- The UI will show relevant "Play" button instead of the re-run "repeat" button (and the links will point to the relevant places etc)
- If the Additional Data tab is accessed on the job result page, I've got it setup to render the following:![Screenshot 2022-08-14 at 21 47 55](https://user-images.githubusercontent.com/655255/184554875-e11a680f-be60-499d-9c87-03b521ef5426.png)