### PR TITLE
Improve handling of various Git repository bad-data scenarios

### DIFF
--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -371,10 +371,7 @@ def update_git_config_contexts(repository_record, job_result):
         try:
             with open(os.path.join(config_context_path, file_name), "r") as fd:
                 # The data file can be either JSON or YAML; since YAML is a superset of JSON, we can load it regardless
-                try:
-                    context_data = yaml.safe_load(fd)
-                except Exception as exc:
-                    raise RuntimeError(f"Error in loading config context data from `{file_name}`: {exc}")
+                context_data = yaml.safe_load(fd)
 
             # A file can contain one config context dict or a list thereof
             if isinstance(context_data, dict):
@@ -385,13 +382,11 @@ def update_git_config_contexts(repository_record, job_result):
                     context_name = import_config_context(context_data_entry, repository_record, job_result, logger)
                     managed_config_contexts.add(context_name)
             else:
-                raise RuntimeError(
-                    f"Error in loading config context data from `{file_name}`: data must be a dict or list of dicts"
-                )
+                raise RuntimeError("data must be a dict or list of dicts")
 
         except Exception as exc:
             job_result.log(
-                str(exc),
+                f"Error in loading config context data from `{file_name}`: {exc}",
                 level_choice=LogLevelChoices.LOG_FAILURE,
                 grouping="config contexts",
                 logger=logger,
@@ -411,6 +406,15 @@ def update_git_config_contexts(repository_record, job_result):
         "tenants",
         "tags",
     ):
+        if os.path.isdir(os.path.join(repository_record.filesystem_path, filter_type)):
+            job_result.log(
+                f'Found "{filter_type}" directory in the repository root. If this is meant to contain config contexts, '
+                "it should be moved into a `config_contexts/` subdirectory.",
+                level_choice=LogLevelChoices.LOG_WARNING,
+                grouping="config contexts",
+                logger=logger,
+            )
+
         dir_path = os.path.join(config_context_path, filter_type)
         if not os.path.isdir(dir_path):
             continue
@@ -425,10 +429,7 @@ def update_git_config_contexts(repository_record, job_result):
             try:
                 with open(os.path.join(dir_path, file_name), "r") as fd:
                     # Data file can be either JSON or YAML; since YAML is a superset of JSON, we can load it regardless
-                    try:
-                        context_data = yaml.safe_load(fd)
-                    except Exception as exc:
-                        raise RuntimeError(f"Error in loading config context data from `{file_name}`: {exc}")
+                    context_data = yaml.safe_load(fd)
 
                 # Unlike the above case, these files always contain just a single config context record
 
@@ -439,7 +440,7 @@ def update_git_config_contexts(repository_record, job_result):
                 managed_config_contexts.add(context_name)
             except Exception as exc:
                 job_result.log(
-                    str(exc),
+                    f"Error in loading config context data from `{file_name}`: {exc}",
                     level_choice=LogLevelChoices.LOG_FAILURE,
                     grouping="config contexts",
                     logger=logger,
@@ -448,6 +449,15 @@ def update_git_config_contexts(repository_record, job_result):
 
     # Finally, handle device- and virtual-machine-specific "local" context in (devices|virtual_machines)/<name>.(json|yaml)
     for local_type in ("devices", "virtual_machines"):
+        if os.path.isdir(os.path.join(repository_record.filesystem_path, local_type)):
+            job_result.log(
+                f'Found "{local_type}" directory in the repository root. If this is meant to contain config contexts, '
+                "it should be moved into a `config_contexts/` subdirectory.",
+                level_choice=LogLevelChoices.LOG_WARNING,
+                grouping="config contexts",
+                logger=logger,
+            )
+
         dir_path = os.path.join(config_context_path, local_type)
         if not os.path.isdir(dir_path):
             continue
@@ -461,10 +471,7 @@ def update_git_config_contexts(repository_record, job_result):
             )
             try:
                 with open(os.path.join(dir_path, file_name), "r") as fd:
-                    try:
-                        context_data = yaml.safe_load(fd)
-                    except Exception as exc:
-                        raise RuntimeError(f"Error in loading local config context from `{file_name}`: {exc}")
+                    context_data = yaml.safe_load(fd)
 
                 import_local_config_context(
                     local_type,
@@ -477,7 +484,7 @@ def update_git_config_contexts(repository_record, job_result):
                 managed_local_config_contexts[local_type].add(device_name)
             except Exception as exc:
                 job_result.log(
-                    str(exc),
+                    f"Error in loading local config context from `{local_type}/{file_name}`: {exc}",
                     level_choice=LogLevelChoices.LOG_FAILURE,
                     grouping="local config contexts",
                     logger=logger,
@@ -509,8 +516,13 @@ def import_config_context(context_data, repository_record, job_result, logger):
     context_record = None
     # TODO: check context_data against a schema of some sort?
 
+    if "_metadata" not in context_data:
+        raise RuntimeError("data is missing the required `_metadata` key.")
+    if "name" not in context_data["_metadata"]:
+        raise RuntimeError("data `_metadata` is missing the required `name` key.")
+
     # Set defaults for optional fields
-    context_metadata = context_data.setdefault("_metadata", {})
+    context_metadata = context_data["_metadata"]
     context_metadata.setdefault("weight", 1000)
     context_metadata.setdefault("description", "")
     context_metadata.setdefault("is_active", True)
@@ -658,21 +670,9 @@ def import_local_config_context(local_type, device_name, context_data, repositor
     except MultipleObjectsReturned:
         # Possible for Device as name is not guaranteed globally unique
         # TODO: come up with a design that accounts for non-unique names, as well as un-named Devices.
-        job_result.log(
-            "Multiple records with the same name found; unable to determine which one to apply to!",
-            level_choice=LogLevelChoices.LOG_FAILURE,
-            grouping="local config contexts",
-            logger=logger,
-        )
-        return
+        raise RuntimeError("multiple records with the same name found; unable to determine which one to apply to!")
     except ObjectDoesNotExist:
-        job_result.log(
-            "Record not found!",
-            level_choice=LogLevelChoices.LOG_FAILURE,
-            grouping="local config contexts",
-            logger=logger,
-        )
-        return
+        raise RuntimeError("record not found!")
 
     if record.local_context_data_owner is not None and record.local_context_data_owner != repository_record:
         job_result.log(
@@ -780,10 +780,7 @@ def update_git_config_context_schemas(repository_record, job_result):
         try:
             with open(os.path.join(config_context_schema_path, file_name), "r") as fd:
                 # The data file can be either JSON or YAML; since YAML is a superset of JSON, we can load it regardless
-                try:
-                    context_schema_data = yaml.safe_load(fd)
-                except Exception as exc:
-                    raise RuntimeError(f"Error in loading config context schema data from `{file_name}`: {exc}")
+                context_schema_data = yaml.safe_load(fd)
 
             # A file can contain one config context dict or a list thereof
             if isinstance(context_schema_data, dict):
@@ -797,16 +794,12 @@ def update_git_config_context_schemas(repository_record, job_result):
                         )
                         managed_config_context_schemas.add(context_name)
                     else:
-                        raise RuntimeError(
-                            f"Error in loading config context schema data from `{file_name}`: data must be a dict or list of dicts"
-                        )
+                        raise RuntimeError("each item in list data must be a dict")
             else:
-                raise RuntimeError(
-                    f"Error in loading config context schema data from `{file_name}`: data must be a dict or list of dicts"
-                )
+                raise RuntimeError("data must be a dict or a list of dicts")
         except Exception as exc:
             job_result.log(
-                str(exc),
+                f"Error in loading config context schema data from `{file_name}`: {exc}",
                 level_choice=LogLevelChoices.LOG_FAILURE,
                 grouping="config context schemas",
                 logger=logger,
@@ -828,10 +821,12 @@ def import_config_context_schema(context_schema_data, repository_record, job_res
     created = False
     modified = False
 
-    schema_metadata = context_schema_data.setdefault("_metadata", {})
+    if "_metadata" not in context_schema_data:
+        raise RuntimeError("data is missing the required `_metadata` key.")
+    if "name" not in context_schema_data["_metadata"]:
+        raise RuntimeError("data `_metadata` is missing the required `name` key.")
 
-    if not schema_metadata.get("name"):
-        raise RuntimeError("File has no name set.")
+    schema_metadata = context_schema_data["_metadata"]
 
     try:
         schema_record = ConfigContextSchema.objects.get(
@@ -983,6 +978,18 @@ def update_git_export_templates(repository_record, job_result):
 
     Templates are located in GIT_ROOT/<repo>/export_templates/<app_label>/<model>/<template name>.
     """
+    # Error checking - did the user put directories in the repository root instead of under /export_templates/?
+    for app_label in ["circuits", "dcim", "extras", "ipam", "tenancy", "users", "virtualization"]:
+        unexpected_path = os.path.join(repository_record.filesystem_path, app_label)
+        if os.path.isdir(unexpected_path):
+            job_result.log(
+                f'Found "{app_label}" directory in the repository root. If this is meant to contain export templates, '
+                "it should be moved into an `export_templates/` subdirectory.",
+                level_choice=LogLevelChoices.LOG_WARNING,
+                grouping="export templates",
+                logger=logger,
+            )
+
     export_template_path = os.path.join(repository_record.filesystem_path, "export_templates")
     if not os.path.isdir(export_template_path):
         return

--- a/nautobot/extras/datasources/utils.py
+++ b/nautobot/extras/datasources/utils.py
@@ -31,7 +31,7 @@ def files_from_contenttype_directories(base_path, job_result, log_grouping):
             except ContentType.DoesNotExist:
                 job_result.log(
                     f"Skipping `{app_label}.{modelname}` as it isn't a known content type",
-                    level_choice=LogLevelChoices.LOG_FAILURE,
+                    level_choice=LogLevelChoices.LOG_WARNING,
                     grouping=log_grouping,
                     logger=logger,
                 )


### PR DESCRIPTION
# Closes: #449
# What's Changed

This came out of an extended troubleshooting session with a user on public Slack.

- More consistent logging in general if failures occur during various Git repository data sync operations
- Warn the user if directories that should exist under `/config_contexts/` are found in the repository root
- Warn the user if directories that should exist under `/export_templates/` are found in the repository root
- Fail gracefully if a config-context file is missing the `_metadata`->`name` key, instead of throwing a DB error when trying to create a record with null `name`
- Change the log message when encountering an unknown content-type in `/export_templates` from a `failure` to a `warning` - I'm open to persuasion that the current behavior is preferable; my thinking in making this change is that potentially a repo can contain export-templates for plugin models, or for models that are newly added in a later Nautobot release, and the presence of these templates shouldn't necessarily fail the sync when run from an older Nautobot version or in the absence of a given plugin
- Enhance `test_pull_git_repository_and_refresh_data_with_bad_data` test case to check for the specific expected log messages in addition to just checking that the sync failed in this case.

# TODO
- [x] Explanation of Change(s)
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design