### PR TITLE
Disable Cacheops by default.

### DIFF
--- a/nautobot/circuits/api/views.py
+++ b/nautobot/circuits/api/views.py
@@ -45,6 +45,7 @@ class CircuitTypeViewSet(NautobotModelViewSet):
 
 
 class CircuitViewSet(StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (for tags it should stay)
     queryset = Circuit.objects.prefetch_related(
         "status", "type", "tenant", "provider", "termination_a", "termination_z"
     ).prefetch_related("tags")
@@ -58,6 +59,7 @@ class CircuitViewSet(StatusViewSetMixin, NautobotModelViewSet):
 
 
 class CircuitTerminationViewSet(PathEndpointMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = CircuitTermination.objects.prefetch_related("circuit", "site", "_path__destination", "cable")
     serializer_class = serializers.CircuitTerminationSerializer
     filterset_class = filters.CircuitTerminationFilterSet

--- a/nautobot/circuits/models.py
+++ b/nautobot/circuits/models.py
@@ -370,6 +370,7 @@ class CircuitTermination(PrimaryModel, PathEndpoint, CableTermination):
     def get_peer_termination(self):
         peer_side = "Z" if self.term_side == "A" else "A"
         try:
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             return CircuitTermination.objects.prefetch_related("site").get(circuit=self.circuit, term_side=peer_side)
         except CircuitTermination.DoesNotExist:
             return None

--- a/nautobot/circuits/views.py
+++ b/nautobot/circuits/views.py
@@ -37,6 +37,7 @@ class CircuitTypeUIViewSet(
         # Circuits
         context = super().get_extra_context(request, instance)
         if self.action == "retrieve":
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             circuits = (
                 Circuit.objects.restrict(request.user, "view")
                 .filter(type=instance)
@@ -88,6 +89,7 @@ class ProviderUIViewSet(NautobotUIViewSet):
     def get_extra_context(self, request, instance):
         context = super().get_extra_context(request, instance)
         if self.action == "retrieve":
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             circuits = (
                 Circuit.objects.restrict(request.user, "view")
                 .filter(provider=instance)
@@ -113,6 +115,7 @@ class CircuitUIViewSet(NautobotUIViewSet):
     filterset_form_class = forms.CircuitFilterForm
     form_class = forms.CircuitForm
     lookup_field = "pk"
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     prefetch_related = ["provider", "type", "tenant", "termination_a", "termination_z"]
     queryset = Circuit.objects.all()
     serializer_class = serializers.CircuitSerializer
@@ -122,6 +125,7 @@ class CircuitUIViewSet(NautobotUIViewSet):
         context = super().get_extra_context(request, instance)
         if self.action == "retrieve":
             # A-side termination
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             termination_a = (
                 CircuitTermination.objects.restrict(request.user, "view")
                 .prefetch_related("site__region")
@@ -138,6 +142,7 @@ class CircuitUIViewSet(NautobotUIViewSet):
                 )
 
             # Z-side termination
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             termination_z = (
                 CircuitTermination.objects.restrict(request.user, "view")
                 .prefetch_related("site__region")
@@ -172,6 +177,7 @@ class ProviderNetworkUIViewSet(NautobotUIViewSet):
     def get_extra_context(self, request, instance):
         context = super().get_extra_context(request, instance)
         if self.action == "retrieve":
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             circuits = (
                 Circuit.objects.restrict(request.user, "view")
                 .filter(Q(termination_a__provider_network=instance.pk) | Q(termination_z__provider_network=instance.pk))

--- a/nautobot/core/api/authentication.py
+++ b/nautobot/core/api/authentication.py
@@ -17,6 +17,7 @@ class TokenAuthentication(authentication.TokenAuthentication):
     def authenticate_credentials(self, key):
         model = self.get_model()
         try:
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             token = model.objects.prefetch_related("user").get(key=key)
         except model.DoesNotExist:
             raise exceptions.AuthenticationFailed("Invalid token")

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -172,6 +172,8 @@ class BulkDestroyModelMixin:
 
 class ModelViewSetMixin:
     brief = False
+    # v2 TODO(jathan): Revisit whether this is still valid post-cacheops. Re: prefetch_related vs.
+    # select_related
     brief_prefetch_fields = []
 
     def get_serializer(self, *args, **kwargs):
@@ -201,6 +203,7 @@ class ModelViewSetMixin:
     def get_queryset(self):
         # If using brief mode, clear all prefetches from the queryset and append only brief_prefetch_fields (if any)
         if self.brief:
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             return super().get_queryset().prefetch_related(None).prefetch_related(*self.brief_prefetch_fields)
 
         return super().get_queryset()

--- a/nautobot/core/authentication.py
+++ b/nautobot/core/authentication.py
@@ -32,6 +32,7 @@ class ObjectPermissionBackend(ModelBackend):
         Return all permissions granted to the user by an ObjectPermission.
         """
         # Retrieve all assigned and enabled ObjectPermissions
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         object_permissions = ObjectPermission.objects.filter(
             Q(users=user_obj) | Q(groups__user=user_obj), enabled=True
         ).prefetch_related("object_types")

--- a/nautobot/core/constants.py
+++ b/nautobot/core/constants.py
@@ -72,6 +72,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "circuit",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": Circuit.objects.prefetch_related("type", "provider", "tenant", "terminations__site"),
                 "filterset": CircuitFilterSet,
                 "table": CircuitTable,
@@ -81,6 +82,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "providernetwork",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": ProviderNetwork.objects.prefetch_related("provider"),
                 "filterset": ProviderNetworkFilterSet,
                 "table": ProviderNetworkTable,
@@ -91,6 +93,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "site",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": Site.objects.prefetch_related("region", "tenant"),
                 "filterset": SiteFilterSet,
                 "table": SiteTable,
@@ -100,6 +103,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "rack",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": Rack.objects.prefetch_related("site", "group", "tenant", "role"),
                 "filterset": RackFilterSet,
                 "table": RackTable,
@@ -109,6 +113,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "rackgroup",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": RackGroup.objects.add_related_count(
                     RackGroup.objects.all(),
                     Rack,
@@ -124,6 +129,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "devicetype",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": DeviceType.objects.prefetch_related("manufacturer").annotate(
                     instance_count=count_related(Device, "device_type")
                 ),
@@ -135,6 +141,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "device",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": Device.objects.prefetch_related(
                     "device_type__manufacturer",
                     "device_role",
@@ -152,6 +159,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "virtualchassis",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": VirtualChassis.objects.prefetch_related("master").annotate(
                     member_count=count_related(Device, "virtual_chassis")
                 ),
@@ -182,6 +190,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "cluster",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": Cluster.objects.prefetch_related("type", "group").annotate(
                     device_count=count_related(Device, "cluster"),
                     vm_count=count_related(VirtualMachine, "cluster"),
@@ -194,6 +203,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "virtualmachine",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": VirtualMachine.objects.prefetch_related(
                     "cluster",
                     "tenant",
@@ -210,6 +220,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "vrf",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": VRF.objects.prefetch_related("tenant"),
                 "filterset": VRFFilterSet,
                 "table": VRFTable,
@@ -219,6 +230,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "aggregate",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": Aggregate.objects.prefetch_related("rir"),
                 "filterset": AggregateFilterSet,
                 "table": AggregateTable,
@@ -228,6 +240,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "prefix",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": Prefix.objects.prefetch_related("site", "vrf__tenant", "tenant", "vlan", "role"),
                 "filterset": PrefixFilterSet,
                 "table": PrefixTable,
@@ -237,6 +250,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "ipaddress",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": IPAddress.objects.prefetch_related("vrf__tenant", "tenant"),
                 "filterset": IPAddressFilterSet,
                 "table": IPAddressTable,
@@ -246,6 +260,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "vlan",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": VLAN.objects.prefetch_related("site", "group", "tenant", "role"),
                 "filterset": VLANFilterSet,
                 "table": VLANTable,
@@ -256,6 +271,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "tenant",
             {
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 "queryset": Tenant.objects.prefetch_related("group"),
                 "filterset": TenantFilterSet,
                 "table": TenantTable,

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -277,7 +277,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
-    "cacheops",
+    "cacheops",  # v2 TODO(jathan); Remove cacheops.
     "corsheaders",
     "django_filters",
     "django_jinja",
@@ -558,6 +558,7 @@ GRAPHQL_COMPUTED_FIELD_PREFIX = "cpf"
 # Caching
 #
 
+# v2 TODO(jathan): Remove all cacheops settings.
 # The django-cacheops plugin is used to cache querysets. The built-in Django
 # caching is not used.
 CACHEOPS = {
@@ -577,7 +578,7 @@ CACHEOPS = {
     "virtualization.*": {"ops": "all"},
 }
 CACHEOPS_DEGRADE_ON_FAILURE = True
-CACHEOPS_ENABLED = True
+CACHEOPS_ENABLED = False
 CACHEOPS_REDIS = "redis://localhost:6379/1"
 CACHEOPS_DEFAULTS = {"timeout": 900}
 

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -113,7 +113,7 @@ ALLOWED_URL_SCHEMES = (
 CACHEOPS_DEFAULTS = {"timeout": int(os.getenv("NAUTOBOT_CACHEOPS_TIMEOUT", "900"))}
 
 # Set to False to disable caching with cacheops. (Default: True)
-CACHEOPS_ENABLED = is_truthy(os.getenv("NAUTOBOT_CACHEOPS_ENABLED", "True"))
+CACHEOPS_ENABLED = is_truthy(os.getenv("NAUTOBOT_CACHEOPS_ENABLED", "False"))
 
 # If True, all origins will be allowed. Other settings restricting allowed origins will be ignored.
 # Defaults to False. Setting this to True can be dangerous, as it allows any website to make

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -62,8 +62,9 @@ CACHES = {
 # up top via `from nautobot.core.settings import *`.
 
 # REDIS CACHEOPS
+# v2 TODO(jathan): Remove all cacheops settings.
 CACHEOPS_REDIS = parse_redis_connection(redis_database=3)
-CACHEOPS_ENABLED = False  # TODO(john): we should revisit this, but caching has caused issues with testing
+CACHEOPS_ENABLED = False
 
 # Testing storages within cli.py
 STORAGE_CONFIG = {

--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -124,6 +124,7 @@ class PassThroughPortMixin:
         Return all CablePaths which traverse a given pass-through port.
         """
         obj = get_object_or_404(self.queryset, pk=pk)
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         cablepaths = CablePath.objects.filter(path__contains=obj).prefetch_related("origin", "destination")
         serializer = serializers.CablePathSerializer(cablepaths, context={"request": request}, many=True)
 
@@ -147,6 +148,7 @@ class RegionViewSet(NautobotModelViewSet):
 
 
 class SiteViewSet(StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Site.objects.prefetch_related("region", "status", "tenant", "tags").annotate(
         device_count=count_related(Device, "site"),
         rack_count=count_related(Rack, "site"),
@@ -165,6 +167,8 @@ class SiteViewSet(StatusViewSetMixin, NautobotModelViewSet):
 
 
 class LocationTypeViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (content_types should remain
+    # prefetch because it is m2m)
     queryset = LocationType.objects.prefetch_related("parent", "content_types")
     serializer_class = serializers.LocationTypeSerializer
     filterset_class = filters.LocationTypeFilterSet
@@ -176,6 +180,7 @@ class LocationTypeViewSet(NautobotModelViewSet):
 
 
 class LocationViewSet(StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Location.objects.prefetch_related("location_type", "parent", "site", "status")
     serializer_class = serializers.LocationSerializer
     filterset_class = filters.LocationFilterSet
@@ -187,6 +192,7 @@ class LocationViewSet(StatusViewSetMixin, NautobotModelViewSet):
 
 
 class RackGroupViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = RackGroup.objects.add_related_count(
         RackGroup.objects.all(), Rack, "group", "rack_count", cumulative=True
     ).prefetch_related("site")
@@ -211,6 +217,7 @@ class RackRoleViewSet(NautobotModelViewSet):
 
 
 class RackViewSet(StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags because it is m2m)
     queryset = Rack.objects.prefetch_related("site", "group__site", "status", "role", "tenant", "tags").annotate(
         device_count=count_related(Device, "rack"),
         powerfeed_count=count_related(PowerFeed, "rack"),
@@ -275,6 +282,7 @@ class RackViewSet(StatusViewSetMixin, NautobotModelViewSet):
 
 
 class RackReservationViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = RackReservation.objects.prefetch_related("rack", "user", "tenant")
     serializer_class = serializers.RackReservationSerializer
     filterset_class = filters.RackReservationFilterSet
@@ -305,11 +313,13 @@ class ManufacturerViewSet(NautobotModelViewSet):
 
 
 class DeviceTypeViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags because it is m2m)
     queryset = DeviceType.objects.prefetch_related("manufacturer", "tags").annotate(
         device_count=count_related(Device, "device_type")
     )
     serializer_class = serializers.DeviceTypeSerializer
     filterset_class = filters.DeviceTypeFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["manufacturer"]
 
 
@@ -319,48 +329,56 @@ class DeviceTypeViewSet(NautobotModelViewSet):
 
 
 class ConsolePortTemplateViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = ConsolePortTemplate.objects.prefetch_related("device_type__manufacturer")
     serializer_class = serializers.ConsolePortTemplateSerializer
     filterset_class = filters.ConsolePortTemplateFilterSet
 
 
 class ConsoleServerPortTemplateViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = ConsoleServerPortTemplate.objects.prefetch_related("device_type__manufacturer")
     serializer_class = serializers.ConsoleServerPortTemplateSerializer
     filterset_class = filters.ConsoleServerPortTemplateFilterSet
 
 
 class PowerPortTemplateViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = PowerPortTemplate.objects.prefetch_related("device_type__manufacturer")
     serializer_class = serializers.PowerPortTemplateSerializer
     filterset_class = filters.PowerPortTemplateFilterSet
 
 
 class PowerOutletTemplateViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = PowerOutletTemplate.objects.prefetch_related("device_type__manufacturer")
     serializer_class = serializers.PowerOutletTemplateSerializer
     filterset_class = filters.PowerOutletTemplateFilterSet
 
 
 class InterfaceTemplateViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = InterfaceTemplate.objects.prefetch_related("device_type__manufacturer")
     serializer_class = serializers.InterfaceTemplateSerializer
     filterset_class = filters.InterfaceTemplateFilterSet
 
 
 class FrontPortTemplateViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = FrontPortTemplate.objects.prefetch_related("device_type__manufacturer")
     serializer_class = serializers.FrontPortTemplateSerializer
     filterset_class = filters.FrontPortTemplateFilterSet
 
 
 class RearPortTemplateViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = RearPortTemplate.objects.prefetch_related("device_type__manufacturer")
     serializer_class = serializers.RearPortTemplateSerializer
     filterset_class = filters.RearPortTemplateFilterSet
 
 
 class DeviceBayTemplateViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = DeviceBayTemplate.objects.prefetch_related("device_type__manufacturer")
     serializer_class = serializers.DeviceBayTemplateSerializer
     filterset_class = filters.DeviceBayTemplateFilterSet
@@ -400,6 +418,7 @@ class PlatformViewSet(NautobotModelViewSet):
 
 
 class DeviceViewSet(ConfigContextQuerySetMixin, StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (extap tags because it is m2m)
     queryset = Device.objects.prefetch_related(
         "device_type__manufacturer",
         "device_role",
@@ -594,32 +613,40 @@ class DeviceViewSet(ConfigContextQuerySetMixin, StatusViewSetMixin, NautobotMode
 
 
 class ConsolePortViewSet(PathEndpointMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = ConsolePort.objects.prefetch_related("device", "_path__destination", "cable", "_cable_peer", "tags")
     serializer_class = serializers.ConsolePortSerializer
     filterset_class = filters.ConsolePortFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["device"]
 
 
 class ConsoleServerPortViewSet(PathEndpointMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = ConsoleServerPort.objects.prefetch_related(
         "device", "_path__destination", "cable", "_cable_peer", "tags"
     )
     serializer_class = serializers.ConsoleServerPortSerializer
     filterset_class = filters.ConsoleServerPortFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["device"]
 
 
 class PowerPortViewSet(PathEndpointMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = PowerPort.objects.prefetch_related("device", "_path__destination", "cable", "_cable_peer", "tags")
     serializer_class = serializers.PowerPortSerializer
     filterset_class = filters.PowerPortFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["device"]
 
 
 class PowerOutletViewSet(PathEndpointMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = PowerOutlet.objects.prefetch_related("device", "_path__destination", "cable", "_cable_peer", "tags")
     serializer_class = serializers.PowerOutletSerializer
     filterset_class = filters.PowerOutletFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["device"]
 
 
@@ -637,6 +664,7 @@ class PowerOutletViewSet(PathEndpointMixin, NautobotModelViewSet):
     update=extend_schema(responses={"200": serializers.InterfaceSerializerVersion12}, versions=["1.2", "1.3"]),
 )
 class InterfaceViewSet(PathEndpointMixin, NautobotModelViewSet, StatusViewSetMixin):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = Interface.objects.prefetch_related(
         "device",
         "parent_interface",
@@ -651,6 +679,7 @@ class InterfaceViewSet(PathEndpointMixin, NautobotModelViewSet, StatusViewSetMix
     )
     serializer_class = serializers.InterfaceSerializer
     filterset_class = filters.InterfaceFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["device"]
 
     def get_serializer_class(self):
@@ -665,30 +694,38 @@ class InterfaceViewSet(PathEndpointMixin, NautobotModelViewSet, StatusViewSetMix
 
 
 class FrontPortViewSet(PassThroughPortMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = FrontPort.objects.prefetch_related("device__device_type__manufacturer", "rear_port", "cable", "tags")
     serializer_class = serializers.FrontPortSerializer
     filterset_class = filters.FrontPortFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["device"]
 
 
 class RearPortViewSet(PassThroughPortMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = RearPort.objects.prefetch_related("device__device_type__manufacturer", "cable", "tags")
     serializer_class = serializers.RearPortSerializer
     filterset_class = filters.RearPortFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["device"]
 
 
 class DeviceBayViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = DeviceBay.objects.prefetch_related("installed_device").prefetch_related("tags")
     serializer_class = serializers.DeviceBaySerializer
     filterset_class = filters.DeviceBayFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["device"]
 
 
 class InventoryItemViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = InventoryItem.objects.prefetch_related("device", "manufacturer").prefetch_related("tags")
     serializer_class = serializers.InventoryItemSerializer
     filterset_class = filters.InventoryItemFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["device"]
 
 
@@ -698,18 +735,21 @@ class InventoryItemViewSet(NautobotModelViewSet):
 
 
 class ConsoleConnectionViewSet(ListModelMixin, GenericViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = ConsolePort.objects.prefetch_related("device", "_path").filter(_path__destination_id__isnull=False)
     serializer_class = serializers.ConsolePortSerializer
     filterset_class = filters.ConsoleConnectionFilterSet
 
 
 class PowerConnectionViewSet(ListModelMixin, GenericViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = PowerPort.objects.prefetch_related("device", "_path").filter(_path__destination_id__isnull=False)
     serializer_class = serializers.PowerPortSerializer
     filterset_class = filters.PowerConnectionFilterSet
 
 
 class InterfaceConnectionViewSet(ListModelMixin, GenericViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Interface.objects.prefetch_related("device", "_path").filter(
         # Avoid duplicate connections by only selecting the lower PK in a connected pair
         _path__destination_id__isnull=False,
@@ -725,6 +765,7 @@ class InterfaceConnectionViewSet(ListModelMixin, GenericViewSet):
 
 
 class CableViewSet(StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Cable.objects.prefetch_related("status", "termination_a", "termination_b")
     serializer_class = serializers.CableSerializer
     filterset_class = filters.CableFilterSet
@@ -741,6 +782,7 @@ class VirtualChassisViewSet(NautobotModelViewSet):
     )
     serializer_class = serializers.VirtualChassisSerializer
     filterset_class = filters.VirtualChassisFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["master"]
 
 
@@ -750,6 +792,7 @@ class VirtualChassisViewSet(NautobotModelViewSet):
 
 
 class PowerPanelViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = PowerPanel.objects.prefetch_related("site", "rack_group").annotate(
         powerfeed_count=count_related(PowerFeed, "power_panel")
     )
@@ -763,6 +806,7 @@ class PowerPanelViewSet(NautobotModelViewSet):
 
 
 class PowerFeedViewSet(PathEndpointMixin, StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = PowerFeed.objects.prefetch_related(
         "power_panel",
         "rack",

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -948,6 +948,7 @@ class RackReservationFilterForm(NautobotFilterForm, TenancyFilterForm):
         query_params={"region": "$region"},
     )
     group_id = DynamicModelMultipleChoiceField(
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         queryset=RackGroup.objects.prefetch_related("site"),
         required=False,
         label="Rack group",
@@ -1893,6 +1894,7 @@ class DeviceForm(LocatableModelFormMixin, NautobotModelForm, TenancyForm, LocalC
                 interface_ids = self.instance.vc_interfaces.values_list("pk", flat=True)
 
                 # Collect interface IPs
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 interface_ips = (
                     IPAddress.objects.ip_family(family)
                     .filter(
@@ -1905,6 +1907,7 @@ class DeviceForm(LocatableModelFormMixin, NautobotModelForm, TenancyForm, LocalC
                     ip_list = [(ip.id, f"{ip.address} ({ip.assigned_object})") for ip in interface_ips]
                     ip_choices.append(("Interface IPs", ip_list))
                 # Collect NAT IPs
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 nat_ips = (
                     IPAddress.objects.prefetch_related("nat_inside")
                     .ip_family(family)
@@ -2945,6 +2948,7 @@ class InterfaceBulkEditForm(
             # See netbox-community/netbox#4523
             if "pk" in self.initial:
                 site = None
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 interfaces = Interface.objects.filter(pk__in=self.initial["pk"]).prefetch_related("device__site")
 
                 # Check interface sites.  First interface should set site, further interfaces will either continue the

--- a/nautobot/dcim/models/racks.py
+++ b/nautobot/dcim/models/racks.py
@@ -455,6 +455,7 @@ class Rack(PrimaryModel, StatusModel):
 
             # Retrieve all devices installed within the rack
             queryset = (
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 Device.objects.prefetch_related("device_type", "device_type__manufacturer", "device_role")
                 .annotate(devicebay_count=Count("devicebays"))
                 .exclude(pk=exclude)
@@ -497,6 +498,7 @@ class Rack(PrimaryModel, StatusModel):
         :param exclude: List of devices IDs to exclude (useful when moving a device within a rack)
         """
         # Gather all devices which consume U space within the rack
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         devices = self.devices.prefetch_related("device_type").filter(position__gte=1)
         if exclude is not None:
             devices = devices.exclude(pk__in=exclude)

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -150,6 +150,7 @@ class RegionView(generic.ObjectView):
     def get_extra_context(self, request, instance):
 
         # Sites
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         sites = (
             Site.objects.restrict(request.user, "view")
             .filter(region__in=instance.get_descendants(include_self=True))
@@ -203,6 +204,7 @@ class SiteListView(generic.ObjectListView):
 
 
 class SiteView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Site.objects.prefetch_related("region", "tenant__group")
 
     def get_extra_context(self, request, instance):
@@ -219,6 +221,7 @@ class SiteView(generic.ObjectView):
             .restrict(request.user, "view")
             .filter(site=instance)
         )
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         locations = (
             Location.objects.restrict(request.user, "view")
             .filter(site=instance)
@@ -257,6 +260,7 @@ class SiteBulkImportView(generic.BulkImportView):
 
 
 class SiteBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Site.objects.prefetch_related("region", "tenant")
     filterset = filters.SiteFilterSet
     table = tables.SiteTable
@@ -264,6 +268,7 @@ class SiteBulkEditView(generic.BulkEditView):
 
 
 class SiteBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Site.objects.prefetch_related("region", "tenant")
     filterset = filters.SiteFilterSet
     table = tables.SiteTable
@@ -285,9 +290,11 @@ class LocationTypeView(generic.ObjectView):
     queryset = LocationType.objects.all()
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         children = (
             LocationType.objects.restrict(request.user, "view").filter(parent=instance).prefetch_related("parent")
         )
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         locations = (
             Location.objects.restrict(request.user, "view")
             .filter(location_type=instance)
@@ -338,6 +345,7 @@ class LocationTypeBulkDeleteView(generic.BulkDeleteView):
 
 
 class LocationListView(generic.ObjectListView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Location.objects.prefetch_related("location_type", "parent", "site", "tenant")
     filterset = filters.LocationFilterSet
     filterset_form = forms.LocationFilterForm
@@ -372,6 +380,7 @@ class LocationView(generic.ObjectView):
             .restrict(request.user, "view")
             .filter(location__in=related_locations)
         )
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         children = (
             Location.objects.restrict(request.user, "view")
             .filter(parent=instance)
@@ -404,6 +413,7 @@ class LocationDeleteView(generic.ObjectDeleteView):
 
 
 class LocationBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Location.objects.prefetch_related("location_type", "parent", "site", "tenant")
     filterset = filters.LocationFilterSet
     table = tables.LocationTable
@@ -417,6 +427,7 @@ class LocationBulkImportView(generic.BulkImportView):
 
 
 class LocationBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Location.objects.prefetch_related("location_type", "parent", "site", "tenant")
     filterset = filters.LocationFilterSet
     table = tables.LocationTable
@@ -442,6 +453,7 @@ class RackGroupView(generic.ObjectView):
     def get_extra_context(self, request, instance):
 
         # Racks
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         racks = (
             Rack.objects.restrict(request.user, "view")
             .filter(group__in=instance.get_descendants(include_self=True))
@@ -478,6 +490,7 @@ class RackGroupBulkImportView(generic.BulkImportView):
 
 
 class RackGroupBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = RackGroup.objects.add_related_count(
         RackGroup.objects.all(), Rack, "group", "rack_count", cumulative=True
     ).prefetch_related("site")
@@ -502,6 +515,7 @@ class RackRoleView(generic.ObjectView):
     def get_extra_context(self, request, instance):
 
         # Racks
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         racks = (
             Rack.objects.restrict(request.user, "view")
             .filter(role=instance)
@@ -548,6 +562,7 @@ class RackRoleBulkDeleteView(generic.BulkDeleteView):
 
 
 class RackListView(generic.ObjectListView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Rack.objects.prefetch_related("site", "group", "tenant", "role", "devices__device_type").annotate(
         device_count=count_related(Device, "rack")
     )
@@ -561,6 +576,7 @@ class RackElevationListView(generic.ObjectListView):
     Display a set of rack elevations side-by-side.
     """
 
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Rack.objects.prefetch_related("role")
     non_filter_params = (
         *generic.ObjectListView.non_filter_params,
@@ -618,10 +634,12 @@ class RackElevationListView(generic.ObjectListView):
 
 
 class RackView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Rack.objects.prefetch_related("site__region", "tenant__group", "group", "role")
 
     def get_extra_context(self, request, instance):
         # Get 0U and child devices located within the rack
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         nonracked_devices = Device.objects.filter(rack=instance, position__isnull=True).prefetch_related(
             "device_type__manufacturer"
         )
@@ -636,6 +654,7 @@ class RackView(generic.ObjectView):
         prev_rack = peer_racks.filter(name__lt=instance.name).order_by("-name").first()
 
         reservations = RackReservation.objects.restrict(request.user, "view").filter(rack=instance)
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         power_feeds = (
             PowerFeed.objects.restrict(request.user, "view").filter(rack=instance).prefetch_related("power_panel")
         )
@@ -669,6 +688,7 @@ class RackBulkImportView(generic.BulkImportView):
 
 
 class RackBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Rack.objects.prefetch_related("site", "group", "tenant", "role")
     filterset = filters.RackFilterSet
     table = tables.RackTable
@@ -676,6 +696,7 @@ class RackBulkEditView(generic.BulkEditView):
 
 
 class RackBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Rack.objects.prefetch_related("site", "group", "tenant", "role")
     filterset = filters.RackFilterSet
     table = tables.RackTable
@@ -694,6 +715,7 @@ class RackReservationListView(generic.ObjectListView):
 
 
 class RackReservationView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = RackReservation.objects.prefetch_related("rack")
 
 
@@ -731,6 +753,7 @@ class RackReservationImportView(generic.BulkImportView):
 
 
 class RackReservationBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = RackReservation.objects.prefetch_related("rack", "user")
     filterset = filters.RackReservationFilterSet
     table = tables.RackReservationTable
@@ -738,6 +761,7 @@ class RackReservationBulkEditView(generic.BulkEditView):
 
 
 class RackReservationBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = RackReservation.objects.prefetch_related("rack", "user")
     filterset = filters.RackReservationFilterSet
     table = tables.RackReservationTable
@@ -764,6 +788,7 @@ class ManufacturerView(generic.ObjectView):
     def get_extra_context(self, request, instance):
 
         # Devices
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         devices = (
             Device.objects.restrict(request.user, "view")
             .filter(device_type__manufacturer=instance)
@@ -809,6 +834,7 @@ class ManufacturerBulkDeleteView(generic.BulkDeleteView):
 
 
 class DeviceTypeListView(generic.ObjectListView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = DeviceType.objects.prefetch_related("manufacturer").annotate(
         instance_count=count_related(Device, "device_type")
     )
@@ -818,6 +844,7 @@ class DeviceTypeListView(generic.ObjectListView):
 
 
 class DeviceTypeView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = DeviceType.objects.prefetch_related("manufacturer")
 
     def get_extra_context(self, request, instance):
@@ -918,6 +945,7 @@ class DeviceTypeImportView(generic.ObjectImportView):
 
 
 class DeviceTypeBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = DeviceType.objects.prefetch_related("manufacturer").annotate(
         instance_count=count_related(Device, "device_type")
     )
@@ -927,6 +955,7 @@ class DeviceTypeBulkEditView(generic.BulkEditView):
 
 
 class DeviceTypeBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = DeviceType.objects.prefetch_related("manufacturer").annotate(
         instance_count=count_related(Device, "device_type")
     )
@@ -1242,6 +1271,7 @@ class DeviceRoleView(generic.ObjectView):
     def get_extra_context(self, request, instance):
 
         # Devices
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         devices = (
             Device.objects.restrict(request.user, "view")
             .filter(device_role=instance)
@@ -1302,6 +1332,7 @@ class PlatformView(generic.ObjectView):
     def get_extra_context(self, request, instance):
 
         # Devices
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         devices = (
             Device.objects.restrict(request.user, "view")
             .filter(platform=instance)
@@ -1355,6 +1386,7 @@ class DeviceListView(generic.ObjectListView):
 
 
 class DeviceView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Device.objects.prefetch_related(
         "site__region",
         "rack__group",
@@ -1392,6 +1424,7 @@ class DeviceConsolePortsView(generic.ObjectView):
     template_name = "dcim/device/consoleports.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         consoleports = (
             ConsolePort.objects.restrict(request.user, "view")
             .filter(device=instance)
@@ -1415,6 +1448,7 @@ class DeviceConsoleServerPortsView(generic.ObjectView):
     template_name = "dcim/device/consoleserverports.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         consoleserverports = (
             ConsoleServerPort.objects.restrict(request.user, "view")
             .filter(device=instance)
@@ -1442,6 +1476,7 @@ class DevicePowerPortsView(generic.ObjectView):
     template_name = "dcim/device/powerports.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         powerports = (
             PowerPort.objects.restrict(request.user, "view")
             .filter(device=instance)
@@ -1465,6 +1500,7 @@ class DevicePowerOutletsView(generic.ObjectView):
     template_name = "dcim/device/poweroutlets.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         poweroutlets = (
             PowerOutlet.objects.restrict(request.user, "view")
             .filter(device=instance)
@@ -1489,6 +1525,8 @@ class DeviceInterfacesView(generic.ObjectView):
     template_name = "dcim/device/interfaces.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related (except
+        # tags/ip_address/member_interfaces: m2m)
         interfaces = instance.vc_interfaces.restrict(request.user, "view").prefetch_related(
             Prefetch("ip_addresses", queryset=IPAddress.objects.restrict(request.user)),
             Prefetch("member_interfaces", queryset=Interface.objects.restrict(request.user)),
@@ -1514,6 +1552,7 @@ class DeviceFrontPortsView(generic.ObjectView):
     template_name = "dcim/device/frontports.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         frontports = (
             FrontPort.objects.restrict(request.user, "view")
             .filter(device=instance)
@@ -1537,6 +1576,7 @@ class DeviceRearPortsView(generic.ObjectView):
     template_name = "dcim/device/rearports.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         rearports = RearPort.objects.restrict(request.user, "view").filter(device=instance).prefetch_related("cable")
         rearport_table = tables.DeviceRearPortTable(data=rearports, user=request.user, orderable=False)
         if request.user.has_perm("dcim.change_rearport") or request.user.has_perm("dcim.delete_rearport"):
@@ -1553,6 +1593,7 @@ class DeviceDeviceBaysView(generic.ObjectView):
     template_name = "dcim/device/devicebays.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         devicebays = (
             DeviceBay.objects.restrict(request.user, "view")
             .filter(device=instance)
@@ -1575,6 +1616,7 @@ class DeviceInventoryView(generic.ObjectView):
     template_name = "dcim/device/inventory.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         inventoryitems = (
             InventoryItem.objects.restrict(request.user, "view")
             .filter(device=instance)
@@ -1607,6 +1649,7 @@ class DeviceLLDPNeighborsView(generic.ObjectView):
     template_name = "dcim/device/lldp_neighbors.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         interfaces = (
             instance.vc_interfaces.restrict(request.user, "view")
             .prefetch_related("_path__destination")
@@ -1675,6 +1718,7 @@ class ChildDeviceBulkImportView(generic.BulkImportView):
 
 
 class DeviceBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Device.objects.prefetch_related(
         "tenant", "site", "rack", "device_role", "device_type__manufacturer", "secrets_group"
     )
@@ -1684,6 +1728,7 @@ class DeviceBulkEditView(generic.BulkEditView):
 
 
 class DeviceBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Device.objects.prefetch_related("tenant", "site", "rack", "device_role", "device_type__manufacturer")
     filterset = filters.DeviceFilterSet
     table = tables.DeviceTable
@@ -1963,6 +2008,7 @@ class InterfaceView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Get assigned IP addresses
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         ipaddress_table = InterfaceIPAddressTable(
             data=instance.ip_addresses.restrict(request.user, "view").prefetch_related("vrf", "tenant"),
             orderable=False,
@@ -1977,6 +2023,8 @@ class InterfaceView(generic.ObjectView):
         if instance.untagged_vlan is not None:
             vlans.append(instance.untagged_vlan)
             vlans[0].tagged = False
+
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         for vlan in instance.tagged_vlans.restrict(request.user).prefetch_related("site", "group", "tenant", "role"):
             vlan.tagged = True
             vlans.append(vlan)
@@ -2354,6 +2402,7 @@ class InventoryItemBulkImportView(generic.BulkImportView):
 
 
 class InventoryItemBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = InventoryItem.objects.prefetch_related("device", "manufacturer")
     filterset = filters.InventoryItemFilterSet
     table = tables.InventoryItemTable
@@ -2365,6 +2414,7 @@ class InventoryItemBulkRenameView(generic.BulkRenameView):
 
 
 class InventoryItemBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = InventoryItem.objects.prefetch_related("device", "manufacturer")
     table = tables.InventoryItemTable
     template_name = "dcim/inventoryitem_bulk_delete.html"
@@ -2514,6 +2564,7 @@ class PathTraceView(generic.ObjectView):
 
         # Otherwise, find all CablePaths which traverse the specified object
         else:
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             related_paths = CablePath.objects.filter(path__contains=instance).prefetch_related("origin")
             # Check for specification of a particular path (when tracing pass-through ports)
             try:
@@ -2629,6 +2680,7 @@ class CableBulkImportView(generic.BulkImportView):
 
 
 class CableBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Cable.objects.prefetch_related("termination_a", "termination_b")
     filterset = filters.CableFilterSet
     table = tables.CableTable
@@ -2636,6 +2688,7 @@ class CableBulkEditView(generic.BulkEditView):
 
 
 class CableBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Cable.objects.prefetch_related("termination_a", "termination_b")
     filterset = filters.CableFilterSet
     table = tables.CableTable
@@ -2791,6 +2844,7 @@ class InterfaceConnectionsListView(ConnectionsListView):
 
 
 class VirtualChassisListView(generic.ObjectListView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VirtualChassis.objects.prefetch_related("master").annotate(
         member_count=count_related(Device, "virtual_chassis")
     )
@@ -2831,6 +2885,7 @@ class VirtualChassisEditView(ObjectPermissionRequiredMixin, GetReturnURLMixin, V
             formset=forms.BaseVCMemberFormSet,
             extra=0,
         )
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         members_queryset = virtual_chassis.members.prefetch_related("rack").order_by("vc_position")
 
         vc_form = forms.VirtualChassisForm(instance=virtual_chassis)
@@ -2856,6 +2911,7 @@ class VirtualChassisEditView(ObjectPermissionRequiredMixin, GetReturnURLMixin, V
             formset=forms.BaseVCMemberFormSet,
             extra=0,
         )
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         members_queryset = virtual_chassis.members.prefetch_related("rack").order_by("vc_position")
 
         vc_form = forms.VirtualChassisForm(request.POST, instance=virtual_chassis)
@@ -3044,6 +3100,7 @@ class VirtualChassisBulkDeleteView(generic.BulkDeleteView):
 
 
 class PowerPanelListView(generic.ObjectListView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = PowerPanel.objects.prefetch_related("site", "rack_group").annotate(
         powerfeed_count=count_related(PowerFeed, "power_panel")
     )
@@ -3056,6 +3113,7 @@ class PowerPanelView(generic.ObjectView):
     queryset = PowerPanel.objects.prefetch_related("site", "rack_group")
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         power_feeds = PowerFeed.objects.restrict(request.user).filter(power_panel=instance).prefetch_related("rack")
         powerfeed_table = tables.PowerFeedTable(data=power_feeds, orderable=False)
         powerfeed_table.exclude = ["power_panel"]
@@ -3082,6 +3140,7 @@ class PowerPanelBulkImportView(generic.BulkImportView):
 
 
 class PowerPanelBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = PowerPanel.objects.prefetch_related("site", "rack_group")
     filterset = filters.PowerPanelFilterSet
     table = tables.PowerPanelTable
@@ -3089,6 +3148,7 @@ class PowerPanelBulkEditView(generic.BulkEditView):
 
 
 class PowerPanelBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = PowerPanel.objects.prefetch_related("site", "rack_group").annotate(
         powerfeed_count=count_related(PowerFeed, "power_panel")
     )
@@ -3109,6 +3169,7 @@ class PowerFeedListView(generic.ObjectListView):
 
 
 class PowerFeedView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = PowerFeed.objects.prefetch_related("power_panel", "rack")
 
 
@@ -3129,6 +3190,7 @@ class PowerFeedBulkImportView(generic.BulkImportView):
 
 
 class PowerFeedBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = PowerFeed.objects.prefetch_related("power_panel", "rack")
     filterset = filters.PowerFeedFilterSet
     table = tables.PowerFeedTable
@@ -3136,6 +3198,7 @@ class PowerFeedBulkEditView(generic.BulkEditView):
 
 
 class PowerFeedBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = PowerFeed.objects.prefetch_related("power_panel", "rack")
     filterset = filters.PowerFeedFilterSet
     table = tables.PowerFeedTable

--- a/nautobot/docs/additional-features/caching.md
+++ b/nautobot/docs/additional-features/caching.md
@@ -10,7 +10,10 @@ Nautobot makes extensive use of caching; this is not a simple topic but it's a u
 
 ## How it Works
 
-Nautobot supports database query caching using [`django-cacheops`](https://github.com/Suor/django-cacheops) and Redis. When a query is made, the results are cached in Redis for a short period of time, as defined by the [`CACHEOPS_DEFAULTS`](../configuration/optional-settings.md#cacheops_defaults) parameter (15 minutes by default). Within that time, all recurrences of that specific query will return the pre-fetched results from the cache. Caching can be enabled by toggling [`CACHEOPS_ENABLED`](../configuration/optional-settings.md#cacheops_enabled) to `True` (it is `False` by default).
+Nautobot optionally supports database query caching using [`django-cacheops`](https://github.com/Suor/django-cacheops) and Redis. Caching can be enabled by toggling [`CACHEOPS_ENABLED`](../configuration/optional-settings.md#cacheops_enabled) to `True` (it is `False` by default). When caching is enabled, and a query is made, the results are cached in Redis for a short period of time, as defined by the [`CACHEOPS_DEFAULTS`](../configuration/optional-settings.md#cacheops_defaults) parameter (15 minutes by default). Within that time, all recurrences of that specific query will return the pre-fetched results from the cache.
+
+!!! caution "Changed in version 1.5.0"
+    Query caching is now disabled by default, and will be removed as a supported option in a future release.
 
 If a change is made to any of the objects returned by the cached query within that time, or if the timeout expires, the cached results are automatically invalidated and the next request for those results will be sent to the database.
 

--- a/nautobot/docs/additional-features/caching.md
+++ b/nautobot/docs/additional-features/caching.md
@@ -10,7 +10,7 @@ Nautobot makes extensive use of caching; this is not a simple topic but it's a u
 
 ## How it Works
 
-Nautobot supports database query caching using [`django-cacheops`](https://github.com/Suor/django-cacheops) and Redis. When a query is made, the results are cached in Redis for a short period of time, as defined by the [`CACHEOPS_DEFAULTS`](../configuration/optional-settings.md#cacheops_defaults) parameter (15 minutes by default). Within that time, all recurrences of that specific query will return the pre-fetched results from the cache. Caching can be completely disabled by toggling [`CACHEOPS_ENABLED`](../configuration/optional-settings.md#cacheops_enabled) to `False` (it is `True` by default).
+Nautobot supports database query caching using [`django-cacheops`](https://github.com/Suor/django-cacheops) and Redis. When a query is made, the results are cached in Redis for a short period of time, as defined by the [`CACHEOPS_DEFAULTS`](../configuration/optional-settings.md#cacheops_defaults) parameter (15 minutes by default). Within that time, all recurrences of that specific query will return the pre-fetched results from the cache. Caching can be enabled by toggling [`CACHEOPS_ENABLED`](../configuration/optional-settings.md#cacheops_enabled) to `True` (it is `False` by default).
 
 If a change is made to any of the objects returned by the cached query within that time, or if the timeout expires, the cached results are automatically invalidated and the next request for those results will be sent to the database.
 
@@ -43,7 +43,7 @@ For more information on the required settings needed to configure Cacheops, plea
 The optional settings include:
 
 * [`CACHEOPS_DEFAULTS`](../configuration/optional-settings.md#cacheops_defaults): To define the cache timeout value (Defaults to 15 minutes)
-* [`CACHEOPS_ENABLED`](../configuration/optional-settings.md#cacheops_enabled) : To turn on/off caching (Defaults to `True`)
+* [`CACHEOPS_ENABLED`](../configuration/optional-settings.md#cacheops_enabled) : To turn on/off caching (Defaults to `False`)
 
 ## Invalidating Cached Data
 

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -185,11 +185,14 @@ Various defaults for caching, the most important of which being the cache timeou
 
 ## CACHEOPS_ENABLED
 
-Default: `True`
+Default: `False`
 
 Environment Variable: `NAUTOBOT_CACHEOPS_ENABLED`
 
 A boolean that turns on/off caching.
+
+!!! check "Changed in 1.5.0"
+    Cachopes is disabled by default and will be removed entirely in a future release.
 
 If set to `False`, all caching is bypassed and Nautobot operates as if there is no cache.
 

--- a/nautobot/docs/development/extending-models.md
+++ b/nautobot/docs/development/extending-models.md
@@ -41,6 +41,7 @@ Add the name of the new field to `csv_headers` and included a CSV-friendly repre
 
 ## 4. Update relevant querysets
 
+<!-- v2 TODO(jathan): Replace prefetch_related with select_related -->
 If you're adding a relational field (e.g. `ForeignKey`) and intend to include the data when retrieving a list of objects, be sure to include the field using `prefetch_related()` as appropriate. This will optimize the view and avoid extraneous database queries.
 
 ## 5. Update API serializer

--- a/nautobot/docs/release-notes/version-1.5.md
+++ b/nautobot/docs/release-notes/version-1.5.md
@@ -12,6 +12,17 @@ If you are a user migrating from NetBox to Nautobot, please refer to the ["Migra
 
 ### Changed
 
+#### Database Query Caching is now Disabled by Default
+
+In prior versions of Nautobot, database query caching using the [`django-cacheops`](https://github.com/Suor/django-cacheops) application (aka Cacheops) was enabled by default. This is determined by the default value of the [`CACHEOPS_ENABLED`](../configuration/optional-settings.md#cacheops_enabled) setting being set to `True`.
+
+Through much trial and error we ultimately decided that this feature is more trouble than it is worth and we have begun to put more emphasis on improving performance of complex database queries over continuing to rely upon the various benefits and pitfalls of utilizing Cacheops.
+
+As a result, the value of this setting now defaults to `False`, disabling database query caching entirely for new deployments. Cacheops will be removed entirely in a future release.
+
+!!! important
+    Users with existing `nautobot_config.py` files generated from earlier versions of Nautobot will still have `CACHEOPS_ENABLED = True` unless they modify or regenerate their configuration. If users no longer desire caching, please be sure to explicitly toggle the value of this setting to `False` and restart your Nautobot services.
+
 ### Fixed
 
 ### Removed

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -174,6 +174,8 @@ class ConfigContextQuerySetMixin:
 
 
 class ConfigContextViewSet(ModelViewSet, NotesViewSetMixin):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except the
+    # plural ones are b2 m2m)
     queryset = ConfigContext.objects.prefetch_related(
         "regions",
         "sites",
@@ -326,6 +328,7 @@ class DynamicGroupViewSet(ModelViewSet, NotesViewSetMixin):
     Manage Dynamic Groups through DELETE, GET, POST, PUT, and PATCH requests.
     """
 
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = DynamicGroup.objects.prefetch_related("content_type")
     serializer_class = serializers.DynamicGroupSerializer
     filterset_class = filters.DynamicGroupFilterSet
@@ -351,6 +354,7 @@ class DynamicGroupMembershipViewSet(ModelViewSet):
     Manage Dynamic Group Memberships through DELETE, GET, POST, PUT, and PATCH requests.
     """
 
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = DynamicGroupMembership.objects.prefetch_related("group", "parent_group")
     serializer_class = serializers.DynamicGroupMembershipSerializer
     filterset_class = filters.DynamicGroupMembershipFilterSet
@@ -803,6 +807,7 @@ class JobLogEntryViewSet(ReadOnlyModelViewSet):
     Retrieve a list of job log entries.
     """
 
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = JobLogEntry.objects.prefetch_related("job_result")
     serializer_class = serializers.JobLogEntrySerializer
     filterset_class = filters.JobLogEntryFilterSet
@@ -821,6 +826,7 @@ class JobResultViewSet(
     Retrieve a list of job results
     """
 
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = JobResult.objects.prefetch_related("job_model", "obj_type", "user")
     serializer_class = serializers.JobResultSerializer
     filterset_class = filters.JobResultFilterSet
@@ -843,6 +849,7 @@ class ScheduledJobViewSet(ReadOnlyModelViewSet):
     Retrieve a list of scheduled jobs
     """
 
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = ScheduledJob.objects.prefetch_related("user")
     serializer_class = serializers.ScheduledJobSerializer
     filterset_class = filters.ScheduledJobFilterSet
@@ -983,6 +990,7 @@ class ScheduledJobViewSet(ReadOnlyModelViewSet):
 
 class NoteViewSet(ModelViewSet):
     metadata_class = ContentTypeMetadata
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Note.objects.prefetch_related("user")
     serializer_class = serializers.NoteSerializer
     filterset_class = filters.NoteFilterSet
@@ -1003,6 +1011,7 @@ class ObjectChangeViewSet(ReadOnlyModelViewSet):
     """
 
     metadata_class = ContentTypeMetadata
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = ObjectChange.objects.prefetch_related("user")
     serializer_class = serializers.ObjectChangeSerializer
     filterset_class = filters.ObjectChangeFilterSet

--- a/nautobot/extras/homepage.py
+++ b/nautobot/extras/homepage.py
@@ -14,6 +14,7 @@ def get_job_results(request):
 
 def get_changelog(request):
     """Callback function to collect changelog for panel."""
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     return ObjectChange.objects.restrict(request.user, "view").prefetch_related("user", "changed_object_type")[:15]
 
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -10,7 +10,6 @@ import traceback
 import warnings
 
 
-from cacheops import file_cache
 from db_file_storage.form_widgets import DBClearableFileInput
 from django import forms
 from django.conf import settings
@@ -940,7 +939,8 @@ def get_jobs():
     return jobs
 
 
-@file_cache.cached(timeout=60)
+# @file_cache.cached(timeout=60)
+# @cache.memoize(timeout=60)
 def _get_job_source_paths():
     """
     Helper function to get_jobs().
@@ -999,7 +999,6 @@ def _get_job_source_paths():
     return paths
 
 
-@file_cache.cached(timeout=60)
 def get_job_classpaths():
     """
     Get a list of all known Job class_path strings.

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -939,8 +939,6 @@ def get_jobs():
     return jobs
 
 
-# @file_cache.cached(timeout=60)
-# @cache.memoize(timeout=60)
 def _get_job_source_paths():
     """
     Helper function to get_jobs().

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -6,7 +6,6 @@ import logging
 import pkgutil
 import sys
 
-from cacheops import file_cache
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
@@ -29,7 +28,6 @@ from nautobot.extras.registry import registry
 logger = logging.getLogger(__name__)
 
 
-@file_cache.cached(timeout=60)
 def get_job_content_type():
     """Return a cached instance of the `ContentType` for `extras.Job`."""
     return ContentType.objects.get(app_label="extras", model="job")

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -270,6 +270,7 @@ class ConfigContextSchemaObjectValidationView(generic.ObjectView):
 
         # Device table
         device_table = DeviceTable(
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             data=instance.device_set.prefetch_related(
                 "tenant", "site", "rack", "device_type", "device_role", "primary_ip"
             ),
@@ -290,6 +291,7 @@ class ConfigContextSchemaObjectValidationView(generic.ObjectView):
 
         # Virtual machine table
         virtual_machine_table = VirtualMachineTable(
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             data=instance.virtualmachine_set.prefetch_related("cluster", "role", "tenant", "primary_ip"),
             orderable=False,
             extra_columns=[
@@ -807,6 +809,7 @@ class GitRepositoryBulkImportView(generic.BulkImportView):
 
 
 class GitRepositoryBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = GitRepository.objects.prefetch_related("secrets_group")
     filterset = filters.GitRepositoryFilterSet
     table = tables.GitRepositoryBulkTable
@@ -993,6 +996,7 @@ class JobListView(generic.ObjectListView):
             queryset = queryset.filter(installed=True)
         if "is_job_hook_receiver" not in request.GET:
             queryset = queryset.filter(is_job_hook_receiver=False)
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         queryset = queryset.prefetch_related("results")
         return queryset
 
@@ -1429,6 +1433,7 @@ class JobResultListView(generic.ObjectListView):
     List JobResults
     """
 
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = JobResult.objects.prefetch_related("job_model", "logs", "obj_type", "user")
     filterset = filters.JobResultFilterSet
     filterset_form = forms.JobResultFilterForm
@@ -1557,6 +1562,7 @@ class ObjectChangeLogView(View):
 
         # Gather all changes for this object (and its related objects)
         content_type = ContentType.objects.get_for_model(model)
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         objectchanges = (
             ObjectChange.objects.restrict(request.user, "view")
             .prefetch_related("user", "changed_object_type")
@@ -1997,6 +2003,7 @@ class TagView(generic.ObjectView):
     queryset = Tag.objects.all()
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         tagged_items = TaggedItem.objects.filter(tag=instance).prefetch_related("content_type", "content_object")
 
         # Generate a table of all items tagged with this Tag

--- a/nautobot/ipam/api/views.py
+++ b/nautobot/ipam/api/views.py
@@ -46,6 +46,7 @@ class IPAMRootView(APIRootView):
 
 
 class VRFViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = (
         VRF.objects.prefetch_related("tenant")
         .prefetch_related("import_targets", "export_targets", "tags")
@@ -64,6 +65,7 @@ class VRFViewSet(NautobotModelViewSet):
 
 
 class RouteTargetViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = RouteTarget.objects.prefetch_related("tenant").prefetch_related("tags")
     serializer_class = serializers.RouteTargetSerializer
     filterset_class = filters.RouteTargetFilterSet
@@ -86,6 +88,7 @@ class RIRViewSet(NautobotModelViewSet):
 
 
 class AggregateViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = Aggregate.objects.prefetch_related("rir").prefetch_related("tags")
     serializer_class = serializers.AggregateSerializer
     filterset_class = filters.AggregateFilterSet
@@ -111,6 +114,7 @@ class RoleViewSet(NautobotModelViewSet):
 
 
 class PrefixViewSet(StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tgs: m2m)
     queryset = Prefix.objects.prefetch_related(
         "role",
         "site",
@@ -309,6 +313,7 @@ class PrefixViewSet(StatusViewSetMixin, NautobotModelViewSet):
     update=extend_schema(responses={"200": serializers.IPAddressSerializerLegacy}, versions=["1.2"]),
 )
 class IPAddressViewSet(StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = IPAddress.objects.prefetch_related(
         "assigned_object",
         "nat_inside",
@@ -359,6 +364,7 @@ class IPAddressViewSet(StatusViewSetMixin, NautobotModelViewSet):
 
 
 class VLANGroupViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VLANGroup.objects.prefetch_related("site").annotate(vlan_count=count_related(VLAN, "group"))
     serializer_class = serializers.VLANGroupSerializer
     filterset_class = filters.VLANGroupFilterSet
@@ -370,6 +376,7 @@ class VLANGroupViewSet(NautobotModelViewSet):
 
 
 class VLANViewSet(StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = VLAN.objects.prefetch_related(
         "group",
         "site",
@@ -388,6 +395,7 @@ class VLANViewSet(StatusViewSetMixin, NautobotModelViewSet):
 
 
 class ServiceViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (except tags: m2m)
     queryset = Service.objects.prefetch_related("device", "virtual_machine", "tags", "ipaddresses")
     serializer_class = serializers.ServiceSerializer
     filterset_class = filters.ServiceFilterSet

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -48,9 +48,11 @@ class VRFView(generic.ObjectView):
     def get_extra_context(self, request, instance):
         prefix_count = Prefix.objects.restrict(request.user, "view").filter(vrf=instance).count()
 
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         import_targets_table = tables.RouteTargetTable(
             instance.import_targets.prefetch_related("tenant"), orderable=False
         )
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         export_targets_table = tables.RouteTargetTable(
             instance.export_targets.prefetch_related("tenant"), orderable=False
         )
@@ -79,6 +81,7 @@ class VRFBulkImportView(generic.BulkImportView):
 
 
 class VRFBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VRF.objects.prefetch_related("tenant")
     filterset = filters.VRFFilterSet
     table = tables.VRFTable
@@ -86,6 +89,7 @@ class VRFBulkEditView(generic.BulkEditView):
 
 
 class VRFBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VRF.objects.prefetch_related("tenant")
     filterset = filters.VRFFilterSet
     table = tables.VRFTable
@@ -107,6 +111,7 @@ class RouteTargetView(generic.ObjectView):
     queryset = RouteTarget.objects.all()
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         importing_vrfs_table = tables.VRFTable(instance.importing_vrfs.prefetch_related("tenant"), orderable=False)
         exporting_vrfs_table = tables.VRFTable(instance.exporting_vrfs.prefetch_related("tenant"), orderable=False)
 
@@ -132,6 +137,7 @@ class RouteTargetBulkImportView(generic.BulkImportView):
 
 
 class RouteTargetBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = RouteTarget.objects.prefetch_related("tenant")
     filterset = filters.RouteTargetFilterSet
     table = tables.RouteTargetTable
@@ -139,6 +145,7 @@ class RouteTargetBulkEditView(generic.BulkEditView):
 
 
 class RouteTargetBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = RouteTarget.objects.prefetch_related("tenant")
     filterset = filters.RouteTargetFilterSet
     table = tables.RouteTargetTable
@@ -163,6 +170,7 @@ class RIRView(generic.ObjectView):
     def get_extra_context(self, request, instance):
 
         # Aggregates
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         aggregates = Aggregate.objects.restrict(request.user, "view").filter(rir=instance).prefetch_related("tenant")
 
         aggregate_table = tables.AggregateTable(aggregates)
@@ -241,6 +249,7 @@ class AggregateView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Find all child prefixes contained by this aggregate
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         child_prefixes = (
             Prefix.objects.restrict(request.user, "view")
             .net_contained_or_equal(instance.prefix)
@@ -294,6 +303,7 @@ class AggregateBulkImportView(generic.BulkImportView):
 
 
 class AggregateBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Aggregate.objects.prefetch_related("rir")
     filterset = filters.AggregateFilterSet
     table = tables.AggregateTable
@@ -301,6 +311,7 @@ class AggregateBulkEditView(generic.BulkEditView):
 
 
 class AggregateBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Aggregate.objects.prefetch_related("rir")
     filterset = filters.AggregateFilterSet
     table = tables.AggregateTable
@@ -326,6 +337,7 @@ class RoleView(generic.ObjectView):
     def get_extra_context(self, request, instance):
 
         # Prefixes
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         prefixes = (
             Prefix.objects.restrict(request.user, "view")
             .filter(role=instance)
@@ -348,6 +360,7 @@ class RoleView(generic.ObjectView):
         RequestConfig(request, paginate).configure(prefix_table)
 
         # VLANs
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         vlans = (
             VLAN.objects.restrict(request.user, "view")
             .filter(role=instance)
@@ -440,6 +453,7 @@ class PrefixListView(generic.ObjectListView):
 
 
 class PrefixView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Prefix.objects.prefetch_related(
         "role",
         "site__region",
@@ -456,6 +470,7 @@ class PrefixView(generic.ObjectView):
             aggregate = None
 
         # Parent prefixes table
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         parent_prefixes = (
             Prefix.objects.restrict(request.user, "view")
             .net_contains(instance.prefix)
@@ -467,6 +482,7 @@ class PrefixView(generic.ObjectView):
         parent_prefix_table.exclude = ("vrf",)
 
         # Duplicate prefixes table
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         duplicate_prefixes = (
             Prefix.objects.restrict(request.user, "view")
             .net_equals(instance.prefix)
@@ -490,6 +506,7 @@ class PrefixPrefixesView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Child prefixes table
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         child_prefixes = (
             instance.get_child_prefixes()
             .restrict(request.user, "view")
@@ -536,6 +553,7 @@ class PrefixIPAddressesView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Find all IPAddresses belonging to this Prefix
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         ipaddresses = (
             instance.get_child_ips()
             .restrict(request.user, "view")
@@ -593,6 +611,7 @@ class PrefixBulkImportView(generic.BulkImportView):
 
 
 class PrefixBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Prefix.objects.prefetch_related("site", "status", "vrf__tenant", "tenant", "vlan", "role")
     filterset = filters.PrefixFilterSet
     table = tables.PrefixTable
@@ -600,6 +619,7 @@ class PrefixBulkEditView(generic.BulkEditView):
 
 
 class PrefixBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Prefix.objects.prefetch_related("site", "status", "vrf__tenant", "tenant", "vlan", "role")
     filterset = filters.PrefixFilterSet
     table = tables.PrefixTable
@@ -618,10 +638,12 @@ class IPAddressListView(generic.ObjectListView):
 
 
 class IPAddressView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = IPAddress.objects.prefetch_related("vrf__tenant", "tenant")
 
     def get_extra_context(self, request, instance):
         # Parent prefixes table
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         parent_prefixes = (
             Prefix.objects.restrict(request.user, "view")
             .net_contains_or_equals(instance.address)
@@ -632,6 +654,7 @@ class IPAddressView(generic.ObjectView):
         parent_prefixes_table.exclude = ("vrf",)
 
         # Duplicate IPs table
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         duplicate_ips = (
             IPAddress.objects.restrict(request.user, "view")
             .filter(vrf=instance.vrf, host=instance.host)
@@ -723,6 +746,7 @@ class IPAddressAssignView(generic.ObjectView):
 
         if form.is_valid():
 
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             addresses = self.queryset.prefetch_related("vrf", "tenant")
             # Limit to 100 results
             addresses = filters.IPAddressFilterSet(request.POST, addresses).qs[:100]
@@ -758,6 +782,7 @@ class IPAddressBulkImportView(generic.BulkImportView):
 
 
 class IPAddressBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = IPAddress.objects.prefetch_related("status", "tenant", "vrf__tenant")
     filterset = filters.IPAddressFilterSet
     table = tables.IPAddressTable
@@ -765,6 +790,7 @@ class IPAddressBulkEditView(generic.BulkEditView):
 
 
 class IPAddressBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = IPAddress.objects.prefetch_related("status", "tenant", "vrf__tenant")
     filterset = filters.IPAddressFilterSet
     table = tables.IPAddressTable
@@ -776,6 +802,7 @@ class IPAddressBulkDeleteView(generic.BulkDeleteView):
 
 
 class VLANGroupListView(generic.ObjectListView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VLANGroup.objects.prefetch_related("site").annotate(vlan_count=count_related(VLAN, "group"))
     filterset = filters.VLANGroupFilterSet
     filterset_form = forms.VLANGroupFilterForm
@@ -838,6 +865,7 @@ class VLANGroupBulkImportView(generic.BulkImportView):
 
 
 class VLANGroupBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VLANGroup.objects.prefetch_related("site").annotate(vlan_count=count_related(VLAN, "group"))
     filterset = filters.VLANGroupFilterSet
     table = tables.VLANGroupTable
@@ -856,6 +884,7 @@ class VLANListView(generic.ObjectListView):
 
 
 class VLANView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VLAN.objects.prefetch_related(
         "role",
         "site__region",
@@ -864,6 +893,7 @@ class VLANView(generic.ObjectView):
     )
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         prefixes = (
             Prefix.objects.restrict(request.user, "view")
             .filter(vlan=instance)
@@ -887,6 +917,7 @@ class VLANInterfacesView(generic.ObjectView):
     template_name = "ipam/vlan_interfaces.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         interfaces = instance.get_interfaces().prefetch_related("device")
         members_table = tables.VLANDevicesTable(interfaces)
 
@@ -907,6 +938,7 @@ class VLANVMInterfacesView(generic.ObjectView):
     template_name = "ipam/vlan_vminterfaces.html"
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         interfaces = instance.get_vminterfaces().prefetch_related("virtual_machine")
         members_table = tables.VLANVirtualMachinesTable(interfaces)
 
@@ -939,6 +971,7 @@ class VLANBulkImportView(generic.BulkImportView):
 
 
 class VLANBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VLAN.objects.prefetch_related(
         "group",
         "site",
@@ -952,6 +985,7 @@ class VLANBulkEditView(generic.BulkEditView):
 
 
 class VLANBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VLAN.objects.prefetch_related(
         "group",
         "site",
@@ -1007,6 +1041,7 @@ class ServiceDeleteView(generic.ObjectDeleteView):
 
 
 class ServiceBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Service.objects.prefetch_related("device", "virtual_machine")
     filterset = filters.ServiceFilterSet
     table = tables.ServiceTable
@@ -1014,6 +1049,7 @@ class ServiceBulkEditView(generic.BulkEditView):
 
 
 class ServiceBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Service.objects.prefetch_related("device", "virtual_machine")
     filterset = filters.ServiceFilterSet
     table = tables.ServiceTable

--- a/nautobot/tenancy/api/views.py
+++ b/nautobot/tenancy/api/views.py
@@ -39,6 +39,7 @@ class TenantGroupViewSet(NautobotModelViewSet):
 
 
 class TenantViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related (it should stay for tags)
     queryset = Tenant.objects.prefetch_related("group", "tags").annotate(
         circuit_count=count_related(Circuit, "tenant"),
         device_count=count_related(Device, "tenant"),

--- a/nautobot/tenancy/views.py
+++ b/nautobot/tenancy/views.py
@@ -82,6 +82,7 @@ class TenantListView(generic.ObjectListView):
 
 
 class TenantView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Tenant.objects.prefetch_related("group")
 
     def get_extra_context(self, request, instance):
@@ -125,6 +126,7 @@ class TenantBulkImportView(generic.BulkImportView):
 
 
 class TenantBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Tenant.objects.prefetch_related("group")
     filterset = filters.TenantFilterSet
     table = tables.TenantTable
@@ -132,6 +134,7 @@ class TenantBulkEditView(generic.BulkEditView):
 
 
 class TenantBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Tenant.objects.prefetch_related("group")
     filterset = filters.TenantFilterSet
     table = tables.TenantTable

--- a/nautobot/users/admin.py
+++ b/nautobot/users/admin.py
@@ -25,6 +25,7 @@ class ObjectPermissionInline(admin.TabularInline):
     verbose_name_plural = "Permissions"
 
     def get_queryset(self, request):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         return super().get_queryset(request).prefetch_related("objectpermission__object_types").nocache()
 
     @staticmethod
@@ -268,6 +269,7 @@ class ObjectPermissionAdmin(NautobotModelAdmin):
     search_fields = ["actions", "constraints", "description", "name"]
 
     def get_queryset(self, request):
+        # v2 TODO(jathan): Replace prefetch_related with select_related (these # might be m2m)
         return super().get_queryset(request).prefetch_related("object_types", "users", "groups")
 
     def list_models(self, obj):

--- a/nautobot/users/api/views.py
+++ b/nautobot/users/api/views.py
@@ -48,6 +48,7 @@ class GroupViewSet(ModelViewSet):
 
 
 class TokenViewSet(ModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_relatedn
     queryset = RestrictedQuerySet(model=Token).prefetch_related("user")
     serializer_class = serializers.TokenSerializer
     filterset_class = filters.TokenFilterSet

--- a/nautobot/utilities/tables.py
+++ b/nautobot/utilities/tables.py
@@ -98,6 +98,7 @@ class BaseTable(tables.Table):
 
         # Dynamically update the table's QuerySet to ensure related fields are pre-fetched
         if isinstance(self.data, TableQuerysetData):
+            # v2 TODO(jathan): Replace prefetch_related with select_related
             prefetch_fields = []
             for column in self.columns:
                 if column.visible:

--- a/nautobot/virtualization/api/views.py
+++ b/nautobot/virtualization/api/views.py
@@ -48,6 +48,7 @@ class ClusterGroupViewSet(NautobotModelViewSet):
 
 
 class ClusterViewSet(NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Cluster.objects.prefetch_related("type", "group", "tenant", "site", "tags").annotate(
         device_count=count_related(Device, "cluster"),
         virtualmachine_count=count_related(VirtualMachine, "cluster"),
@@ -62,6 +63,7 @@ class ClusterViewSet(NautobotModelViewSet):
 
 
 class VirtualMachineViewSet(ConfigContextQuerySetMixin, StatusViewSetMixin, NautobotModelViewSet):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VirtualMachine.objects.prefetch_related(
         "cluster__site",
         "platform",
@@ -113,11 +115,13 @@ class VirtualMachineViewSet(ConfigContextQuerySetMixin, StatusViewSetMixin, Naut
     update=extend_schema(responses={"200": serializers.VMInterfaceSerializerVersion12}, versions=["1.2", "1.3"]),
 )
 class VMInterfaceViewSet(StatusViewSetMixin, ModelViewSet, NotesViewSetMixin):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VMInterface.objects.prefetch_related(
         "virtual_machine", "parent_interface", "bridge", "status", "tags", "tagged_vlans"
     )
     serializer_class = serializers.VMInterfaceSerializer
     filterset_class = filters.VMInterfaceFilterSet
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     brief_prefetch_fields = ["virtual_machine"]
 
     def get_serializer_class(self):

--- a/nautobot/virtualization/forms.py
+++ b/nautobot/virtualization/forms.py
@@ -331,6 +331,7 @@ class VirtualMachineForm(NautobotModelForm, TenancyForm, LocalContextModelForm):
                     ip_list = [(ip.id, f"{ip.address} ({ip.assigned_object})") for ip in interface_ips]
                     ip_choices.append(("Interface IPs", ip_list))
                 # Collect NAT IPs
+                # v2 TODO(jathan): Replace prefetch_related with select_related
                 nat_ips = (
                     IPAddress.objects.prefetch_related("nat_inside")
                     .ip_family(family)

--- a/nautobot/virtualization/views.py
+++ b/nautobot/virtualization/views.py
@@ -35,6 +35,7 @@ class ClusterTypeView(generic.ObjectView):
     def get_extra_context(self, request, instance):
 
         # Clusters
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         clusters = (
             Cluster.objects.restrict(request.user, "view")
             .filter(type=instance)
@@ -95,6 +96,7 @@ class ClusterGroupView(generic.ObjectView):
     def get_extra_context(self, request, instance):
 
         # Clusters
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         clusters = (
             Cluster.objects.restrict(request.user, "view")
             .filter(group=instance)
@@ -158,6 +160,7 @@ class ClusterView(generic.ObjectView):
     queryset = Cluster.objects.all()
 
     def get_extra_context(self, request, instance):
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         devices = (
             Device.objects.restrict(request.user, "view")
             .filter(cluster=instance)
@@ -189,6 +192,7 @@ class ClusterBulkImportView(generic.BulkImportView):
 
 
 class ClusterBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Cluster.objects.prefetch_related("type", "group", "site")
     filterset = filters.ClusterFilterSet
     table = tables.ClusterTable
@@ -196,6 +200,7 @@ class ClusterBulkEditView(generic.BulkEditView):
 
 
 class ClusterBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = Cluster.objects.prefetch_related("type", "group", "site")
     filterset = filters.ClusterFilterSet
     table = tables.ClusterTable
@@ -311,10 +316,13 @@ class VirtualMachineListView(generic.ObjectListView):
 
 
 class VirtualMachineView(generic.ObjectView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VirtualMachine.objects.prefetch_related("tenant__group")
 
     def get_extra_context(self, request, instance):
         # Interfaces
+        # v2 TODO(jathan): Replace prefetch_related with select_related although this one may be
+        # valid since `ip_addresses` is m2m.
         vminterfaces = (
             VMInterface.objects.restrict(request.user, "view")
             .filter(virtual_machine=instance)
@@ -327,6 +335,7 @@ class VirtualMachineView(generic.ObjectView):
             vminterface_table.columns.show("pk")
 
         # Services
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         services = (
             Service.objects.restrict(request.user, "view")
             .filter(virtual_machine=instance)
@@ -361,6 +370,7 @@ class VirtualMachineBulkImportView(generic.BulkImportView):
 
 
 class VirtualMachineBulkEditView(generic.BulkEditView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VirtualMachine.objects.prefetch_related("cluster", "role", "status", "tenant")
     filterset = filters.VirtualMachineFilterSet
     table = tables.VirtualMachineTable
@@ -368,6 +378,7 @@ class VirtualMachineBulkEditView(generic.BulkEditView):
 
 
 class VirtualMachineBulkDeleteView(generic.BulkDeleteView):
+    # v2 TODO(jathan): Replace prefetch_related with select_related
     queryset = VirtualMachine.objects.prefetch_related("cluster", "role", "status", "tenant")
     filterset = filters.VirtualMachineFilterSet
     table = tables.VirtualMachineTable
@@ -391,6 +402,7 @@ class VMInterfaceView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Get assigned IP addresses
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         ipaddress_table = InterfaceIPAddressTable(
             data=instance.ip_addresses.restrict(request.user, "view").prefetch_related("vrf", "tenant"),
             orderable=False,
@@ -407,6 +419,8 @@ class VMInterfaceView(generic.ObjectView):
         if instance.untagged_vlan is not None:
             vlans.append(instance.untagged_vlan)
             vlans[0].tagged = False
+
+        # v2 TODO(jathan): Replace prefetch_related with select_related
         for vlan in instance.tagged_vlans.restrict(request.user).prefetch_related("site", "group", "tenant", "role"):
             vlan.tagged = True
             vlans.append(vlan)


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1721 
# What's Changed

- `CACHEOPS_ENABLED` now defaults to `False`
- Documentation updated to reflect the new default value of `CACHEOPS_ENABLED`
- Also remove instances of Cacheops `@file_cache.cache` as they are no longer necessary as of the `Job` model rewrite and `JobResult` refactoring from v1.4.0.
- Added `v2 TODO` comments to remind us to reap `cacheops` in v2 release.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design