### PR TITLE
Fixed unable to create an instance of `AnotherExampleModel`.

### DIFF
--- a/changes/2526.fixed
+++ b/changes/2526.fixed
@@ -1,0 +1,1 @@
+Fixed unable to create an instance of `AnotherExampleModel` by adding `get_absolute_url()` method to `AnotherExampleModel` class and an `AnotherExampleModel` detail view template.

--- a/changes/2526.fixed
+++ b/changes/2526.fixed
@@ -1,1 +1,1 @@
-Fixed unable to create an instance of `AnotherExampleModel` by adding `get_absolute_url()` method to `AnotherExampleModel` class and an `AnotherExampleModel` detail view template.
+Fixed error in rendering the example plugin's `AnotherExampleModel` list view by adding a `get_absolute_url()` method to the `AnotherExampleModel` class and adding an `AnotherExampleModel` detail view template.

--- a/examples/example_plugin/example_plugin/models.py
+++ b/examples/example_plugin/example_plugin/models.py
@@ -52,3 +52,6 @@ class AnotherExampleModel(OrganizationalModel):
 
     class Meta:
         ordering = ["name"]
+
+    def get_absolute_url(self):
+        return reverse("plugins:example_plugin:anotherexamplemodel", kwargs={"pk": self.pk})

--- a/examples/example_plugin/example_plugin/templates/example_plugin/anotherexamplemodel.html
+++ b/examples/example_plugin/example_plugin/templates/example_plugin/anotherexamplemodel.html
@@ -1,0 +1,88 @@
+<!-- this is a view demonstrating the capabilities of generic/object_detail.thml -->
+{% extends 'generic/object_detail.html' %}
+{% load helpers %}
+
+{% block extra_breadcrumb %}
+<li>
+    <a href="{% url 'plugins:example_plugin:anotherexamplemodel_list' %}?number={{ object.number }}">{{ object.number }}
+        (Breadcrumbs)</a>
+</li>
+{% endblock extra_breadcrumb %}
+
+{% block extra_buttons %}
+<a onClick="alert('I am from the detail view template.')" class="btn btn-success">
+    <span class="mdi mdi-exclamation-thick" aria-hidden="true"></span> Extra Buttons go here
+</a>
+{% endblock extra_buttons %}
+
+{% block panel_buttons %}
+<a onClick="alert('I am from the detail view template.')" class="btn btn-primary">
+    <span class="mdi mdi-help" aria-hidden="true"></span> Panel Buttons go here
+</a>
+<a onClick="alert('I am from the detail view template.')" class="btn btn-primary">
+    <span class="mdi mdi-help" aria-hidden="true"></span> Another Panel Button
+</a>
+{% endblock panel_buttons %}
+
+{% block content_left_page %}
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <strong>AnotherExampleModel (Left Page Content)</strong>
+    </div>
+
+    <table class="table table-hover panel-body attr-table">
+        <tr>
+            <td>Name</td>
+            <td><span>{{ object.name }}</span></td>
+        </tr>
+        <tr>
+            <td>Number</td>
+            <td><span>{{ object.number }}</span></td>
+        </tr>
+    </table>
+</div>
+{% endblock content_left_page %}
+
+{% block content_right_page %}
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <strong>View Template Right Page Content</strong>
+    </div>
+
+    <table class="table table-hover panel-body attr-table">
+        <tr>
+            <th>Things</th>
+            <th>Stuff</th>
+        </tr>
+        <tr>
+            <td><span>Shoe, Horse, Dog</span></td>
+            <td><span>Widgets, Cogs, Sprockets</span></td>
+        </tr>
+    </table>
+</div>
+{% endblock content_right_page %}
+
+{% block content_full_width_page %}
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <strong>View Template Full Width Page Content</strong>
+    </div>
+
+    <table class="table table-hover panel-body attr-table">
+        <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Number</th>
+            <th>Salt</th>
+            <th>Pepper</th>
+        </tr>
+        <tr>
+            <td>1</td>
+            <td>Bob</td>
+            <td>-42</td>
+            <td>Yes</td>
+            <td>No</td>
+        </tr>
+    </table>
+</div>
+{% endblock content_full_width_page %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2526 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Added`get_absolute_url()` method to `AnotherExampleModel` class
- Added an `AnotherExampleModel` detail view template

# TODO
<!--
    Please feel free to update todos to keep of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design