### PR TITLE
[WIP] Exposes `SESSION_ENGINE` as ENVVAR Setting, Always Run `collectstatic`

### DIFF
--- a/changes/2477.added
+++ b/changes/2477.added
@@ -1,0 +1,1 @@
+Added envvar NAUTOBOT_SESSION_ENGINE to allow for overriding the SESSION_ENGINE setting.

--- a/changes/2477.fixed
+++ b/changes/2477.fixed
@@ -1,0 +1,1 @@
+Fixed the Docker Entrypoint file so it runs nautobot-server collectstatic if envvar NAUTOBOT_DOCKER_SKIP_INIT is set to True.

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -23,6 +23,9 @@ if [[ "$NAUTOBOT_DOCKER_SKIP_INIT" == "false" ]]; then
     echo "❌ Waited ${MAX_DB_WAIT_TIME}s or more for the DB to become ready."
     exit 1
   fi
+# if NAUTOBOT_DOCKER_SKIP_INIT=True then only deploy static files
+else
+  nautobot-server collectstatic
 fi
 
 # Run a quick healthcheck and bail if something fails, --deploy will warn on potential issues for production

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -270,6 +270,10 @@ DATABASES = {
 # The secret key is used to encrypt session keys and salt passwords.
 SECRET_KEY = os.getenv("SECRET_KEY")
 
+# Set the SESSION_ENGINE
+# By default, Nautobot will use 'django.contrib.sessions.backends.db' however if you need a maintenance mode / read-only instance then this can be overriden
+SESSION_ENGINE = os.getenv("NAUTOBOT_SESSION_ENGINE", "django.contrib.sessions.backends.db")
+
 # Default overrides
 ALLOWED_HOSTS = []
 CSRF_TRUSTED_ORIGINS = []

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -224,10 +224,6 @@ PLUGINS = []
 REMOTE_AUTH_AUTO_CREATE_USER = False
 REMOTE_AUTH_HEADER = "HTTP_REMOTE_USER"
 
-# Set the SESSION_ENGINE
-# By default, Nautobot will use 'django.contrib.sessions.backends.db' however if you need a maintenance mode / read-only instance then this can be overriden
-SESSION_ENGINE = os.getenv("NAUTOBOT_SESSION_ENGINE", "django.contrib.sessions.backends.db")
-
 # The length of time (in seconds) for which a user will remain logged into the web UI before being prompted to
 # re-authenticate. (Default: 1209600 [14 days])
 SESSION_COOKIE_AGE = int(os.getenv("NAUTOBOT_SESSION_COOKIE_AGE", "1209600"))  # 2 weeks, in seconds

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -224,6 +224,10 @@ PLUGINS = []
 REMOTE_AUTH_AUTO_CREATE_USER = False
 REMOTE_AUTH_HEADER = "HTTP_REMOTE_USER"
 
+# Set the SESSION_ENGINE
+# By default, Nautobot will use 'django.contrib.sessions.backends.db' however if you need a maintenance mode / read-only instance then this can be overriden
+SESSION_ENGINE = os.getenv("NAUTOBOT_SESSION_ENGINE", "django.contrib.sessions.backends.db")
+
 # The length of time (in seconds) for which a user will remain logged into the web UI before being prompted to
 # re-authenticate. (Default: 1209600 [14 days])
 SESSION_COOKIE_AGE = int(os.getenv("NAUTOBOT_SESSION_COOKIE_AGE", "1209600"))  # 2 weeks, in seconds

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -986,6 +986,8 @@ The age of session cookies, in seconds.
 
 Default: `'django.contrib.sessions.backends.db'`
 
+Environment Variable: `NAUTOBOT_SESSION_ENGINE`
+
 Controls where Nautobot stores session data.
 
 To use cache-based sessions, set this to `'django.contrib.sessions.backends.cache'`.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2477
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Changes the Docker Entrypoint so it runs `nautobot-server collectstatic` if `NAUTOBOT_DOCKER_SKIP_INIT=True`, this is needed so static content can be served when standing up in maintenance mode.
- Allows for easier overriding of the SESSION_ENGINE default with ENVVAR `NAUTOBOT_SESSION_ENGINE`, this is changed when standing up in maintenance mode.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
