### PR TITLE
Remove invalid and redundant Pythonv version constraint.

### DIFF
--- a/changes/2445.fixed
+++ b/changes/2445.fixed
@@ -1,0 +1,1 @@
+Fix invalid Renovate config with unnecessary constraint.

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,5 @@
 {
   "baseBranches": ["develop", "next"],
-  "constraints": {
-    "python": "3.7"
-  },
   "enabledManagers": ["pip_requirements", "poetry"],
   "extends": [
     "config:base"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2445
# What's Changed
Per reading the Renovate config this shouldn't be necessary as the `pyproject.toml` should be doing enough of a constraint for us.


# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- NA Attached Screenshots, Payload Example
- NA Unit, Integration Tests
- NA Documentation Updates (when adding/changing features)
- NA Example Plugin Updates (when adding/changing features)
- NA Outline Remaining Work, Constraints from Design