### PR TITLE
Fix Location editing "parent" autopopulation

### DIFF
--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -466,7 +466,6 @@ class LocationForm(NautobotModelForm, TenancyForm):
     parent = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         query_params={"child_location_type": "$location_type"},
-        to_field_name="slug",
         required=False,
     )
     site = DynamicModelChoiceField(queryset=Site.objects.all(), required=False)


### PR DESCRIPTION
# Closes: #2311 
# What's Changed

Remove incorrect `to_field_name` setting on the "parent" form field. Confirmed that it now is initialized correctly when editing an existing Location:

![image](https://user-images.githubusercontent.com/5603551/186969768-a4233b41-e3b7-4ecf-b1dd-49631a68be45.png)


# TODO
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design