### PR TITLE
Update to django-taggit 3.0 but keep Python API backwards-compatible

### DIFF
--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -211,7 +211,7 @@ class TaggedObjectSerializer(BaseModelSerializer):
 
     def _save_tags(self, instance, tags):
         if tags:
-            instance.tags.set(*[t.name for t in tags])
+            instance.tags.set([t.name for t in tags])
         else:
             instance.tags.clear()
 

--- a/nautobot/extras/tests/test_changelog.py
+++ b/nautobot/extras/tests/test_changelog.py
@@ -77,7 +77,7 @@ class ChangeLogViewTest(ModelViewTestCase):
         )
         site.save()
         tags = self.create_tags("Tag 1", "Tag 2", "Tag 3")
-        site.tags.set("Tag 1", "Tag 2")
+        site.tags.set(["Tag 1", "Tag 2"])
 
         form_data = {
             "name": "Test Site X",
@@ -117,7 +117,7 @@ class ChangeLogViewTest(ModelViewTestCase):
         )
         site.save()
         self.create_tags("Tag 1", "Tag 2")
-        site.tags.set("Tag 1", "Tag 2")
+        site.tags.set(["Tag 1", "Tag 2"])
 
         request = {
             "path": self._get_url("delete", instance=site),
@@ -298,7 +298,7 @@ class ChangeLogAPITest(APITestCase):
             _custom_field_data={"my_field": "ABC", "my_field_select": "Bar"},
         )
         site.save()
-        site.tags.set(*Tag.objects.all()[:2])
+        site.tags.set(Tag.objects.all()[:2])
         self.assertEqual(ObjectChange.objects.count(), 0)
         self.add_permissions("dcim.delete_site", "extras.view_status")
         url = reverse("dcim-api:site-detail", kwargs={"pk": site.pk})

--- a/nautobot/extras/tests/test_tags.py
+++ b/nautobot/extras/tests/test_tags.py
@@ -4,7 +4,35 @@ from rest_framework import status
 
 from nautobot.dcim.models import Site, Device
 from nautobot.extras.models import Status, Tag
-from nautobot.utilities.testing import APITestCase
+from nautobot.utilities.testing import APITestCase, TestCase
+
+
+class TaggedItemORMTest(TestCase):
+    """
+    Test the application of tags via the Python API (ORM).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.site = Site.objects.create(name="Test Site", slug="test-site", status=Status.objects.get(slug="active"))
+
+    def test_tags_set_taggit_1(self):
+        """Test that obj.tags.set() works when invoked like django-taggit 1.x."""
+        self.site.tags.set("Tag 1", "Tag 2")
+        self.assertListEqual(sorted([t.name for t in self.site.tags.all()]), ["Tag 1", "Tag 2"])
+
+        self.site.tags.set(Tag.objects.get(name="Tag 1"))
+        self.assertListEqual(sorted([t.name for t in self.site.tags.all()]), ["Tag 1"])
+
+    def test_tags_set_taggit_2(self):
+        """Test that obj.tags.set() works when invoked like django-taggit 2.x and later."""
+        self.site.tags.set(["Tag 1", "Tag 2"])
+        self.assertListEqual(sorted([t.name for t in self.site.tags.all()]), ["Tag 1", "Tag 2"])
+
+        self.site.tags.set([Tag.objects.get(name="Tag 1")])
+        self.assertListEqual(sorted([t.name for t in self.site.tags.all()]), ["Tag 1"])
 
 
 class TaggedItemTest(APITestCase):

--- a/poetry.lock
+++ b/poetry.lock
@@ -105,10 +105,10 @@ typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implem
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-uvloop = ["uvloop (>=0.15.2)"]
-jupyter = ["tokenize-rt (>=3.2.0)", "ipython (>=7.8.0)"]
-d = ["aiohttp (>=3.7.4)"]
 colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "cached-property"
@@ -358,7 +358,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 wrapt = ">=1.10,<2"
 
 [package.extras]
-dev = ["pytest-cov", "pytest", "PyTest-Cov (<2.6)", "PyTest (<5)", "zipp (<2)", "sphinxcontrib-websupport (<2)", "configparser (<5)", "importlib-resources (<4)", "importlib-metadata (<3)", "sphinx (<2)", "bump2version (<1)", "tox"]
+dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
 
 [[package]]
 name = "django"
@@ -568,7 +568,7 @@ python-versions = ">=3.6"
 django-js-asset = "*"
 
 [package.extras]
-tests = ["coverage", "mock-django"]
+tests = ["mock-django", "coverage"]
 
 [[package]]
 name = "django-picklefield"
@@ -624,8 +624,8 @@ redis = ">=3"
 rq = ">=1.2"
 
 [package.extras]
-testing = ["mock (>=2.0.0)"]
 sentry = ["raven (>=6.1.0)"]
+testing = ["mock (>=2.0.0)"]
 
 [[package]]
 name = "django-storages"
@@ -639,12 +639,12 @@ python-versions = ">=3.5"
 Django = ">=2.2"
 
 [package.extras]
-sftp = ["paramiko"]
-libcloud = ["apache-libcloud"]
-google = ["google-cloud-storage (>=1.27.0)"]
-dropbox = ["dropbox (>=7.2.1)"]
-boto3 = ["boto3 (>=1.4.4)"]
 azure = ["azure-storage-blob (>=12.0.0)"]
+boto3 = ["boto3 (>=1.4.4)"]
+dropbox = ["dropbox (>=7.2.1)"]
+google = ["google-cloud-storage (>=1.27.0)"]
+libcloud = ["apache-libcloud"]
+sftp = ["paramiko"]
 
 [[package]]
 name = "django-tables2"
@@ -662,14 +662,14 @@ tablib = ["tablib"]
 
 [[package]]
 name = "django-taggit"
-version = "1.5.1"
+version = "3.0.0"
 description = "django-taggit is a reusable Django application for simple tagging."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-Django = ">=2.2"
+Django = ">=3.2"
 
 [[package]]
 name = "django-timezone-field"
@@ -762,8 +762,8 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 uritemplate = ">=2.0.0"
 
 [package.extras]
-sidecar = ["drf-spectacular-sidecar"]
 offline = ["drf-spectacular-sidecar"]
+sidecar = ["drf-spectacular-sidecar"]
 
 [[package]]
 name = "drf-spectacular-sidecar"
@@ -925,9 +925,9 @@ graphql-relay = ">=2,<3"
 six = ">=1.10.0,<2"
 
 [package.extras]
-test = ["iso8601", "pytz", "mock", "six", "promise", "coveralls", "snapshottest", "fastdiff (==0.2.0)", "pytest-mock", "pytest-cov", "pytest-benchmark", "pytest"]
-sqlalchemy = ["graphene-sqlalchemy"]
 django = ["graphene-django"]
+sqlalchemy = ["graphene-sqlalchemy"]
+test = ["pytest", "pytest-benchmark", "pytest-cov", "pytest-mock", "fastdiff (==0.2.0)", "snapshottest", "coveralls", "promise", "six", "mock", "pytz", "iso8601"]
 
 [[package]]
 name = "graphene-django"
@@ -947,9 +947,9 @@ six = ">=1.10.0"
 text-unidecode = "*"
 
 [package.extras]
-test = ["django-filter (>=2)", "django-filter (<2)", "djangorestframework (>=3.6.3)", "pytest-django (>=3.3.2)", "pytz", "mock", "coveralls", "pytest-cov", "pytest (>=3.6.3)"]
+dev = ["black (==19.10b0)", "flake8 (==3.7.9)", "flake8-black (==0.1.1)", "flake8-bugbear (==20.1.4)", "pytest (>=3.6.3)", "pytest-cov", "coveralls", "mock", "pytz", "pytest-django (>=3.3.2)", "djangorestframework (>=3.6.3)", "django-filter (<2)", "django-filter (>=2)"]
 rest_framework = ["djangorestframework (>=3.6.3)"]
-dev = ["django-filter (>=2)", "django-filter (<2)", "djangorestframework (>=3.6.3)", "pytest-django (>=3.3.2)", "pytz", "mock", "coveralls", "pytest-cov", "pytest (>=3.6.3)", "flake8-bugbear (==20.1.4)", "flake8-black (==0.1.1)", "flake8 (==3.7.9)", "black (==19.10b0)"]
+test = ["pytest (>=3.6.3)", "pytest-cov", "coveralls", "mock", "pytz", "pytest-django (>=3.3.2)", "djangorestframework (>=3.6.3)", "django-filter (<2)", "django-filter (>=2)"]
 
 [[package]]
 name = "graphene-django-optimizer"
@@ -973,8 +973,8 @@ rx = ">=1.6,<2"
 six = ">=1.10.0"
 
 [package.extras]
-test = ["pytest-mock (==2.0.0)", "pytest-benchmark (==3.2.3)", "gevent (==1.5.0)", "cython (==0.29.17)", "coveralls (==1.11.1)", "pytest-cov (==2.8.1)", "pytest-django (==3.9.0)", "pytest (==4.6.10)", "pyannotate (==1.2.0)", "six (==1.14.0)"]
 gevent = ["gevent (>=1.1)"]
+test = ["six (==1.14.0)", "pyannotate (==1.2.0)", "pytest (==4.6.10)", "pytest-django (==3.9.0)", "pytest-cov (==2.8.1)", "coveralls (==1.11.1)", "cython (==0.29.17)", "gevent (==1.5.0)", "pytest-benchmark (==3.2.3)", "pytest-mock (==2.0.0)"]
 
 [[package]]
 name = "graphql-relay"
@@ -1037,8 +1037,8 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
-docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "inflection"
@@ -1105,8 +1105,8 @@ pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-format-nongpl = ["webcolors (>=1.11)", "uri-template", "rfc3986-validator (>0.1.0)", "rfc3339-validator", "jsonpointer (>1.13)", "isoduration", "idna", "fqdn"]
-format = ["webcolors (>=1.11)", "uri-template", "rfc3987", "rfc3339-validator", "jsonpointer (>1.13)", "isoduration", "idna", "fqdn"]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
 
 [[package]]
 name = "junos-eznc"
@@ -1145,20 +1145,20 @@ importlib-metadata = {version = ">=0.18", markers = "python_version < \"3.8\""}
 vine = "*"
 
 [package.extras]
-zookeeper = ["kazoo (>=1.3.1)"]
-yaml = ["PyYAML (>=3.10)"]
-sqs = ["urllib3 (>=1.26.7)", "pycurl (>=7.44.1,<7.45.0)", "boto3 (>=1.9.12)"]
-sqlalchemy = ["sqlalchemy"]
-slmq = ["softlayer-messaging (>=1.0.3)"]
-redis = ["redis (>=3.4.1,!=4.0.0,!=4.0.1)"]
-qpid = ["qpid-tools (>=0.26)", "qpid-python (>=0.26)"]
-pyro = ["pyro4"]
-msgpack = ["msgpack"]
-mongodb = ["pymongo (>=3.3.0,<3.12.1)"]
-librabbitmq = ["librabbitmq (>=2.0.0)"]
-consul = ["python-consul (>=0.6.0)"]
-azurestoragequeues = ["azure-storage-queue"]
 azureservicebus = ["azure-servicebus (>=7.0.0)"]
+azurestoragequeues = ["azure-storage-queue"]
+consul = ["python-consul (>=0.6.0)"]
+librabbitmq = ["librabbitmq (>=2.0.0)"]
+mongodb = ["pymongo (>=3.3.0,<3.12.1)"]
+msgpack = ["msgpack"]
+pyro = ["pyro4"]
+qpid = ["qpid-python (>=0.26)", "qpid-tools (>=0.26)"]
+redis = ["redis (>=3.4.1,!=4.0.0,!=4.0.1)"]
+slmq = ["softlayer-messaging (>=1.0.3)"]
+sqlalchemy = ["sqlalchemy"]
+sqs = ["boto3 (>=1.9.12)", "pycurl (>=7.44.1,<7.45.0)", "urllib3 (>=1.26.7)"]
+yaml = ["PyYAML (>=3.10)"]
+zookeeper = ["kazoo (>=1.3.1)"]
 
 [[package]]
 name = "loguru"
@@ -1184,10 +1184,10 @@ optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
 
 [package.extras]
-source = ["Cython (>=0.29.7)"]
-htmlsoup = ["beautifulsoup4"]
-html5 = ["html5lib"]
 cssselect = ["cssselect (>=0.7)"]
+html5 = ["html5lib"]
+htmlsoup = ["beautifulsoup4"]
+source = ["Cython (>=0.29.7)"]
 
 [[package]]
 name = "markdown"
@@ -1259,8 +1259,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-test = ["pytest-cov (==3.0.0)", "pytest (==6.2.5)"]
-dev = ["yamllint (==1.26.1)", "pyupgrade (==2.19.4)", "pytest-cov (==3.0.0)", "pytest (==6.2.5)", "pre-commit (==2.13.0)", "mkdocs (==1.2.3)", "mdpo (==0.3.61)", "isort (==5.9.1)", "flake8-print (==4.0.0)", "flake8-implicit-str-concat (==0.2.0)", "flake8 (==3.9.2)", "bump2version (==1.0.1)"]
+dev = ["bump2version (==1.0.1)", "flake8 (==3.9.2)", "flake8-implicit-str-concat (==0.2.0)", "flake8-print (==4.0.0)", "isort (==5.9.1)", "mdpo (==0.3.61)", "mkdocs (==1.2.3)", "pre-commit (==2.13.0)", "pytest (==6.2.5)", "pytest-cov (==3.0.0)", "pyupgrade (==2.19.4)", "yamllint (==1.26.1)"]
+test = ["pytest (==6.2.5)", "pytest-cov (==3.0.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -1340,7 +1340,7 @@ scp = ">=0.13.2"
 tenacity = "*"
 
 [package.extras]
-test = ["pytest (>=5.1.2)", "pyyaml (>=5.1.2)"]
+test = ["pyyaml (>=5.1.2)", "pytest (>=5.1.2)"]
 
 [[package]]
 name = "netutils"
@@ -1411,10 +1411,10 @@ pynacl = ">=1.0.1"
 six = "*"
 
 [package.extras]
+all = ["pyasn1 (>=0.1.7)", "pynacl (>=1.0.1)", "bcrypt (>=3.1.3)", "invoke (>=1.3)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
+ed25519 = ["pynacl (>=1.0.1)", "bcrypt (>=3.1.3)"]
+gssapi = ["pyasn1 (>=0.1.7)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
 invoke = ["invoke (>=1.3)"]
-gssapi = ["pywin32 (>=2.1.8)", "gssapi (>=1.4.1)", "pyasn1 (>=0.1.7)"]
-ed25519 = ["bcrypt (>=3.1.3)", "pynacl (>=1.0.1)"]
-all = ["pywin32 (>=2.1.8)", "gssapi (>=1.4.1)", "invoke (>=1.3)", "bcrypt (>=3.1.3)", "pynacl (>=1.0.1)", "pyasn1 (>=0.1.7)"]
 
 [[package]]
 name = "passlib"
@@ -1447,8 +1447,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-tests = ["pytest-timeout", "pytest-cov", "pytest", "pyroma", "packaging", "olefile", "markdown2", "defusedxml", "coverage", "check-manifest"]
-docs = ["sphinxext-opengraph", "sphinx-removed-in", "sphinx-issues (>=3.0.1)", "sphinx-copybutton", "sphinx (>=2.4)", "olefile", "furo"]
+docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-issues (>=3.0.1)", "sphinx-removed-in", "sphinxext-opengraph"]
+tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "platformdirs"
@@ -1624,8 +1624,8 @@ python-versions = ">=3.6"
 cryptography = ">=35.0"
 
 [package.extras]
-test = ["pytest (>=3.0.1)", "pretend", "flaky"]
-docs = ["sphinx-rtd-theme", "sphinx"]
+docs = ["sphinx", "sphinx-rtd-theme"]
+test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]
 name = "pyparsing"
@@ -1705,9 +1705,9 @@ pyasn1 = "*"
 rsa = "*"
 
 [package.extras]
-pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
-pycrypto = ["pyasn1", "pycrypto (>=2.6.0,<2.7.0)"]
 cryptography = ["cryptography (>=3.4.0)"]
+pycrypto = ["pycrypto (>=2.6.0,<2.7.0)", "pyasn1"]
+pycryptodome = ["pycryptodome (>=3.3.1,<4.0.0)", "pyasn1"]
 
 [[package]]
 name = "python-ldap"
@@ -1803,8 +1803,8 @@ packaging = ">=20.4"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-ocsp = ["requests (>=2.26.0)", "pyopenssl (==20.0.1)", "cryptography (>=36.0.1)"]
 hiredis = ["hiredis (>=1.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
 
 [[package]]
 name = "requests"
@@ -2004,11 +2004,11 @@ requests = ">=2.9.1"
 requests-oauthlib = ">=0.6.1"
 
 [package.extras]
-saml = ["lxml (<4.7)", "python3-saml (>=1.2.1)"]
-openidconnect = ["python-jose (>=3.0.0)"]
+all = ["python-jose (>=3.0.0)", "python3-saml (>=1.2.1)", "lxml (<4.7)", "cryptography (>=2.1.1)"]
+allpy3 = ["python-jose (>=3.0.0)", "python3-saml (>=1.2.1)", "lxml (<4.7)", "cryptography (>=2.1.1)"]
 azuread = ["cryptography (>=2.1.1)"]
-allpy3 = ["cryptography (>=2.1.1)", "lxml (<4.7)", "python3-saml (>=1.2.1)", "python-jose (>=3.0.0)"]
-all = ["cryptography (>=2.1.1)", "lxml (<4.7)", "python3-saml (>=1.2.1)", "python-jose (>=3.0.0)"]
+openidconnect = ["python-jose (>=3.0.0)"]
+saml = ["python3-saml (>=1.2.1)", "lxml (<4.7)"]
 
 [[package]]
 name = "sortedcontainers"
@@ -2027,12 +2027,12 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-"zope.testbrowser" = ["cssselect", "lxml (>=4.2.4)", "zope.testbrowser (>=5.5.1)"]
-selenium4 = ["selenium (>=4.1.0,<5.0)"]
-selenium3 = ["selenium (>=3.141.0,<4.0)"]
-flask = ["cssselect", "lxml (>=4.2.4)", "Flask (>=2.0.2)"]
+django = ["Django (>=2.0.6)", "lxml (>=4.2.4)", "cssselect"]
 edge = ["msedge-selenium-tools"]
-django = ["cssselect", "lxml (>=4.2.4)", "Django (>=2.0.6)"]
+flask = ["Flask (>=2.0.2)", "lxml (>=4.2.4)", "cssselect"]
+selenium3 = ["selenium (>=3.141.0,<4.0)"]
+selenium4 = ["selenium (>=4.1.0,<5.0)"]
+"zope.testbrowser" = ["zope.testbrowser (>=5.5.1)", "lxml (>=4.2.4)", "cssselect"]
 
 [[package]]
 name = "sqlparse"
@@ -2072,7 +2072,7 @@ optional = true
 python-versions = ">=3.6"
 
 [package.extras]
-doc = ["tornado (>=4.5)", "sphinx", "reno"]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
 
 [[package]]
 name = "text-unidecode"
@@ -2287,8 +2287,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "func-timeout", "jaraco.itertools", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
-docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [extras]
 all = ["django-auth-ldap", "django-storages", "mysqlclient", "napalm", "social-auth-core"]
@@ -2301,7 +2301,7 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "2e4cd5a6d9ae2e965a99233b68a2b3cc1f5531ef139fbcb57df4c156682f87fa"
+content-hash = "72f404cb20c650907df32faf33314c98c364aed48cbf266c69432c32b130ed9d"
 
 [metadata.files]
 amqp = [
@@ -2655,8 +2655,8 @@ django-tables2 = [
     {file = "django_tables2-2.4.1-py2.py3-none-any.whl", hash = "sha256:50762bf3d7c61a4eb70e763c3e278650d7266bb78d0497fc8fafcf4e507c9a64"},
 ]
 django-taggit = [
-    {file = "django-taggit-1.5.1.tar.gz", hash = "sha256:e5bb62891f458d55332e36a32e19c08d20142c43f74bc5656c803f8af25c084a"},
-    {file = "django_taggit-1.5.1-py3-none-any.whl", hash = "sha256:dfe9e9c10b5929132041de0c00093ef0072c73c2a97d0f74a818ae50fa77149a"},
+    {file = "django-taggit-3.0.0.tar.gz", hash = "sha256:e645b8e3dd4f85989d5ef5c5a3d5ebbe5badf5d1e51b53e42d0af726240b00b9"},
+    {file = "django_taggit-3.0.0-py3-none-any.whl", hash = "sha256:ca2df20399a11321db75988404afb640a08eff61e52bde35f6c16f307004ec9e"},
 ]
 django-timezone-field = [
     {file = "django-timezone-field-4.1.2.tar.gz", hash = "sha256:cffac62452d060e365938aa9c9f7b72d70d8b26b9c60243bce227b35abd1b9df"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,7 @@ django-storages = {version = "~1.12.3", optional = true}
 # Advanced HTML tables
 django-tables2 = "~2.4.1"
 # Tags
-# NOTE: django-taggit 2.x is available but has breaking API changes
-django-taggit = "~1.5.1"
+django-taggit = "~3.0.0"
 # Represent time zones in Django
 # NOTE: django-timezone-field 4.2.x is available but appears to break our initial migrations?
 django-timezone-field = "~4.1.2"


### PR DESCRIPTION
# Closes: #1983 
# What's Changed

Update django-taggit from 1.5.x to 3.0.0. This brings in the following "breaking" changes:

- 1.x to 2.x --> change in API from `tags.set(tag1, tag2, tag3)` to `tags.set([tag1, tag2, tag3])`
    - I've updated the few cases in our code where we were calling this API to use the new style
    - I've implemented a custom subclass of `_TaggableManager` to allow for backwards-compatibility of the API (with a logged warning) in case we have Jobs or Plugins that are calling the old API
- 2.x to 3.x --> tag slugs default to including rather than omitting Unicode characters
    - Should have no particular impact to us.

# TODO
- [x] Explanation of Change(s)
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design