### PR TITLE
Fix broken pagination in Dynamic Group detail "Members" tab.

### DIFF
--- a/nautobot/core/templates/generic/object_retrieve.html
+++ b/nautobot/core/templates/generic/object_retrieve.html
@@ -187,7 +187,7 @@
     }
 
 
-    function switch_tab(tab_href) {
+    function switch_tab(tab_href, reload=false) {
 
         let [tab_url, tab_id] = tab_href.split("#")
 
@@ -196,6 +196,10 @@
         else if (window.history.state["id"] != tab_id){
             window.history.pushState({id: tab_id}, document.title, `${tab_url}?tab=${tab_id}`);
         }
+
+        // If set, reload the page after asserting state.
+        reload && window.location.reload();
+
     }
 
     window.onpopstate = function(event) {

--- a/nautobot/extras/templates/extras/dynamicgroup.html
+++ b/nautobot/extras/templates/extras/dynamicgroup.html
@@ -3,7 +3,7 @@
 
 {% block extra_nav_tabs %}
         <li role="presentation"{% if request.GET.tab == 'members' %} class="active"{% endif %}>
-            <a href="{{ object.get_absolute_url }}#members" onclick="switch_tab(this.href)" aria-controls="members" role="tab" data-toggle="tab">
+            <a href="{{ object.get_absolute_url }}#members" onclick="switch_tab(this.href, reload=true)" aria-controls="members" role="tab" data-toggle="tab">
                 Members {% badge object.count %}
             </a>
         </li>


### PR DESCRIPTION



<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2219 
# What's Changed

This may not be the correct fix long-term, but it does address the bug for now.

- This adds a `reload` boolean (default: `false`) argument to the JS `switch_tab()`
  function provided by the `generic/object_retrieve.html` (formerly `generic/object_detail.html`)
- When set e.g. `switch_tab(href, reload=true)` when that tab is clicked, it will also reload the page.

Likely, I'll spend a little more time to adapt this to be a distinct view with its own endpoint per the new Notes feature and the `notes/` detail endpiont in the UI, however, that appears out of scope at this time.

Credit to @christhant for helping me to isolate the root cause and @gsnider2195 for rubber-fucking.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design