### PR TITLE
Allow and Handle Multipart Payloads Job API 

### DIFF
--- a/changes/2473.added
+++ b/changes/2473.added
@@ -1,0 +1,1 @@
+Added `multipart/form-data` support to Job run API.

--- a/changes/2644.changed
+++ b/changes/2644.changed
@@ -1,0 +1,1 @@
+Changed published accepted content types for REST API to remove unsupported types.

--- a/examples/example_plugin/example_plugin/jobs.py
+++ b/examples/example_plugin/example_plugin/jobs.py
@@ -3,7 +3,7 @@ import time
 from django.conf import settings
 
 from nautobot.extras.choices import ObjectChangeActionChoices
-from nautobot.extras.jobs import IntegerVar, Job, JobHookReceiver
+from nautobot.extras.jobs import IntegerVar, Job, JobHookReceiver, FileVar
 
 
 name = "ExamplePlugin jobs"
@@ -11,8 +11,14 @@ name = "ExamplePlugin jobs"
 
 class ExampleJob(Job):
 
+    # interval = IntegerVar(default=4, description="The time in seconds to sleep.")
+    my_file = FileVar(description="The file.")
+
     # specify template_name to override the default job scheduling template
     template_name = "example_plugin/example_with_custom_template.html"
+
+    def run(self, data, commit):
+        print(data)
 
     class Meta:
         name = "Example job, does nothing"

--- a/examples/example_plugin/example_plugin/jobs.py
+++ b/examples/example_plugin/example_plugin/jobs.py
@@ -3,7 +3,7 @@ import time
 from django.conf import settings
 
 from nautobot.extras.choices import ObjectChangeActionChoices
-from nautobot.extras.jobs import IntegerVar, Job, JobHookReceiver, FileVar
+from nautobot.extras.jobs import IntegerVar, Job, JobHookReceiver
 
 
 name = "ExamplePlugin jobs"
@@ -11,14 +11,8 @@ name = "ExamplePlugin jobs"
 
 class ExampleJob(Job):
 
-    # interval = IntegerVar(default=4, description="The time in seconds to sleep.")
-    my_file = FileVar(description="The file.")
-
     # specify template_name to override the default job scheduling template
     template_name = "example_plugin/example_with_custom_template.html"
-
-    def run(self, data, commit):
-        print(data)
 
     class Meta:
         name = "Example job, does nothing"

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -189,6 +189,7 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.JSONRenderer",
         "nautobot.core.api.renderers.FormlessBrowsableAPIRenderer",
     ),
+    "DEFAULT_PARSER_CLASSES": ("rest_framework.parsers.JSONParser",),
     "DEFAULT_SCHEMA_CLASS": "nautobot.core.api.schema.NautobotAutoSchema",
     # Version to use if the client doesn't request otherwise.
     # This should only change (if at all) with Nautobot major (breaking) releases.

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -256,6 +256,10 @@ SPECTACULAR_SETTINGS = {
         "RackStatusChoices": "nautobot.dcim.api.serializers.RackSerializer.status_choices",
         "VirtualMachineStatusChoices": "nautobot.virtualization.api.serializers.VirtualMachineWithConfigContextSerializer.status_choices",
         "VLANStatusChoices": "nautobot.ipam.api.serializers.VLANSerializer.status_choices",
+        # These choice enums need to be overridden because they get assigned to different names with the same choice set and
+        # result in this error:
+        #   encountered multiple names for the same choice set
+        "JobExecutionTypeIntervalChoices": "nautobot.extras.choices.JobExecutionType",
     },
     # Create separate schema components for PATCH requests (fields generally are not `required` on PATCH)
     "COMPONENT_SPLIT_PATCH": True,

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -20,6 +20,7 @@ from django.utils.safestring import mark_safe
 from django.views.generic.edit import FormView
 
 from rest_framework import mixins, exceptions
+from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
@@ -71,6 +72,7 @@ class NautobotViewSetMixin(GenericViewSet, AccessMixin, GetReturnURLMixin, FormV
     filterset_class = None
     filterset_form_class = None
     form_class = None
+    parser_classes = [MultiPartParser]
     queryset = None
     # serializer_class has to be specified to eliminate the need to override retrieve() in the RetrieveModelMixin for now.
     serializer_class = None

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -594,6 +594,24 @@ When providing input data, it is possible to specify complex values contained in
 * `MultiObjectVar`s can be specified as a list of primary keys.
 * `IPAddressVar`s can be provided as strings in CIDR notation.
 
+#### Jobs with Files
+
+To run a job that contains `FileVar` inputs via the REST API, you must use `multipart/form-data` content type requests instead of `application/json`. This also requires a slightly different request payload than the example above. The `commit`, `task_queue`, and `schedule` data are flattened and prefixed with underscore to differentiate them from job-specific data. Job specific data is also flattened and not located under the top-level `data` dictionary key.
+
+An example of running a job with both `FileVar` (named `myfile`) and `StringVar` (named `interval`) input:
+
+```no-highlight
+curl -X POST \
+-H 'Authorization: Token $TOKEN' \
+-H "Accept: application/json; version=1.3; indent=4" \
+'http://nautobot/api/extras/jobs/$JOB_ID/run/' \
+-F '_commit="true"' \
+-F '_schedule_interval="immediately"' \
+-F '_schedule_start_time="2022-10-18T17:31:23.698Z"' \
+-F 'interval="3"' \
+-F 'myfile=@"/path/to/my/file.txt"' \
+```
+
 ### Via the CLI
 
 Jobs can be run from the CLI by invoking the management command:

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -603,6 +603,7 @@ An example of running a job with both `FileVar` (named `myfile`) and `StringVar`
 ```no-highlight
 curl -X POST \
 -H 'Authorization: Token $TOKEN' \
+-H 'Content-Type: multipart/form-data' \
 -H "Accept: application/json; version=1.3; indent=4" \
 'http://nautobot/api/extras/jobs/$JOB_ID/run/' \
 -F '_commit="true"' \

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -979,14 +979,14 @@ class JobInputSerializer(serializers.Serializer):
 class JobMultiPartInputSerializer(serializers.Serializer):
     _commit = serializers.BooleanField(required=False, default=None)
     _schedule_name = serializers.CharField(max_length=255, required=False)
-    _schedule_start_time = serializers.DateTimeField(format=None, required=True)
-    _schedule_interval = ChoiceField(choices=JobExecutionType)
+    _schedule_start_time = serializers.DateTimeField(format=None, required=False)
+    _schedule_interval = ChoiceField(choices=JobExecutionType, required=False)
     _schedule_crontab = serializers.CharField(required=False, allow_blank=True)
     _task_queue = serializers.CharField(required=False, allow_blank=True)
 
     def validate(self, data):
 
-        if data["_schedule_interval"] != JobExecutionType.TYPE_IMMEDIATELY:
+        if "_schedule_interval" in data and data["_schedule_interval"] != JobExecutionType.TYPE_IMMEDIATELY:
             if "_schedule_name" not in data:
                 raise serializers.ValidationError({"_schedule_name": "Please provide a name for the job schedule."})
 

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -977,6 +977,8 @@ class JobInputSerializer(serializers.Serializer):
 
 
 class JobMultiPartInputSerializer(serializers.Serializer):
+    """JobMultiPartInputSerializer is a "flattened" version of JobInputSerializer for use with multipart/form-data submissions which only accept key-value pairs"""
+
     _commit = serializers.BooleanField(required=False, default=None)
     _schedule_name = serializers.CharField(max_length=255, required=False)
     _schedule_start_time = serializers.DateTimeField(format=None, required=False)

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -31,6 +31,7 @@ from nautobot.extras.api.fields import StatusSerializerField
 from nautobot.extras.choices import (
     CustomFieldFilterLogicChoices,
     CustomFieldTypeChoices,
+    JobExecutionType,
     JobResultStatusChoices,
     ObjectChangeActionChoices,
 )
@@ -973,6 +974,41 @@ class JobInputSerializer(serializers.Serializer):
     commit = serializers.BooleanField(required=False, default=None)
     schedule = NestedScheduledJobSerializer(required=False)
     task_queue = serializers.CharField(required=False, allow_blank=True)
+
+
+class JobMultiPartInputSerializer(serializers.Serializer):
+    _commit = serializers.BooleanField(required=False, default=None)
+    _schedule_name = serializers.CharField(max_length=255, required=False)
+    _schedule_start_time = serializers.DateTimeField(format=None, required=True)
+    _schedule_interval = ChoiceField(choices=JobExecutionType)
+    _schedule_crontab = serializers.CharField(required=False, allow_blank=True)
+    _task_queue = serializers.CharField(required=False, allow_blank=True)
+
+    def validate(self, data):
+
+        if data["_schedule_interval"] != JobExecutionType.TYPE_IMMEDIATELY:
+            if "_schedule_name" not in data:
+                raise serializers.ValidationError({"_schedule_name": "Please provide a name for the job schedule."})
+
+            if ("_schedule_start_time" not in data and data["_schedule_interval"] != JobExecutionType.TYPE_CUSTOM) or (
+                "_schedule_start_time" in data and data["_schedule_start_time"] < ScheduledJob.earliest_possible_time()
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "_schedule_start_time": "Please enter a valid date and time greater than or equal to the current date and time."
+                    }
+                )
+
+            if data["_schedule_interval"] == JobExecutionType.TYPE_CUSTOM:
+
+                if data.get("_schedule_crontab") is None:
+                    raise serializers.ValidationError({"_schedule_crontab": "Please enter a valid crontab."})
+                try:
+                    ScheduledJob.get_crontab(data["_schedule_crontab"])
+                except Exception as e:
+                    raise serializers.ValidationError({"_schedule_crontab": e})
+
+        return data
 
 
 class JobLogEntrySerializer(BaseModelSerializer):

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -985,6 +985,7 @@ class JobMultiPartInputSerializer(serializers.Serializer):
     _task_queue = serializers.CharField(required=False, allow_blank=True)
 
     def validate(self, data):
+        data = super().validate(data)
 
         if "_schedule_interval" in data and data["_schedule_interval"] != JobExecutionType.TYPE_IMMEDIATELY:
             if "_schedule_name" not in data:

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -585,7 +585,7 @@ def _run_job(request, job_model, legacy_response=False):
     if schedule_data:
         schedule = _create_schedule(
             schedule_data,
-            job_model.job_class.serialize_data(cleaned_data),
+            job_class.serialize_data(cleaned_data),
             commit,
             job,
             job_model,
@@ -604,7 +604,7 @@ def _run_job(request, job_model, legacy_response=False):
             job_content_type,
             request.user,
             celery_kwargs={"queue": task_queue},
-            data=job_model.job_class.serialize_data(cleaned_data),
+            data=job_class.serialize_data(cleaned_data),
             request=copy_safe_request(request),
             commit=commit,
             task_queue=input_serializer.validated_data.get("task_queue", None),

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -533,7 +533,7 @@ def _run_job(request, job_model, legacy_response=False):
     data = request.data
     files = None
 
-    if 'multipart/form-data' in request.content_type:
+    if "multipart/form-data" in request.content_type:
         data = request._data  # .data will return data and files, we just want the data
         files = request.FILES
 

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -564,14 +564,15 @@ def _run_job(request, job_model, legacy_response=False):
 
         # List of keys in serializer that are effectively exploded versions of the schedule dictionary from JobInputSerializer
         schedule_keys = ("_schedule_name", "_schedule_start_time", "_schedule_interval", "_schedule_crontab")
+
+        # Assign the key from the validated_data output to dictionary without prefixed "_schedule_"
+        # For all the keys that are schedule keys
+        # Assign only if they key is in the output since we don't want None's if not provided
         if any(schedule_key in non_job_keys for schedule_key in schedule_keys):
             schedule_data = {
-                k.replace("_schedule_", ""): input_serializer.validated_data[
-                    k
-                ]  # Assign the key from the validated_data output to dictionary without prefixed "_schedule_"
-                for k in schedule_keys  # For all the keys that are schedule keys
-                if k
-                in input_serializer.validated_data  # Assign only if they key is in the output since we don't want None's if not provided
+                k.replace("_schedule_", ""): input_serializer.validated_data[k]
+                for k in schedule_keys
+                if k in input_serializer.validated_data
             }
 
     else:

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -530,6 +530,19 @@ def _run_job(request, job_model, legacy_response=False):
         raise MethodNotAllowed(request.method, detail="This job's source code could not be located and cannot be run")
     job = job_class()
 
+    print("=================")
+    print(dir(request))
+    print(request.FILES)
+    print(request.content_type)
+    print(dir(request.data))
+    print(request.data)
+    print("=================")
+
+    # if 'application/json' in request.content_type:
+    #     data = request.data
+    # elif 'multipart/form-data' in request.content_type and 'body' in request.data:
+    #     data = request.data['body']
+
     input_serializer = serializers.JobInputSerializer(data=request.data, context={"request": request})
     input_serializer.is_valid(raise_exception=True)
 

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -547,7 +547,7 @@ def _run_job(request, job_model, legacy_response=False):
     if "multipart/form-data" in request.content_type:
         data = request._data.dict()  # .data will return data and files, we just want the data
         files = request.FILES
-        
+
         # JobMultiPartInputSerializer is a "flattened" version of JobInputSerializer
         input_serializer = serializers.JobMultiPartInputSerializer(data=data, context={"request": request})
         input_serializer.is_valid(raise_exception=True)
@@ -566,9 +566,12 @@ def _run_job(request, job_model, legacy_response=False):
         schedule_keys = ("_schedule_name", "_schedule_start_time", "_schedule_interval", "_schedule_crontab")
         if any(schedule_key in non_job_keys for schedule_key in schedule_keys):
             schedule_data = {
-                k.replace("_schedule_", ""): input_serializer.validated_data[k]  # Assign the key from the validated_data output to dictionary without prefixed "_schedule_"
+                k.replace("_schedule_", ""): input_serializer.validated_data[
+                    k
+                ]  # Assign the key from the validated_data output to dictionary without prefixed "_schedule_"
                 for k in schedule_keys  # For all the keys that are schedule keys
-                if k in input_serializer.validated_data  # Assign only if they key is in the output since we don't want None's if not provided
+                if k
+                in input_serializer.validated_data  # Assign only if they key is in the output since we don't want None's if not provided
             }
 
     else:

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -568,7 +568,7 @@ def _run_job(request, job_model, legacy_response=False):
 
         # Assign the key from the validated_data output to dictionary without prefixed "_schedule_"
         # For all the keys that are schedule keys
-        # Assign only if they key is in the output since we don't want None's if not provided
+        # Assign only if the key is in the output since we don't want None's if not provided
         if any(schedule_key in non_job_keys for schedule_key in schedule_keys):
             schedule_data = {
                 k.replace("_schedule_", ""): input_serializer.validated_data[k]

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -592,9 +592,9 @@ def _run_job(request, job_model, legacy_response=False):
 
     cleaned_data = None
     try:
-        cleaned_data = job.validate_data(data, files)
+        cleaned_data = job.validate_data(data, files=files)
         cleaned_data.pop(
-            "_commit"
+            "_commit", None
         )  # We don't get commit from the form, instead it's part of the serializer's validated data
 
     except FormsValidationError as e:

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -553,6 +553,10 @@ def _run_job(request, job_model, legacy_response=False):
     cleaned_data = None
     try:
         cleaned_data = job.validate_data(data, files)
+        cleaned_data.pop(
+            "_commit"
+        )  # We don't get commit from the form, instead it's part of the serializer's validated data
+
     except FormsValidationError as e:
         # message_dict can only be accessed if ValidationError got a dict
         # in the constructor (saved as error_dict). Otherwise we get a list

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -12,6 +12,7 @@ from graphql import GraphQLError
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import MethodNotAllowed, PermissionDenied, ValidationError
+from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.response import Response
 from rest_framework.routers import APIRootView
 from rest_framework import mixins, viewsets
@@ -817,12 +818,16 @@ class JobViewSet(
         methods=["post"],
         request={
             "application/json": serializers.JobInputSerializer,
-            "application/x-www-form-urlencoded": serializers.JobInputSerializer,
             "multipart/form-data": serializers.JobMultiPartInputSerializer,
         },
         responses={"201": serializers.JobRunResponseSerializer},
     )
-    @action(detail=True, methods=["post"], permission_classes=[JobRunTokenPermissions])
+    @action(
+        detail=True,
+        methods=["post"],
+        permission_classes=[JobRunTokenPermissions],
+        parser_classes=[JSONParser, MultiPartParser],
+    )
     def run(self, request, *args, pk, **kwargs):
         """Run the specified Job."""
         job_model = self.get_object()
@@ -841,6 +846,7 @@ class JobViewSet(
         permission_classes=[JobRunTokenPermissions],
         url_path="(?P<class_path>[^/]+/[^/]+/[^/]+)/run",  # /api/extras/jobs/<class_path>/run/
         url_name="run",
+        parser_classes=[JSONParser, MultiPartParser],
     )
     def run_deprecated(self, request, class_path):
         """

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -456,6 +456,7 @@ class BaseJob:
         # defer validation to the form object
         f = self.as_form(data=self.deserialize_data(data))
         if not f.is_valid():
+            print("invalid data")
             raise ValidationError(f.errors)
 
     @staticmethod

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -458,6 +458,8 @@ class BaseJob:
         if not f.is_valid():
             raise ValidationError(f.errors)
 
+        return f.cleaned_data
+
     @staticmethod
     def load_file(pk):
         """Load a file proxy stored in the database by primary key.

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -443,7 +443,7 @@ class BaseJob:
 
         return return_data
 
-    def validate_data(self, data):
+    def validate_data(self, data, files=None):
         cls_vars = self._get_vars()
 
         if not isinstance(data, dict):
@@ -454,9 +454,8 @@ class BaseJob:
                 raise ValidationError({k: "Job data contained an unknown property"})
 
         # defer validation to the form object
-        f = self.as_form(data=self.deserialize_data(data))
+        f = self.as_form(data=self.deserialize_data(data), files=files)
         if not f.is_valid():
-            print("invalid data")
             raise ValidationError(f.errors)
 
     @staticmethod

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -342,7 +342,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
             self.assertEqual(response.data["description"], data["description"])
 
         # Try to create one more IP
-        response = self.client.post(url, {}, **self.header)
+        response = self.client.post(url, {}, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_204_NO_CONTENT)
         self.assertIn("detail", response.data)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2473
# What's Changed
- `request.data` contains request payload and files when multipart. Conditionally handle that case.
    - See: https://github.com/encode/django-rest-framework/blob/3.13.1/rest_framework/request.py#L213-L217
    - And: https://github.com/encode/django-rest-framework/blob/3.13.1/rest_framework/request.py#L274-L284 
- Extend `validate_data` to take in files, and return cleaned data (similar to UI)
    - https://github.com/nautobot/nautobot/blob/v1.4.7/nautobot/extras/views.py#L1117
    - https://github.com/nautobot/nautobot/blob/v1.4.7/nautobot/extras/views.py#L1137
- Enqueue job with `job_class.serialize_data` instead of directly (similar to UI)
    - https://github.com/nautobot/nautobot/blob/v1.4.7/nautobot/extras/views.py#L1169 
- `JobMultiPartInputSerializer` created to be a "flattened" representation of `JobInputSerializer` to address the key-value nature of multipart forms
- Changed `DEFAULT_PARSER_CLASSES` to only be the working, accepted parser: `rest_framework.parsers.JSONParser`
    - Even a simple use of `multipart/form-data` and `x-www-form-urlencoded` failed to work.
- Job Run API schema extended to support conditional schema representation:
<img width="1453" alt="image" src="https://user-images.githubusercontent.com/31187/202564897-34b16f1d-58a6-4a41-9b22-c1c0141c14ae.png">
<img width="1436" alt="Screen Shot 2022-11-17 at 15 08 57" src="https://user-images.githubusercontent.com/31187/202564637-ec5bb6e0-5607-462e-bb5d-b1fef8261126.png">


# Demo

_Example Job Code_

```python
class ExampleJob(Job):

    my_file = FileVar(description="The file.")

    def run(self, data, commit):
        import json
        print(json.load(data['my_file']))
```

_Example Payload_

```json
{"file": "content"}
```

_Example Requests Call_

```python
>>> url
'http://nautobot.test/api/extras/jobs/ff6286e3-09af-4817-ae77-e9009b99310f/run/'
>>> token
'5012a37affc51062813c41a6a492f09591bcdde4'
>>> data
{'commit': True, 'dry_run': False, 'memory_profiling': True, 'delete_confirmed': False}
>>> headers
{'Authorization': 'Token 5012a37affc51062813c41a6a492f09591bcdde4'}
>>> r = requests.post( url=url, files={"my_file": open("payload.json", "rb")}, data=data, headers=headers)
>>> r.content
b'{"schedule":null,"job_result":{"display":"594e8b48-b4ba-43cf-83c7-231e9b475cb7","id":"08671111-de92-4e0d-b30a-d9188bc947b5","url":"http://nautobot.test/api/extras/job-results/08671111-de92-4e0d-b30a-d9188bc947b5/","name":"plugins/example_plugin.jobs/ExampleJob","created":"2022-10-19T02:04:31.141095Z","completed":null,"user":{"display":"admin","id":"be807b06-3e37-456b-9325-6e84fd58a079","url":"http://nautobot.test/api/users/users/be807b06-3e37-456b-9325-6e84fd58a079/","username":"admin"},"status":{"value":"pending","label":"Pending"}}}'
```

_Celery Log Run (API)_

```syslog
[2022-10-19 02:06:52,932: INFO/MainProcess] celery@0c4d3b3641c9 ready.
02:07:02.906 DEBUG   nautobot.core.celery __init__.py     nautobot_kombu_json_loads_hook() :
  Performing nautobot deserialization for type nautobot.utilities.utils.NautobotFakeRequest
[2022-10-19 02:07:02,906: DEBUG/MainProcess] Performing nautobot deserialization for type nautobot.utilities.utils.NautobotFakeRequest
[2022-10-19 02:07:02,911: INFO/MainProcess] Task nautobot.extras.jobs.run_job[c846b5f8-902f-403b-b6f8-54e395cb5b85] received
02:07:02.912 DEBUG   nautobot.core.celery __init__.py     nautobot_kombu_json_loads_hook() :
  Performing nautobot deserialization for type nautobot.utilities.utils.NautobotFakeRequest
[2022-10-19 02:07:02,912: DEBUG/ForkPoolWorker-3] Performing nautobot deserialization for type nautobot.utilities.utils.NautobotFakeRequest
02:07:02.929 INFO    nautobot.jobs.ExampleJob jobs.py                                run_job() :
  Running job (commit=True)
[2022-10-19 02:07:02,929: INFO/ForkPoolWorker-3] Running job (commit=True)
[2022-10-19 02:07:02,934: WARNING/ForkPoolWorker-3] {'file': 'content'}
02:07:02.934 INFO    nautobot.jobs.ExampleJob jobs.py                               _run_job() :
  job completed successfully
[2022-10-19 02:07:02,934: INFO/ForkPoolWorker-3] job completed successfully
02:07:02.942 DEBUG   nautobot.jobs        jobs.py                           delete_files() :
  Deleted 1 file proxies
[2022-10-19 02:07:02,942: DEBUG/ForkPoolWorker-3] Deleted 1 file proxies
02:07:02.945 INFO    nautobot.jobs.ExampleJob jobs.py                               _run_job() :
  Job completed in 0 minutes, 0.06 seconds
[2022-10-19 02:07:02,945: INFO/ForkPoolWorker-3] Job completed in 0 minutes, 0.06 seconds
[2022-10-19 02:07:02,946: INFO/ForkPoolWorker-3] Task nautobot.extras.jobs.run_job[c846b5f8-902f-403b-b6f8-54e395cb5b85] succeeded in 0.028749291028361768s: True
```

_Celery Log Run (UI)_

```syslog
02:08:25.777 DEBUG   nautobot.core.celery __init__.py     nautobot_kombu_json_loads_hook() :
  Performing nautobot deserialization for type nautobot.utilities.utils.NautobotFakeRequest
[2022-10-19 02:08:25,777: DEBUG/MainProcess] Performing nautobot deserialization for type nautobot.utilities.utils.NautobotFakeRequest
[2022-10-19 02:08:25,781: INFO/MainProcess] Task nautobot.extras.jobs.run_job[5d3ab704-9be6-4404-81ce-0035512fef95] received
02:08:25.786 DEBUG   nautobot.core.celery __init__.py     nautobot_kombu_json_loads_hook() :
  Performing nautobot deserialization for type nautobot.utilities.utils.NautobotFakeRequest
[2022-10-19 02:08:25,786: DEBUG/ForkPoolWorker-3] Performing nautobot deserialization for type nautobot.utilities.utils.NautobotFakeRequest
02:08:25.810 INFO    nautobot.jobs.ExampleJob jobs.py                                run_job() :
  Running job (commit=True)
[2022-10-19 02:08:25,810: INFO/ForkPoolWorker-3] Running job (commit=True)
[2022-10-19 02:08:25,817: WARNING/ForkPoolWorker-3] {'file': 'content'}
02:08:25.817 INFO    nautobot.jobs.ExampleJob jobs.py                               _run_job() :
  job completed successfully
[2022-10-19 02:08:25,817: INFO/ForkPoolWorker-3] job completed successfully
02:08:25.825 DEBUG   nautobot.jobs        jobs.py                           delete_files() :
  Deleted 1 file proxies
[2022-10-19 02:08:25,825: DEBUG/ForkPoolWorker-3] Deleted 1 file proxies
02:08:25.828 INFO    nautobot.jobs.ExampleJob jobs.py                               _run_job() :
  Job completed in 0 minutes, 0.06 seconds
[2022-10-19 02:08:25,828: INFO/ForkPoolWorker-3] Job completed in 0 minutes, 0.06 seconds
[2022-10-19 02:08:25,829: INFO/ForkPoolWorker-3] Task nautobot.extras.jobs.run_job[5d3ab704-9be6-4404-81ce-0035512fef95] succeeded in 0.030288875044789165s: True
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- NA Documentation Updates (when adding/changing features)
- NA Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
