### PR TITLE
Fixed errors encountered when a job model is deleted while a job is running

### DIFF
--- a/changes/2324.fixed
+++ b/changes/2324.fixed
@@ -1,0 +1,1 @@
+Fixed errors encountered when a job model is deleted while a job is running.

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -18,7 +18,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.validators import RegexValidator
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import Model
 from django.db.models.query import QuerySet
 from django.forms import ValidationError
@@ -1199,7 +1199,12 @@ def run_job(data, request, job_result_pk, commit=True, *args, **kwargs):
             job_result.set_status(JobResultStatusChoices.STATUS_ERRORED)
 
         finally:
-            job_result.save()
+            try:
+                job_result.save()
+            except IntegrityError:
+                # handle job_model deleted while job was running
+                job_result.job_model = None
+                job_result.save()
             if file_ids:
                 job.delete_files(*file_ids)  # Cleanup FileProxy objects
 

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1441,7 +1441,7 @@ class JobResultView(generic.ObjectView):
     Display a JobResult and its Job data.
     """
 
-    queryset = JobResult.objects.all()
+    queryset = JobResult.objects.prefetch_related("job_model", "obj_type", "user")
     template_name = "extras/jobresult.html"
 
     def get_extra_context(self, request, instance):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2324
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Fixed JobResult page 500 error described in #2324 
- Added exception handling to allow the job result to be saved when a job is deleted while the job is running so the job result isn't stuck in a "running" state

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design