### PR TITLE
Fix #2364: gracefully handle absence of Rich library in tasks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -19,8 +19,13 @@ import re
 from invoke import Collection, task as invoke_task
 from invoke.exceptions import Exit
 
-# Override built-in print function with rich's pretty-printer function
-from rich import print  # pylint: disable=redefined-builtin
+try:
+    # Override built-in print function with rich's pretty-printer function, if available
+    from rich import print  # pylint: disable=redefined-builtin
+
+    RICH_PRINT = True
+except ModuleNotFoundError:
+    RICH_PRINT = False
 
 
 def is_truthy(arg):
@@ -117,7 +122,10 @@ def docker_compose(context, command, **kwargs):
     env.update({"PYTHON_VER": context.nautobot.python_ver})
     if "hide" not in kwargs:
         env_str = " \\\n    ".join(f"{var}={value}" for var, value in env.items())
-        print(f"[dim]{env_str} \\\n    {compose_command}[/dim]")
+        if RICH_PRINT:
+            print(f"[dim]{env_str} \\\n    {compose_command}[/dim]")
+        else:
+            print(f"{env_str} \\\n    {compose_command}")
     return context.run(compose_command, env=env, **kwargs)
 
 


### PR DESCRIPTION
# Closes: #2364 
# What's Changed

Gracefully handle absence of `rich` library in `tasks.py`.

Without rich:

![image](https://user-images.githubusercontent.com/5603551/189360382-0f0e44ab-c23d-44d2-b19c-6d5e0af55448.png)

With rich:

![image](https://user-images.githubusercontent.com/5603551/189360441-6cefdc5d-a27b-4955-919c-06f06e38e0c0.png)


# TODO

- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design