### PR TITLE
Add docs directory to Poetry Build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ include = [
     "CONTRIBUTING.md",
     "LICENSE.txt",
     "NOTICE",
+    # Poetry by default will exclude these files as they are in .gitignore
+    "nautobot/project-static/docs/**/*",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2341 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Poetry skips files that are found in .gitignore, this tells the build to add the project-static/docs folder.
