### PR TITLE
Circuits - fix broken link, improve table column display

### DIFF
--- a/changes/2632.fixed
+++ b/changes/2632.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect link from Circuit Type detail view to filtered Circuits table.

--- a/nautobot/circuits/tables.py
+++ b/nautobot/circuits/tables.py
@@ -12,10 +12,13 @@ from nautobot.utilities.tables import (
 from .models import Circuit, CircuitType, Provider, ProviderNetwork
 
 CIRCUIT_TERMINATION_PARENT = """
+{% load helpers %}
 {% if value.provider_network %}
-<a href="{{ value.provider_network.get_absolute_url }}">{{ value.provider_network }}</a>
+{{ value.provider_network|hyperlinked_object }}
 {% elif value.site %}
-<a href="{{ value.site.get_absolute_url }}">{{ value.site }}</a>
+{{ value.site|hyperlinked_object }}
+{% else %}
+{{ None|placeholder }}
 {% endif %}
 """
 

--- a/nautobot/circuits/templates/circuits/circuittype_retrieve.html
+++ b/nautobot/circuits/templates/circuits/circuittype_retrieve.html
@@ -14,7 +14,7 @@
                 <tr>
                     <td>Circuits</td>
                     <td>
-                        <a href="{% url 'circuits:circuit_list' %}?circuit_type={{ object.slug }}">{{ circuits_table.rows|length }}</a>
+                        <a href="{% url 'circuits:circuit_list' %}?type={{ object.slug }}">{{ circuits_table.rows|length }}</a>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
# Closes: #2632 
# What's Changed

- Fix incorrect link from circuit-type detail view to filtered circuits table
- In testing the above, I noticed that the circuits table had incorrect (empty) columns for the case of a circuit without terminations
    - I fixed the column template so that it renders the standard placeholder string instead
    - and switched the other cases of this column to use `hyperlinked_object`.

---

![image](https://user-images.githubusercontent.com/5603551/196510605-60d45a74-5776-4d74-934e-4152ccbd7150.png)

---

![image](https://user-images.githubusercontent.com/5603551/196510737-b63e2854-1c84-4d2e-84df-7be4a698ed0e.png)


No straightforward approach to unit test automation for either of these at present that I can see, and neither of these feel critical enough to me to add to the integration tests either.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
