### PR TITLE
Rack power utilization

### DIFF
--- a/changes/2099.fixed
+++ b/changes/2099.fixed
@@ -1,0 +1,3 @@
+Fixed PowerFeed Utilization on Rack View not displaying correctly.
+Fixed Total Power Utilization on Rack View not taking into account direct-connected devices.
+Fixed created_updated template adding the end small tag twice.

--- a/nautobot/core/templates/inc/created_updated.html
+++ b/nautobot/core/templates/inc/created_updated.html
@@ -2,7 +2,7 @@
 <p>
     <small class="text-muted">
     {% if object.created %}
-    Created {{ object.created }} &middot;</small>
+    Created {{ object.created }} &middot;
     {% endif %}
     Updated <span title="{{ object.last_updated }}">{{ object.last_updated|timesince }}</span> ago
     </small>

--- a/nautobot/dcim/models/racks.py
+++ b/nautobot/dcim/models/racks.py
@@ -604,6 +604,7 @@ class Rack(PrimaryModel, StatusModel):
             _cable_peer_type=ContentType.objects.get_for_model(PowerFeed),
             _cable_peer_id__in=powerfeeds.values_list("id", flat=True),
         )
+        direct_allocated_draw = pf_powerports.aggregate(Sum("allocated_draw"))["allocated_draw__sum"] or 0
         poweroutlets = PowerOutlet.objects.filter(power_port_id__in=pf_powerports)
         allocated_draw_total = (
             PowerPort.objects.filter(
@@ -612,6 +613,7 @@ class Rack(PrimaryModel, StatusModel):
             ).aggregate(Sum("allocated_draw"))["allocated_draw__sum"]
             or 0
         )
+        allocated_draw_total += direct_allocated_draw
 
         return UtilizationData(numerator=allocated_draw_total, denominator=available_power_total)
 

--- a/nautobot/dcim/templates/dcim/rack.html
+++ b/nautobot/dcim/templates/dcim/rack.html
@@ -191,7 +191,13 @@
                             </td>
                             {% with power_port=powerfeed.connected_endpoint %}
                                 {% if power_port %}
-                                    <td>{% utilization_graph power_port.get_power_draw.utilization_data %}</td>
+                                    {% with utilization=power_port.get_power_draw %}
+                                        {% if utilization %}
+                                            {% if powerfeed.available_power > 0 %}
+                                                <td>{% utilization_graph_raw_data utilization.allocated powerfeed.available_power %}</td>
+                                            {% endif %}
+                                        {% endif %}
+                                    {% endwith %}
                                 {% else %}
                                     <td class="text-muted">N/A</td>
                                 {% endif %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2099 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Fixed PowerFeed Utilization on Rack View not displaying correctly.
Fixed Total Power Utilization on Rack View not taking into account direct-connected devices.
Fixed created_updated template adding the end small tag twice.

![image](https://user-images.githubusercontent.com/17092348/196589466-f97c3da9-ed1e-4935-b7cd-08a2a07010e7.png)
![image (13)](https://user-images.githubusercontent.com/17092348/196588879-0b55713e-e408-4dbe-af8c-eba009b5faf6.png)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
