### PR TITLE
Bubble up exceptions to the JobResult logs when Git repository Job loading fails

### DIFF
--- a/changes/138.fixed
+++ b/changes/138.fixed
@@ -1,0 +1,1 @@
+Fixed lack of user-facing message when an exception occurs while discovering Jobs from a Git repository.

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -916,7 +916,16 @@ def refresh_git_jobs(repository_record, job_result, delete=False):
     if not delete:
         jobs_path = os.path.join(repository_record.filesystem_path, "jobs")
         if os.path.isdir(jobs_path):
-            for job_info in jobs_in_directory(jobs_path):
+            for job_info in jobs_in_directory(jobs_path, report_errors=True):
+                if job_info.error is not None:
+                    job_result.log(
+                        message=f"Error in loading Jobs from `{job_info.module_name}`: `{job_info.error}`",
+                        grouping="jobs",
+                        level_choice=LogLevelChoices.LOG_FAILURE,
+                        logger=logger,
+                    )
+                    continue
+
                 job_model, created = refresh_job_model_from_job_class(
                     Job,
                     JobSourceChoices.SOURCE_GIT,

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -610,7 +610,8 @@ class GitTest(TransactionTestCase):
                 )
                 failure_logs.get(
                     grouping="jobs",
-                    message__contains="Error in loading Jobs from `syntaxerror`: `unexpected EOF while parsing",
+                    # The specific exception message differs between Python versions
+                    message__contains="Error in loading Jobs from `syntaxerror`: ",
                 )
                 failure_logs.get(
                     grouping="jobs",

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -117,7 +117,7 @@ class GitTest(TransactionTestCase):
 
     def populate_repo(self, path, url, *args, **kwargs):
         os.makedirs(path)
-        # Just make config_contexts and export_templates directories as we don't load jobs
+        # TODO: populate Jobs as well?
         os.makedirs(os.path.join(path, "config_contexts"))
         os.makedirs(os.path.join(path, "config_contexts", "devices"))
         os.makedirs(os.path.join(path, "config_context_schemas"))
@@ -266,7 +266,10 @@ class GitTest(TransactionTestCase):
                 self.repo.refresh_from_db()
                 self.assertEqual(self.repo.current_head, self.COMMIT_HEXSHA, self.job_result.data)
                 MockGitRepo.assert_called_with(os.path.join(tempdir, self.repo.slug), "http://localhost/git.git")
-                # TODO: inspect the logs in job_result.data?
+
+                log_entries = JobLogEntry.objects.filter(job_result=self.job_result)
+                warning_logs = log_entries.filter(log_level=LogLevelChoices.LOG_WARNING)
+                warning_logs.get(grouping="jobs", message__contains="No `jobs` subdirectory found")
 
     def test_pull_git_repository_and_refresh_data_with_token(self, MockGitRepo):
         """
@@ -506,12 +509,12 @@ class GitTest(TransactionTestCase):
 
                 def populate_repo(path, url):
                     os.makedirs(path)
-                    # Just make config_contexts and export_templates directories as we don't load jobs
                     os.makedirs(os.path.join(path, "config_contexts"))
                     os.makedirs(os.path.join(path, "config_contexts", "devices"))
                     os.makedirs(os.path.join(path, "config_context_schemas"))
                     os.makedirs(os.path.join(path, "export_templates", "nosuchapp", "device"))
                     os.makedirs(os.path.join(path, "export_templates", "dcim", "nosuchmodel"))
+                    os.makedirs(os.path.join(path, "jobs"))
                     # Incorrect directories
                     os.makedirs(os.path.join(path, "devices"))
                     os.makedirs(os.path.join(path, "dcim"))
@@ -537,6 +540,11 @@ class GitTest(TransactionTestCase):
                         fd.write("{% for device in queryset %}\n{{ device.name }}\n{% endfor %}")
                     with open(os.path.join(path, "export_templates", "dcim", "nosuchmodel", "template.j2"), "w") as fd:
                         fd.write("{% for device in queryset %}\n{{ device.name }}\n{% endfor %}")
+                    # Malformed Python
+                    with open(os.path.join(path, "jobs", "syntaxerror.py"), "w") as fd:
+                        fd.write("print(")
+                    with open(os.path.join(path, "jobs", "importerror.py"), "w") as fd:
+                        fd.write("import nosuchmodule")
                     return mock.DEFAULT
 
                 MockGitRepo.side_effect = populate_repo
@@ -560,7 +568,6 @@ class GitTest(TransactionTestCase):
                 warning_logs.get(
                     grouping="config contexts", message__contains='Found "devices" directory in the repository root'
                 )
-                warning_logs.get(grouping="jobs", message__contains="No `jobs` subdirectory found")
                 warning_logs.get(
                     grouping="export templates", message__contains='Found "dcim" directory in the repository root'
                 )
@@ -600,6 +607,14 @@ class GitTest(TransactionTestCase):
                     grouping="local config contexts",
                     message__contains="Error in loading local config context from `devices/nosuchdevice.json`: "
                     "record not found",
+                )
+                failure_logs.get(
+                    grouping="jobs",
+                    message__contains="Error in loading Jobs from `syntaxerror`: `unexpected EOF while parsing",
+                )
+                failure_logs.get(
+                    grouping="jobs",
+                    message__contains="Error in loading Jobs from `importerror`: `No module named 'nosuchmodule'`",
                 )
 
     def test_delete_git_repository_cleanup(self, MockGitRepo):

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -196,11 +196,16 @@ def get_worker_count(request=None):
 
 
 # namedtuple class yielded by the jobs_in_directory generator function, below
-# Example: ("devices", <module "devices">, "Hostname", <class "devices.Hostname">)
-JobClassInfo = collections.namedtuple("JobClassInfo", ["module_name", "module", "job_class_name", "job_class"])
+# Example: ("devices", <module "devices">, "Hostname", <class "devices.Hostname">, None)
+# Example: ("devices", None, None, None, "error at line 40")
+JobClassInfo = collections.namedtuple(
+    "JobClassInfo",
+    ["module_name", "module", "job_class_name", "job_class", "error"],
+    defaults=(None, None, None, None),  # all parameters except `module_name` are optional and default to None.
+)
 
 
-def jobs_in_directory(path, module_name=None, reload_modules=True):
+def jobs_in_directory(path, module_name=None, reload_modules=True, report_errors=False):
     """
     Walk the available Python modules in the given directory, and for each module, walk its Job class members.
 
@@ -208,9 +213,11 @@ def jobs_in_directory(path, module_name=None, reload_modules=True):
         path (str): Directory to import modules from, outside of sys.path
         module_name (str): Specific module name to select; if unspecified, all modules will be inspected
         reload_modules (bool): Whether to force reloading of modules even if previously loaded into Python.
+        report_errors (bool): If True, when an error is encountered, yield a JobClassInfo with the given error.
+                              If False (default), log the error but do not yield anything.
 
     Yields:
-        JobClassInfo: (module_name, module, job_class_name, job_class)
+        JobClassInfo: (module_name, module, job_class_name, job_class, error)
     """
     from .jobs import is_job  # avoid circular import
 
@@ -221,13 +228,13 @@ def jobs_in_directory(path, module_name=None, reload_modules=True):
             del sys.modules[discovered_module_name]
         try:
             module = importer.find_module(discovered_module_name).load_module(discovered_module_name)
+            # Get all members of the module that are Job subclasses
+            for job_class_name, job_class in inspect.getmembers(module, is_job):
+                yield JobClassInfo(discovered_module_name, module, job_class_name, job_class)
         except Exception as exc:
-            logger.error(f"Unable to load module {module_name} from {path}: {exc}")
-            # TODO: we want to be able to report these errors to the UI in some fashion?
-            continue
-        # Get all members of the module that are Job subclasses
-        for job_class_name, job_class in inspect.getmembers(module, is_job):
-            yield JobClassInfo(discovered_module_name, module, job_class_name, job_class)
+            logger.error(f"Unable to load module {discovered_module_name} from {path}: {exc}")
+            if report_errors:
+                yield JobClassInfo(module_name=discovered_module_name, error=exc)
 
 
 def refresh_job_model_from_job_class(job_model_class, job_source, job_class, *, git_repository=None):


### PR DESCRIPTION
# Closes: #138 (blast from the past!)
# What's Changed

- The `jobs_in_directory()` iterator function now includes a `report_errors` optional argument (defaulting to False for backward compatibility with other uses of this iterator). When this argument is set to True, if an exception occurs while loading a given module from the directory, the iterator will yield an item with the exception details as a parameter.
- The Git sync usage of `jobs_in_directory()` now specifies `report_errors=True`, and when an item with an exception is yielded, the exception details are logged to the JobResult.

![image](https://user-images.githubusercontent.com/5603551/190003848-0fe16ff6-72da-47f2-b69a-e7c14d5252b8.png)

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design