### PR TITLE
Exclude non-API viewsets from Swagger, add integration test for Swagger UI

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -202,6 +202,7 @@ SPECTACULAR_SETTINGS = {
     # trim it from all of the individual paths correspondingly.
     # See also https://github.com/nautobot/nautobot-ansible/pull/135 for an example of why this is desirable.
     "SERVERS": [{"url": "/api"}],
+    "SCHEMA_PATH_PREFIX": "/api",
     "SCHEMA_PATH_PREFIX_TRIM": True,
     # use sidecar - locally packaged UI files, not CDN
     "SWAGGER_UI_DIST": "SIDECAR",

--- a/nautobot/core/tests/integration/test_swagger.py
+++ b/nautobot/core/tests/integration/test_swagger.py
@@ -1,0 +1,56 @@
+import time
+
+from django.urls import reverse
+
+from nautobot.utilities.testing.integration import SeleniumTestCase
+
+
+class SwaggerUITestCase(SeleniumTestCase):
+    """Integration tests for the Swagger UI."""
+
+    def setUp(self):
+        super().setUp()
+        self.user.is_superuser = True
+        self.user.save()
+        self.login(self.user.username, self.password)
+
+    def tearDown(self):
+        self.logout()
+        super().tearDown()
+
+    def test_endpoint_render(self):
+        """Check that the dcim.site API endpoints are rendered correctly."""
+        self.browser.visit(self.live_server_url + reverse("api_docs"))
+        # Wait for Swagger UI to load
+        load_time = 0
+        while self.browser.find_by_xpath("//div[@class[contains(., 'loading')]]"):
+            print("Waiting for schema to load...")
+            time.sleep(1)
+            load_time += 1
+            if load_time > 20:
+                self.fail("Schema took more than 20 seconds to load")
+
+        # Look for the site-list endpoint in the UI and click on it to expand it.
+        dcim_sites_list = self.browser.find_by_id("operations-dcim-dcim_sites_list").first
+        dcim_sites_list.find_by_tag("button").first.click()
+
+        # Look for the "Try it out" button and click it
+        dcim_sites_list.find_by_xpath("//button[contains(text(), 'Try it out')]").first.click()
+
+        # Look for the "Execute" button and click it
+        dcim_sites_list.find_by_xpath("//button[contains(text(), 'Execute')]").first.click()
+
+        load_time = 0
+        while dcim_sites_list.find_by_xpath("//div[@class[contains(., 'loading')]]"):
+            print("Waiting for response to load...")
+            time.sleep(1)
+            load_time += 1
+            if load_time > 20:
+                self.fail("Response took more than 20 seconds to load")
+
+        # Look at the response status code
+        response_code = dcim_sites_list.find_by_xpath(
+            "//table[@class[contains(.,'live-responses-table')]]/tbody//td[@class[contains(.,'response-col_status')]]"
+        ).first.text
+        self.assertEqual(response_code, "200")
+        # The response body is wrapped in a bunch of <span>s to apply syntax-highlighting, so it's not worth inspecting.

--- a/nautobot/core/tests/integration/test_swagger.py
+++ b/nautobot/core/tests/integration/test_swagger.py
@@ -1,5 +1,3 @@
-import time
-
 from django.urls import reverse
 
 from nautobot.utilities.testing.integration import SeleniumTestCase
@@ -21,17 +19,8 @@ class SwaggerUITestCase(SeleniumTestCase):
     def test_endpoint_render(self):
         """Check that the dcim.site API endpoints are rendered correctly."""
         self.browser.visit(self.live_server_url + reverse("api_docs"))
-        # Wait for Swagger UI to load
-        load_time = 0
-        while self.browser.find_by_xpath("//div[@class[contains(., 'loading')]]"):
-            print("Waiting for schema to load...")
-            time.sleep(1)
-            load_time += 1
-            if load_time > 20:
-                self.fail("Schema took more than 20 seconds to load")
-
-        # Look for the site-list endpoint in the UI and click on it to expand it.
-        dcim_sites_list = self.browser.find_by_id("operations-dcim-dcim_sites_list").first
+        # Wait for Swagger UI to load, look for the site-list endpoint in the UI and click on it to expand it.
+        dcim_sites_list = self.browser.find_by_id("operations-dcim-dcim_sites_list", wait_time=20).first
         dcim_sites_list.find_by_tag("button").first.click()
 
         # Look for the "Try it out" button and click it
@@ -40,17 +29,10 @@ class SwaggerUITestCase(SeleniumTestCase):
         # Look for the "Execute" button and click it
         dcim_sites_list.find_by_xpath("//button[contains(text(), 'Execute')]").first.click()
 
-        load_time = 0
-        while dcim_sites_list.find_by_xpath("//div[@class[contains(., 'loading')]]"):
-            print("Waiting for response to load...")
-            time.sleep(1)
-            load_time += 1
-            if load_time > 20:
-                self.fail("Response took more than 20 seconds to load")
-
         # Look at the response status code
         response_code = dcim_sites_list.find_by_xpath(
-            "//table[@class[contains(.,'live-responses-table')]]/tbody//td[@class[contains(.,'response-col_status')]]"
+            "//table[@class[contains(.,'live-responses-table')]]/tbody//td[@class[contains(.,'response-col_status')]]",
+            wait_time=20,
         ).first.text
         self.assertEqual(response_code, "200")
         # The response body is wrapped in a bunch of <span>s to apply syntax-highlighting, so it's not worth inspecting.

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -23,6 +23,8 @@ from rest_framework import mixins
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
+from drf_spectacular.utils import extend_schema
+
 from nautobot.core.api.views import BulkCreateModelMixin, BulkDestroyModelMixin, BulkUpdateModelMixin
 from nautobot.extras.models import CustomField, ExportTemplate
 from nautobot.utilities.error_handlers import handle_protectederror
@@ -53,6 +55,7 @@ PERMISSIONS_ACTION_MAP = {
 }
 
 
+@extend_schema(exclude=True)
 class NautobotViewSetMixin(GenericViewSet, AccessMixin, GetReturnURLMixin, FormView):
     """
     NautobotViewSetMixin is an aggregation of various mixins from DRF, Django and Nautobot to acheive the desired behavior pattern for NautobotUIViewSet


### PR DESCRIPTION
# Closes: #2232 and #2222
# What's Changed

- Add `extend_schema(exclude=True)` on the base `NautobotViewSetMixin` class. This prevents these non-API viewsets from being added to the OpenAPI schema and hence the Swagger UI.
- DRF-Spectacular still detects that not all viewsets are under the `/api` URL endpoint any more so it wants to provide the full path to the API endpoints, which is redundant with the additional `/api` already provided via `settings.SPECTACULAR_SETTINGS["SERVERS"]` as added in #1670. The solution is to configure `settings.SPECTACULAR_SETTINGS["SCHEMA_PATH_PREFIX"] = "/api"` as well so that (in combination with the existing `SCHEMA_PATH_PREFIX_TRIM: True` configuration) drf-spectacular will strip that prefix back off of the URL patterns.
- Add an integration test verifying that the Swagger UI loads, includes the expected dcim_site_list endpoint, and that this endpoint returns a 200 response when executed via the UI. This adds about 60 seconds to the integration test runtime locally because it takes some time to render the UI and navigate through it. I think it's worthwhile though.

![image](https://user-images.githubusercontent.com/5603551/185224015-b00f98a7-f0e9-42cf-966b-39464724674c.png)

![image](https://user-images.githubusercontent.com/5603551/185224122-2636acf0-4b34-44af-8ae3-02f3d68ea277.png)

# TODO
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design