### PR TITLE
Enhance Site and Location detail views

### DIFF
--- a/nautobot/dcim/templates/dcim/location.html
+++ b/nautobot/dcim/templates/dcim/location.html
@@ -59,6 +59,64 @@
 {% block content_right_page %}
     <div class="panel panel-default">
         <div class="panel-heading">
+            <strong>Stats</strong>
+        </div>
+        <div class="row panel-body">
+            <div class="col-md-4 text-center">
+                <h2><a href="{% url 'dcim:rack_list' %}?location={{ object.slug }}" class="btn {% if stats.rack_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.rack_count }}</a></h2>
+                <p>Racks</p>
+            </div>
+            <div class="col-md-4 text-center">
+                <h2><a href="{% url 'dcim:device_list' %}?location={{ object.slug }}" class="btn {% if stats.device_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.device_count }}</a></h2>
+                <p>Devices</p>
+            </div>
+            <div class="col-md-4 text-center">
+                <h2><a href="{% url 'ipam:prefix_list' %}?location={{ object.slug }}" class="btn {% if stats.prefix_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.prefix_count }}</a></h2>
+                <p>Prefixes</p>
+            </div>
+            <div class="col-md-4 text-center">
+                <h2><a href="{% url 'ipam:vlan_list' %}?location={{ object.slug }}" class="btn {% if stats.vlan_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.vlan_count }}</a></h2>
+                <p>VLANs</p>
+            </div>
+            <div class="col-md-4 text-center">
+                <h2><a href="{% url 'circuits:circuit_list' %}?location={{ object.slug }}" class="btn {% if stats.circuit_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.circuit_count }}</a></h2>
+                <p>Circuits</p>
+            </div>
+            <div class="col-md-4 text-center">
+                <h2><a href="{% url 'virtualization:virtualmachine_list' %}?location={{ object.slug }}" class="btn {% if stats.vm_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.vm_count }}</a></h2>
+                <p>Virtual Machines</p>
+            </div>
+        </div>
+    </div>
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <strong>Rack Groups</strong>
+        </div>
+        <table class="table table-hover panel-body">
+            {% for rg in rack_groups %}
+                <tr>
+                    <td style="padding-left: {{ rg.level }}8px"><i class="mdi mdi-folder-open"></i> <a href="{{ rg.get_absolute_url }}">{{ rg }}</a></td>
+                    <td>{{ rg.rack_count }}</td>
+                    <td class="text-right noprint">
+                        <a href="{% url 'dcim:rack_elevation_list' %}?group_id={{ rg.pk }}" class="btn btn-xs btn-primary" title="View elevations">
+                            <i class="mdi mdi-server"></i>
+                        </a>
+                    </td>
+                </tr>
+            {% endfor %}
+            <tr>
+                <td><i class="mdi mdi-folder-open"></i> All racks</td>
+                <td>{{ stats.rack_count }}</td>
+                <td class="text-right noprint">
+                    <a href="{% url 'dcim:rack_elevation_list' %}?location={{ object.slug }}" class="btn btn-xs btn-primary" title="View elevations">
+                        <i class="mdi mdi-server"></i>
+                    </a>
+                </td>
+            </tr>
+        </table>
+    </div>
+    <div class="panel panel-default">
+        <div class="panel-heading">
             <strong>Images</strong>
         </div>
         {% include 'inc/image_attachments.html' with images=object.images.all %}

--- a/nautobot/dcim/templates/dcim/site.html
+++ b/nautobot/dcim/templates/dcim/site.html
@@ -212,3 +212,20 @@
             {% endif %}
         </div>
 {% endblock content_right_page%}
+
+{% block content_full_width_page %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <strong>Locations</strong>
+        </div>
+        {% include 'inc/table.html' with table=locations_table %}
+        {% if perms.dcim.add_location %}
+            <div class="panel-footer text-right noprint">
+                <a href="{% url 'dcim:location_add' %}?site={{ object.pk }}" class="btn btn-xs btn-primary">
+                    <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add location
+                </a>
+            </div>
+        {% endif %}
+    </div>
+    {% include 'inc/paginator.html' with paginator=locations_table.paginator page=locations_table.page %}
+{% endblock content_full_width_page %}

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -219,8 +219,22 @@ class SiteView(generic.ObjectView):
             .restrict(request.user, "view")
             .filter(site=instance)
         )
+        locations = (
+            Location.objects.restrict(request.user, "view")
+            .filter(site=instance)
+            .prefetch_related("parent", "location_type")
+        )
+
+        locations_table = tables.LocationTable(locations)
+
+        paginate = {
+            "paginator_class": EnhancedPaginator,
+            "per_page": get_paginate_count(request),
+        }
+        RequestConfig(request, paginate).configure(locations_table)
 
         return {
+            "locations_table": locations_table,
             "stats": stats,
             "rack_groups": rack_groups,
         }
@@ -334,6 +348,23 @@ class LocationView(generic.ObjectView):
     queryset = Location.objects.all()
 
     def get_extra_context(self, request, instance):
+        stats = {
+            "rack_count": Rack.objects.restrict(request.user, "view").filter(location=instance).count(),
+            "device_count": Device.objects.restrict(request.user, "view").filter(location=instance).count(),
+            "prefix_count": Prefix.objects.restrict(request.user, "view").filter(location=instance).count(),
+            "vlan_count": VLAN.objects.restrict(request.user, "view").filter(location=instance).count(),
+            "circuit_count": Circuit.objects.restrict(request.user, "view")
+            .filter(terminations__location=instance)
+            .count(),
+            "vm_count": VirtualMachine.objects.restrict(request.user, "view")
+            .filter(cluster__location=instance)
+            .count(),
+        }
+        rack_groups = (
+            RackGroup.objects.add_related_count(RackGroup.objects.all(), Rack, "group", "rack_count", cumulative=True)
+            .restrict(request.user, "view")
+            .filter(location=instance)
+        )
         children = (
             Location.objects.restrict(request.user, "view")
             .filter(parent=instance)
@@ -350,6 +381,8 @@ class LocationView(generic.ObjectView):
 
         return {
             "children_table": children_table,
+            "rack_groups": rack_groups,
+            "stats": stats,
         }
 
 


### PR DESCRIPTION
# Closes: #2250
# What's Changed

- Add "Locations" table to Site detail view, similar to what Location detail view already has:

![image](https://user-images.githubusercontent.com/5603551/185645313-6416f6bf-1402-404a-83b0-99f1a3b47304.png)

- Add "Stats" and "Rack Groups" tables to Location detail view, similar to what Site detail view already has:

![image](https://user-images.githubusercontent.com/5603551/185645444-ca85570b-5032-45f6-96e9-7912ae053493.png)

# Notes

- ~The stats on the Location detail are only for objects *associated directly to this Location*, **not** objects *associated to this Location or any of its children*.~ Fixed, thank you @bryanculver!
- I'm opening this PR as a fix against `develop` rather than a feature against `next` as IMHO this was missed functionality against 1.4.0.

# TODO
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design