### PR TITLE
Fix automatic tagging of buildx builds

### DIFF
--- a/changes/2661.fixed
+++ b/changes/2661.fixed
@@ -1,0 +1,1 @@
+Fixed default tagging of Docker images built with `invoke buildx`.


### PR DESCRIPTION
# Closes: #N/A
# What's Changed

- Add a new `print_command` helper function to `tasks.py` to generalize some logic that was specific to the `docker_compose` function and provide a common entry point for printing a CLI command before running it.
- Replace hard-coded default tag of `networktocode/nautobot-dev-py3.7:local` on `buildx` task to derive appropriate automatic tags for `dev` and `final` images based on the specified Python version - I needed the `print_command` to help me demonstrate that this was working correctly. :-)
- Add `print_command` in a few other cases.

```
$ INVOKE_NAUTOBOT_PYTHON_VER=3.9 invoke buildx --target final
Building Nautobot final target with Python 3.9 for linux/amd64...
PYTHON_VER=3.9 \
docker buildx build . \
    --platform linux/amd64 \
    --target final \
    --load -f ./docker/Dockerfile \
    --build-arg PYTHON_VER=3.9 \
    -t networktocode/nautobot-py3.9:local \   <------------<<
    --no-cache
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
