### PR TITLE
Fix database concurrency issues with uWSGI pre-forking.

### DIFF
--- a/changes/950.fixed
+++ b/changes/950.fixed
@@ -1,1 +1,1 @@
-Fix database concurrency issues with uWSGI pre-forking.
+Fixed database concurrency issues with uWSGI pre-forking.

--- a/changes/950.fixed
+++ b/changes/950.fixed
@@ -1,0 +1,1 @@
+Fix database concurrency issues with uWSGI pre-forking.

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -269,6 +269,10 @@ SHORT_DATETIME_FORMAT = "Y-m-d H:i"
 TIME_FORMAT = "g:i a"
 TIME_ZONE = "UTC"
 
+# Disable importing the WSGI module before starting the server application. This is required for
+# uWSGI postfork callbacks to execute as is currently required in `nautobot.core.wsgi`.
+WEBSERVER_WARMUP = False
+
 # Installed apps and Django plugins. Nautobot plugins will be appended here later.
 INSTALLED_APPS = [
     "django.contrib.auth",

--- a/nautobot/core/wsgi.py
+++ b/nautobot/core/wsgi.py
@@ -1,4 +1,8 @@
+import logging
+
+from django.core import cache
 from django.core.wsgi import get_wsgi_application
+from django.db import connections
 
 import nautobot
 
@@ -9,5 +13,24 @@ import nautobot
 # Instead of importing `DJANGO_SETTINGS_MODULE` we're using the custom loader
 # pattern from `nautobot.core.runner` to read environment or config path for us.
 nautobot.setup()
+
+# Use try/except because we might not be running uWSGI. If `settings.WEBSERVER_WARMUP` is `True`,
+# will first call `get_internal_wsgi_application` which does not have `uwsgi` module loaded
+# already. Therefore, `settings.WEBSERVER_WARMUP` to `False` for this code to be loaded.
+try:
+    import uwsgidecorators
+
+    @uwsgidecorators.postfork
+    def fix_uwsgi():
+        import uwsgi
+
+        logging.getLogger("nautobot").info(
+            f"Closing existing DB and cache connections on worker {uwsgi.worker_id()} after uWSGI forked ..."
+        )
+        connections.close_all()
+        cache.close_caches()
+
+except ImportError:
+    pass
 
 application = get_wsgi_application()

--- a/nautobot/core/wsgi.py
+++ b/nautobot/core/wsgi.py
@@ -24,7 +24,7 @@ try:
     def fix_uwsgi():
         import uwsgi
 
-        logging.getLogger("nautobot").info(
+        logging.getLogger(__name__).info(
             f"Closing existing DB and cache connections on worker {uwsgi.worker_id()} after uWSGI forked ..."
         )
         connections.close_all()

--- a/nautobot/docs/installation/services.md
+++ b/nautobot/docs/installation/services.md
@@ -334,26 +334,6 @@ Once you've verified that the WSGI service and worker are up and running, move o
 
 ## Troubleshooting
 
-### SSL Error
-
-If you see the error `SSL error: decryption failed or bad record mac`, it is likely due to a mismatch in the uWSGI
-configuration and Nautobot's database settings.
-
-* Set `DATABASES` -> `default` -> `CONN_MAX_AGE=0` in `nautobot_config.py` and restart the Nautobot service.
-
-For example:
-
-```python
-DATABASES = {
-    "default": {
-        # Other settings...
-        "CONN_MAX_AGE": int(os.getenv("NAUTOBOT_DB_TIMEOUT", 0)),  # Change the value to 0
-    }
-}
-```
-
-Please see [SSL error: decryption failed or bad record mac & SSL SYSCALL error: EOF detected (#127)](https://github.com/nautobot/nautobot/issues/127) for more details.
-
 ### Operational Error: Incorrect string value
 
 When using MySQL as a database backend, if you encounter a server error along the lines of `Incorrect string value: '\\xF0\\x9F\\x92\\x80' for column`, it is because you are running afoul of the legacy implementation of Unicode (aka `utf8`) encoding in MySQL. This often occurs when using modern Unicode glyphs like the famous poop emoji.


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #950

# What's Changed

- Implements `@uwsgidecorators.postfork` callback to explicitly close database and cache connections when a uWSGI worker is forked from the main thread.
- Explicitly set `WEBSERVER_WARMUP = False` within `nautobot.core.settings` to work with this `postfork` callback. This is an internal setting that is not intended to be user-serviceable.
- Credit to @u1735067 for the detailed troubleshooting and the patience of a saint in identifying and testing the fix for this.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design