### PR TITLE
Fix last login time being updated during maintenance mode with remote user authentication

### DIFF
--- a/changes/2477.fixed
+++ b/changes/2477.fixed
@@ -1,0 +1,1 @@
+Fixed last login time being updated during maintenance mode when remote user authentication is used.

--- a/nautobot/core/apps/__init__.py
+++ b/nautobot/core/apps/__init__.py
@@ -671,6 +671,15 @@ class CoreConfig(NautobotConfig):
             """Convert BigIntegerField to BigInteger scalar."""
             return BigInteger()
 
+        from django.conf import settings
+        from django.contrib.auth.models import update_last_login
+        from django.contrib.auth.signals import user_logged_in
+
+        # If maintenance mode is enabled, assume the database is read-only, and disable updating the user's
+        # last_login time upon authentication.
+        if settings.MAINTENANCE_MODE:
+            user_logged_in.disconnect(update_last_login, dispatch_uid="update_last_login")
+
         post_migrate.connect(post_migrate_send_nautobot_database_ready, sender=self)
 
         super().ready()

--- a/nautobot/core/apps/__init__.py
+++ b/nautobot/core/apps/__init__.py
@@ -678,6 +678,7 @@ class CoreConfig(NautobotConfig):
         # If maintenance mode is enabled, assume the database is read-only, and disable updating the user's
         # last_login time upon authentication.
         if settings.MAINTENANCE_MODE:
+            logger.warning("Maintenance mode enabled: disabling update of most recent login time")
             user_logged_in.disconnect(update_last_login, dispatch_uid="update_last_login")
 
         post_migrate.connect(post_migrate_send_nautobot_database_ready, sender=self)

--- a/nautobot/core/middleware.py
+++ b/nautobot/core/middleware.py
@@ -1,7 +1,5 @@
 from django.conf import settings
 from django.contrib.auth.middleware import RemoteUserMiddleware as RemoteUserMiddleware_
-from django.contrib.auth.signals import user_logged_in
-from django.contrib.auth.models import update_last_login
 from django.db import ProgrammingError
 from django.http import Http404
 from django.urls import resolve
@@ -37,11 +35,6 @@ class RemoteUserMiddleware(RemoteUserMiddleware_):
         # Bypass middleware if remote authentication is not enabled
         if not remote_auth_enabled(auth_backends=settings.AUTHENTICATION_BACKENDS):
             return None
-
-        # If maintenance mode is enabled, assume the database is read-only, and disable updating the user's
-        # last_login time upon authentication.
-        if settings.MAINTENANCE_MODE:
-            user_logged_in.disconnect(update_last_login, dispatch_uid="update_last_login")
 
         return super().process_request(request)
 

--- a/nautobot/users/views.py
+++ b/nautobot/users/views.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import (
     BACKEND_SESSION_KEY,
@@ -9,8 +8,6 @@ from django.contrib.auth import (
     update_session_auth_hash,
 )
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.contrib.auth.models import update_last_login
-from django.contrib.auth.signals import user_logged_in
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -61,12 +58,6 @@ class LoginView(View):
 
         if form.is_valid():
             logger.debug("Login form validation was successful")
-
-            # If maintenance mode is enabled, assume the database is read-only, and disable updating the user's
-            # last_login time upon authentication.
-            if settings.MAINTENANCE_MODE:
-                logger.warning("Maintenance mode enabled: disabling update of most recent login time")
-                user_logged_in.disconnect(update_last_login, dispatch_uid="update_last_login")
 
             # Authenticate user
             auth_login(request, form.get_user())


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2477 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Added a missing check for `MAINTENANCE_MODE` during remote user authentication similarly to how it is done in [users/views.py](https://github.com/nautobot/nautobot/blob/21c85f25e6458ad97e62484bc89e5effa1328a80/nautobot/users/views.py)
  - Last login time for remotely authenticated users was still being updated during maintenance mode, which would fail if the underlying database was read-only

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
