### PR TITLE
Removes source lookup from extras.jobs.Job

### DIFF
--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -111,9 +111,6 @@ class BaseJob:
         self.failed = False
         self._job_result = None
 
-        # Grab some info about the job
-        self.source = inspect.getsource(self.__class__)
-
         # Compile test methods and initialize results skeleton
         self.test_methods = []
 


### PR DESCRIPTION
Since source code is no longer displayed in Nautobot Jobs (see nautobot/nautobot/issues#1462), `inspect.getsource` is no longer needed. Additionally, `inspect.getsource` will throw an exception in some cases, such as dynamically created classes.

# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
This change removes source code lookups for extras.jobs.Job. Since the job source is no longer displayed in the job view, this lookup is not needed.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [ ] ~~Attached Screenshots, Payload Example~~
- [X] Unit, Integration Tests
- [ ] ~~Documentation Updates (when adding/changing features)~~
- [ ] ~~Example Plugin Updates (when adding/changing features)~~
- [ ] ~~Outline Remaining Work, Constraints from Design~~