### PR TITLE
Implement a 'dynamic_groups' field on the DeviceType for GraphQL.

### DIFF
--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -42,7 +42,7 @@ from nautobot.dcim.graphql.types import (
 from nautobot.extras.registry import registry
 from nautobot.extras.models import ComputedField, CustomField, Relationship
 from nautobot.extras.choices import CustomFieldTypeChoices, RelationshipSideChoices
-from nautobot.extras.graphql.types import TagType
+from nautobot.extras.graphql.types import TagType, DynamicGroupType
 from nautobot.ipam.graphql.types import AggregateType, IPAddressType, PrefixType
 from nautobot.virtualization.graphql.types import VirtualMachineType, VMInterfaceType
 
@@ -65,6 +65,7 @@ registry["graphql_types"]["dcim.rack"] = RackType
 registry["graphql_types"]["dcim.rearport"] = RearPortType
 registry["graphql_types"]["dcim.site"] = SiteType
 registry["graphql_types"]["extras.tag"] = TagType
+registry["graphql_types"]["extras.dynamicgroup"] = DynamicGroupType
 registry["graphql_types"]["ipam.aggregate"] = AggregateType
 registry["graphql_types"]["ipam.ipaddress"] = IPAddressType
 registry["graphql_types"]["ipam.prefix"] = PrefixType

--- a/nautobot/core/graphql/utils.py
+++ b/nautobot/core/graphql/utils.py
@@ -4,6 +4,7 @@ from django_filters.filters import BooleanFilter, NumberFilter, MultipleChoiceFi
 import graphene
 
 from nautobot.core.graphql import BigInteger
+from nautobot.extras.models import DynamicGroup
 from nautobot.utilities.filters import MultiValueBigNumberFilter, MultiValueNumberFilter
 from nautobot.utilities.utils import slugify_dashes_to_underscores
 

--- a/nautobot/core/graphql/utils.py
+++ b/nautobot/core/graphql/utils.py
@@ -4,7 +4,6 @@ from django_filters.filters import BooleanFilter, NumberFilter, MultipleChoiceFi
 import graphene
 
 from nautobot.core.graphql import BigInteger
-from nautobot.extras.models import DynamicGroup
 from nautobot.utilities.filters import MultiValueBigNumberFilter, MultiValueNumberFilter
 from nautobot.utilities.utils import slugify_dashes_to_underscores
 

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -57,7 +57,7 @@ class DeviceType(gql_optimizer.OptimizedDjangoObjectType):
     dynamic_groups = graphene.List("nautobot.extras.graphql.types.DynamicGroupType")
 
     def resolve_dynamic_groups(self, args):
-        return DynamicGroup.objects.get_for_object(Device.objects.get(pk=self.pk))
+        return DynamicGroup.objects.get_for_object(self)
 
 
 class RackType(gql_optimizer.OptimizedDjangoObjectType):
@@ -71,7 +71,7 @@ class RackType(gql_optimizer.OptimizedDjangoObjectType):
     dynamic_groups = graphene.List("nautobot.extras.graphql.types.DynamicGroupType")
 
     def resolve_dynamic_groups(self, args):
-        return DynamicGroup.objects.get_for_object(Rack.objects.get(pk=self.pk))
+        return DynamicGroup.objects.get_for_object(self)
 
 
 class CableType(gql_optimizer.OptimizedDjangoObjectType):

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -56,7 +56,7 @@ class DeviceType(gql_optimizer.OptimizedDjangoObjectType):
 
     dynamic_groups = graphene.List("nautobot.extras.graphql.types.DynamicGroupType")
 
-    def resolve_dynamic_groups(self, info):
+    def resolve_dynamic_groups(self, args):
         return DynamicGroup.objects.get_for_object(Device.objects.get(pk=self.pk))
 
 
@@ -67,6 +67,11 @@ class RackType(gql_optimizer.OptimizedDjangoObjectType):
         model = Rack
         filterset_class = RackFilterSet
         exclude = ["images"]
+
+    dynamic_groups = graphene.List("nautobot.extras.graphql.types.DynamicGroupType")
+
+    def resolve_dynamic_groups(self, args):
+        return DynamicGroup.objects.get_for_object(Rack.objects.get(pk=self.pk))
 
 
 class CableType(gql_optimizer.OptimizedDjangoObjectType):

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -34,6 +34,7 @@ from nautobot.dcim.filters import (
     SiteFilterSet,
 )
 from nautobot.extras.graphql.types import TagType  # noqa: F401
+from nautobot.extras.models import DynamicGroup
 
 
 class SiteType(gql_optimizer.OptimizedDjangoObjectType):
@@ -52,6 +53,11 @@ class DeviceType(gql_optimizer.OptimizedDjangoObjectType):
         model = Device
         filterset_class = DeviceFilterSet
         exclude = ["_name"]
+
+    dynamic_groups = graphene.List("nautobot.extras.graphql.types.DynamicGroupType")
+
+    def resolve_dynamic_groups(self, info):
+        return DynamicGroup.objects.get_for_object(Device.objects.get(pk=self.pk))
 
 
 class RackType(gql_optimizer.OptimizedDjangoObjectType):

--- a/nautobot/dcim/tests/test_graphql.py
+++ b/nautobot/dcim/tests/test_graphql.py
@@ -1,0 +1,27 @@
+from django.contrib.contenttypes.models import ContentType
+from django.test import override_settings
+
+from nautobot.core.graphql import execute_query
+from nautobot.dcim.models import Device, DeviceType, DeviceRole, Manufacturer, Site
+from nautobot.extras.models import DynamicGroup
+from nautobot.utilities.testing import create_test_user, TestCase
+
+
+class GraphQLTestCase(TestCase):
+    def setUp(self):
+        self.user = create_test_user("graphql_testuser")
+        self.site = Site.objects.create(name="Site")
+        self.device_role = DeviceRole.objects.create(name="Switch")
+        self.manufacturer = Manufacturer.objects.create(name="Brand")
+        self.device_type = DeviceType.objects.create(model="Model", manufacturer=self.manufacturer)
+        self.device = Device.objects.create(site=self.site, device_role=self.device_role, device_type=self.device_type, name="Device")
+        self.dynamic_group = DynamicGroup.objects.create(
+            name="Dynamic_Group", content_type=ContentType.objects.get_for_model(Device)
+        )
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_execute_query(self):
+        query = "query {devices {name dynamic_groups {name}}}"
+        resp = execute_query(query, user=self.user).to_dict()
+        self.assertFalse(resp["data"].get("error"))
+        self.assertEqual(resp["data"]["devices"][0]["dynamic_groups"][0]["name"], self.dynamic_group.name)

--- a/nautobot/dcim/tests/test_graphql.py
+++ b/nautobot/dcim/tests/test_graphql.py
@@ -14,7 +14,9 @@ class GraphQLTestCase(TestCase):
         self.device_role = DeviceRole.objects.create(name="Switch")
         self.manufacturer = Manufacturer.objects.create(name="Brand")
         self.device_type = DeviceType.objects.create(model="Model", manufacturer=self.manufacturer)
-        self.device = Device.objects.create(site=self.site, device_role=self.device_role, device_type=self.device_type, name="Device")
+        self.device = Device.objects.create(
+            site=self.site, device_role=self.device_role, device_type=self.device_type, name="Device"
+        )
         self.dynamic_group = DynamicGroup.objects.create(
             name="Dynamic_Group", content_type=ContentType.objects.get_for_model(Device)
         )

--- a/nautobot/extras/graphql/types.py
+++ b/nautobot/extras/graphql/types.py
@@ -1,7 +1,7 @@
 import graphene_django_optimizer as gql_optimizer
 
-from nautobot.extras.models import Status, Tag
-from nautobot.extras.filters import StatusFilterSet, TagFilterSet
+from nautobot.extras.models import Status, Tag, DynamicGroup
+from nautobot.extras.filters import StatusFilterSet, TagFilterSet, DynamicGroupFilterSet
 
 
 class TagType(gql_optimizer.OptimizedDjangoObjectType):
@@ -18,3 +18,11 @@ class StatusType(gql_optimizer.OptimizedDjangoObjectType):
     class Meta:
         model = Status
         filterset_class = StatusFilterSet
+
+
+class DynamicGroupType(gql_optimizer.OptimizedDjangoObjectType):
+    """Graphql Type object for `DynamicGroup` model."""
+
+    class Meta:
+        model = DynamicGroup
+        filterset_class = DynamicGroupFilterSet

--- a/nautobot/ipam/graphql/types.py
+++ b/nautobot/ipam/graphql/types.py
@@ -2,6 +2,7 @@ import graphene
 import graphene_django_optimizer as gql_optimizer
 
 from nautobot.dcim.graphql.types import InterfaceType
+from nautobot.extras.models import DynamicGroup
 from nautobot.ipam import models, filters
 from nautobot.extras.graphql.types import TagType  # noqa: F401
 from nautobot.virtualization.graphql.types import VMInterfaceType
@@ -41,6 +42,7 @@ class IPAddressType(gql_optimizer.OptimizedDjangoObjectType):
     interface = graphene.Field("nautobot.dcim.graphql.types.InterfaceType")
     vminterface = graphene.Field("nautobot.virtualization.graphql.types.VMInterfaceType")
     nat_outside = graphene.Field(lambda: IPAddressType)
+    dynamic_groups = graphene.List("nautobot.extras.graphql.types.DynamicGroupType")
 
     class Meta:
         model = models.IPAddress
@@ -69,12 +71,16 @@ class IPAddressType(gql_optimizer.OptimizedDjangoObjectType):
             return self.assigned_object
         return None
 
+    def resolve_dynamic_groups(self, args):
+        return DynamicGroup.objects.get_for_object(models.IPAddress.objects.get(pk=self.pk))
+
 
 class PrefixType(gql_optimizer.OptimizedDjangoObjectType):
     """Graphql Type Object for Prefix model."""
 
     prefix = graphene.String()
     family = graphene.Int()
+    dynamic_groups = graphene.List("nautobot.extras.graphql.types.DynamicGroupType")
 
     class Meta:
         model = models.Prefix
@@ -82,3 +88,6 @@ class PrefixType(gql_optimizer.OptimizedDjangoObjectType):
 
     def resolve_family(self, args):
         return self.family
+
+    def resolve_dynamic_groups(self, args):
+        return DynamicGroup.objects.get_for_object(models.IPAddress.objects.get(pk=self.pk))

--- a/nautobot/ipam/graphql/types.py
+++ b/nautobot/ipam/graphql/types.py
@@ -72,7 +72,7 @@ class IPAddressType(gql_optimizer.OptimizedDjangoObjectType):
         return None
 
     def resolve_dynamic_groups(self, args):
-        return DynamicGroup.objects.get_for_object(models.IPAddress.objects.get(pk=self.pk))
+        return DynamicGroup.objects.get_for_objectƒ(self)
 
 
 class PrefixType(gql_optimizer.OptimizedDjangoObjectType):
@@ -90,4 +90,4 @@ class PrefixType(gql_optimizer.OptimizedDjangoObjectType):
         return self.family
 
     def resolve_dynamic_groups(self, args):
-        return DynamicGroup.objects.get_for_object(models.IPAddress.objects.get(pk=self.pk))
+        return DynamicGroup.objects.get_for_object(self)

--- a/nautobot/virtualization/graphql/types.py
+++ b/nautobot/virtualization/graphql/types.py
@@ -1,16 +1,35 @@
 import graphene
 import graphene_django_optimizer as gql_optimizer
 
-from nautobot.virtualization.models import VirtualMachine, VMInterface
-from nautobot.virtualization.filters import VirtualMachineFilterSet, VMInterfaceFilterSet
+from nautobot.extras.models import DynamicGroup
+from nautobot.virtualization.models import VirtualMachine, VMInterface, Cluster
+from nautobot.virtualization.filters import VirtualMachineFilterSet, VMInterfaceFilterSet, ClusterFilterSet
+
+
+class ClusterType(gql_optimizer.OptimizedDjangoObjectType):
+    """GraphQL type object for Cluster model."""
+
+    dynamic_groups = graphene.List("nautobot.extras.graphql.types.DynamicGroupType")
+
+    class Meta:
+        model = Cluster
+        filterset_class = ClusterFilterSet
+
+    def resolve_dynamic_groups(self, args):
+        return DynamicGroup.objects.get_for_object(Cluster.objects.get(pk=self.pk))
 
 
 class VirtualMachineType(gql_optimizer.OptimizedDjangoObjectType):
     """GraphQL type object for VirtualMachine model."""
 
+    dynamic_groups = graphene.List("nautobot.extras.graphql.types.DynamicGroupType")
+
     class Meta:
         model = VirtualMachine
         filterset_class = VirtualMachineFilterSet
+
+    def resolve_dynamic_groups(self, args):
+        return DynamicGroup.objects.get_for_object(VirtualMachine.objects.get(pk=self.pk))
 
 
 class VMInterfaceType(gql_optimizer.OptimizedDjangoObjectType):

--- a/nautobot/virtualization/graphql/types.py
+++ b/nautobot/virtualization/graphql/types.py
@@ -16,7 +16,7 @@ class ClusterType(gql_optimizer.OptimizedDjangoObjectType):
         filterset_class = ClusterFilterSet
 
     def resolve_dynamic_groups(self, args):
-        return DynamicGroup.objects.get_for_object(Cluster.objects.get(pk=self.pk))
+        return DynamicGroup.objects.get_for_object(self)
 
 
 class VirtualMachineType(gql_optimizer.OptimizedDjangoObjectType):
@@ -29,7 +29,7 @@ class VirtualMachineType(gql_optimizer.OptimizedDjangoObjectType):
         filterset_class = VirtualMachineFilterSet
 
     def resolve_dynamic_groups(self, args):
-        return DynamicGroup.objects.get_for_object(VirtualMachine.objects.get(pk=self.pk))
+        return DynamicGroup.objects.get_for_object(self)
 
 
 class VMInterfaceType(gql_optimizer.OptimizedDjangoObjectType):


### PR DESCRIPTION
# Closes: #2307

# What's Changed

- Implement a `dynamic_groups` field on the GraphQL `DeviceType` that shows to which dynamic groups the device belongs to
- Statically create `DynamicGroupType` because otherwise I would get the following error

```
Exception Value: 	

Could not import 'nautobot.core.graphql.schema_init.schema' for Graphene setting 'SCHEMA'. ImportError: Module "nautobot.extras.graphql.types" does not define a "DynamicGroupType" attribute/class.
```

Example screenshot:
![Screenshot 2022-08-26 at 09 28 30](https://user-images.githubusercontent.com/12400533/186847187-580757e4-2f6d-4576-8d60-70cf4745d652.png)

# TODO
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design