### PR TITLE
Fix #2461: add check to avoid an exception in serializer corner case

### DIFF
--- a/changes/2461.fixed
+++ b/changes/2461.fixed
@@ -1,0 +1,1 @@
+Fixed an exception during OpenAPI schema generation when certain Nautobot apps (including `nautobot-firewall-models`) were installed.

--- a/nautobot/core/api/schema.py
+++ b/nautobot/core/api/schema.py
@@ -242,7 +242,13 @@ class NautobotAutoSchema(AutoSchema):
         but Nautobot bulk partial updates require the `id` field to be specified for each object to update.
         """
         component = super().resolve_serializer(serializer, direction, bypass_extensions)
-        if component and self.is_bulk_action and self.is_partial_action and direction == "request":
+        if (
+            component
+            and component.schema is not None
+            and self.is_bulk_action
+            and self.is_partial_action
+            and direction == "request"
+        ):
             component.schema["required"] = ["id"]
         return component
 

--- a/nautobot/core/api/schema.py
+++ b/nautobot/core/api/schema.py
@@ -242,7 +242,7 @@ class NautobotAutoSchema(AutoSchema):
         but Nautobot bulk partial updates require the `id` field to be specified for each object to update.
         """
         component = super().resolve_serializer(serializer, direction, bypass_extensions)
-        if self.is_bulk_action and self.is_partial_action and direction == "request":
+        if component and self.is_bulk_action and self.is_partial_action and direction == "request":
             component.schema["required"] = ["id"]
         return component
 


### PR DESCRIPTION
# Closes: #2461 
# What's Changed

In some cases, the base `resolve_serializer()` method in drf-spectacular's AutoSchema class (which we subclass from) may return a `ResolvedComponent` object with `None` for any or all of its fields. This isn't encountered with any of our core REST API, but we have found that `nautobot-firewall-models` had a quirk in its API serializers that did trigger this case. (I think this is actually a small bug in the plugin, and I'll be submitting a PR to change that as well).

We were missing code in core to handle this case, resulting in an exception when trying to set `component.schema["required"]` but `component.schema` was `None` rather than the expected dict.

The fix is simple enough, make sure that `component` is truthy (`ResolvedComponent` has a custom `__bool__` implementation), and just to be extra safe, check that `component.schema is not None` as well, before trying to modify `component.schema`.

No easy way to automate a unit test for this, but when we add #2023 it'll be helpful to catch issues like this in the future.

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design