### PR TITLE
Augment `get_route_for_model()` to support REST API routes.

### DIFF
--- a/changes/2223.changed
+++ b/changes/2223.changed
@@ -1,0 +1,1 @@
+Augment `get_route_for_model()` to support REST API routes.

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -41,6 +41,7 @@ from nautobot.utilities.permissions import get_permission_for_model
 from nautobot.utilities.templatetags.helpers import validated_viewname
 from nautobot.utilities.utils import (
     csv_format,
+    get_route_for_model,
     normalize_querydict,
     prepare_cloned_fields,
 )
@@ -96,9 +97,7 @@ class ObjectView(ObjectPermissionRequiredMixin, View):
         if meta.model_name == "objectchange":
             return None
 
-        route = f"{meta.app_label}:{meta.model_name}_changelog"
-        if meta.app_label in settings.PLUGINS:
-            route = f"plugins:{route}"
+        route = get_route_for_model(instance, "changelog")
 
         # Iterate the pk-like fields and try to get a URL, or return None.
         fields = ["pk", "slug"]

--- a/nautobot/docs/development/best-practices.md
+++ b/nautobot/docs/development/best-practices.md
@@ -23,7 +23,7 @@ A common Django pattern is to check whether a model instance's primary key (`pk`
 Because of the way Nautobot's UUID primary keys are implemented, **this check will not work as expected** because model instances are assigned a UUID in memory _at instance creation time_, not at the time they are written to the database (when the model's `save()` method is called).
 Instead, for any model which inherits from `nautobot.core.models.BaseModel`, you should check an instance's `present_in_database` property which will be either `True` or `False`.
 
-Wrong:
+Instead of:
 
 ```python
 if instance.pk:
@@ -35,7 +35,7 @@ else:
     ...
 ```
 
-Right:
+Use:
 
 ```python
 if instance.present_in_database:
@@ -78,6 +78,71 @@ class ExampleModel(PrimaryModel):
     name = models.CharField(max_length=100, unique=True)
     slug = AutoSlugField(populate_from='name')
 ```
+
+## Getting URL Routes
+
+When developing new models a need often arises to retrieve a reversible route for a model to access it in either the web UI or the REST API. When this time comes, you **must** always use `nautobot.utilities.utils.get_route_for_model`. You **must not** write your own logic to construct route names.
+
+```python
+from nautobot.utilities.utils import get_route_for_model
+```
+
+This utility function supports both UI and API views for both Nautobot core apps and Nautobot plugins.
+
+## UI Routes
+
+Instead of:
+
+```python
+route = f"{model._meta.app_label}:{model._meta.model_name}_list"
+if model._meta.app_label in settings.PLUGINS:
+    route = f"plugins:{route}"
+```
+
+Use:
+
+```python
+route = get_route_for_model(model, "list")
+```
+
+### REST API Routes
+
+Instead of:
+
+```python
+api_route = f"{model._meta.app_label}-api:{model._meta.model_name}-list"
+if model._meta.app_label in settings.PLUGINS:
+    api_route = f"plugins-api:{api_route}"
+```
+
+Use:
+
+```python
+route = get_route_for_model(model, "list", api=True)
+```
+
+### Examples
+
+Core models:
+
+```python
+>>> get_route_for_model(Device, "list")
+"dcim:device_list"
+>>> get_route_for_model(Device, "list", api=True)
+"dcim-api:device-list"
+```
+
+Plugin models:
+
+```python
+>>> get_route_for_model(ExampleModel, "list")
+"plugins:example_plugin:examplemodel_list"
+>>> get_route_for_model(ExampleModel, "list", api=True)
+"plugins-api:example_plugin-api:examplemodel-list"
+```
+
+!!! tip
+    The first argument may also optionally be an instance of a model, or a string using the dotted notation of `{app_label}.{model}` (e.g. `dcim.device`).
 
 ## Filtering Models with FilterSets
 

--- a/nautobot/docs/development/best-practices.md
+++ b/nautobot/docs/development/best-practices.md
@@ -81,7 +81,7 @@ class ExampleModel(PrimaryModel):
 
 ## Getting URL Routes
 
-When developing new models a need often arises to retrieve a reversible route for a model to access it in either the web UI or the REST API. When this time comes, you **must** always use `nautobot.utilities.utils.get_route_for_model`. You **must not** write your own logic to construct route names.
+When developing new models a need often arises to retrieve a reversible route for a model to access it in either the web UI or the REST API. When this time comes, you **must** use `nautobot.utilities.utils.get_route_for_model`. You **must not** write your own logic to construct route names.
 
 ```python
 from nautobot.utilities.utils import get_route_for_model
@@ -89,7 +89,10 @@ from nautobot.utilities.utils import get_route_for_model
 
 This utility function supports both UI and API views for both Nautobot core apps and Nautobot plugins.
 
-## UI Routes
+!!! check "Added in 1.4.3"
+    Support for generating API routes was added to `get_route_for_model()` by passing the argument `api=True`.
+
+### UI Routes
 
 Instead of:
 
@@ -118,7 +121,7 @@ if model._meta.app_label in settings.PLUGINS:
 Use:
 
 ```python
-route = get_route_for_model(model, "list", api=True)
+api_route = get_route_for_model(model, "list", api=True)
 ```
 
 ### Examples
@@ -143,6 +146,21 @@ Plugin models:
 
 !!! tip
     The first argument may also optionally be an instance of a model, or a string using the dotted notation of `{app_label}.{model}` (e.g. `dcim.device`).
+
+Using an instance:
+
+```python
+>>> instance = Device.objects.first()
+>>> get_route_for_model(instance, "list")
+"dcim:device_list"
+```
+
+Using dotted notation:
+
+```python
+>>> get_route_for_model("dcim.device", "list")
+"dcim:device_list"
+```
 
 ## Filtering Models with FilterSets
 

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.functional import classproperty
@@ -70,7 +69,7 @@ from nautobot.tenancy.api.nested_serializers import (
 from nautobot.tenancy.models import Tenant, TenantGroup
 from nautobot.users.api.nested_serializers import NestedUserSerializer
 from nautobot.utilities.api import get_serializer_for_model
-from nautobot.utilities.utils import slugify_dashes_to_underscores
+from nautobot.utilities.utils import get_route_for_model, slugify_dashes_to_underscores
 from nautobot.virtualization.api.nested_serializers import (
     NestedClusterGroupSerializer,
     NestedClusterSerializer,
@@ -129,9 +128,7 @@ class NotesSerializerMixin(BaseModelSerializer):
 
     @extend_schema_field(serializers.URLField())
     def get_notes_url(self, instance):
-        notes_url = f"{instance._meta.app_label}-api:{instance._meta.model_name}-notes"
-        if instance._meta.app_label in settings.PLUGINS:
-            notes_url = f"plugins-api:{notes_url}"
+        notes_url = get_route_for_model(instance, "notes", api=True)
         return reverse(notes_url, args=[instance.id], request=self.context["request"])
 
 

--- a/nautobot/extras/models/change_logging.py
+++ b/nautobot/extras/models/change_logging.py
@@ -9,7 +9,7 @@ from nautobot.core.celery import NautobotKombuJSONEncoder
 from nautobot.core.models import BaseModel
 from nautobot.extras.choices import ObjectChangeActionChoices, ObjectChangeEventContextChoices
 from nautobot.extras.utils import extras_features
-from nautobot.utilities.utils import serialize_object, serialize_object_v2, shallow_compare_dict
+from nautobot.utilities.utils import get_route_for_model, serialize_object, serialize_object_v2, shallow_compare_dict
 
 
 #
@@ -46,11 +46,7 @@ class ChangeLoggedModel(models.Model):
 
     def get_changelog_url(self):
         """Return the changelog URL for this object."""
-        meta = self._meta
-
-        route = f"{meta.app_label}:{meta.model_name}_changelog"
-        if meta.app_label in settings.PLUGINS:
-            route = f"plugins:{route}"
+        route = get_route_for_model(self, "changelog")
 
         # Iterate the pk-like fields and try to get a URL, or return None.
         fields = ["pk", "slug"]

--- a/nautobot/extras/models/mixins.py
+++ b/nautobot/extras/models/mixins.py
@@ -4,12 +4,12 @@ Class-modifying mixins that need to be standalone to avoid circular imports.
 import sys
 
 from cacheops.utils import family_has_profile
-from django.conf import settings
 from django.db.models import Q
 from django.urls import NoReverseMatch, reverse
 from funcy import once_per
 
 from nautobot.utilities.forms.fields import DynamicModelMultipleChoiceField
+from nautobot.utilities.utils import get_route_for_model
 
 
 class DynamicGroupMixin:
@@ -47,11 +47,7 @@ class NotesMixin:
 
     def get_notes_url(self):
         """Return the changelog URL for a given instance."""
-        meta = self._meta
-
-        route = f"{meta.app_label}:{meta.model_name}_notes"
-        if meta.app_label in settings.PLUGINS:
-            route = f"plugins:{route}"
+        route = get_route_for_model(self, "notes")
 
         # Iterate the pk-like fields and try to get a URL, or return None.
         fields = ["pk", "slug"]

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -62,7 +62,7 @@ from nautobot.users.models import ObjectPermission
 from nautobot.utilities.choices import ColorChoices
 from nautobot.utilities.testing import APITestCase, APIViewTestCases
 from nautobot.utilities.testing.utils import disable_warnings
-from nautobot.utilities.utils import slugify_dashes_to_underscores
+from nautobot.utilities.utils import get_route_for_model, slugify_dashes_to_underscores
 
 
 User = get_user_model()
@@ -1733,10 +1733,8 @@ class JobTestVersion13(
     def test_get_job_variables(self):
         """Test the job/<pk>/variables API endpoint."""
         self.add_permissions("extras.view_job")
-        response = self.client.get(
-            reverse(f"{self._get_view_namespace()}:job-variables", kwargs={"pk": self.job_model.pk}),
-            **self.header,
-        )
+        route = get_route_for_model(self.model, "variables", api=True)
+        response = self.client.get(reverse(route, kwargs={"pk": self.job_model.pk}), **self.header)
         self.assertEqual(4, len(response.data))  # 4 variables, in order
         self.assertEqual(response.data[0], {"name": "var1", "type": "StringVar", "required": True})
         self.assertEqual(response.data[1], {"name": "var2", "type": "IntegerVar", "required": True})

--- a/nautobot/users/tests/test_api.py
+++ b/nautobot/users/tests/test_api.py
@@ -27,7 +27,6 @@ class AppTest(APITestCase):
 
 class UserTest(APIViewTestCases.APIViewTestCase):
     model = User
-    view_namespace = "users"
     brief_fields = ["display", "id", "url", "username"]
     validation_excluded_fields = ["password"]
     create_data = [
@@ -56,7 +55,6 @@ class UserTest(APIViewTestCases.APIViewTestCase):
 class GroupTest(APIViewTestCases.APIViewTestCase):
     model = Group
     filterset = GroupFilterSet
-    view_namespace = "users"
     brief_fields = ["display", "id", "name", "url"]
     create_data = [
         {
@@ -69,6 +67,14 @@ class GroupTest(APIViewTestCases.APIViewTestCase):
             "name": "Group 6",
         },
     ]
+
+    def _get_detail_url(self, instance):
+        """Can't use get_route_for_model because this is not a Nautobot core model."""
+        return reverse("users-api:group-detail", kwargs={"pk": instance.pk})
+
+    def _get_list_url(self):
+        """Can't use get_route_for_model because this is not a Nautobot core model."""
+        return reverse("users-api:group-list")
 
     @classmethod
     def setUpTestData(cls):

--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -16,7 +16,7 @@ from django.urls import reverse
 
 from nautobot.extras.utils import FeatureQuery
 from nautobot.utilities.choices import unpack_grouped_choices
-from nautobot.utilities.utils import is_uuid
+from nautobot.utilities.utils import get_route_for_model, is_uuid
 from nautobot.utilities.validators import EnhancedURLValidator
 from . import widgets
 from .constants import ALPHANUMERIC_EXPANSION_PATTERN, IP4_EXPANSION_PATTERN, IP6_EXPANSION_PATTERN
@@ -499,12 +499,8 @@ class DynamicModelChoiceMixin:
         # Set the data URL on the APISelect widget (if not already set)
         widget = bound_field.field.widget
         if not widget.attrs.get("data-url"):
-            app_label = self.queryset.model._meta.app_label
-            model_name = self.queryset.model._meta.model_name
-            if app_label in settings.PLUGINS:
-                data_url = reverse(f"plugins-api:{app_label}-api:{model_name}-list")
-            else:
-                data_url = reverse(f"{app_label}-api:{model_name}-list")
+            route = get_route_for_model(self.queryset.model, "list", api=True)
+            data_url = reverse(route)
             widget.attrs["data-url"] = data_url
 
         return bound_field

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -70,6 +70,7 @@ class ModelViewTestCase(ModelTestCase):
     If unspecified, "slug" and "pk" will be tried, in that order.
     """
 
+    # 2.0 TODO(jathan): Eliminate the need to overload `_get_base_url()` at all and just rely on `get_route_for_model()`
     def _get_base_url(self):
         """
         Return the base format for a URL for the test's model. Override this to test for a model which belongs
@@ -79,6 +80,7 @@ class ModelViewTestCase(ModelTestCase):
             return f"plugins:{self.model._meta.app_label}:{self.model._meta.model_name}_{{}}"
         return f"{self.model._meta.app_label}:{self.model._meta.model_name}_{{}}"
 
+    # 2.0 TODO(jathan): Eliminate the need to overload `_get_url()` at all and just rely on `get_route_for_model()`
     def _get_url(self, action, instance=None):
         """
         Return the URL name for a specific action and optionally a specific instance

--- a/nautobot/utilities/tests/test_utils.py
+++ b/nautobot/utilities/tests/test_utils.py
@@ -176,6 +176,7 @@ class GetFooForModelTest(TestCase):
         """
         Test the util function `get_route_for_model` returns the appropriate URL route name, if model (as dotted string or class) provided.
         """
+        # UI
         self.assertEqual(get_route_for_model("dcim.device", "list"), "dcim:device_list")
         self.assertEqual(get_route_for_model(Device, "list"), "dcim:device_list")
         self.assertEqual(get_route_for_model("dcim.site", "list"), "dcim:site_list")
@@ -184,6 +185,19 @@ class GetFooForModelTest(TestCase):
             get_route_for_model("example_plugin.examplemodel", "list"), "plugins:example_plugin:examplemodel_list"
         )
         self.assertEqual(get_route_for_model(ExampleModel, "list"), "plugins:example_plugin:examplemodel_list")
+
+        # API
+        self.assertEqual(get_route_for_model("dcim.device", "list", api=True), "dcim-api:device-list")
+        self.assertEqual(get_route_for_model(Device, "list", api=True), "dcim-api:device-list")
+        self.assertEqual(get_route_for_model("dcim.site", "detail", api=True), "dcim-api:site-detail")
+        self.assertEqual(get_route_for_model(Site, "detail", api=True), "dcim-api:site-detail")
+        self.assertEqual(
+            get_route_for_model("example_plugin.examplemodel", "list", api=True),
+            "plugins-api:example_plugin-api:examplemodel-list",
+        )
+        self.assertEqual(
+            get_route_for_model(ExampleModel, "list", api=True), "plugins-api:example_plugin-api:examplemodel-list"
+        )
 
     def test_get_table_for_model(self):
         """

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -54,7 +54,7 @@ def csv_format(data):
     return ",".join(csv)
 
 
-def get_route_for_model(model, action):
+def get_route_for_model(model, action, api=False):
     """
     Return the URL route name for the given model and action. Does not perform any validation.
     Supports both core and plugin routes.
@@ -62,19 +62,36 @@ def get_route_for_model(model, action):
     Args:
         model (models.Model, str): Class, Instance, or dotted string of a Django Model
         action (str): name of the action in the route
+        api (bool): If set, return an API route.
 
     Returns:
         str: return the name of the view for the model/action provided.
+
     Examples:
         >>> get_route_for_model(Device, "list")
         "dcim:device_list"
+        >>> get_route_for_model(Device, "list", api=True)
+        "dcim-api:device-list"
+        >>> get_route_for_model("dcim.site", "list")
+        "dcim:site_list"
+        >>> get_route_for_model("dcim.site", "list", api=True)
+        "dcim-api:site-list"
+        >>> get_route_for_model(ExampleModel, "list")
+        "plugins:example_plugin:examplemodel_list"
+        >>> get_route_for_model(ExampleModel, "list", api=True)
+        "plugins-api:example_plugin-api:examplemodel-list"
     """
 
     if isinstance(model, str):
         model = get_model_from_name(model)
-    viewname = f"{model._meta.app_label}:{model._meta.model_name}_{action}"
+
+    suffix = "" if not api else "-api"
+    prefix = f"{model._meta.app_label}{suffix}:{model._meta.model_name}"
+    sep = "_" if not api else "-"
+    viewname = f"{prefix}{sep}{action}"
+
     if model._meta.app_label in settings.PLUGINS:
-        viewname = f"plugins:{viewname}"
+        viewname = f"plugins{suffix}:{viewname}"
 
     return viewname
 

--- a/nautobot/utilities/views.py
+++ b/nautobot/utilities/views.py
@@ -1,10 +1,10 @@
-from django.conf import settings
 from django.contrib.auth.mixins import AccessMixin
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.http import is_safe_url
 
+from nautobot.utilities.utils import get_route_for_model
 from .permissions import resolve_permission
 
 
@@ -144,10 +144,8 @@ class GetReturnURLMixin:
 
         # Attempt to dynamically resolve the list view for the object
         if hasattr(self, "queryset"):
-            model_opts = self.queryset.model._meta
             try:
-                prefix = "plugins:" if model_opts.app_label in settings.PLUGINS else ""
-                return reverse(f"{prefix}{model_opts.app_label}:{model_opts.model_name}_list")
+                return reverse(get_route_for_model(self.queryset.model, "list"))
             except NoReverseMatch:
                 pass
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
- This adds an `api=True` argument to `nautobot.utilities.utils.get_route_for_model()`
- Replaced almost all bespoke implementations of manual route construction for plugins or API routes with calls to `get_route_for_model()`
- Expanded the Development Best Practices guide with a section on "Getting URL Routes"


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design