### PR TITLE
Implement factories for DCIM `DeviceRole`, `DeviceType`, `Manufacturer`, and `Platform`

### DIFF
--- a/changes/2594.added
+++ b/changes/2594.added
@@ -1,1 +1,1 @@
-Added factories for DCIM `DeviceType`, `Manufacturer`, and `Platform`.
+Added factories for DCIM `DeviceRole`, `DeviceType`, `Manufacturer`, and `Platform`.

--- a/changes/2594.added
+++ b/changes/2594.added
@@ -1,0 +1,1 @@
+Added factories for DCIM `DeviceType`, `Manufacturer`, and `Platform`

--- a/changes/2594.added
+++ b/changes/2594.added
@@ -1,1 +1,1 @@
-Added factories for DCIM `DeviceType`, `Manufacturer`, and `Platform`
+Added factories for DCIM `DeviceType`, `Manufacturer`, and `Platform`.

--- a/nautobot/core/management/commands/generate_test_data.py
+++ b/nautobot/core/management/commands/generate_test_data.py
@@ -28,6 +28,7 @@ class Command(BaseCommand):
         try:
             import factory.random
 
+            from nautobto.dcim.factory import DeviceTypeFactory, ManufacturerFactory, PlatformFactory
             from nautobot.extras.factory import StatusFactory, TagFactory
             from nautobot.extras.management import populate_status_choices
             from nautobot.extras.utils import TaggableClassesQuery
@@ -96,5 +97,11 @@ Type 'yes' to continue, or 'no' to cancel: """
         AggregateFactory.create_batch(5, has_tenant_group=True)
         AggregateFactory.create_batch(5, has_tenant_group=False, has_tenant=True)
         AggregateFactory.create_batch(10)
+        self.stdout.write("Creating Manufacturers...")
+        ManufacturerFactory.create_batch(10)
+        self.stdout.write("Creating Platforms...")
+        PlatformFactory.create_batch(10)
+        self.stdout.write("Creating DeviceTypes...")
+        DeviceTypeFactory.create_batch(10)
 
         self.stdout.write(self.style.SUCCESS("Database populated successfully!"))

--- a/nautobot/core/management/commands/generate_test_data.py
+++ b/nautobot/core/management/commands/generate_test_data.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         try:
             import factory.random
 
-            from nautobto.dcim.factory import DeviceTypeFactory, ManufacturerFactory, PlatformFactory
+            from nautobot.dcim.factory import DeviceTypeFactory, ManufacturerFactory, PlatformFactory
             from nautobot.extras.factory import StatusFactory, TagFactory
             from nautobot.extras.management import populate_status_choices
             from nautobot.extras.utils import TaggableClassesQuery
@@ -98,10 +98,11 @@ Type 'yes' to continue, or 'no' to cancel: """
         AggregateFactory.create_batch(5, has_tenant_group=False, has_tenant=True)
         AggregateFactory.create_batch(10)
         self.stdout.write("Creating Manufacturers...")
-        ManufacturerFactory.create_batch(10)
+        ManufacturerFactory.create_batch(14)  # All 14 hard-coded Manufacturers for now.
         self.stdout.write("Creating Platforms...")
-        PlatformFactory.create_batch(10)
+        PlatformFactory.create_batch(20, has_manufacturer=True)
+        PlatformFactory.create_batch(5, has_manufacturer=False)
         self.stdout.write("Creating DeviceTypes...")
-        DeviceTypeFactory.create_batch(10)
+        DeviceTypeFactory.create_batch(20)
 
         self.stdout.write(self.style.SUCCESS("Database populated successfully!"))

--- a/nautobot/core/management/commands/generate_test_data.py
+++ b/nautobot/core/management/commands/generate_test_data.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         try:
             import factory.random
 
-            from nautobot.dcim.factory import DeviceTypeFactory, ManufacturerFactory, PlatformFactory
+            from nautobot.dcim.factory import DeviceRoleFactory, DeviceTypeFactory, ManufacturerFactory, PlatformFactory
             from nautobot.extras.factory import StatusFactory, TagFactory
             from nautobot.extras.management import populate_status_choices
             from nautobot.extras.utils import TaggableClassesQuery
@@ -99,10 +99,13 @@ Type 'yes' to continue, or 'no' to cancel: """
         AggregateFactory.create_batch(10)
         self.stdout.write("Creating Manufacturers...")
         ManufacturerFactory.create_batch(14)  # All 14 hard-coded Manufacturers for now.
-        self.stdout.write("Creating Platforms...")
+        self.stdout.write("Creating Platforms (with manufacturers)...")
         PlatformFactory.create_batch(20, has_manufacturer=True)
+        self.stdout.write("Creating Platforms (without manufacturers)...")
         PlatformFactory.create_batch(5, has_manufacturer=False)
         self.stdout.write("Creating DeviceTypes...")
         DeviceTypeFactory.create_batch(20)
+        self.stdout.write("Creating DeviceRoles...")
+        DeviceRoleFactory.create_batch(10)
 
         self.stdout.write(self.style.SUCCESS("Database populated successfully!"))

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1219,7 +1219,7 @@ query {
         )
         result = self.execute_query(query)
 
-        self.assertEqual(len(result.data["devices"]), 3)
+        self.assertEqual(len(result.data["devices"]), 2)
         expected = list(Device.objects.filter(device_role=self.device_role1).values_list("name", flat=True))
         device_names = [item["name"] for item in result.data["devices"]]
         self.assertEqual(sorted(device_names), sorted(expected))

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1219,8 +1219,8 @@ query {
         )
         result = self.execute_query(query)
 
-        self.assertEqual(len(result.data["devices"]), 2)
         expected = list(Device.objects.filter(device_role=self.device_role1).values_list("name", flat=True))
+        self.assertEqual(len(result.data["devices"]), len(expected))
         device_names = [item["name"] for item in result.data["devices"]]
         self.assertEqual(sorted(device_names), sorted(expected))
 

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1219,7 +1219,7 @@ query {
         )
         result = self.execute_query(query)
 
-        self.assertEqual(len(result.data["devices"]), 2)
+        self.assertEqual(len(result.data["devices"]), 3)
         expected = list(Device.objects.filter(device_role=self.device_role1).values_list("name", flat=True))
         device_names = [item["name"] for item in result.data["devices"]]
         self.assertEqual(sorted(device_names), sorted(expected))

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1,3 +1,4 @@
+import random
 import types
 from unittest import skip
 import uuid
@@ -44,7 +45,6 @@ from nautobot.dcim.models import (
     DeviceType,
     FrontPort,
     Interface,
-    Manufacturer,
     PowerFeed,
     PowerPort,
     PowerOutlet,
@@ -646,16 +646,11 @@ class GraphQLQueryTest(TestCase):
         cls.request.user = cls.user
 
         # Populate Data
-        manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
-        cls.devicetype = DeviceType.objects.create(
-            manufacturer=manufacturer, model="Device Type 1", slug="device-type-1"
-        )
-        cls.upsdevicetype = DeviceType.objects.create(
-            manufacturer=manufacturer, model="UPS Device Type 1", slug="ups-device-type-1"
-        )
-        cls.devicerole1 = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
-        cls.devicerole2 = DeviceRole.objects.create(name="Device Role 2", slug="device-role-2")
-        cls.upsdevicerole = DeviceRole.objects.create(name="UPS Device Role 1", slug="ups-device-role-1")
+        cls.device_type1 = DeviceType.objects.first()
+        cls.device_type2 = DeviceType.objects.last()
+        cls.device_role1 = DeviceRole.objects.first()
+        cls.device_role2 = DeviceRole.objects.last()
+        cls.device_role3 = random.choice(DeviceRole.objects.all())
         cls.site_statuses = list(Status.objects.get_for_model(Site))[:2]
         cls.region1 = Region.objects.create(name="Region1", slug="region1")
         cls.region2 = Region.objects.create(name="Region2", slug="region2")
@@ -690,8 +685,8 @@ class GraphQLQueryTest(TestCase):
         cls.device_statuses = list(Status.objects.get_for_model(Device))[:2]
         cls.upsdevice1 = Device.objects.create(
             name="UPS 1",
-            device_type=cls.upsdevicetype,
-            device_role=cls.upsdevicerole,
+            device_type=cls.device_type2,
+            device_role=cls.device_role3,
             site=cls.site1,
             status=cls.device_statuses[0],
             rack=cls.rack1,
@@ -710,8 +705,8 @@ class GraphQLQueryTest(TestCase):
 
         cls.device1 = Device.objects.create(
             name="Device 1",
-            device_type=cls.devicetype,
-            device_role=cls.devicerole1,
+            device_type=cls.device_type1,
+            device_role=cls.device_role1,
             site=cls.site1,
             status=cls.device_statuses[0],
             rack=cls.rack1,
@@ -797,8 +792,8 @@ class GraphQLQueryTest(TestCase):
 
         cls.device2 = Device.objects.create(
             name="Device 2",
-            device_type=cls.devicetype,
-            device_role=cls.devicerole2,
+            device_type=cls.device_type1,
+            device_role=cls.device_role2,
             site=cls.site1,
             status=cls.device_statuses[1],
             rack=cls.rack2,
@@ -822,8 +817,8 @@ class GraphQLQueryTest(TestCase):
 
         cls.device3 = Device.objects.create(
             name="Device 3",
-            device_type=cls.devicetype,
-            device_role=cls.devicerole1,
+            device_type=cls.device_type1,
+            device_role=cls.device_role1,
             site=cls.site2,
             status=cls.device_statuses[0],
         )
@@ -1210,19 +1205,24 @@ query {
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_device_role_filter(self):
 
-        query = """
-            query {
-                devices(role: "device-role-1") {
-                    id
-                    name
+        query = (
+            # pylint: disable=consider-using-f-string
+            """
+                query {
+                    devices(role: "%s") {
+                        id
+                        name
+                    }
                 }
-            }
-        """
+            """
+            % (self.device_role1.slug,)
+        )
         result = self.execute_query(query)
 
         self.assertEqual(len(result.data["devices"]), 2)
+        expected = list(Device.objects.filter(device_role=self.device_role1).values_list("name", flat=True))
         device_names = [item["name"] for item in result.data["devices"]]
-        self.assertEqual(sorted(device_names), ["Device 1", "Device 3"])
+        self.assertEqual(sorted(device_names), sorted(expected))
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_with_bad_filter(self):
@@ -1275,44 +1275,60 @@ query {
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_devices_filter(self):
 
-        filters = (
-            ('name: "Device 1"', 1),
-            ('name: ["Device 1"]', 1),
-            ('name: ["Device 1", "Device 2"]', 2),
-            ('name__ic: "Device"', 3),
-            ('name__ic: ["Device"]', 3),
-            ('name__nic: "Device"', 1),
-            ('name__nic: ["Device"]', 1),
-            (f'id: "{self.device1.pk}"', 1),
-            (f'id: ["{self.device1.pk}"]', 1),
-            (f'id: ["{self.device1.pk}", "{self.device2.pk}"]', 2),
-            ('role: "device-role-1"', 2),
-            ('role: ["device-role-1"]', 2),
-            ('role: ["device-role-1", "device-role-2"]', 3),
-            ('site: "site-1"', 3),
-            ('site: ["site-1"]', 3),
-            ('site: ["site-1", "site-2"]', 4),
-            ('region: "region1"', 3),
-            ('region: ["region1"]', 3),
-            ('region: ["region1", "region2"]', 4),
-            ('face: "front"', 2),
-            ('face: "rear"', 1),
-            (f'status: "{self.device_statuses[0].slug}"', 3),
-            (f'status: ["{self.device_statuses[1].slug}"]', 1),
-            (f'status: ["{self.device_statuses[0].slug}", "{self.device_statuses[1].slug}"]', 4),
-            ("is_full_depth: true", 4),
-            ("is_full_depth: false", 0),
-            ("has_primary_ip: true", 0),
-            ("has_primary_ip: false", 4),
-            ('mac_address: "00:11:11:11:11:11"', 1),
-            ('mac_address: ["00:12:12:12:12:12"]', 1),
-            ('mac_address: ["00:11:11:11:11:11", "00:12:12:12:12:12"]', 2),
-            ('mac_address: "99:11:11:11:11:11"', 0),
-            ('q: "first"', 1),
-            ('q: "notthere"', 0),
-        )
+        filterset_class = DeviceFilterSet
+        queryset = Device.objects.all()
 
-        for filterv, nbr_expected_results in filters:
+        def _count(params, filterset_class=filterset_class, queryset=queryset):
+            return filterset_class(params, queryset).qs.count()
+
+        filters = {
+            f'name: "{self.device1.name}"': _count({"name": [self.device1.name]}),
+            f'name: ["{self.device1.name}"]': _count({"name": [self.device1.name]}),
+            f'name: ["{self.device1.name}", "{self.device2.name}"]': _count(
+                {"name": [self.device1.name, self.device2.name]}
+            ),
+            'name__ic: "Device"': _count({"name__ic": ["Device"]}),
+            'name__ic: ["Device"]': _count({"name__ic": ["Device"]}),
+            'name__nic: "Device"': _count({"name__nic": ["Device"]}),
+            'name__nic: ["Device"]': _count({"name__nic": ["Device"]}),
+            f'id: "{self.device1.pk}"': _count({"id": [self.device1.pk]}),
+            f'id: ["{self.device1.pk}"]': _count({"id": [self.device1.pk]}),
+            f'id: ["{self.device1.pk}", "{self.device2.pk}"]': _count({"id": [self.device1.pk, self.device2.pk]}),
+            f'role: "{self.device_role1.slug}"': _count({"role": [self.device_role1.slug]}),
+            f'role: ["{self.device_role1.slug}"]': _count({"role": [self.device_role1.slug]}),
+            f'role: ["{self.device_role1.slug}", "{self.device_role2.slug}"]': _count(
+                {"role": [self.device_role1.slug, self.device_role2.slug]}
+            ),
+            f'site: "{self.site1.slug}"': _count({"site": [self.site1.slug]}),
+            f'site: ["{self.site1.slug}"]': _count({"site": [self.site1.slug]}),
+            f'site: ["{self.site1.slug}", "{self.site2.slug}"]': _count({"site": [self.site1.slug, self.site2.slug]}),
+            f'region: "{self.region1.slug}"': _count({"region": [self.region1.slug]}),
+            f'region: ["{self.region1.slug}"]': _count({"region": [self.region1.slug]}),
+            f'region: ["{self.region1.slug}", "{self.region2.slug}"]': _count(
+                {"region": [self.region1.slug, self.region2.slug]}
+            ),
+            'face: "front"': _count({"face": "front"}),
+            'face: "rear"': _count({"face": "rear"}),
+            f'status: "{self.device_statuses[0].slug}"': _count({"status": [self.device_statuses[0].slug]}),
+            f'status: ["{self.device_statuses[1].slug}"]': _count({"status": [self.device_statuses[1].slug]}),
+            f'status: ["{self.device_statuses[0].slug}", "{self.device_statuses[1].slug}"]': _count(
+                {"status": [self.device_statuses[0].slug, self.device_statuses[1].slug]}
+            ),
+            "is_full_depth: true": _count({"is_full_depth": True}),
+            "is_full_depth: false": _count({"is_full_depth": False}),
+            "has_primary_ip: true": _count({"has_primary_ip": True}),
+            "has_primary_ip: false": _count({"has_primary_ip": False}),
+            'mac_address: "00:11:11:11:11:11"': _count({"mac_address": ["00:11:11:11:11:11"]}),
+            'mac_address: ["00:12:12:12:12:12"]': _count({"mac_address": ["00:12:12:12:12:12"]}),
+            'mac_address: ["00:11:11:11:11:11", "00:12:12:12:12:12"]': _count(
+                {"mac_address": ["00:11:11:11:11:11", "00:12:12:12:12:12"]}
+            ),
+            'mac_address: "99:11:11:11:11:11"': _count({"mac_address": ["99:11:11:11:11:11"]}),
+            'q: "first"': _count({"q": "first"}),
+            'q: "notthere"': _count({"q": "notthere"}),
+        }
+
+        for filterv, nbr_expected_results in filters.items():
             with self.subTest(msg=f"Checking {filterv}", filterv=filterv, nbr_expected_results=nbr_expected_results):
                 query = "query {devices(" + filterv + "){ name }}"
                 result = self.execute_query(query)
@@ -1778,7 +1794,7 @@ query {
         self.assertIsNone(result.errors)
         self.assertIsInstance(result.data, dict, result)
         self.assertIsInstance(result.data["device_types"], list, result)
-        self.assertEqual(result.data["device_types"][0]["model"], self.devicetype.model, result)
+        self.assertEqual(result.data["device_types"][0]["model"], self.device_type1.model, result)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_interface_pagination(self):

--- a/nautobot/dcim/factory.py
+++ b/nautobot/dcim/factory.py
@@ -104,7 +104,7 @@ class DeviceTypeFactory(PrimaryModelFactory):
 
     # If randomly a subdevice, set u_height to 0.
     is_subdevice_child = factory.Faker("boolean", chance_of_getting_true=33)
-    u_height = factory.Maybe("is_subdevice_child", 0, factory.fuzzy.FuzzyInteger(1, 4))
+    u_height = factory.Maybe("is_subdevice_child", 0, factory.fuzzy.FuzzyInteger(1, 2))
 
     is_full_depth = factory.Faker("pybool")
 

--- a/nautobot/dcim/factory.py
+++ b/nautobot/dcim/factory.py
@@ -51,7 +51,7 @@ class ManufacturerFactory(OrganizationalModelFactory):
     name = UniqueFaker("word", ext_word_list=MANUFACTURER_NAMES)
 
     has_description = factory.Faker("pybool")
-    description = factory.Maybe("has_description", factory.Faker("text", max_nb_chars=200), "")
+    description = factory.Maybe("has_description", factory.Faker("sentence"), "")
 
 
 class PlatformFactory(OrganizationalModelFactory):
@@ -84,7 +84,7 @@ class PlatformFactory(OrganizationalModelFactory):
     )
 
     has_description = factory.Faker("pybool")
-    description = factory.Maybe("has_description", factory.Faker("text", max_nb_chars=200), "")
+    description = factory.Maybe("has_description", factory.Faker("sentence"), "")
 
 
 class DeviceTypeFactory(PrimaryModelFactory):
@@ -134,4 +134,4 @@ class DeviceRoleFactory(OrganizationalModelFactory):
     vm_role = factory.Faker("pybool")
 
     has_description = factory.Faker("pybool")
-    description = factory.Maybe("has_description", factory.Faker("text", max_nb_chars=200), "")
+    description = factory.Maybe("has_description", factory.Faker("sentence"), "")

--- a/nautobot/dcim/factory.py
+++ b/nautobot/dcim/factory.py
@@ -1,7 +1,8 @@
 import logging
+import random
 
 import factory
-import faker
+import factory.fuzzy
 
 from nautobot.core.factory import OrganizationalModelFactory, PrimaryModelFactory
 from nautobot.dcim.models import DeviceType, Manufacturer, Platform
@@ -12,41 +13,68 @@ from nautobot.utilities.factory import random_instance, UniqueFaker
 logger = logging.getLogger(__name__)
 
 
+# For a randomly deterministic set of vendor names. Must be a tuple.
+MANUFACTURER_NAMES = (
+    "A10",
+    "Arista",
+    "Aruba",
+    "Brocade",
+    "Cisco",
+    "Citrix",
+    "Dell",
+    "F5",
+    "Force10",
+    "Fortinet",
+    "Huawei",
+    "Juniper",
+    "HP",
+    "Palo Alto",
+)
+
+# For `Platform.napalm_driver`, either randomly choose based on Manufacturer slug.
+NAPALM_DRIVERS = {
+    "arista": ["eos"],
+    "cisco": ["ios", "iosxr", "iosxr_netconf", "nxos", "nxos_ssh"],
+    "juniper": ["junos"],
+    "palo-alto": ["panos"],
+}
+
+
 class ManufacturerFactory(OrganizationalModelFactory):
     class Meta:
         model = Manufacturer
         exclude = ("has_description",)
 
-    class Params:
-        unique_name = UniqueFaker("word")
-
     # Slug isn't defined here since it will always inherit from name.
-    name = factory.LazyAttribute(lambda o: o.unique_name.title())
+    name = UniqueFaker("word", ext_word_list=MANUFACTURER_NAMES)
 
     has_description = factory.Faker("pybool")
     description = factory.Maybe("has_description", factory.Faker("text", max_nb_chars=200), "")
 
 
-class ManufacturerGetOrCreateFactory(ManufacturerFactory):
-    class Meta:
-        django_get_or_create = ("name",)
-
-
 class PlatformFactory(OrganizationalModelFactory):
     class Meta:
         model = Platform
-        exclude = ("has_manufacturer", "has_description", "has_napalm_driver", "has_napalm_args")
+        exclude = ("has_manufacturer", "manufacturer_slug", "has_description", "has_napalm_args")
+
+    # This dictates `name` and `napalm_driver`.
+    has_manufacturer = factory.Faker("pybool")
 
     # Slug isn't defined here since it will always inherit from name.
-    name = factory.LazyFunction(
-        lambda: faker.Faker().word(part_of_speech="adjective").title() + " " + faker.Faker().word().title()
+    name = factory.Maybe(
+        "has_manufacturer",
+        factory.LazyAttributeSequence(lambda o, n: "%s Platform %d" % (o.manufacturer.name, n + 1)),
+        factory.Sequence(lambda n: "Platform %d" % n),
     )
 
-    has_manufacturer = factory.Faker("pybool")
     manufacturer = factory.Maybe("has_manufacturer", random_instance(Manufacturer), None)
 
-    has_napalm_driver = factory.Faker("pybool")
-    napalm_driver = factory.Maybe("has_napalm_driver", factory.Faker("locale"), "")
+    # If it has a manufacturer, it *might* have a naplam_driver.
+    napalm_driver = factory.Maybe(
+        "has_manufacturer",
+        factory.LazyAttribute(lambda o: random.choice(NAPALM_DRIVERS.get(o.manufacturer.slug, [""]))),
+        "",
+    )
 
     has_napalm_args = factory.Faker("pybool")
     napalm_args = factory.Maybe(
@@ -68,17 +96,15 @@ class DeviceTypeFactory(PrimaryModelFactory):
 
     manufacturer = random_instance(Manufacturer)
 
-    model = factory.LazyFunction(
-        lambda: faker.Faker().word(part_of_speech="adjective").title() + " " + faker.Faker().word().title()
-    )
+    # Slug isn't defined here since it will always inherit from model.
+    model = factory.LazyAttributeSequence(lambda o, n: "%s DeviceType %d" % (o.manufacturer.name, n + 1))
 
-    slug = UniqueFaker("word")
     has_part_number = factory.Faker("pybool")
     part_number = factory.Maybe("has_part_number", factory.Faker("ean", length=8), "")
 
     # If randomly a subdevice, set u_height to 0.
-    is_subdevice_child = factory.Faker("pybool")
-    u_height = factory.Maybe("is_subdevice_child", 0, factory.Faker("random_int", min=1, max=4))
+    is_subdevice_child = factory.Faker("boolean", chance_of_getting_true=33)
+    u_height = factory.Maybe("is_subdevice_child", 0, factory.fuzzy.FuzzyInteger(1, 4))
 
     is_full_depth = factory.Faker("pybool")
 

--- a/nautobot/dcim/factory.py
+++ b/nautobot/dcim/factory.py
@@ -1,0 +1,98 @@
+import logging
+
+import factory
+
+from nautobot.core.factory import OrganizationalModelFactory, PrimaryModelFactory
+from nautobot.dcim.models import DeviceType, Manufacturer, Platform
+from nautobot.dcim.choices import SubdeviceRoleChoices
+from nautobot.utilities.factory import random_instance, UniqueFaker
+
+
+logger = logging.getLogger(__name__)
+
+
+class ManufacturerFactory(OrganizationalModelFactory):
+    class Meta:
+        model = Manufacturer
+        exclude = ("has_description",)
+
+    class Params:
+        unique_name = UniqueFaker("word")
+
+    # Slug isn't defined here since it will always inherit from name.
+    name = factory.LazyAttribute(lambda o: o.unique_name.title())
+
+    has_description = factory.Faker("pybool")
+    description = factory.Maybe("has_description", factory.Faker("text", max_nb_chars=200), "")
+
+
+class ManufacturerGetOrCreateFactory(ManufacturerFactory):
+    class Meta:
+        django_get_or_create = ("name",)
+
+
+class PlatformFactory(OrganizationalModelFactory):
+    class Meta:
+        model = Platform
+        exclude = ("has_manufacturer", "has_description", "has_napalm_driver", "has_napalm_args")
+
+    class Params:
+        first = UniqueFaker("word")
+        last = UniqueFaker("word")
+
+    # Slug isn't defined here since it will always inherit from name.
+    name = factory.LazyAttribute(lambda o: f"{o.first} {o.last}".title())
+
+    has_manufacturer = factory.Faker("pybool")
+    manufacturer = factory.Maybe("has_manufacturer", random_instance(Manufacturer), None)
+
+    has_napalm_driver = factory.Faker("pybool")
+    napalm_driver = factory.Maybe("has_napalm_driver", factory.Faker("locale"), "")
+
+    has_napalm_args = factory.Faker("pybool")
+    napalm_args = factory.Maybe(
+        "has_napalm_args", factory.Faker("pydict", nb_elements=2, value_types=[str, bool, int]), None
+    )
+
+    has_description = factory.Faker("pybool")
+    description = factory.Maybe("has_description", factory.Faker("text", max_nb_chars=200), "")
+
+
+class DeviceTypeFactory(PrimaryModelFactory):
+    class Meta:
+        model = DeviceType
+        exclude = (
+            "has_part_number",
+            "is_subdevice_child",
+            "has_comments",
+        )
+
+    class Params:
+        first = UniqueFaker("word")
+        last = UniqueFaker("word")
+
+    # For now this is creating a new Manufacturer every time a DeviceType is created.
+    manufacturer = factory.SubFactory(ManufacturerGetOrCreateFactory)
+
+    model = factory.LazyAttribute(lambda o: f"{o.first} {o.last}".title())
+
+    slug = UniqueFaker("word")
+
+    has_part_number = factory.Faker("pybool")
+    part_number = factory.Maybe("has_part_number", factory.Faker("ean", length=8), "")
+
+    # If randomly a subdevice, set u_height to 0.
+    is_subdevice_child = factory.Faker("pybool")
+    u_height = factory.Maybe("is_subdevice_child", 0, factory.Faker("random_int", min=1, max=4))
+
+    is_full_depth = factory.Faker("pybool")
+
+    # If randomly a subdevice, also set subdevice_role to "child". We might want to reconsider this.
+    subdevice_role = factory.Maybe(
+        "is_subdevice_child",
+        SubdeviceRoleChoices.ROLE_CHILD,
+        factory.Faker("random_element", elements=["", SubdeviceRoleChoices.ROLE_PARENT]),
+    )
+
+    has_comments = factory.Faker("pybool")
+    comments = factory.Maybe("has_comments", factory.Faker("paragraph"), "")

--- a/nautobot/dcim/factory.py
+++ b/nautobot/dcim/factory.py
@@ -1,6 +1,7 @@
 import logging
 
 import factory
+import faker
 
 from nautobot.core.factory import OrganizationalModelFactory, PrimaryModelFactory
 from nautobot.dcim.models import DeviceType, Manufacturer, Platform
@@ -36,12 +37,10 @@ class PlatformFactory(OrganizationalModelFactory):
         model = Platform
         exclude = ("has_manufacturer", "has_description", "has_napalm_driver", "has_napalm_args")
 
-    class Params:
-        first = UniqueFaker("word")
-        last = UniqueFaker("word")
-
     # Slug isn't defined here since it will always inherit from name.
-    name = factory.LazyAttribute(lambda o: f"{o.first} {o.last}".title())
+    name = factory.LazyFunction(
+        lambda: faker.Faker().word(part_of_speech="adjective").title() + " " + faker.Faker().word().title()
+    )
 
     has_manufacturer = factory.Faker("pybool")
     manufacturer = factory.Maybe("has_manufacturer", random_instance(Manufacturer), None)
@@ -67,17 +66,13 @@ class DeviceTypeFactory(PrimaryModelFactory):
             "has_comments",
         )
 
-    class Params:
-        first = UniqueFaker("word")
-        last = UniqueFaker("word")
+    manufacturer = random_instance(Manufacturer)
 
-    # For now this is creating a new Manufacturer every time a DeviceType is created.
-    manufacturer = factory.SubFactory(ManufacturerGetOrCreateFactory)
-
-    model = factory.LazyAttribute(lambda o: f"{o.first} {o.last}".title())
+    model = factory.LazyFunction(
+        lambda: faker.Faker().word(part_of_speech="adjective").title() + " " + faker.Faker().word().title()
+    )
 
     slug = UniqueFaker("word")
-
     has_part_number = factory.Faker("pybool")
     part_number = factory.Maybe("has_part_number", factory.Faker("ean", length=8), "")
 

--- a/nautobot/dcim/factory.py
+++ b/nautobot/dcim/factory.py
@@ -2,8 +2,6 @@ import logging
 import random
 
 import factory
-import factory.fuzzy
-import faker
 
 from nautobot.core.factory import OrganizationalModelFactory, PrimaryModelFactory
 from nautobot.dcim.models import DeviceRole, DeviceType, Manufacturer, Platform
@@ -66,12 +64,12 @@ class PlatformFactory(OrganizationalModelFactory):
     name = factory.Maybe(
         "has_manufacturer",
         factory.LazyAttributeSequence(lambda o, n: f"{o.manufacturer.name} Platform {n + 1}"),
-        factory.Sequence(lambda n: f"Platform {n}"),
+        factory.Sequence(lambda n: f"Fake Platform {n}"),
     )
 
     manufacturer = factory.Maybe("has_manufacturer", random_instance(Manufacturer), None)
 
-    # If it has a manufacturer, it *might* have a naplam_driver.
+    # If it has a manufacturer, it *might* have a napalm_driver.
     napalm_driver = factory.Maybe(
         "has_manufacturer",
         factory.LazyAttribute(lambda o: random.choice(NAPALM_DRIVERS.get(o.manufacturer.slug, [""]))),
@@ -106,7 +104,7 @@ class DeviceTypeFactory(PrimaryModelFactory):
 
     # If randomly a subdevice, set u_height to 0.
     is_subdevice_child = factory.Faker("boolean", chance_of_getting_true=33)
-    u_height = factory.Maybe("is_subdevice_child", 0, factory.fuzzy.FuzzyInteger(1, 2))
+    u_height = factory.Maybe("is_subdevice_child", 0, factory.Faker("pyint", min_value=1, max_value=2))
 
     is_full_depth = factory.Faker("pybool")
 
@@ -127,9 +125,7 @@ class DeviceRoleFactory(OrganizationalModelFactory):
         exclude = ("has_description",)
 
     # Slug isn't defined here since it will always inherit from name.
-    name = factory.LazyFunction(
-        lambda: "".join(word.title() for word in faker.Faker().words(nb=2, part_of_speech="adjective", unique=True))
-    )
+    name = factory.Sequence(lambda n: f"Fake Device Role {n}")
     color = factory.Iterator(ColorChoices.CHOICES, getter=lambda choice: choice[0])
     vm_role = factory.Faker("pybool")
 

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -844,7 +844,9 @@ class ManufacturerTest(APIViewTestCases.APIViewTestCase):
     @classmethod
     def setUpTestData(cls):
 
-        # Pre-existing DeviceType and Platforms need to be deleted first.
+        # FIXME(jathan): This has to be replaced with# `get_deletable_object` and
+        # `get_deletable_object_pks` but this is a workaround just so all of these objects are
+        # deletable for now.
         DeviceType.objects.all().delete()
         Platform.objects.all().delete()
 

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -1811,7 +1811,6 @@ class FrontPortTest(Mixins.BasePortTestMixin):
 
     def test_trace(self):
         """FrontPorts don't support trace."""
-        pass
 
     @classmethod
     def setUpTestData(cls):
@@ -1876,7 +1875,6 @@ class RearPortTest(Mixins.BasePortTestMixin):
 
     def test_trace(self):
         """RearPorts don't support trace."""
-        pass
 
     @classmethod
     def setUpTestData(cls):

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -2110,20 +2110,19 @@ class ConnectedDeviceTest(APITestCase):
 
         cable_status = Status.objects.get_for_model(Cable).get(slug="connected")
 
-        device1 = Device.objects.create(
+        self.device1 = Device.objects.create(
             device_type=device_type,
             device_role=device_role,
             name="TestDevice1",
             site=site,
         )
-        self.device1 = device1
         device2 = Device.objects.create(
             device_type=device_type,
             device_role=device_role,
             name="TestDevice2",
             site=site,
         )
-        interface1 = Interface.objects.create(device=device1, name="eth0")
+        interface1 = Interface.objects.create(device=self.device1, name="eth0")
         interface2 = Interface.objects.create(device=device2, name="eth0")
 
         cable = Cable(termination_a=interface1, termination_b=interface2, status=cable_status)

--- a/nautobot/dcim/tests/test_filters.py
+++ b/nautobot/dcim/tests/test_filters.py
@@ -1438,7 +1438,7 @@ class ManufacturerTestCase(FilterTestCases.NameSlugFilterTestCase):
         InventoryItem.objects.create(device=devices[2], name="Inventory Item 3", manufacturer=cls.manufacturers[2])
 
     def test_description(self):
-        descriptions = [m.description for m in self.manufacturers[:2]]
+        descriptions = [m.description for m in self.manufacturers[::2]]
         params = {"description": descriptions}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(descriptions))
 

--- a/nautobot/dcim/tests/test_filters.py
+++ b/nautobot/dcim/tests/test_filters.py
@@ -1438,12 +1438,11 @@ class ManufacturerTestCase(FilterTestCases.NameSlugFilterTestCase):
         InventoryItem.objects.create(device=devices[2], name="Inventory Item 3", manufacturer=cls.manufacturers[2])
 
     def test_description(self):
-        # FIXME(jathan): We only want 1st/3rd manufacturer and only care right now because of random
-        # seed determinisim and mixed bag of static/dynamic fixture creation. Rip this out when all
-        # factories are done.
-        descriptions = [m.description for m in (self.manufacturers[0], self.manufacturers[-1])]
-        params = {"description": descriptions}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(descriptions))
+        manufacturers = self.queryset.exclude(description="")[:2]
+        params = {"description": [manufacturers[0].description, manufacturers[1].description]}
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset(params, self.queryset).qs, self.queryset.filter(description__in=params["description"])
+        )
 
     def test_inventory_items(self):
         inventory_items = list(InventoryItem.objects.all()[:2])

--- a/nautobot/dcim/tests/test_filters.py
+++ b/nautobot/dcim/tests/test_filters.py
@@ -1438,7 +1438,10 @@ class ManufacturerTestCase(FilterTestCases.NameSlugFilterTestCase):
         InventoryItem.objects.create(device=devices[2], name="Inventory Item 3", manufacturer=cls.manufacturers[2])
 
     def test_description(self):
-        descriptions = [m.description for m in self.manufacturers[::2]]
+        # FIXME(jathan): We only want 1st/3rd manufacturer and only care right now because of random
+        # seed determinisim and mixed bag of static/dynamic fixture creation. Rip this out when all
+        # factories are done.
+        descriptions = [m.description for m in (self.manufacturers[0], self.manufacturers[-1])]
         params = {"description": descriptions}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(descriptions))
 
@@ -1462,6 +1465,8 @@ class ManufacturerTestCase(FilterTestCases.NameSlugFilterTestCase):
             )
 
     def test_device_types(self):
+        # FIXME(jathan): Hard-coding around expected values should be ripped out
+        # once all fixture factory work has completed.
         device_types = list(DeviceType.objects.filter(model__startswith="Model")[:2])
         params = {"device_types": [device_types[0].pk, device_types[1].slug]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(device_types))
@@ -1481,6 +1486,8 @@ class ManufacturerTestCase(FilterTestCases.NameSlugFilterTestCase):
             )
 
     def test_platforms(self):
+        # FIXME(jathan): Hard-coding around expected values should be ripped out
+        # once all fixture factory work has completed.
         platforms = list(Platform.objects.filter(name__startswith="Platform")[:2])
         params = {"platforms": [platforms[0].pk, platforms[1].slug]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(platforms))
@@ -1520,21 +1527,29 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
         )
 
     def test_model(self):
+        # FIXME(jathan): Hard-coding around expected values should be ripped out
+        # once all fixture factory work has completed.
         models = ["Model 1", "Model 2"]
         params = {"model": models}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(models))
 
     def test_slug(self):
+        # FIXME(jathan): Hard-coding around expected values should be ripped out
+        # once all fixture factory work has completed.
         slugs = ["model-1", "model-2"]
         params = {"slug": slugs}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(slugs))
 
     def test_part_number(self):
+        # FIXME(jathan): Hard-coding around expected values should be ripped out
+        # once all fixture factory work has completed.
         part_numbers = ["Part Number 1", "Part Number 2"]
         params = {"part_number": part_numbers}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(part_numbers))
 
     def test_u_height(self):
+        # FIXME(jathan): Hard-coding around expected values should be ripped out
+        # once all fixture factory work has completed.
         heights = [1, 2]
         params = {"u_height": heights}
         self.assertEqual(
@@ -1691,6 +1706,8 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.values_list("pk", flat=True)[0], value)
 
     def test_comments(self):
+        # FIXME(jathan): Hard-coding around expected values should be ripped out
+        # once all fixture factory work has completed.
         comments = ["Device type 1", "Device type 2"]
         params = {"comments": comments}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(comments))
@@ -2216,6 +2233,8 @@ class PlatformTestCase(FilterTestCases.NameSlugFilterTestCase):
         common_test_data(cls)
 
     def test_description(self):
+        # FIXME(jathan): Hard-coding around expected values should be ripped out
+        # once all fixture factory work has completed.
         descriptions = ["A", "B"]
         params = {"description": descriptions}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(descriptions))
@@ -2243,6 +2262,8 @@ class PlatformTestCase(FilterTestCases.NameSlugFilterTestCase):
             )
 
     def test_napalm_args(self):
+        # FIXME(jathan): Hard-coding around expected values should be ripped out
+        # once all fixture factory work has completed.
         napalm_args = ['["--test", "--arg1"]', '["--test", "--arg2"]']
         params = {"napalm_args": napalm_args}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(napalm_args))

--- a/nautobot/dcim/tests/test_filters.py
+++ b/nautobot/dcim/tests/test_filters.py
@@ -1450,15 +1450,15 @@ class ManufacturerTestCase(FilterTestCases.NameSlugFilterTestCase):
     def test_has_inventory_items(self):
         with self.subTest():
             params = {"has_inventory_items": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(inventory_items__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(inventory_items__isnull=True),
             )
         with self.subTest():
             params = {"has_inventory_items": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(inventory_items__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(inventory_items__isnull=False),
             )
 
     def test_device_types(self):
@@ -1469,15 +1469,15 @@ class ManufacturerTestCase(FilterTestCases.NameSlugFilterTestCase):
     def test_has_device_types(self):
         with self.subTest():
             params = {"has_device_types": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(device_types__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(device_types__isnull=True),
             )
         with self.subTest():
             params = {"has_device_types": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(device_types__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(device_types__isnull=False),
             )
 
     def test_platforms(self):
@@ -1488,15 +1488,15 @@ class ManufacturerTestCase(FilterTestCases.NameSlugFilterTestCase):
     def test_has_platforms(self):
         with self.subTest():
             params = {"has_platforms": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(platforms__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(platforms__isnull=True),
             )
         with self.subTest():
             params = {"has_platforms": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(platforms__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(platforms__isnull=False),
             )
 
 
@@ -1544,29 +1544,29 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
     def test_is_full_depth(self):
         with self.subTest():
             params = {"is_full_depth": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(is_full_depth=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(is_full_depth=True),
             )
         with self.subTest():
             params = {"is_full_depth": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(is_full_depth=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(is_full_depth=False),
             )
 
     def test_subdevice_role(self):
         with self.subTest():
             params = {"subdevice_role": SubdeviceRoleChoices.ROLE_PARENT}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(subdevice_role=SubdeviceRoleChoices.ROLE_PARENT).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(subdevice_role=SubdeviceRoleChoices.ROLE_PARENT),
             )
         with self.subTest():
             params = {"subdevice_role": SubdeviceRoleChoices.ROLE_CHILD}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(subdevice_role=SubdeviceRoleChoices.ROLE_CHILD).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(subdevice_role=SubdeviceRoleChoices.ROLE_CHILD),
             )
 
     def test_manufacturer(self):
@@ -1574,115 +1574,115 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
         with self.subTest():
             pk_list = [manufacturers[0].pk, manufacturers[1].pk]
             params = {"manufacturer_id": pk_list}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(manufacturer_id__in=pk_list).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(manufacturer_id__in=pk_list),
             )
         with self.subTest():
             slugs = [manufacturers[0].slug, manufacturers[1].slug]
             params = {"manufacturer": slugs}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(manufacturer__slug__in=slugs).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(manufacturer__slug__in=slugs),
             )
 
     def test_console_ports(self):
         with self.subTest():
             params = {"console_ports": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(consoleporttemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(consoleporttemplates__isnull=True),
             )
         with self.subTest():
             params = {"console_ports": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(consoleporttemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(consoleporttemplates__isnull=False),
             )
 
     def test_console_server_ports(self):
         with self.subTest():
             params = {"console_server_ports": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(consoleserverporttemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(consoleserverporttemplates__isnull=True),
             )
         with self.subTest():
             params = {"console_server_ports": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(consoleserverporttemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(consoleserverporttemplates__isnull=False),
             )
 
     def test_power_ports(self):
         with self.subTest():
             params = {"power_ports": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(powerporttemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(powerporttemplates__isnull=True),
             )
         with self.subTest():
             params = {"power_ports": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(powerporttemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(powerporttemplates__isnull=False),
             )
 
     def test_power_outlets(self):
         with self.subTest():
             params = {"power_outlets": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(poweroutlettemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(poweroutlettemplates__isnull=True),
             )
         with self.subTest():
             params = {"power_outlets": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(poweroutlettemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(poweroutlettemplates__isnull=False),
             )
 
     def test_interfaces(self):
         with self.subTest():
             params = {"interfaces": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(interfacetemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(interfacetemplates__isnull=True),
             )
         with self.subTest():
             params = {"interfaces": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(interfacetemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(interfacetemplates__isnull=False),
             )
 
     def test_pass_through_ports(self):
         query = Q(frontporttemplates__isnull=False, rearporttemplates__isnull=False)
         with self.subTest():
             params = {"pass_through_ports": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(query).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(query),
             )
         with self.subTest():
             params = {"pass_through_ports": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(~query).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(~query),
             )
 
     def test_device_bays(self):
         with self.subTest():
             params = {"device_bays": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(devicebaytemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(devicebaytemplates__isnull=True),
             )
         with self.subTest():
             params = {"device_bays": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(devicebaytemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(devicebaytemplates__isnull=False),
             )
 
     def test_search(self):
@@ -1703,15 +1703,15 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
     def test_has_instances(self):
         with self.subTest():
             params = {"has_instances": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(instances__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(instances__isnull=True),
             )
         with self.subTest():
             params = {"has_instances": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(instances__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(instances__isnull=False),
             )
 
     def test_console_port_templates(self):
@@ -1722,15 +1722,15 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
     def test_has_console_port_templates(self):
         with self.subTest():
             params = {"has_console_port_templates": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(consoleporttemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(consoleporttemplates__isnull=True),
             )
         with self.subTest():
             params = {"has_console_port_templates": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(consoleporttemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(consoleporttemplates__isnull=False),
             )
 
     def test_console_server_port_templates(self):
@@ -1741,15 +1741,15 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
     def test_has_console_server_port_templates(self):
         with self.subTest():
             params = {"has_console_server_port_templates": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(consoleserverporttemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(consoleserverporttemplates__isnull=True),
             )
         with self.subTest():
             params = {"has_console_server_port_templates": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(consoleserverporttemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(consoleserverporttemplates__isnull=False),
             )
 
     def test_power_port_templates(self):
@@ -1760,15 +1760,15 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
     def test_has_power_port_templates(self):
         with self.subTest():
             params = {"has_power_port_templates": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(powerporttemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(powerporttemplates__isnull=True),
             )
         with self.subTest():
             params = {"has_power_port_templates": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(powerporttemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(powerporttemplates__isnull=False),
             )
 
     def test_power_outlet_templates(self):
@@ -1779,15 +1779,15 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
     def test_has_power_outlet_templates(self):
         with self.subTest():
             params = {"has_power_outlet_templates": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(poweroutlettemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(poweroutlettemplates__isnull=True),
             )
         with self.subTest():
             params = {"has_power_outlet_templates": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(poweroutlettemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(poweroutlettemplates__isnull=False),
             )
 
     def test_interface_templates(self):
@@ -1798,15 +1798,15 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
     def test_has_interface_templates(self):
         with self.subTest():
             params = {"has_interface_templates": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(interfacetemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(interfacetemplates__isnull=True),
             )
         with self.subTest():
             params = {"has_interface_templates": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(interfacetemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(interfacetemplates__isnull=False),
             )
 
     def test_front_port_templates(self):
@@ -1817,15 +1817,15 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
     def test_has_front_port_templates(self):
         with self.subTest():
             params = {"has_front_port_templates": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(frontporttemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(frontporttemplates__isnull=True),
             )
         with self.subTest():
             params = {"has_front_port_templates": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(frontporttemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(frontporttemplates__isnull=False),
             )
 
     def test_rear_port_templates(self):
@@ -1836,15 +1836,15 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
     def test_has_rear_port_templates(self):
         with self.subTest():
             params = {"has_rear_port_templates": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(rearporttemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(rearporttemplates__isnull=True),
             )
         with self.subTest():
             params = {"has_rear_port_templates": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(rearporttemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(rearporttemplates__isnull=False),
             )
 
     def test_device_bay_templates(self):
@@ -1855,15 +1855,15 @@ class DeviceTypeTestCase(FilterTestCases.FilterTestCase):
     def test_has_device_bay_templates(self):
         with self.subTest():
             params = {"has_device_bay_templates": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(devicebaytemplates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(devicebaytemplates__isnull=True),
             )
         with self.subTest():
             params = {"has_device_bay_templates": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(devicebaytemplates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(devicebaytemplates__isnull=False),
             )
 
 
@@ -1886,17 +1886,17 @@ class Mixins:
         def test_devicetype_id(self):
             pk_list = [self.device_types[0].pk, self.device_types[1].pk]
             params = {"devicetype_id": pk_list}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(device_type_id__in=pk_list).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(device_type_id__in=pk_list),
             )
 
         def test_device_type(self):
             slugs = [self.device_types[0].slug, self.device_types[1].slug]
             params = {"device_type": slugs}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(device_type__slug__in=slugs).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(device_type__slug__in=slugs),
             )
 
         def test_label(self):
@@ -1963,15 +1963,15 @@ class PowerPortTemplateTestCase(Mixins.ComponentTemplateMixin):
     def test_has_power_outlet_templates(self):
         with self.subTest():
             params = {"has_power_outlet_templates": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(poweroutlet_templates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(poweroutlet_templates__isnull=True),
             )
         with self.subTest():
             params = {"has_power_outlet_templates": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(poweroutlet_templates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(poweroutlet_templates__isnull=False),
             )
 
 
@@ -1998,9 +1998,9 @@ class PowerOutletTemplateTestCase(Mixins.ComponentTemplateMixin):
     def test_feed_leg(self):
         # TODO: Support filtering for multiple values
         params = {"feed_leg": PowerOutletFeedLegChoices.FEED_LEG_A}
-        self.assertEqual(
-            self.filterset(params, self.queryset).qs.count(),
-            self.queryset.filter(**params).count(),
+        self.assertQuerysetEqual(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(**params),
         )
 
     def test_power_port_template(self):
@@ -2019,23 +2019,23 @@ class InterfaceTemplateTestCase(Mixins.ComponentTemplateMixin):
     def test_type(self):
         # TODO: Support filtering for multiple values
         params = {"type": InterfaceTypeChoices.TYPE_1GE_FIXED}
-        self.assertEqual(
-            self.filterset(params, self.queryset).qs.count(),
-            self.queryset.filter(**params).count(),
+        self.assertQuerysetEqual(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(**params),
         )
 
     def test_mgmt_only(self):
         with self.subTest():
             params = {"mgmt_only": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(**params).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(**params),
             )
         with self.subTest():
             params = {"mgmt_only": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(**params).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(**params),
             )
 
 
@@ -2049,17 +2049,17 @@ class FrontPortTemplateTestCase(Mixins.ComponentTemplateMixin):
     def test_type(self):
         # TODO: Support filtering for multiple values
         params = {"type": PortTypeChoices.TYPE_8P8C}
-        self.assertEqual(
-            self.filterset(params, self.queryset).qs.count(),
-            self.queryset.filter(**params).count(),
+        self.assertQuerysetEqual(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(**params),
         )
 
     def test_rear_port_position(self):
         positions = [1, 2]
         params = {"rear_port_position": positions}
-        self.assertEqual(
-            self.filterset(params, self.queryset).qs.count(),
-            self.queryset.filter(rear_port_position__in=positions).count(),
+        self.assertQuerysetEqual(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(rear_port_position__in=positions),
         )
 
     def test_rear_port_template(self):
@@ -2092,17 +2092,17 @@ class RearPortTemplateTestCase(Mixins.ComponentTemplateMixin):
     def test_type(self):
         # TODO: Support filtering for multiple values
         params = {"type": PortTypeChoices.TYPE_8P8C}
-        self.assertEqual(
-            self.filterset(params, self.queryset).qs.count(),
-            self.queryset.filter(**params).count(),
+        self.assertQuerysetEqual(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(**params),
         )
 
     def test_positions(self):
         positions = [1, 2]
         params = {"positions": positions}
-        self.assertEqual(
-            self.filterset(params, self.queryset).qs.count(),
-            self.queryset.filter(positions__in=positions).count(),
+        self.assertQuerysetEqual(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(positions__in=positions),
         )
 
     def test_front_port_templates(self):
@@ -2113,15 +2113,15 @@ class RearPortTemplateTestCase(Mixins.ComponentTemplateMixin):
     def test_has_front_port_templates(self):
         with self.subTest():
             params = {"has_front_port_templates": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(frontport_templates__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(frontport_templates__isnull=True),
             )
         with self.subTest():
             params = {"has_front_port_templates": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(frontport_templates__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(frontport_templates__isnull=False),
             )
 
 
@@ -2144,23 +2144,23 @@ class DeviceRoleTestCase(FilterTestCases.NameSlugFilterTestCase):
     def test_color(self):
         colors = ["ff0000", "00ff00"]
         params = {"color": colors}
-        self.assertEqual(
-            self.filterset(params, self.queryset).qs.count(),
-            self.queryset.filter(color__in=colors).count(),
+        self.assertQuerysetEqual(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(color__in=colors),
         )
 
     def test_vm_role(self):
         with self.subTest():
             params = {"vm_role": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(vm_role=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(vm_role=True),
             )
         with self.subTest():
             params = {"vm_role": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(vm_role=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(vm_role=False),
             )
 
     def test_description(self):
@@ -2176,15 +2176,15 @@ class DeviceRoleTestCase(FilterTestCases.NameSlugFilterTestCase):
     def test_has_devices(self):
         with self.subTest():
             params = {"has_devices": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(devices__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(devices__isnull=True),
             )
         with self.subTest():
             params = {"has_devices": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(devices__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(devices__isnull=False),
             )
 
     def test_virtual_machines(self):
@@ -2195,15 +2195,15 @@ class DeviceRoleTestCase(FilterTestCases.NameSlugFilterTestCase):
     def test_has_virtual_machines(self):
         with self.subTest():
             params = {"has_virtual_machines": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(virtual_machines__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(virtual_machines__isnull=True),
             )
         with self.subTest():
             params = {"has_virtual_machines": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(virtual_machines__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(virtual_machines__isnull=False),
             )
 
 
@@ -2230,16 +2230,16 @@ class PlatformTestCase(FilterTestCases.NameSlugFilterTestCase):
         with self.subTest():
             pk_list = [manufacturers[0].pk, manufacturers[1].pk]
             params = {"manufacturer_id": pk_list}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(manufacturer_id__in=pk_list).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(manufacturer_id__in=pk_list),
             )
         with self.subTest():
             slugs = [manufacturers[0].slug, manufacturers[1].slug]
             params = {"manufacturer": slugs}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.filter(manufacturer__slug__in=slugs).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.filter(manufacturer__slug__in=slugs),
             )
 
     def test_napalm_args(self):
@@ -2255,15 +2255,15 @@ class PlatformTestCase(FilterTestCases.NameSlugFilterTestCase):
     def test_has_devices(self):
         with self.subTest():
             params = {"has_devices": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(devices__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(devices__isnull=True),
             )
         with self.subTest():
             params = {"has_devices": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(devices__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(devices__isnull=False),
             )
 
     def test_virtual_machines(self):
@@ -2274,15 +2274,15 @@ class PlatformTestCase(FilterTestCases.NameSlugFilterTestCase):
     def test_has_virtual_machines(self):
         with self.subTest():
             params = {"has_virtual_machines": True}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(virtual_machines__isnull=True).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(virtual_machines__isnull=True),
             )
         with self.subTest():
             params = {"has_virtual_machines": False}
-            self.assertEqual(
-                self.filterset(params, self.queryset).qs.count(),
-                self.queryset.exclude(virtual_machines__isnull=False).count(),
+            self.assertQuerysetEqual(
+                self.filterset(params, self.queryset).qs,
+                self.queryset.exclude(virtual_machines__isnull=False),
             )
 
 

--- a/nautobot/dcim/tests/test_forms.py
+++ b/nautobot/dcim/tests/test_forms.py
@@ -40,12 +40,13 @@ class DeviceTestCase(TestCase):
             u_height=1,
             is_full_depth=True,
         ).first()
-        cls.platform = Platform.objects.filter(manufacturer=cls.device_type.manufacturer).first()
         cls.manufacturer = cls.device_type.manufacturer
+        cls.platform = Platform.objects.filter(manufacturer=cls.device_type.manufacturer).first()
         cls.device_role = DeviceRole.objects.first()
 
         Device.objects.create(
             name="Device 1",
+            status=Status.objects.get_for_model(Device).get(slug="active"),
             device_type=cls.device_type,
             device_role=cls.device_role,
             site=cls.site,

--- a/nautobot/dcim/tests/test_forms.py
+++ b/nautobot/dcim/tests/test_forms.py
@@ -30,14 +30,24 @@ class DeviceTestCase(TestCase):
 
         cls.site = Site.objects.create(name="Site 1", slug="site-1")
         cls.rack = Rack.objects.create(name="Rack 1", site=cls.site)
-        cls.device_type = DeviceType.objects.filter(u_height=1).first()
+
+        # Platforms that have a manufacturer.
+        mfr_platforms = Platform.objects.filter(manufacturer__isnull=False)
+
+        # Get a DeviceType that has a manufacturer in line with one of the platforms.
+        cls.device_type = DeviceType.objects.filter(
+            manufacturer__in=mfr_platforms.values("manufacturer"),
+            u_height=1,
+            is_full_depth=True,
+        ).first()
         cls.platform = Platform.objects.filter(manufacturer=cls.device_type.manufacturer).first()
         cls.manufacturer = cls.device_type.manufacturer
-        device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1", color="ff0000")
+        cls.device_role = DeviceRole.objects.first()
+
         Device.objects.create(
             name="Device 1",
             device_type=cls.device_type,
-            device_role=device_role,
+            device_role=cls.device_role,
             site=cls.site,
             rack=cls.rack,
             position=1,
@@ -51,7 +61,7 @@ class DeviceTestCase(TestCase):
         form = DeviceForm(
             data={
                 "name": "New Device",
-                "device_role": DeviceRole.objects.first().pk,
+                "device_role": self.device_role.pk,
                 "tenant": None,
                 "manufacturer": self.manufacturer.pk,
                 "device_type": self.device_type.pk,
@@ -70,7 +80,7 @@ class DeviceTestCase(TestCase):
         form = DeviceForm(
             data={
                 "name": "test",
-                "device_role": DeviceRole.objects.first().pk,
+                "device_role": self.device_role.pk,
                 "tenant": None,
                 "manufacturer": self.manufacturer.pk,
                 "device_type": self.device_type.pk,
@@ -89,7 +99,7 @@ class DeviceTestCase(TestCase):
         form = DeviceForm(
             data={
                 "name": "New Device",
-                "device_role": DeviceRole.objects.first().pk,
+                "device_role": self.device_role.pk,
                 "tenant": None,
                 "manufacturer": self.manufacturer.pk,
                 "device_type": self.device_type.pk,
@@ -109,7 +119,7 @@ class DeviceTestCase(TestCase):
         form = DeviceForm(
             data={
                 "name": "New Device",
-                "device_role": DeviceRole.objects.first().pk,
+                "device_role": self.device_role.pk,
                 "tenant": None,
                 "manufacturer": self.manufacturer.pk,
                 "device_type": self.device_type.pk,
@@ -127,7 +137,7 @@ class DeviceTestCase(TestCase):
         form = DeviceForm(
             data={
                 "name": "New Device",
-                "device_role": DeviceRole.objects.first().pk,
+                "device_role": self.device_role.pk,
                 "tenant": None,
                 "manufacturer": self.manufacturer.pk,
                 "device_type": self.device_type.pk,
@@ -147,7 +157,7 @@ class LabelTestCase(TestCase):
     def setUpTestData(cls):
         site = Site.objects.create(name="Site 2", slug="site-2")
         device_type = DeviceType.objects.first()
-        device_role = DeviceRole.objects.create(name="Device Role 2", slug="device-role-2", color="ffff00")
+        device_role = DeviceRole.objects.first()
         cls.device = Device.objects.create(
             name="Device 2",
             device_type=device_type,
@@ -188,7 +198,7 @@ class TestCableCSVForm(TestCase):
     def setUpTestData(cls):
         site = Site.objects.create(name="Site 2", slug="site-2")
         device_type = DeviceType.objects.first()
-        device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1", color="ffff00")
+        device_role = DeviceRole.objects.first()
         cls.device_1 = Device.objects.create(
             name="Device 1",
             device_type=device_type,
@@ -243,7 +253,7 @@ class TestInterfaceCSVForm(TestCase):
     def setUpTestData(cls):
         site = Site.objects.create(name="Site 1", slug="site-1")
         device_type = DeviceType.objects.first()
-        device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
+        device_role = DeviceRole.objects.first()
 
         cls.devices = (
             Device.objects.create(

--- a/nautobot/dcim/tests/test_forms.py
+++ b/nautobot/dcim/tests/test_forms.py
@@ -8,7 +8,6 @@ from nautobot.dcim.models import (
     DeviceRole,
     DeviceType,
     Interface,
-    Manufacturer,
     Platform,
     Rack,
     Site,
@@ -29,23 +28,18 @@ class DeviceTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
 
-        site = Site.objects.create(name="Site 1", slug="site-1")
-        rack = Rack.objects.create(name="Rack 1", site=site)
-        manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
-        device_type = DeviceType.objects.create(
-            manufacturer=manufacturer,
-            model="Device Type 1",
-            slug="device-type-1",
-            u_height=1,
-        )
+        cls.site = Site.objects.create(name="Site 1", slug="site-1")
+        cls.rack = Rack.objects.create(name="Rack 1", site=cls.site)
+        cls.device_type = DeviceType.objects.filter(u_height=1).first()
+        cls.platform = Platform.objects.filter(manufacturer=cls.device_type.manufacturer).first()
+        cls.manufacturer = cls.device_type.manufacturer
         device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1", color="ff0000")
-        Platform.objects.create(name="Platform 1", slug="platform-1")
         Device.objects.create(
             name="Device 1",
-            device_type=device_type,
+            device_type=cls.device_type,
             device_role=device_role,
-            site=site,
-            rack=rack,
+            site=cls.site,
+            rack=cls.rack,
             position=1,
         )
         cluster_type = ClusterType.objects.create(name="Cluster Type 1", slug="cluster-type-1")
@@ -59,13 +53,13 @@ class DeviceTestCase(TestCase):
                 "name": "New Device",
                 "device_role": DeviceRole.objects.first().pk,
                 "tenant": None,
-                "manufacturer": Manufacturer.objects.first().pk,
-                "device_type": DeviceType.objects.first().pk,
-                "site": Site.objects.first().pk,
-                "rack": Rack.objects.first().pk,
+                "manufacturer": self.manufacturer.pk,
+                "device_type": self.device_type.pk,
+                "site": self.site.pk,
+                "rack": self.rack.pk,
                 "face": DeviceFaceChoices.FACE_FRONT,
                 "position": 2,
-                "platform": Platform.objects.first().pk,
+                "platform": self.platform.pk,
                 "status": self.device_status.pk,
             }
         )
@@ -78,13 +72,13 @@ class DeviceTestCase(TestCase):
                 "name": "test",
                 "device_role": DeviceRole.objects.first().pk,
                 "tenant": None,
-                "manufacturer": Manufacturer.objects.first().pk,
-                "device_type": DeviceType.objects.first().pk,
-                "site": Site.objects.first().pk,
-                "rack": Rack.objects.first().pk,
+                "manufacturer": self.manufacturer.pk,
+                "device_type": self.device_type.pk,
+                "site": self.site.pk,
+                "rack": self.rack.pk,
                 "face": DeviceFaceChoices.FACE_FRONT,
                 "position": 1,
-                "platform": Platform.objects.first().pk,
+                "platform": self.platform.pk,
                 "status": self.device_status.pk,
             }
         )
@@ -97,13 +91,13 @@ class DeviceTestCase(TestCase):
                 "name": "New Device",
                 "device_role": DeviceRole.objects.first().pk,
                 "tenant": None,
-                "manufacturer": Manufacturer.objects.first().pk,
-                "device_type": DeviceType.objects.first().pk,
-                "site": Site.objects.first().pk,
+                "manufacturer": self.manufacturer.pk,
+                "device_type": self.device_type.pk,
+                "site": self.site.pk,
                 "rack": None,
                 "face": None,
                 "position": None,
-                "platform": Platform.objects.first().pk,
+                "platform": self.platform.pk,
                 "status": self.device_status.pk,
                 "secrets_group": SecretsGroup.objects.first().pk,
             }
@@ -117,9 +111,9 @@ class DeviceTestCase(TestCase):
                 "name": "New Device",
                 "device_role": DeviceRole.objects.first().pk,
                 "tenant": None,
-                "manufacturer": Manufacturer.objects.first().pk,
-                "device_type": DeviceType.objects.first().pk,
-                "site": Site.objects.first().pk,
+                "manufacturer": self.manufacturer.pk,
+                "device_type": self.device_type.pk,
+                "site": self.site.pk,
                 "rack": None,
                 "face": DeviceFaceChoices.FACE_REAR,
                 "platform": None,
@@ -135,9 +129,9 @@ class DeviceTestCase(TestCase):
                 "name": "New Device",
                 "device_role": DeviceRole.objects.first().pk,
                 "tenant": None,
-                "manufacturer": Manufacturer.objects.first().pk,
-                "device_type": DeviceType.objects.first().pk,
-                "site": Site.objects.first().pk,
+                "manufacturer": self.manufacturer.pk,
+                "device_type": self.device_type.pk,
+                "site": self.site.pk,
                 "rack": None,
                 "position": 10,
                 "platform": None,
@@ -152,17 +146,11 @@ class LabelTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         site = Site.objects.create(name="Site 2", slug="site-2")
-        manufacturer = Manufacturer.objects.create(name="Manufacturer 2", slug="manufacturer-2")
-        cls.device_type = DeviceType.objects.create(
-            manufacturer=manufacturer,
-            model="Device Type 2",
-            slug="device-type-2",
-            u_height=1,
-        )
+        device_type = DeviceType.objects.first()
         device_role = DeviceRole.objects.create(name="Device Role 2", slug="device-role-2", color="ffff00")
         cls.device = Device.objects.create(
             name="Device 2",
-            device_type=cls.device_type,
+            device_type=device_type,
             device_role=device_role,
             site=site,
         )
@@ -199,13 +187,7 @@ class TestCableCSVForm(TestCase):
     @classmethod
     def setUpTestData(cls):
         site = Site.objects.create(name="Site 2", slug="site-2")
-        manufacturer = Manufacturer.objects.create(name="Manufacturer 2", slug="manufacturer-2")
-        device_type = DeviceType.objects.create(
-            manufacturer=manufacturer,
-            model="Device Type 1",
-            slug="device-type-1",
-            u_height=1,
-        )
+        device_type = DeviceType.objects.first()
         device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1", color="ffff00")
         cls.device_1 = Device.objects.create(
             name="Device 1",
@@ -260,8 +242,7 @@ class TestInterfaceCSVForm(TestCase):
     @classmethod
     def setUpTestData(cls):
         site = Site.objects.create(name="Site 1", slug="site-1")
-        manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
-        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="Model 1", slug="model-1")
+        device_type = DeviceType.objects.first()
         device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
 
         cls.devices = (

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1250,7 +1250,7 @@ class DeviceRoleTestCase(ViewTestCases.OrganizationalObjectViewTestCase):
         DeviceRole.objects.create(name="Device Role 1", slug="device-role-1")
         DeviceRole.objects.create(name="Device Role 2", slug="device-role-2")
         DeviceRole.objects.create(name="Device Role 3", slug="device-role-3")
-        DeviceRole.objects.create(name="Device Role 8")
+        device_role = DeviceRole.objects.create(name="Slug Test Role 8", slug="slug-test-role-8")
 
         cls.form_data = {
             "name": "Device Role X",
@@ -1268,7 +1268,7 @@ class DeviceRoleTestCase(ViewTestCases.OrganizationalObjectViewTestCase):
             "Device Role 7,,0000ff",
         )
 
-        cls.slug_test_object = "Device Role 8"
+        cls.slug_test_object = device_role.name
         cls.slug_source = "name"
 
 
@@ -1298,8 +1298,8 @@ class PlatformTestCase(ViewTestCases.OrganizationalObjectViewTestCase):
             "Platform 7,,Seventh platform",
         )
 
-        cls.slug_source = "name"
         cls.slug_test_object = platform.name
+        cls.slug_source = "name"
 
 
 class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -716,7 +716,7 @@ class DeviceTypeTestCase(
         }
 
         cls.slug_source = "model"
-        cls.slug_test_object = "Device Type 4"
+        cls.slug_test_object = "Test Device Type 4"
 
     # Temporary FIXME(jathan): Literally just trying to get the tests running so
     # we can keep moving on the fixture factories. This should be removed once

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -692,10 +692,10 @@ class DeviceTypeTestCase(
             Manufacturer.objects.last(),
         )
 
-        DeviceType.objects.create(model="Device Type 1", slug="device-type-1", manufacturer=manufacturers[0])
-        DeviceType.objects.create(model="Device Type 2", slug="device-type-2", manufacturer=manufacturers[0])
-        DeviceType.objects.create(model="Device Type 3", slug="device-type-3", manufacturer=manufacturers[0])
-        DeviceType.objects.create(model="Device Type 4", manufacturer=manufacturers[1])
+        DeviceType.objects.create(model="Test Device Type 1", slug="device-type-1", manufacturer=manufacturers[0])
+        DeviceType.objects.create(model="Test Device Type 2", slug="device-type-2", manufacturer=manufacturers[0])
+        DeviceType.objects.create(model="Test Device Type 3", slug="device-type-3", manufacturer=manufacturers[0])
+        DeviceType.objects.create(model="Test Device Type 4", manufacturer=manufacturers[1])
 
         cls.form_data = {
             "manufacturer": manufacturers[1].pk,
@@ -717,6 +717,24 @@ class DeviceTypeTestCase(
 
         cls.slug_source = "model"
         cls.slug_test_object = "Device Type 4"
+
+    # Temporary FIXME(jathan): Literally just trying to get the tests running so
+    # we can keep moving on the fixture factories. This should be removed once
+    # we've cleaned up all the hard-coded object comparisons and are all in on
+    # factories.
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_bulk_edit_objects_with_constrained_permission(self):
+        DeviceType.objects.exclude(model__startswith="Test Device Type").delete()
+        super().test_bulk_edit_objects_with_constrained_permission()
+
+    # Temporary FIXME(jathan): Literally just trying to get the tests running so
+    # we can keep moving on the fixture factories. This should be removed once
+    # we've cleaned up all the hard-coded object comparisons and are all in on
+    # factories.
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_bulk_edit_objects_with_permission(self):
+        DeviceType.objects.exclude(model__startswith="Test Device Type").delete()
+        super().test_bulk_edit_objects_with_permission()
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_import_objects(self):

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -178,6 +178,7 @@ class ConfigContextTestCase(FilterTestCases.FilterTestCase):
             DeviceRole.objects.create(name="Device Role 2", slug="device-role-2"),
             DeviceRole.objects.create(name="Device Role 3", slug="device-role-3"),
         )
+        cls.device_roles = device_roles
 
         manufacturer = Manufacturer.objects.create(name="Manufacturer 1", slug="manufacturer-1")
 
@@ -186,12 +187,14 @@ class ConfigContextTestCase(FilterTestCases.FilterTestCase):
             DeviceType.objects.create(model="Device Type 2", slug="device-type-2", manufacturer=manufacturer),
             DeviceType.objects.create(model="Device Type 3", slug="device-type-3", manufacturer=manufacturer),
         )
+        cls.device_types = device_types
 
         platforms = (
             Platform.objects.create(name="Platform 1", slug="platform-1"),
             Platform.objects.create(name="Platform 2", slug="platform-2"),
             Platform.objects.create(name="Platform 3", slug="platform-3"),
         )
+        cls.platforms = platforms
 
         cluster_groups = (
             ClusterGroup.objects.create(name="Cluster Group 1", slug="cluster-group-1"),
@@ -252,25 +255,25 @@ class ConfigContextTestCase(FilterTestCases.FilterTestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_role(self):
-        device_roles = DeviceRole.objects.all()[:2]
+        device_roles = self.device_roles[:2]
         params = {"role_id": [device_roles[0].pk, device_roles[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(device_roles))
         params = {"role": [device_roles[0].slug, device_roles[1].slug]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(device_roles))
 
     def test_type(self):
-        device_types = DeviceType.objects.all()[:2]
+        device_types = self.device_types[:2]
         params = {"device_type_id": [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(device_types))
         params = {"device_type": [device_types[0].slug, device_types[1].slug]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(device_types))
 
     def test_platform(self):
-        platforms = Platform.objects.all()[:2]
+        platforms = self.platforms[:2]
         params = {"platform_id": [platforms[0].pk, platforms[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(platforms))
         params = {"platform": [platforms[0].slug, platforms[1].slug]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(platforms))
 
     def test_cluster_group(self):
         cluster_groups = ClusterGroup.objects.all()[:2]

--- a/nautobot/virtualization/tests/test_filters.py
+++ b/nautobot/virtualization/tests/test_filters.py
@@ -299,12 +299,14 @@ class VirtualMachineTestCase(FilterTestCases.FilterTestCase, FilterTestCases.Ten
             Platform.objects.create(name="Platform 2", slug="platform-2"),
             Platform.objects.create(name="Platform 3", slug="platform-3"),
         )
+        cls.platforms = platforms
 
         roles = (
             DeviceRole.objects.create(name="Device Role 1", slug="device-role-1"),
             DeviceRole.objects.create(name="Device Role 2", slug="device-role-2"),
             DeviceRole.objects.create(name="Device Role 3", slug="device-role-3"),
         )
+        cls.roles = roles
 
         tenants = Tenant.objects.filter(group__isnull=False)[:3]
 
@@ -494,18 +496,18 @@ class VirtualMachineTestCase(FilterTestCases.FilterTestCase, FilterTestCases.Ten
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_role(self):
-        roles = DeviceRole.objects.all()[:2]
+        roles = self.roles[:2]
         params = {"role_id": [roles[0].pk, roles[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(roles))
         params = {"role": [roles[0].slug, roles[1].slug]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(roles))
 
     def test_platform(self):
-        platforms = Platform.objects.all()[:2]
+        platforms = self.platforms[:2]
         params = {"platform_id": [platforms[0].pk, platforms[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(platforms))
         params = {"platform": [platforms[0].slug, platforms[1].slug]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), len(platforms))
 
     def test_mac_address(self):
         params = {"mac_address": ["00-00-00-00-00-01", "00-00-00-00-00-02"]}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #1334, Related: #2282
# What's Changed

This implements `DeviceRoleFactory`, `DeviceTypeFactory`, `ManufacturerFactory`, and `PlatformFactory`.

- Implemented hard-coding a list of desired manufacturer names, derived platform and device type names from that e.g. `Manufacturer.name = "Cisco"` would result in `Platform.name = "Cisco Platform 1"` and `DeviceType.name = "Cisco DeviceType 1"`. 
- Refactored a large share of tests that create their own bespoke objects of these types, however, have not yet completed it. This is a big step forward, however, especially in reducing duplication of code in the test suite.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
