### PR TITLE
[WIP] Introduce RestrictedQuerySet.with_related.

### DIFF
--- a/changes/2657.added
+++ b/changes/2657.added
@@ -1,0 +1,1 @@
+Added RestrictedQuerySet.with_related

--- a/nautobot/utilities/tests/test_querysets.py
+++ b/nautobot/utilities/tests/test_querysets.py
@@ -1,0 +1,43 @@
+from django.test.utils import override_settings
+
+from nautobot.dcim.models import Site, Region
+from nautobot.tenancy.models import Tenant
+from nautobot.utilities.testing import TestCase
+
+
+class QuerySetTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_tenant_names = ["Test-Tenant-1", "Test-Tenant-2"]
+        cls.test_region_name = "Test-Region-1"
+        cls.tenant_1 = Tenant.objects.create(name=cls.test_tenant_names[0])
+        cls.tenant_2 = Tenant.objects.create(name=cls.test_tenant_names[1])
+        cls.region = Region.objects.create(name=cls.test_region_name)
+        cls.site_1 = Site.objects.create(name="Test-Site-1", tenant=cls.tenant_1, region=cls.region)
+        cls.site_2 = Site.objects.create(name="Test-Site-2", tenant=cls.tenant_2, region=cls.region)
+
+    def test_invalid_with_related(self):
+        """Assert that calling with_related with non-relationship field on a queryset fails."""
+        with self.assertRaises(ValueError):
+            Site.objects.with_related("name").all()
+
+    @override_settings(DEBUG=True)
+    def test_foreign_key_with_related(self):
+        """Test using with_related on ForeignKey relationships."""
+        sites = Site.objects.with_related("tenant", "region").all()
+        # One query is expected here instead of the five that the default behavior would take.
+        with self.assertNumQueries(1):
+            # Access the foreign keys to ensure they are loaded from the DB
+            for index, site in enumerate(sites):
+                self.assertEqual(site.tenant.name, self.test_tenant_names[index])
+                self.assertEqual(site.region.name, self.test_region_name)
+
+    @override_settings(DEBUG=True)
+    def test_many_to_one_with_related(self):
+        """Test using with_related on ForeignKey relationships."""
+        tenants = Tenant.objects.with_related("sites").all()
+        # Two queries are expected here instead of the three queries the default behavior would take.
+        with self.assertNumQueries(2):
+            # Access the relation to ensure it is loaded from the DB
+            for tenant in tenants:
+                self.assertIsNotNone(tenant.sites.first().name)

--- a/nautobot/utilities/tests/test_querysets.py
+++ b/nautobot/utilities/tests/test_querysets.py
@@ -1,6 +1,7 @@
 from django.test.utils import override_settings
 
-from nautobot.dcim.models import Site, Region
+from nautobot.dcim.factory import SiteFactory
+from nautobot.dcim.models import Site
 from nautobot.tenancy.models import Tenant
 from nautobot.utilities.testing import TestCase
 
@@ -8,13 +9,8 @@ from nautobot.utilities.testing import TestCase
 class QuerySetTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.test_tenant_names = ["Test-Tenant-1", "Test-Tenant-2"]
-        cls.test_region_name = "Test-Region-1"
-        cls.tenant_1 = Tenant.objects.create(name=cls.test_tenant_names[0])
-        cls.tenant_2 = Tenant.objects.create(name=cls.test_tenant_names[1])
-        cls.region = Region.objects.create(name=cls.test_region_name)
-        cls.site_1 = Site.objects.create(name="Test-Site-1", tenant=cls.tenant_1, region=cls.region)
-        cls.site_2 = Site.objects.create(name="Test-Site-2", tenant=cls.tenant_2, region=cls.region)
+        sites = SiteFactory.create_batch(2, has_region=True, has_tenant=True)
+        cls.queryset = Site.objects.filter(pk__in=[site.pk for site in sites])
 
     def test_invalid_with_related(self):
         """Assert that calling with_related with non-relationship field on a queryset fails."""
@@ -24,20 +20,22 @@ class QuerySetTestCase(TestCase):
     @override_settings(DEBUG=True)
     def test_foreign_key_with_related(self):
         """Test using with_related on ForeignKey relationships."""
-        sites = Site.objects.with_related("tenant", "region").all()
+        # Filter to only the sites we created ourselves so we can be sure they have tenants and regions
+        sites = self.queryset.with_related("tenant", "region")
         # One query is expected here instead of the five that the default behavior would take.
         with self.assertNumQueries(1):
             # Access the foreign keys to ensure they are loaded from the DB
-            for index, site in enumerate(sites):
-                self.assertEqual(site.tenant.name, self.test_tenant_names[index])
-                self.assertEqual(site.region.name, self.test_region_name)
+            for site in sites:
+                _ = site.tenant.name
+                _ = site.region.name
 
     @override_settings(DEBUG=True)
     def test_many_to_one_with_related(self):
         """Test using with_related on ForeignKey relationships."""
-        tenants = Tenant.objects.with_related("sites").all()
+        # Get a tenant for which we know it has a site
+        tenant_pk = self.queryset.first().tenant.pk
         # Two queries are expected here instead of the three queries the default behavior would take.
         with self.assertNumQueries(2):
+            tenant = Tenant.objects.with_related("sites").get(pk=tenant_pk)
             # Access the relation to ensure it is loaded from the DB
-            for tenant in tenants:
-                self.assertIsNotNone(tenant.sites.first().name)
+            _ = tenant.sites.first().name


### PR DESCRIPTION
# Closes: #3734
# What's Changed

Introduced `RestrictedQuerySet.with_related` to selectively call `prefetch_related` or `select_related` depending on the kind of field that is passed.

# TODO
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Add further unit tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
- [ ] Take CacheOps into account (possible use `prefetch_related` only as long as CacheOps is installed/enabled?)
