### PR TITLE
Resolves #2437 - Catch CSRF Failure when DEBUG=False

### DIFF
--- a/changes/2437.added
+++ b/changes/2437.added
@@ -1,0 +1,1 @@
+Catch 403 CSRF errors and return stylized nautobot view.

--- a/changes/2437.added
+++ b/changes/2437.added
@@ -1,1 +1,1 @@
-Catch 403 CSRF errors and return stylized nautobot view.
+Added Nautobot-themed error page for handling 403 CSRF errors.

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -273,6 +273,7 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # Default overrides
 ALLOWED_HOSTS = []
 CSRF_TRUSTED_ORIGINS = []
+CSRF_FAILURE_VIEW = "nautobot.core.views.csrf_failure"
 DATETIME_FORMAT = "N j, Y g:i a"
 INTERNAL_IPS = ("127.0.0.1", "::1")
 FORCE_SCRIPT_NAME = None

--- a/nautobot/core/templates/403_csrf_failure.html
+++ b/nautobot/core/templates/403_csrf_failure.html
@@ -1,0 +1,9 @@
+{% extends '40x.html' %}
+
+{% block title %}Invalid Form Submission{% endblock %}
+
+{% block icon %}<i class="mdi mdi-alert"></i>{% endblock %}
+
+{% block message %}
+    CSRF failure has occurred.
+{% endblock %}

--- a/nautobot/core/templates/403_csrf_failure.html
+++ b/nautobot/core/templates/403_csrf_failure.html
@@ -5,5 +5,19 @@
 {% block icon %}<i class="mdi mdi-alert"></i>{% endblock %}
 
 {% block message %}
-    CSRF failure has occurred.
+    CSRF failure has occurred.<br/>
+    <p>
+        There was a problem with your request. Please contact an administrator.
+    </p>
+    <p>
+        The reason for failure is provided below:
+    </p>
+<pre><strong>{{ reason }}</strong><br/>
+
+Python version: {{ python_version }}
+Nautobot version: {{ nautobot_version }}
+</pre>
+    <p>
+        If further assistance is required, please join the <b>#nautobot</b> channel on <a href="https://slack.networktocode.com/">Network to Code's Slack community</a> and post your question.
+    </p>
 {% endblock %}

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -207,7 +207,7 @@ def csrf_failure(request, reason="", template_name="403_csrf_failure.html"):
     if settings.DEBUG:
         return _csrf_failure(request, reason=reason)
     t = loader.get_template(template_name)
-    context = {"settings": settings}
+    context = {"settings": settings, "reason": reason}
     return HttpResponseForbidden(t.render(context), content_type="text/html")
 
 

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -4,13 +4,14 @@ import sys
 
 from django.conf import settings
 from django.contrib.auth.mixins import AccessMixin
-from django.http import HttpResponseServerError, JsonResponse
+from django.http import HttpResponseServerError, JsonResponse, HttpResponseForbidden
 from django.shortcuts import render
 from django.template import loader, RequestContext, Template
 from django.template.exceptions import TemplateDoesNotExist
 from django.urls import reverse
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.defaults import ERROR_500_TEMPLATE_NAME, page_not_found
+from django.views.csrf import csrf_failure as _csrf_failure
 from django.views.generic import TemplateView, View
 from packaging import version
 from graphene_django.views import GraphQLView
@@ -194,6 +195,20 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
             }
         )
     )
+
+
+def csrf_failure(request, reason="", template_name="403_csrf_failure.html"):
+    """Custom 403 CSRF failure handler to account for additional context.
+
+    If Nautobot is set to DEBUG the default view for csrf_failure.
+    `403_csrf_failure.html` template name is used over `403_csrf.html` to account for
+    additional context that is required to render the inherited templates.
+    """
+    if settings.DEBUG:
+        return _csrf_failure(request, reason=reason)
+    t = loader.get_template(template_name)
+    context = {"settings": settings}
+    return HttpResponseForbidden(t.render(context), content_type="text/html")
 
 
 class CustomGraphQLView(GraphQLView):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2437 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
- Changed settings.py to use new view for CSRF failure
- Added template for failure
- Added view to render template when DEBUG=False OR return upstream Django view when DEBUG=True
![image](https://user-images.githubusercontent.com/26559188/190865729-3ccff290-9de0-4215-b0a3-a4c19256b427.png)

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design