### PR TITLE
Run button now appears if re-run is unavailable on job result list an…

### DIFF
--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -705,8 +705,9 @@ class JobResultTable(BaseTable):
                     <i class="mdi mdi-repeat"></i>
                 </a>
             {% else %}
-                <a href="#" class="btn btn-xs btn-default disabled" title="No saved job arguments, cannot be re-run">
-                    <i class="mdi mdi-repeat-off"></i>
+                <a href="{% url 'extras:job_run' slug=record.job_model.slug %}" class="btn btn-primary btn-xs"
+                   title="Run job">
+                    <i class="mdi mdi-play"></i>
                 </a>
             {% endif %}
             <a href="{% url 'extras:jobresult_delete' pk=record.pk %}" class="btn btn-xs btn-danger"

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -699,20 +699,22 @@ class JobResultTable(BaseTable):
     actions = tables.TemplateColumn(
         template_code="""
             {% load helpers %}
-            {% if record.job_model and record.job_kwargs %}
-                <a href="{% url 'extras:job_run' slug=record.job_model.slug %}?kwargs_from_job_result={{ record.pk }}"
-                   class="btn btn-xs btn-success" title="Re-run job with same arguments.">
-                    <i class="mdi mdi-repeat"></i>
-                </a>
-            {% elif record.job_model is not None %}
-                <a href="{% url 'extras:job_run' slug=record.job_model.slug %}" class="btn btn-primary btn-xs"
-                   title="Run job">
-                    <i class="mdi mdi-play"></i>
-                </a>
-            {% else %}
-                <a href="#" class="btn btn-xs btn-default disabled" title="Job is not available, cannot be re-run">
-                    <i class="mdi mdi-repeat-off"></i>
-                </a>
+            {% if perms.extras.run_job %}
+                {% if record.job_model and record.job_kwargs %}
+                    <a href="{% url 'extras:job_run' slug=record.job_model.slug %}?kwargs_from_job_result={{ record.pk }}"
+                       class="btn btn-xs btn-success" title="Re-run job with same arguments.">
+                        <i class="mdi mdi-repeat"></i>
+                    </a>
+                {% elif record.job_model is not None %}
+                    <a href="{% url 'extras:job_run' slug=record.job_model.slug %}" class="btn btn-primary btn-xs"
+                       title="Run job">
+                        <i class="mdi mdi-play"></i>
+                    </a>
+                {% else %}
+                    <a href="#" class="btn btn-xs btn-default disabled" title="Job is not available, cannot be re-run">
+                        <i class="mdi mdi-repeat-off"></i>
+                    </a>
+                {% endif %}
             {% endif %}
             <a href="{% url 'extras:jobresult_delete' pk=record.pk %}" class="btn btn-xs btn-danger"
                title="Delete this job result.">

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -704,10 +704,14 @@ class JobResultTable(BaseTable):
                    class="btn btn-xs btn-success" title="Re-run job with same arguments.">
                     <i class="mdi mdi-repeat"></i>
                 </a>
-            {% else %}
+            {% elif record.job_model is not None %}
                 <a href="{% url 'extras:job_run' slug=record.job_model.slug %}" class="btn btn-primary btn-xs"
                    title="Run job">
                     <i class="mdi mdi-play"></i>
+                </a>
+            {% else %}
+                <a href="#" class="btn btn-xs btn-default disabled" title="No saved job arguments, cannot be re-run">
+                    <i class="mdi mdi-repeat-off"></i>
                 </a>
             {% endif %}
             <a href="{% url 'extras:jobresult_delete' pk=record.pk %}" class="btn btn-xs btn-danger"

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -710,7 +710,7 @@ class JobResultTable(BaseTable):
                     <i class="mdi mdi-play"></i>
                 </a>
             {% else %}
-                <a href="#" class="btn btn-xs btn-default disabled" title="No saved job arguments, cannot be re-run">
+                <a href="#" class="btn btn-xs btn-default disabled" title="Job is not available, cannot be re-run">
                     <i class="mdi mdi-repeat-off"></i>
                 </a>
             {% endif %}

--- a/nautobot/extras/templates/extras/jobresult.html
+++ b/nautobot/extras/templates/extras/jobresult.html
@@ -33,12 +33,17 @@
 
 {% block buttons %}
     {{ block.super }}
-     {% if perms.extras.run_job %}
+    {% if perms.extras.run_job %}
         {% if result.job_model and result.job_kwargs %}
-        <a href="{% url 'extras:job_run' slug=result.job_model.slug %}?kwargs_from_job_result={{ result.pk }}"
-           class="btn btn-info">
-            <span class="mdi mdi-repeat" aria-hidden="true"></span> Re-Run
-        </a>
+            <a href="{% url 'extras:job_run' slug=result.job_model.slug %}?kwargs_from_job_result={{ result.pk }}"
+               class="btn btn-info">
+                <span class="mdi mdi-repeat" aria-hidden="true"></span> Re-Run
+            </a>
+        {% else %}
+            <a href="{% url 'extras:job_run' slug=result.job_model.slug %}"
+               class="btn btn-info">
+                <span class="mdi mdi-play" aria-hidden="true"></span> Run
+            </a>
         {% endif %}
     {% endif %}
 {% endblock buttons %}

--- a/nautobot/extras/templates/extras/jobresult.html
+++ b/nautobot/extras/templates/extras/jobresult.html
@@ -32,20 +32,20 @@
 {% endblock breadcrumbs %}
 
 {% block buttons %}
-    {{ block.super }}
     {% if perms.extras.run_job %}
         {% if result.job_model and result.job_kwargs %}
             <a href="{% url 'extras:job_run' slug=result.job_model.slug %}?kwargs_from_job_result={{ result.pk }}"
-               class="btn btn-info">
+               class="btn btn-success">
                 <span class="mdi mdi-repeat" aria-hidden="true"></span> Re-Run
             </a>
-        {% else %}
+        {% elif result.job_model is not None %}
             <a href="{% url 'extras:job_run' slug=result.job_model.slug %}"
-               class="btn btn-info">
+               class="btn btn-primary">
                 <span class="mdi mdi-play" aria-hidden="true"></span> Run
             </a>
         {% endif %}
     {% endif %}
+    {{ block.super }}
 {% endblock buttons %}
 
 {% block title %}


### PR DESCRIPTION
…d job result detail.
# Closes: #2206 
# What's Changed
The job run button now appears on a job result detail page or the list if this job has no saved input data.

# TODO
- [ ] Unit, Integration Tests
- [ ] Release Note