### PR TITLE
Applied hotfix for multiple jobs executing from a single scheduled job.

### DIFF
--- a/changes/2546.fixed
+++ b/changes/2546.fixed
@@ -1,0 +1,1 @@
+Applied a hotfix for multiple jobs executing from a single scheduled job.


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2546
# What's Changed

- This applies a documented workaround (See: https://github.com/celery/django-celery-beat/issues/558) provided by a community member for what appears to be a known issue in Celery's core beat `Scheduler` process as it intersects with the `DatabaseScheduler` and the `ModelEntry` objects provided by `django-celery-beat`.
- The root cause analysis has not yet been completed, as this issue is not a simple one, however this workaround appears to alleviate the issue for the time being.
- For this reason, there are no tests, and it should be expected that as we zero in on the root cause, that this hotfix will hopefully be temporary as we work to find a long-term fix.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
