### PR TITLE
Fix #2342, and updates for Poetry 1.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -137,7 +137,7 @@ RUN apt-get update && \
 # https://python-poetry.org/docs/master/#installing-with-the-official-installer
 # This also makes it so that Poetry will *not* be included in the "final" image since it's not installed to /usr/local/
 RUN curl -sSL https://install.python-poetry.org -o /tmp/install-poetry.py && \
-    python /tmp/install-poetry.py && \
+    python /tmp/install-poetry.py --version 1.2.0 && \
     rm -f /tmp/install-poetry.py
 
 # Add poetry install location to the $PATH

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -266,6 +266,7 @@ RUN pip install --no-deps --no-cache-dir /source/dist/*.whl && \
 # Remove Poetry's cache of PyPI files to keep image size down
 # poetry cache clear --no-interactive actually doesn't clear anything - see
 # https://github.com/python-poetry/poetry/issues/4998
+# hadolint ignore=DL4006
 RUN yes | poetry cache clear --all PyPI
 
 ################################ Stage: final (production-ready image)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -162,7 +162,7 @@ WORKDIR /source
 # pyuwsgi wheel doesn't support ssl so we build it from source
 # https://github.com/nautobot/nautobot/issues/193
 RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi==${PYUWSGI_VER} && \
-    poetry install --no-root --no-dev --no-ansi --extras all
+    poetry install --no-root --only main --no-ansi --extras all
 
 ################################ Stage: dependencies-dev-python (intermediate build target)
 # We need dev dependencies for building the docs but don't want them in the final build image
@@ -171,7 +171,7 @@ RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi==${PYUWSGI_VER} && \
 
 FROM dependencies as dependencies-dev-python
 
-# Development-specific dependencies of Nautobot
+# Add development-specific dependencies of Nautobot to the installation
 RUN poetry install --no-root --no-ansi --extras all
 
 ################################ Stage: build-docs (intermediate build target)
@@ -253,7 +253,7 @@ CMD ["nautobot-server", "runserver", "0.0.0.0:8080", "--insecure"]
 
 FROM dependencies-dev as dev
 
-RUN poetry install --no-ansi && \
+RUN poetry install --no-ansi --extras all && \
     rm -rf /source
 
 ################################ Stage: final-dev (development environment for Nautobot plugins)
@@ -262,6 +262,11 @@ FROM dependencies-dev as final-dev
 
 RUN pip install --no-deps --no-cache-dir /source/dist/*.whl && \
     rm -rf /source
+
+# Remove Poetry's cache of PyPI files to keep image size down
+# poetry cache clear --no-interactive actually doesn't clear anything - see
+# https://github.com/python-poetry/poetry/issues/4998
+RUN yes | poetry cache clear --all PyPI
 
 ################################ Stage: final (production-ready image)
 


### PR DESCRIPTION
# Closes: #2342 
# What's Changed

- Poetry 1.2.0 is released now
   - It has an underdocumented behavior change that `poetry install --extras ...` followed by `poetry install` (without any `--extras`) will result in Poetry removing the previously installed extras.
- Change our install of Nautobot itself in the `dev` image to account for this change
- `poetry install --no-dev` is deprecated in favor of `poetry install --only main`, so I've made that change.
- Add `poetry cache clear --all PyPI` to the `final-dev` image build, fixing #2342 (with a workaround for a couple of Poetry bugs)