### PR TITLE
Fix code and logic around MACAddressCharField

### DIFF
--- a/nautobot/dcim/apps.py
+++ b/nautobot/dcim/apps.py
@@ -1,5 +1,3 @@
-import graphene
-
 from nautobot.core.apps import NautobotConfig
 
 
@@ -10,11 +8,3 @@ class DCIMConfig(NautobotConfig):
     def ready(self):
         super().ready()
         import nautobot.dcim.signals  # noqa: F401
-
-        from graphene_django.converter import convert_django_field
-        from nautobot.dcim.fields import MACAddressField
-
-        @convert_django_field.register(MACAddressField)
-        def convert_field_to_string(field, registry=None):
-            """Convert MACAddressField to String."""
-            return graphene.String()

--- a/nautobot/dcim/fields.py
+++ b/nautobot/dcim/fields.py
@@ -1,9 +1,10 @@
 from django.core.exceptions import ValidationError
-from django.core.validators import MinValueValidator, MaxValueValidator
+from django.core.validators import MaxLengthValidator, MaxValueValidator, MinValueValidator
 from django.db import models
 from netaddr import AddrFormatError, EUI, mac_unix_expanded
 
 from nautobot.ipam.constants import BGP_ASN_MAX, BGP_ASN_MIN
+from nautobot.utilities.deprecation import class_deprecated_in_favor_of
 from nautobot.utilities.fields import JSONArrayField
 from .lookups import PathContains
 
@@ -28,8 +29,48 @@ class mac_unix_expanded_uppercase(mac_unix_expanded):
     word_fmt = "%.2X"
 
 
+class MACAddressCharField(models.CharField):
+    description = "MAC Address Varchar field"
+
+    def __init__(self, *args, **kwargs):
+        kwargs["max_length"] = 18
+        super().__init__(*args, **kwargs)
+        for validator in list(self.validators):
+            # CharField will automatically add a MaxLengthValidator, but that doesn't work with EUI objects
+            if isinstance(validator, MaxLengthValidator):
+                self.validators.remove(validator)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        del kwargs["max_length"]
+        return name, path, args, kwargs
+
+    def python_type(self):
+        return EUI
+
+    def from_db_value(self, value, expression, connection):
+        return self.to_python(value)
+
+    def to_python(self, value):
+        if value is None:
+            return value
+        if isinstance(value, str):
+            value = value.strip()
+        try:
+            return EUI(value, version=48, dialect=mac_unix_expanded_uppercase)
+        except AddrFormatError:
+            raise ValidationError("Invalid MAC address format: {}".format(value))
+
+    def get_prep_value(self, value):
+        if not value:
+            return None
+        return str(self.to_python(value))
+
+
+# 2.0 TODO: remove this class, it's unused in core and plugins shouldn't be using it in their models
+@class_deprecated_in_favor_of(MACAddressCharField)
 class MACAddressField(models.Field):
-    description = "PostgreSQL MAC Address field"
+    description = "PostgreSQL-only MAC Address field"
 
     def python_type(self):
         return EUI
@@ -47,45 +88,6 @@ class MACAddressField(models.Field):
 
     def db_type(self, connection):
         return "macaddr"
-
-    def get_prep_value(self, value):
-        if not value:
-            return None
-        return str(self.to_python(value))
-
-
-class MACAddressCharField(models.CharField):
-    description = "MAC Address Varchar field"
-
-    def __init__(self, *args, **kwargs):
-        kwargs["max_length"] = 18
-        super().__init__(*args, **kwargs)
-
-    def deconstruct(self):
-        name, path, args, kwargs = super().deconstruct()
-        del kwargs["max_length"]
-        return name, path, args, kwargs
-
-    def python_type(self):
-        return EUI
-
-    @property
-    def validators(self):  # pylint: disable=invalid-overridden-method
-        # rely on db to validate len
-        return []
-
-    def from_db_value(self, value, expression, connection):
-        return self.to_python(value)
-
-    def to_python(self, value):
-        if value is None:
-            return value
-        if isinstance(value, str):
-            value = value.strip()
-        try:
-            return EUI(value, version=48, dialect=mac_unix_expanded_uppercase)
-        except AddrFormatError:
-            raise ValidationError("Invalid MAC address format: {}".format(value))
 
     def get_prep_value(self, value):
         if not value:

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -16,6 +16,7 @@ from django_filters.utils import get_model_field, resolve_field
 from mptt.models import MPTTModel
 from tree_queries.models import TreeNode
 
+from nautobot.dcim.fields import MACAddressCharField
 from nautobot.dcim.forms import MACAddressField
 from nautobot.extras.models import Tag
 from nautobot.utilities.constants import (
@@ -540,7 +541,7 @@ class BaseFilterSet(django_filters.FilterSet):
             models.TimeField: {"filter_class": MultiValueTimeFilter},
             models.URLField: {"filter_class": MultiValueCharFilter},
             models.UUIDField: {"filter_class": MultiValueUUIDFilter},
-            MACAddressField: {"filter_class": MultiValueMACAddressFilter},
+            MACAddressCharField: {"filter_class": MultiValueMACAddressFilter},
             TaggableManager: {"filter_class": TagFilter},
         }
     )

--- a/nautobot/utilities/tests/test_filters.py
+++ b/nautobot/utilities/tests/test_filters.py
@@ -6,7 +6,7 @@ from mptt.fields import TreeForeignKey
 from taggit.managers import TaggableManager
 
 from nautobot.dcim.choices import DeviceFaceChoices
-from nautobot.dcim.fields import MACAddressField
+from nautobot.dcim.fields import MACAddressCharField
 from nautobot.dcim.filters import DeviceFilterSet, SiteFilterSet
 from nautobot.dcim.models import (
     Device,
@@ -320,7 +320,7 @@ class TestModel(models.Model):
     datefield = models.DateField()
     datetimefield = models.DateTimeField()
     integerfield = models.IntegerField()
-    macaddressfield = MACAddressField()
+    macaddressfield = MACAddressCharField()
     textfield = models.TextField()
     timefield = models.TimeField()
     treeforeignkeyfield = TreeForeignKey(to="self", on_delete=models.CASCADE)


### PR DESCRIPTION
# Closes: #n/a
# What's Changed

@gsnider2195 pointed out in #2314 that pylint was warning about `MACAddressCharField.validators` because we were overriding a `@cached_property` with a `@property`. I dug into this and came up with the following set of changes/fixes:

- Instead of overriding the `validators` cached_property to always return an empty list, add logic in `MACAddressCharField.__init__` to just strip out the problematic validator from the (no longer overridden) `validators` list.
- Additionally, I realized on looking at this code, that after some of the early MySQL work back in 2021, we actually have two separate model field classes - `MACAddressCharField` (what `Interface` and `VMInterface` use now, compatible with both MySQL and PostgreSQL) but also still `MACAddressField` (Postgres-specific, should not be used). This led me to the following fixes:
  - Add `@class_deprecated_in_favor_of` decorator to `MACAddressField`. (This required swapping the order of `MACAddressField` and `MACAddressCharField` in `fields.py`, which makes the diff a bit confusing as they have a lot of duplicated code between them.)
  - Removed Graphene code for mapping the deprecated `MACAddressField` to a string. As far as I can tell `MACAddressCharField` already works fine as-is in GraphQL so we don't need an equivalent function for it.
  - Fixed filter logic in `utilities.filters` to correctly assign a `MultiValueMACAddressFilter` to instances of `MACAddressCharField` (previously it was incorrectly assigning it to instances of the *form* (not *model*) field of `dcim.forms.MACAddressField`, which would be a no-op since no models have a form field as part of the model fields.)
  - Fixed test-only data model in `utilities.tests.test_filters` to use a `MACAddressCharField` instead of a `MACAddressField`, since that matches what we actually use in our real models.


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design