### PR TITLE
Fix #2269: include block.super in various javascript blocks

### DIFF
--- a/nautobot/core/templates/generic/object_retrieve.html
+++ b/nautobot/core/templates/generic/object_retrieve.html
@@ -67,7 +67,7 @@
 
     <ul id="tabs" class="nav nav-tabs">
     {% block nav_tabs %}
-        <li role="presentation"{% if not active_tab and not request.GET.tab or request.GET.tab == "main" %} class="active"{% endif %}>
+        <li role="presentation"{% if active_tab == "main" or request.GET.tab == "main" %} class="active"{% endif %}>
             <a href="{{ object.get_absolute_url }}#main" onclick="switch_tab(this.href)" aria-controls="main" role="tab" data-toggle="tab">
                 {{ verbose_name|bettertitle }}
             </a>
@@ -106,7 +106,7 @@
 
 {% block content %}
     <div class="tab-content">
-        <div id="main" role="tabpanel" class="tab-pane {% if not active_tab and not request.GET.tab or request.GET.tab == "main" %}active{% else %}fade{% endif %}">
+        <div id="main" role="tabpanel" class="tab-pane {% if active_tab == "main" or request.GET.tab == "main" %}active{% else %}fade{% endif %}">
             <div class="row">
                 <div class="col-md-6">
                     {% block content_left_page %}{% endblock content_left_page %}

--- a/nautobot/dcim/templates/dcim/rack_elevation_list.html
+++ b/nautobot/dcim/templates/dcim/rack_elevation_list.html
@@ -58,5 +58,6 @@
 {% endblock %}
 
 {% block javascript %}
+{{ block.super }}
 <script src="{% static 'js/rack_elevations.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock %}

--- a/nautobot/dcim/templates/dcim/rackreservation.html
+++ b/nautobot/dcim/templates/dcim/rackreservation.html
@@ -87,5 +87,6 @@
 {% endblock content_right_page %}
 
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/rack_elevations.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock javascript %}

--- a/nautobot/extras/templates/extras/gitrepository_result.html
+++ b/nautobot/extras/templates/extras/gitrepository_result.html
@@ -14,6 +14,7 @@
 {% endblock content %}
 
 {% block javascript %}
+    {{ block.super }}
     {% include 'extras/inc/jobresult_js.html' with result=result %}
     <script src="{% static 'js/tableconfig.js' %}?v{{ settings.VERSION }}"></script>
     <script src="{% static 'js/log_level_filtering.js' %}?v{{ settings.VERSION }}"></script>

--- a/nautobot/extras/templates/extras/graphqlquery.html
+++ b/nautobot/extras/templates/extras/graphqlquery.html
@@ -48,6 +48,7 @@
 {% endblock content_right_page %}
 
 {% block javascript %}
+{{ block.super }}
 <script>
     function test_query() {
         var output = $("#query_output");

--- a/nautobot/extras/templates/extras/job.html
+++ b/nautobot/extras/templates/extras/job.html
@@ -112,6 +112,7 @@
     </div>
 {% endblock %}
 {% block javascript %}
+{{ block.super }}
 <script type="text/javascript">
     var requires_approval = {{ job_model.approval_required|yesno:"true,false" }};
     var run_now_text;

--- a/nautobot/extras/templates/extras/plugins_list.html
+++ b/nautobot/extras/templates/extras/plugins_list.html
@@ -30,5 +30,6 @@
 {% endblock %}
 
 {% block javascript %}
+{{ block.super }}
 <script src="{% static 'js/tableconfig.js' %}"></script>
 {% endblock %}

--- a/nautobot/extras/templates/extras/secret_edit.html
+++ b/nautobot/extras/templates/extras/secret_edit.html
@@ -41,6 +41,7 @@
 {% endblock form %}
 
 {% block javascript %}
+{{ block.super }}
 <script type="text/javascript">
     /* When changing any field in the parameters_form, re-render the JSON in parameters_json */
     function changeProviderParameter() {

--- a/nautobot/extras/templates/extras/secretsgroup_edit.html
+++ b/nautobot/extras/templates/extras/secretsgroup_edit.html
@@ -72,6 +72,7 @@
 {% endblock form %}
 
 {% block javascript %}
+{{ block.super }}
 <script src="{% static 'jquery/jquery.formset.js' %}"></script>
 <script type="text/javascript">
     $('.formset_row-{{ secrets.prefix }}').formset({

--- a/nautobot/users/templates/users/api_tokens.html
+++ b/nautobot/users/templates/users/api_tokens.html
@@ -70,6 +70,7 @@
 {% endblock %}
 
 {% block javascript %}
+{{ block.super }}
 <script type="text/javascript">
 new ClipboardJS('.copy-token');
 </script>


### PR DESCRIPTION
# Closes: #2269 
# What's Changed

Added `{{ block.super }}` to various templates that override a base template's `{% block javascript %}` but were missing this reference beforehand. This absence caused `graphqlquery.html` and `rackreservation.html` to not include the appropriate tab-switching JS code, and including it in all templates that override this block is a good practice anyways.

Additionally, fix the template rendering logic in `object_retrieve.html` so that even without the tab-switching JS being properly loaded, the "main" tab is initially rendered as visible. (This was probably broken inadvertently by the change in `ObjectDetailView.get_extra_context` in #1843). 

# TODO
- [x] Explanation of Change(s)
- n/a Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design