### PR TITLE
Add Django natural key to `extras.Status`

### DIFF
--- a/nautobot/extras/models/statuses.py
+++ b/nautobot/extras/models/statuses.py
@@ -29,6 +29,9 @@ class StatusQuerySet(RestrictedQuerySet):
         content_type = ContentType.objects.get_for_model(model._meta.concrete_model)
         return self.filter(content_types=content_type)
 
+    def get_by_natural_key(self, slug):
+        return self.get(slug=slug)
+
 
 @extras_features(
     "custom_fields",
@@ -68,6 +71,9 @@ class Status(BaseModel, ChangeLoggedModel, CustomFieldModel, RelationshipModel, 
 
     def __str__(self):
         return self.name
+
+    def natural_key(self):
+        return (self.slug,)
 
     def get_absolute_url(self):
         return reverse("extras:status", args=[self.slug])


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1809, Related: #1574
# What's Changed

- Added `Status.natural_key(slug)` method
- Added `StatusQuerySet.get_by_natural_key(slug)` method

## Gve it a whirl:

Start with a fresh install of Nautobot with migrations executed

Run `nautobot-server dumpdata --natural-primary --natural-foreign extras.Status > statuses.json`

```no-highlight
$ nautobot-server dumpdata --natural-primary --natural-foreign extras.Status > statuses.json
```

Fire up `nautobot-server nbshell`, run `Status.objects.all().delete()` and then exit `nbshell`

```no-highlight
$ nautobot-server nbshell
### Nautobot interactive shell (jathy-mbp-m1)
### Python 3.9.10 | Django 3.2.14 | Nautobot 1.4.0a3
### lsmodels() will show available models. Use help(<model>) for more info.
>>> Status.objects.all().delete()
(83, {'extras.Status_content_types': 63, 'extras.Status': 20})
>>>
now exiting InteractiveConsole...
```

Observe that the dumped statuses have no primary keys and are using natural keys using `python -m json.tool statuses.json`:

```bash
$ python -m json.tool statuses.json                                                                          <<<
[
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:53:02.051Z",
            "_custom_field_data": {},
            "name": "Maintenance",
            "color": "9e9e9e",
            "slug": "maintenance",
            "description": "Unit is under maintenance",
            "content_types": [
                [
                    "dcim",
                    "interface"
                ],
                [
                    "virtualization",
                    "vminterface"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.257Z",
            "_custom_field_data": {},
            "name": "Deprecated",
            "color": "f44336",
            "slug": "deprecated",
            "description": "Unit has been deprecated",
            "content_types": [
                [
                    "dcim",
                    "rack"
                ],
                [
                    "ipam",
                    "prefix"
                ],
                [
                    "ipam",
                    "ipaddress"
                ],
                [
                    "ipam",
                    "vlan"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.170Z",
            "_custom_field_data": {},
            "name": "Offline",
            "color": "ffc107",
            "slug": "offline",
            "description": "Unit is offline",
            "content_types": [
                [
                    "dcim",
                    "device"
                ],
                [
                    "dcim",
                    "powerfeed"
                ],
                [
                    "circuits",
                    "circuit"
                ],
                [
                    "virtualization",
                    "virtualmachine"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.261Z",
            "_custom_field_data": {},
            "name": "Connected",
            "color": "4caf50",
            "slug": "connected",
            "description": "Cable is connected",
            "content_types": [
                [
                    "dcim",
                    "cable"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.197Z",
            "_custom_field_data": {},
            "name": "Staged",
            "color": "2196f3",
            "slug": "staged",
            "description": "Unit has been staged",
            "content_types": [
                [
                    "dcim",
                    "device"
                ],
                [
                    "virtualization",
                    "virtualmachine"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.239Z",
            "_custom_field_data": {},
            "name": "Reserved",
            "color": "ffc107",
            "slug": "reserved",
            "description": "Unit is reserved",
            "content_types": [
                [
                    "dcim",
                    "rack"
                ],
                [
                    "ipam",
                    "prefix"
                ],
                [
                    "ipam",
                    "ipaddress"
                ],
                [
                    "ipam",
                    "vlan"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.331Z",
            "_custom_field_data": {},
            "name": "DHCP",
            "color": "4caf50",
            "slug": "dhcp",
            "description": "Dynamically assigned IPv4/IPv6 address",
            "content_types": [
                [
                    "ipam",
                    "ipaddress"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.299Z",
            "_custom_field_data": {},
            "name": "Decommissioned",
            "color": "9e9e9e",
            "slug": "decommissioned",
            "description": "Circuit has been decommissioned",
            "content_types": [
                [
                    "circuits",
                    "circuit"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.193Z",
            "_custom_field_data": {},
            "name": "Planned",
            "color": "00bcd4",
            "slug": "planned",
            "description": "Unit has been planned",
            "content_types": [
                [
                    "dcim",
                    "device"
                ],
                [
                    "dcim",
                    "site"
                ],
                [
                    "dcim",
                    "location"
                ],
                [
                    "dcim",
                    "rack"
                ],
                [
                    "dcim",
                    "cable"
                ],
                [
                    "dcim",
                    "powerfeed"
                ],
                [
                    "circuits",
                    "circuit"
                ],
                [
                    "virtualization",
                    "virtualmachine"
                ],
                [
                    "dcim",
                    "interface"
                ],
                [
                    "virtualization",
                    "vminterface"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.334Z",
            "_custom_field_data": {},
            "name": "SLAAC",
            "color": "4caf50",
            "slug": "slaac",
            "description": "Dynamically assigned IPv6 address",
            "content_types": [
                [
                    "ipam",
                    "ipaddress"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.213Z",
            "_custom_field_data": {},
            "name": "Staging",
            "color": "2196f3",
            "slug": "staging",
            "description": "Site is in the process of being staged",
            "content_types": [
                [
                    "dcim",
                    "site"
                ],
                [
                    "dcim",
                    "location"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.306Z",
            "_custom_field_data": {},
            "name": "Container",
            "color": "9e9e9e",
            "slug": "container",
            "description": "Network contains children",
            "content_types": [
                [
                    "ipam",
                    "prefix"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.207Z",
            "_custom_field_data": {},
            "name": "Decommissioning",
            "color": "ffc107",
            "slug": "decommissioning",
            "description": "Unit is being decommissioned",
            "content_types": [
                [
                    "dcim",
                    "device"
                ],
                [
                    "dcim",
                    "site"
                ],
                [
                    "dcim",
                    "location"
                ],
                [
                    "dcim",
                    "cable"
                ],
                [
                    "virtualization",
                    "virtualmachine"
                ],
                [
                    "dcim",
                    "interface"
                ],
                [
                    "virtualization",
                    "vminterface"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.200Z",
            "_custom_field_data": {},
            "name": "Failed",
            "color": "f44336",
            "slug": "failed",
            "description": "Unit has failed",
            "content_types": [
                [
                    "dcim",
                    "device"
                ],
                [
                    "dcim",
                    "powerfeed"
                ],
                [
                    "virtualization",
                    "virtualmachine"
                ],
                [
                    "dcim",
                    "interface"
                ],
                [
                    "virtualization",
                    "vminterface"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.202Z",
            "_custom_field_data": {},
            "name": "Inventory",
            "color": "9e9e9e",
            "slug": "inventory",
            "description": "Device is in inventory",
            "content_types": [
                [
                    "dcim",
                    "device"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.182Z",
            "_custom_field_data": {},
            "name": "Active",
            "color": "4caf50",
            "slug": "active",
            "description": "Unit is active",
            "content_types": [
                [
                    "dcim",
                    "device"
                ],
                [
                    "dcim",
                    "site"
                ],
                [
                    "dcim",
                    "location"
                ],
                [
                    "dcim",
                    "rack"
                ],
                [
                    "dcim",
                    "powerfeed"
                ],
                [
                    "circuits",
                    "circuit"
                ],
                [
                    "ipam",
                    "prefix"
                ],
                [
                    "ipam",
                    "ipaddress"
                ],
                [
                    "ipam",
                    "vlan"
                ],
                [
                    "virtualization",
                    "virtualmachine"
                ],
                [
                    "dcim",
                    "interface"
                ],
                [
                    "virtualization",
                    "vminterface"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.219Z",
            "_custom_field_data": {},
            "name": "Retired",
            "color": "f44336",
            "slug": "retired",
            "description": "Site has been retired",
            "content_types": [
                [
                    "dcim",
                    "site"
                ],
                [
                    "dcim",
                    "location"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.284Z",
            "_custom_field_data": {},
            "name": "Provisioning",
            "color": "2196f3",
            "slug": "provisioning",
            "description": "Circuit is being provisioned",
            "content_types": [
                [
                    "circuits",
                    "circuit"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.296Z",
            "_custom_field_data": {},
            "name": "Deprovisioning",
            "color": "ffc107",
            "slug": "deprovisioning",
            "description": "Circuit is being deprovisioned",
            "content_types": [
                [
                    "circuits",
                    "circuit"
                ]
            ]
        }
    },
    {
        "model": "extras.status",
        "fields": {
            "created": "2022-08-16",
            "last_updated": "2022-08-16T18:52:57.242Z",
            "_custom_field_data": {},
            "name": "Available",
            "color": "4caf50",
            "slug": "available",
            "description": "Unit is available",
            "content_types": [
                [
                    "dcim",
                    "rack"
                ]
            ]
        }
    }
]
```

Load the statuses from the dump with `nautobot-server loaddata statuses`
```no-highlight
$ nautobot-server loaddata statuses
Installed 20 object(s) from 1 fixture(s)
```

Fire up `nautobot-server nbshell` again and retrieve a `Status`

```python
$ nautobot-server nbshell
### Nautobot interactive shell (jathy-mbp-m1)
### Python 3.9.10 | Django 3.2.14 | Nautobot 1.4.0a3
### lsmodels() will show available models. Use help(<model>) for more info.
>>> Status.objects.get(slug="active")
<Status: Active>
>>>
```

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design