### PR TITLE
Fix `AttributeError` on Dynamic Group detail view parent group containing child group filtered on single value.

### DIFF
--- a/changes/2299.fixed
+++ b/changes/2299.fixed
@@ -1,0 +1,1 @@
+Remove `render_filter()` method and `filter` field from table columns

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -324,47 +324,11 @@ class DynamicGroupMembershipTable(DynamicGroupTable):
             "operator",
             "name",
             "weight",
-            # "filter",  # FIXME(jathan): Revisit rendering this in a future release.
             "members",
             "description",
             "actions",
         )
         exclude = ("content_type",)
-
-    def render_filter(self, value, record):
-        """Turns the filter dict into a prettified list of HTML links."""
-        # Display an empty filter as None
-        if not value:
-            return None
-
-        # Use the filterset for the record to construct links to the objects used in the filter.
-        fs = record.group.filterset_class(record.filter, record.group.get_queryset())
-        fs.is_valid()  # Required or we don't get the inner form's `cleaned_data`
-
-        # Iterate over each key in the filter and extract the value from the inner form's
-        # cleaned_data`, calling `get_absolute_url()` on each to create links.
-        # TODO(jathan): If an instance doesn't have `get_absolute_url()` we're gonna have a bad time.
-        items = []
-        for field_name in record.filter:
-            filters = fs.form.cleaned_data[field_name]
-            links = []
-
-            for item in filters:
-                if isinstance(item, (str, int)):  # single-value char/int filter
-                    multi = False
-                    links.append(repr(item))
-                else:
-                    multi = True
-                    links.append(format_html('<a href="{}">{}</a>', item.get_absolute_url(), item))
-
-            # Only wrap the values in [] if it's a multi-value filter.
-            links_str = ", ".join(links)
-            if multi:
-                links_str = f"[{links_str}]"
-
-            items.append(f"{field_name.title()}: {links_str}")
-
-        return format_html("<br/>".join(items))
 
 
 DESCENDANTS_LINK = """

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -324,7 +324,7 @@ class DynamicGroupMembershipTable(DynamicGroupTable):
             "operator",
             "name",
             "weight",
-            "filter",
+            # "filter",  # FIXME(jathan): Revisit rendering this in a future release.
             "members",
             "description",
             "actions",

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -346,9 +346,22 @@ class DynamicGroupMembershipTable(DynamicGroupTable):
         # TODO(jathan): If an instance doesn't have `get_absolute_url()` we're gonna have a bad time.
         items = []
         for field_name in record.filter:
-            value = fs.form.cleaned_data[field_name]
-            links = [format_html('<a href="{}">{}</a>', item.get_absolute_url(), item) for item in value]
-            links_str = "[" + ", ".join(links) + "]"
+            filters = fs.form.cleaned_data[field_name]
+            links = []
+
+            for item in filters:
+                if isinstance(item, (str, int)):  # single-value char/int filter
+                    multi = False
+                    links.append(repr(item))
+                else:
+                    multi = True
+                    links.append(format_html('<a href="{}">{}</a>', item.get_absolute_url(), item))
+
+            # Only wrap the values in [] if it's a multi-value filter.
+            links_str = ", ".join(links)
+            if multi:
+                links_str = f"[{links_str}]"
+
             items.append(f"{field_name.title()}: {links_str}")
 
         return format_html("<br/>".join(items))


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2299 
# What's Changed

This removes the `filter` column and `render_filter()` method from `DynamicGroupMembershipTable`. The implementation is flawed and of questionable use in its current form and should be revisited in a future release.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design