### PR TITLE
fix: add html element id for hyperlinks

### DIFF
--- a/changes/2406.fixed
+++ b/changes/2406.fixed
@@ -1,0 +1,1 @@
+Fixed missing HTML element ID for hyperlinks.

--- a/nautobot/dcim/templates/dcim/device.html
+++ b/nautobot/dcim/templates/dcim/device.html
@@ -146,7 +146,7 @@
                                         <td>
                                             {% if object.primary_ip4 %}
                                                 <span class="hover_copy">
-                                                    {{ object.primary_ip4|hyperlinked_object }}
+                                                    {{ object.primary_ip4|hyperlinked_object|add_html_id:"ipv4" }}
                                                     {% if object.primary_ip4.nat_inside %}
                                                         <span>(NAT for {{ object.primary_ip4.nat_inside.address.ip }})</span>
                                                     {% elif object.primary_ip4.nat_outside %}
@@ -167,7 +167,7 @@
                                         <td>
                                             {% if object.primary_ip6 %}
                                                 <span class="hover_copy">
-                                                    {{ object.primary_ip6|hyperlinked_object }}
+                                                    {{ object.primary_ip6|hyperlinked_object|add_html_id:"ipv6" }}
                                                     {% if object.primary_ip6.nat_inside %}
                                                         <span>(NAT for {{ object.primary_ip6.nat_inside.address.ip }})</span>
                                                     {% elif object.primary_ip6.nat_outside %}

--- a/nautobot/utilities/templatetags/helpers.py
+++ b/nautobot/utilities/templatetags/helpers.py
@@ -57,10 +57,13 @@ def hyperlinked_object(value):
     if value is None:
         return placeholder(value)
     display = value.display if hasattr(value, "display") else str(value)
+    element_id = f" id=ipv{value.family}" if hasattr(value, "family") else ""
     if hasattr(value, "get_absolute_url"):
         if hasattr(value, "description") and value.description:
-            return format_html('<a href="{}" title="{}">{}</a>', value.get_absolute_url(), value.description, display)
-        return format_html('<a href="{}">{}</a>', value.get_absolute_url(), display)
+            return format_html(
+                '<a href="{}" title="{}"{}>{}</a>', value.get_absolute_url(), value.description, element_id, display
+            )
+        return format_html('<a href="{}"{}>{}</a>', value.get_absolute_url(), element_id, display)
     return format_html("{}", display)
 
 

--- a/nautobot/utilities/templatetags/helpers.py
+++ b/nautobot/utilities/templatetags/helpers.py
@@ -57,13 +57,10 @@ def hyperlinked_object(value):
     if value is None:
         return placeholder(value)
     display = value.display if hasattr(value, "display") else str(value)
-    element_id = f" id=ipv{value.family}" if hasattr(value, "family") else ""
     if hasattr(value, "get_absolute_url"):
         if hasattr(value, "description") and value.description:
-            return format_html(
-                '<a href="{}" title="{}"{}>{}</a>', value.get_absolute_url(), value.description, element_id, display
-            )
-        return format_html('<a href="{}"{}>{}</a>', value.get_absolute_url(), element_id, display)
+            return format_html('<a href="{}" title="{}">{}</a>', value.get_absolute_url(), value.description, display)
+        return format_html('<a href="{}">{}</a>', value.get_absolute_url(), display)
     return format_html("{}", display)
 
 
@@ -87,6 +84,30 @@ def placeholder(value):
     if value:
         return value
     return mark_safe(HTML_NONE)
+
+
+@library.filter()
+@register.filter()
+def add_html_id(element_str, id_str):
+    """Add an HTML `id="..."` attribute to the given HTML element string.
+
+    Args:
+        element_str (str): String describing an HTML element.
+        id_str (str): String to add as the `id` attribute of the element_str.
+
+    Returns:
+        str: HTML string with added `id`.
+
+    Example:
+        >>> add_html_id("<div></div>", "my-div")
+        '<div id="my-div"></div>'
+        >>> add_html_id('<a href="..." title="...">Hello!</a>', "my-a")
+        '<a id="my-a" href="..." title="...">Hello!</a>'
+    """
+    match = re.match(r"^(.*?<\w+) ?(.*)$", element_str, flags=re.DOTALL)
+    if not match:
+        return element_str
+    return mark_safe(match.group(1) + format_html(' id="{}" ', id_str) + match.group(2))
 
 
 @library.filter()

--- a/nautobot/utilities/tests/test_templatetags_helpers.py
+++ b/nautobot/utilities/tests/test_templatetags_helpers.py
@@ -29,6 +29,7 @@ from nautobot.utilities.templatetags.helpers import (
 )
 from nautobot.extras.models import Status
 from nautobot.dcim.models import Site
+from nautobot.ipam.models import IPAddress
 from example_plugin.models import AnotherExampleModel, ExampleModel
 
 
@@ -51,6 +52,11 @@ class NautobotTemplatetagsHelperTest(TestCase):
         site.save()
         self.assertEqual(
             hyperlinked_object(site), '<a href="/dcim/sites/test-site/" title="An important site">Test Site</a>'
+        )
+        # An IP address object gives a hyperlink with a proper element id
+        ipaddr1 = IPAddress.objects.create(address="1.1.1.1/32")
+        self.assertEqual(
+            hyperlinked_object(ipaddr1), f'<a href="/ipam/ip-addresses/{ipaddr1.id}/" id=ipv4>1.1.1.1/32</a>'
         )
 
     def test_placeholder(self):


### PR DESCRIPTION

# Closes: #2406 
# What's Changed
Hi, a simple PR for adding an ID element for IP address object (IPv4 and IPv6) within html page. This makes the js clipboard tool actually work for this type of data. A unit test added as well.

No element ID before:
![image](https://user-images.githubusercontent.com/14314517/196283665-546b3cbf-2f2e-468d-9206-f3df354810cc.png)

HTML tag with ID after update:
![image](https://user-images.githubusercontent.com/14314517/196283586-0ac97a4a-b2ac-4b73-af4d-0dd7f3dc6c6c.png)

I just tried to do a simple straightforward fix. Any suggestions that would need to be implemented? 

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
