### PR TITLE
Remove cruft from Docker dev image; use no-binary pyuwsgi

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -296,8 +296,6 @@ jobs:
         uses: "actions/checkout@v2"
       - run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: "gitbranch"
-      - run: echo "##[set-output name=version;]$(egrep -m1 'file.*pyuwsgi-' poetry.lock | cut -f2 -d-)"
-        id: "pyuwsgi"
       - name: "Set up QEMU"
         uses: "docker/setup-qemu-action@v1"
       - name: "Set up Docker Buildx"
@@ -338,7 +336,6 @@ jobs:
           context: "."
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
-            PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
             POETRY_PARALLEL=true
       - name: "Docker Dev Metadata"
         id: "dockerdevmeta"
@@ -370,5 +367,4 @@ jobs:
           context: "."
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
-            PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
             POETRY_PARALLEL=true

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -61,8 +61,6 @@ jobs:
         uses: "actions/checkout@v2"
       - run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: "gitbranch"
-      - run: echo "##[set-output name=version;]$(egrep -m1 'file.*pyuwsgi-' poetry.lock | cut -f2 -d-)"
-        id: "pyuwsgi"
       - name: "Set up QEMU"
         uses: "docker/setup-qemu-action@v1"
       - name: "Set up Docker Buildx"
@@ -104,7 +102,6 @@ jobs:
           context: "."
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
-            PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
             POETRY_PARALLEL=false
       - name: "Docker Dev Metadata"
         id: "dockerdevmeta"
@@ -132,7 +129,6 @@ jobs:
           context: "."
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
-            PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
             POETRY_PARALLEL=false
 
   slack-notify:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,6 @@ jobs:
         uses: "actions/checkout@v2"
       - run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: "gitbranch"
-      - run: echo "##[set-output name=version;]$(egrep -m1 'file.*pyuwsgi-' poetry.lock | cut -f2 -d-)"
-        id: "pyuwsgi"
       - name: "Set up QEMU"
         uses: "docker/setup-qemu-action@v1"
       - name: "Set up Docker Buildx"
@@ -108,7 +106,6 @@ jobs:
           context: "."
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
-            PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
             POETRY_PARALLEL=false
       - name: "Docker Dev Metadata"
         id: "dockerdevmeta"
@@ -140,7 +137,6 @@ jobs:
           context: "."
           build-args: |
             PYTHON_VER=${{ matrix.python-version }}
-            PYUWSGI_VER=${{ steps.pyuwsgi.outputs.version }}
             POETRY_PARALLEL=false
 
   slack-notify:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
 ARG PYTHON_VER
-ARG PYUWSGI_VER
 
 ################################ Overview
 # This builds the following hierarchy of images:
@@ -101,13 +100,14 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install all OS package upgrades and dependencies needed to run Nautobot in production
 # hadolint ignore=DL3005,DL3008,DL3013
-RUN apt-get update && \
+RUN --mount=type=cache,target="/root/.cache/pip" \
+    apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y git mime-support curl libxml2 libmariadb3 openssl && \
     apt-get autoremove -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/* && \
-    pip --no-cache-dir install --upgrade pip wheel
+    pip install --upgrade pip wheel
 
 HEALTHCHECK --interval=5s --timeout=5s --start-period=5s --retries=1 CMD curl --fail http://localhost:8080/health/ || exit 1
 
@@ -121,7 +121,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 ################################ Stage: dependencies (intermediate build target)
 
 FROM base as dependencies
-ARG PYUWSGI_VER
 ARG POETRY_PARALLEL
 
 # Install development/install-time OS dependencies
@@ -136,7 +135,8 @@ RUN apt-get update && \
 # if we instead used "pip install poetry" it would install its own dependencies globally which may conflict with ours.
 # https://python-poetry.org/docs/master/#installing-with-the-official-installer
 # This also makes it so that Poetry will *not* be included in the "final" image since it's not installed to /usr/local/
-RUN curl -sSL https://install.python-poetry.org -o /tmp/install-poetry.py && \
+RUN --mount=type=cache,target="/root/.cache/pip" \
+    curl -sSL https://install.python-poetry.org -o /tmp/install-poetry.py && \
     python /tmp/install-poetry.py --version 1.2.0 && \
     rm -f /tmp/install-poetry.py
 
@@ -148,8 +148,11 @@ ENV PATH="${PATH}:/root/.local/bin"
 # unfortunately it seems to have some issues with installing/updating "requests" and "certifi"
 # while simultaneously atttempting to *use* those packages to install other packages.
 # This is disabled by default (safer), but can be re-enabled by setting POETRY_PARALLEL=true
+# pyuwsgi wheel doesn't support ssl so we build it from source
+# https://github.com/nautobot/nautobot/issues/193
 RUN poetry config virtualenvs.create false && \
-    poetry config installer.parallel ${POETRY_PARALLEL:-false}
+    poetry config installer.parallel ${POETRY_PARALLEL:-false} && \
+    poetry config installer.no-binary pyuwsgi
 
 COPY pyproject.toml poetry.lock README.md /source/
 
@@ -159,10 +162,10 @@ COPY examples /source/examples
 WORKDIR /source
 
 # Install (non-development) Python dependencies of Nautobot
-# pyuwsgi wheel doesn't support ssl so we build it from source
-# https://github.com/nautobot/nautobot/issues/193
-RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi==${PYUWSGI_VER} && \
-    poetry install --no-root --only main --no-ansi --extras all
+RUN --mount=type=cache,target="/root/.cache/pip" \
+    --mount=type=cache,target="/root/.cache/pypoetry" \
+    poetry install --no-root --only main --no-ansi --extras all && \
+    rm -rf /tmp/tmp*
 
 ################################ Stage: dependencies-dev-python (intermediate build target)
 # We need dev dependencies for building the docs but don't want them in the final build image
@@ -172,7 +175,12 @@ RUN pip install --no-cache-dir --no-binary=pyuwsgi pyuwsgi==${PYUWSGI_VER} && \
 FROM dependencies as dependencies-dev-python
 
 # Add development-specific dependencies of Nautobot to the installation
-RUN poetry install --no-root --no-ansi --extras all
+# Poetry 1.2.0 leaves files in /tmp after doing an install
+# https://github.com/python-poetry/poetry/issues/6425
+RUN --mount=type=cache,target="/root/.cache/pip" \
+    --mount=type=cache,target="/root/.cache/pypoetry" \
+    poetry install --no-root --no-ansi --extras all && \
+    rm -rf /tmp/tmp*
 
 ################################ Stage: build-docs (intermediate build target)
 # Docs get built as their own stage because again we need dev dependencies as a base but
@@ -253,8 +261,13 @@ CMD ["nautobot-server", "runserver", "0.0.0.0:8080", "--insecure"]
 
 FROM dependencies-dev as dev
 
-RUN poetry install --no-ansi --extras all && \
-    rm -rf /source
+# Poetry 1.2.0 leaves files in /tmp after doing an install
+# https://github.com/python-poetry/poetry/issues/6425
+RUN --mount=type=cache,target="/root/.cache/pip" \
+    --mount=type=cache,target="/root/.cache/pypoetry" \
+    poetry install --no-ansi --extras all && \
+    rm -rf /source && \
+    rm -rf /tmp/tmp*
 
 ################################ Stage: final-dev (development environment for Nautobot plugins)
 
@@ -262,12 +275,6 @@ FROM dependencies-dev as final-dev
 
 RUN pip install --no-deps --no-cache-dir /source/dist/*.whl && \
     rm -rf /source
-
-# Remove Poetry's cache of PyPI files to keep image size down
-# poetry cache clear --no-interactive actually doesn't clear anything - see
-# https://github.com/python-poetry/poetry/issues/4998
-# hadolint ignore=DL4006
-RUN yes | poetry cache clear --all PyPI
 
 ################################ Stage: final (production-ready image)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG PYTHON_VER
 
 ################################ Overview
@@ -100,14 +101,13 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install all OS package upgrades and dependencies needed to run Nautobot in production
 # hadolint ignore=DL3005,DL3008,DL3013
-RUN --mount=type=cache,target="/root/.cache/pip" \
-    apt-get update && \
+RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y git mime-support curl libxml2 libmariadb3 openssl && \
     apt-get autoremove -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --upgrade pip wheel
+    pip --no-cache-dir install --upgrade pip wheel
 
 HEALTHCHECK --interval=5s --timeout=5s --start-period=5s --retries=1 CMD curl --fail http://localhost:8080/health/ || exit 1
 

--- a/tasks.py
+++ b/tasks.py
@@ -151,7 +151,6 @@ def build(context, force_rm=False, cache=True, poetry_parallel=True, pull=False)
     command = (
         "build"
         f" --build-arg PYTHON_VER={context.nautobot.python_ver}"
-        f" --build-arg PYUWSGI_VER={get_dependency_version('pyuwsgi')}"
     )
 
     if not cache:
@@ -194,7 +193,6 @@ def buildx(
     command = (
         f"docker buildx build --platform {platforms} -t {tag} --target {target} --load -f ./docker/Dockerfile"
         f" --build-arg PYTHON_VER={context.nautobot.python_ver}"
-        f" --build-arg PYUWSGI_VER={get_dependency_version('pyuwsgi')}"
         " ."
     )
     if not cache:

--- a/tasks.py
+++ b/tasks.py
@@ -113,9 +113,12 @@ def docker_compose(context, command, **kwargs):
 
     print(f'Running docker-compose command "{command}"')
     compose_command = " \\\n    ".join(compose_command_tokens)
+    env = kwargs.pop("env", {})
+    env.update({"PYTHON_VER": context.nautobot.python_ver})
     if "hide" not in kwargs:
-        print(f"[dim]PYTHON_VER={context.nautobot.python_ver} \\\n    {compose_command}[/dim]")
-    return context.run(compose_command, env={"PYTHON_VER": context.nautobot.python_ver}, **kwargs)
+        env_str = " \\\n    ".join(f"{var}={value}" for var, value in env.items())
+        print(f"[dim]{env_str} \\\n    {compose_command}[/dim]")
+    return context.run(compose_command, env=env, **kwargs)
 
 
 def run_command(context, command, **kwargs):
@@ -148,10 +151,7 @@ def run_command(context, command, **kwargs):
 )
 def build(context, force_rm=False, cache=True, poetry_parallel=True, pull=False):
     """Build Nautobot docker image."""
-    command = (
-        "build"
-        f" --build-arg PYTHON_VER={context.nautobot.python_ver}"
-    )
+    command = f"build --build-arg PYTHON_VER={context.nautobot.python_ver}"
 
     if not cache:
         command += " --no-cache"
@@ -163,7 +163,7 @@ def build(context, force_rm=False, cache=True, poetry_parallel=True, pull=False)
         command += " --pull"
 
     print(f"Building Nautobot with Python {context.nautobot.python_ver}...")
-    docker_compose(context, command)
+    docker_compose(context, command, env={"DOCKER_BUILDKIT": "1", "COMPOSE_DOCKER_CLI_BUILD": "1"})
 
     # Build the docs so they are available.
     build_nautobot_docs(context)


### PR DESCRIPTION
# Closes: #DNE
# What's Changed

- Poetry 1.2 adds a `installer.no-binary` config option, which we can use to force a local build of pyuwsgi via Poetry, avoiding the need for a separate PYUWSGI_VER build argument and separate `pip install --no-binary pyuwsgi` command.
- Remove some more unneeded cruft from the `dev` and `final-dev` Docker images:
  - Unlike pip, Poetry doesn't have a `--no-cache-dir` option, and because it uses pip under the hood, various Poetry steps will populate both the pip and Poetry caches on disk. Rather than manually clean up these caches at the end of the build (as was incompletely implemented in #2349), use Docker buildkit [cache-mount](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mounttypecache) feature to essentially treat these directories as temporary filesystems that don't get propagated forward into the final image.
  - There is some interaction between Poetry 1.2.0, pip, and the `requests` library that results in certificate files being created in `/tmp` for each package Poetry installs. https://github.com/python-poetry/poetry/issues/6425 was closed, but as a workaround, it's simple enough to manually `rm -rf /tmp/tmp*` after each Poetry command we run.

As a result, the `dev`/`final-dev` image `/tmp` directory is once again empty, and the `/root/.cache/` directory is nearly empty as well, reducing the final image size by about 120 MB as compared to the 1.4.2 image:

```
root@bdbf0d213905:/source# ls /tmp
root@bdbf0d213905:/source# du -sh /root/.cache/
12K	/root/.cache/
```

```
docker image ls
REPOSITORY                          TAG                              IMAGE ID       CREATED          SIZE
networktocode/nautobot-dev-py3.7    local                            f6076c14a9d6   22 seconds ago   1.37GB
networktocode/nautobot-dev          1.4.2                            74d5c0da8dc7   46 hours ago     1.49GB
```

Also confirmed that `pyuwsgi` still supports SSL:

```
root@f815d36c2c05:/source# uwsgi --help | grep https
    --https-socket                          bind to the specified UNIX/TCP socket using HTTPS protocol
    --https-socket-modifier1                force the specified modifier1 when using HTTPS protocol
    --https-socket-modifier2                force the specified modifier2 when using HTTPS protocol
    --https                                 add an https router/server on the specified address with specified certificate and key
    --https2                                add an https/spdy router/server using keyval options
    --https-export-cert                     export uwsgi variable HTTPS_CC containing the raw client certificate
    --https-session-context                 set the session id context to the specified value
    --http-to-https                         add an http router/server on the specified address and redirect all of the requests to https
```

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] CI updates
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design