### PR TITLE
fixed invalid filter error message in CableListView when color and type field is empty

### DIFF
--- a/nautobot/dcim/filters.py
+++ b/nautobot/dcim/filters.py
@@ -1540,8 +1540,8 @@ class VirtualChassisFilterSet(NautobotFilterSet):
 
 class CableFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
     q = SearchFilter(filter_predicates={"label": "icontains"})
-    type = django_filters.MultipleChoiceFilter(choices=CableTypeChoices)
-    color = django_filters.MultipleChoiceFilter(choices=ColorChoices)
+    type = django_filters.ChoiceFilter(choices=CableTypeChoices)
+    color = django_filters.ChoiceFilter(choices=ColorChoices)
     device_id = MultiValueUUIDFilter(method="filter_device", label="Device (ID)")
     device = MultiValueCharFilter(method="filter_device", field_name="device__name", label="Device (name)")
     rack_id = MultiValueUUIDFilter(method="filter_device", field_name="device__rack_id", label="Rack (ID)")

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -3893,7 +3893,7 @@ class CableBulkEditForm(TagsBulkEditFormMixin, StatusModelBulkEditFormMixin, Nau
             raise forms.ValidationError({"length_unit": "Must specify a unit when setting length"})
 
 
-class CableFilterForm(BootstrapMixin, StatusModelFilterFormMixin, forms.Form):
+class CableFilterForm(BootstrapMixin, StatusModelFilterFormMixin):
     model = Cable
     q = forms.CharField(required=False, label="Search")
     region = DynamicModelMultipleChoiceField(queryset=Region.objects.all(), to_field_name="slug", required=False)


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2375 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Changed color and type filters in CableFilterSet from `MultipleChoiceFilter` to `ChoiceFilter.` `MultipleChoiceFilter` is expecting an empty list therefore it does not take `None` as a valid choice.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design