### PR TITLE
Remove profile from mkdocs docker

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -78,8 +78,6 @@ services:
         - "15900:5900"
     shm_size: 2g
   mkdocs:
-    profiles:
-      - mkdocs
     image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
     entrypoint: "mkdocs serve -a '0.0.0.0:8001'"
     healthcheck:


### PR DESCRIPTION

# Closes: DNE
# What's Changed

There is a Docker profile assigned to the default Docker build. Additionally, there does not seem to be a way to enable the profile via invoke, which makes it difficult for the common Docker development workflow. 

# TODO
N/A