### PR TITLE
Fixed an issue with `DynamicGroup` not properly filtering by `Region` or `Location`.

### DIFF
--- a/changes/2513.fixed
+++ b/changes/2513.fixed
@@ -1,0 +1,1 @@
+Fixed an issue with `DynamicGroup` not properly filtering by `Region` or `Location`.

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -310,12 +310,16 @@ class DynamicGroup(OrganizationalModel):
     @property
     def members(self):
         """Return the member objects for this group."""
-        return self.get_group_queryset()
+        # If there are child groups, return the generated group queryset, otherwise use this group's
+        # `filter` directly.
+        if self.children.exists():
+            return self.get_group_queryset()
+        return self.get_queryset()
 
     @property
     def count(self):
         """Return the number of member objects in this group."""
-        return self.get_group_queryset().count()
+        return self.members.count()
 
     def get_absolute_url(self):
         return reverse("extras:dynamicgroup", kwargs={"slug": self.slug})

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -7,11 +7,21 @@ from django.urls import reverse
 
 from nautobot.dcim.choices import PortTypeChoices
 from nautobot.dcim.filters import DeviceFilterSet
-from nautobot.dcim.forms import DeviceForm, DeviceFilterForm
-from nautobot.dcim.models import Device, DeviceRole, DeviceType, FrontPort, Manufacturer, RearPort, Site
+from nautobot.dcim.forms import DeviceFilterForm, DeviceForm
+from nautobot.dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    FrontPort,
+    Location,
+    LocationType,
+    Manufacturer,
+    RearPort,
+    Site,
+)
 from nautobot.extras.choices import DynamicGroupOperatorChoices
-from nautobot.extras.models import DynamicGroup, DynamicGroupMembership, Status
 from nautobot.extras.filters import DynamicGroupFilterSet, DynamicGroupMembershipFilterSet
+from nautobot.extras.models import DynamicGroup, DynamicGroupMembership, Status
 from nautobot.ipam.models import Prefix
 from nautobot.utilities.testing import TestCase
 
@@ -237,6 +247,53 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
 
         self.assertIn(device1, group.members)
         self.assertNotIn(device2, group.members)
+
+    def test_members_tree_nodes(self):
+        """
+        Test `DynamicGroup.members` when filtering on tree nodes like `Location`.
+        """
+        # Grab some values we'll used to setup the test case.
+        device1 = self.devices[0]
+        device2 = self.devices[1]
+        site = device1.site
+        status = Status.objects.get(slug="active")
+
+        # Create two LocationTypes (My Region > My Site)
+        loc_type_region = LocationType.objects.create(name="My Region", slug="my-region")
+        loc_type_region.content_types.add(self.device_ct)
+        loc_type_site = LocationType.objects.create(name="My Site", slug="my-site", parent=loc_type_region)
+        loc_type_site.content_types.add(self.device_ct)
+
+        loc_region = Location.objects.create(name="Location A", location_type=loc_type_region, site=site, status=status)
+        loc_site = Location.objects.create(
+            name="Location B", location_type=loc_type_site, parent=loc_region, status=status
+        )
+
+        # Add Location A to device1
+        device1.location = loc_region
+        device1.validated_save()
+
+        # Add Location B to device2
+        device2.site = device1.site
+        device2.location = loc_site
+        device2.validated_save()
+
+        names = [device1.name, device2.name]
+
+        # Create the Dynamic Group filtering on Location A
+        group = DynamicGroup.objects.create(
+            name="Devices Location",
+            slug="devices-location",
+            content_type=self.device_ct,
+            filter={"location": ["location-a"]},
+        )
+
+        # We are expecting that the group members here should be nested results from any devices
+        # that have a Location whose parent is "Location A".
+        self.assertEqual(
+            sorted(m.name for m in group.members),
+            sorted(names),
+        )
 
     def test_count(self):
         """Test `DynamicGroup.count`."""

--- a/nautobot/utilities/constants.py
+++ b/nautobot/utilities/constants.py
@@ -22,8 +22,6 @@ FILTER_NUMERIC_BASED_LOOKUP_MAP = dict(n="exact", lte="lte", lt="lt", gte="gte",
 
 FILTER_NEGATION_LOOKUP_MAP = dict(n="exact")
 
-FILTER_TREENODE_NEGATION_LOOKUP_MAP = dict(n="in")
-
 
 #
 # HTTP Request META safe copy

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -24,7 +24,6 @@ from nautobot.utilities.constants import (
     FILTER_CHAR_BASED_LOOKUP_MAP,
     FILTER_NEGATION_LOOKUP_MAP,
     FILTER_NUMERIC_BASED_LOOKUP_MAP,
-    FILTER_TREENODE_NEGATION_LOOKUP_MAP,
 )
 from nautobot.utilities.forms.fields import MultiMatchModelMultipleChoiceField
 
@@ -564,10 +563,6 @@ class BaseFilterSet(django_filters.FilterSet):
         ):
             lookup_map = FILTER_NUMERIC_BASED_LOOKUP_MAP
 
-        elif isinstance(existing_filter, (TreeNodeMultipleChoiceFilter,)):
-            # TreeNodeMultipleChoiceFilter only support negation but must maintain the `in` lookup expression
-            lookup_map = FILTER_TREENODE_NEGATION_LOOKUP_MAP
-
         # These filter types support only negation
         elif isinstance(
             existing_filter,
@@ -575,12 +570,15 @@ class BaseFilterSet(django_filters.FilterSet):
                 django_filters.ModelChoiceFilter,
                 django_filters.ModelMultipleChoiceFilter,
                 TagFilter,
+                TreeNodeMultipleChoiceFilter,
             ),
         ):
             lookup_map = FILTER_NEGATION_LOOKUP_MAP
+
         # These filter types support only negation
         elif existing_filter.extra.get("choices"):
             lookup_map = FILTER_NEGATION_LOOKUP_MAP
+
         elif isinstance(
             existing_filter,
             (

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -491,14 +491,20 @@ class TreeNodeMultipleChoiceFilter(NaturalKeyOrPKMultipleChoiceFilter):
         new_value = []
         if value:
             for node in value:
+                # django-tree-queries
                 if isinstance(node, TreeNode):
                     method = "descendants"
+                # django-mptt
                 elif isinstance(node, MPTTModel):
                     method = "get_descendants"
                 else:
-                    continue
+                    method = None
 
-                descendants = getattr(node, method)(include_self=True)
+                if method is not None:
+                    descendants = getattr(node, method)(include_self=True)
+                else:
+                    descendants = node
+
                 new_value.append(descendants)
 
         # This new_value is going to be a list of querysets that needs to be flattened.

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -450,7 +450,7 @@ class NaturalKeyOrPKMultipleChoiceFilter(django_filters.ModelMultipleChoiceFilte
         if not is_pk:
             name = f"{self.field_name}__{self.field.to_field_name}"
         else:
-            logger.debug("UUID or list/qs detected: Filtering using field name")
+            logger.debug("UUID detected: Filtering using field name")
             name = self.field_name
 
         if name and self.lookup_expr != django_filters.conf.settings.DEFAULT_LOOKUP_EXPR:

--- a/nautobot/utilities/tests/test_filters.py
+++ b/nautobot/utilities/tests/test_filters.py
@@ -671,9 +671,9 @@ class BaseFilterSetTest(TestCase):
 
     def test_tree_node_multiple_choice_filter(self):
         self.assertIsInstance(self.filters["treeforeignkeyfield"], TreeNodeMultipleChoiceFilter)
-        self.assertEqual(self.filters["treeforeignkeyfield"].lookup_expr, "in")
+        self.assertEqual(self.filters["treeforeignkeyfield"].lookup_expr, "exact")
         self.assertEqual(self.filters["treeforeignkeyfield"].exclude, False)
-        self.assertEqual(self.filters["treeforeignkeyfield__n"].lookup_expr, "in")
+        self.assertEqual(self.filters["treeforeignkeyfield__n"].lookup_expr, "exact")
         self.assertEqual(self.filters["treeforeignkeyfield__n"].exclude, True)
 
 

--- a/nautobot/utilities/tests/test_utils.py
+++ b/nautobot/utilities/tests/test_utils.py
@@ -6,6 +6,7 @@ from nautobot.core.settings_funcs import is_truthy
 from nautobot.utilities.utils import (
     deepmerge,
     dict_to_filter_params,
+    flatten_iterable,
     get_form_for_model,
     get_filterset_for_model,
     get_model_from_name,
@@ -145,6 +146,20 @@ class DeepMergeTest(TestCase):
         }
 
         self.assertEqual(deepmerge(dict1, dict2), merged)
+
+
+class FlattenIterableTest(TestCase):
+    """Tests for the `flatten_iterable()` function."""
+
+    def test_list_of_lists(self):
+        items = [[1, 2, 3], [4, 5], 6]
+        expected = [1, 2, 3, 4, 5, 6]
+        self.assertEqual(list(flatten_iterable(items)), expected)
+
+    def test_list_of_strings(self):
+        items = ["foo", ["bar"], ["baz"]]
+        expected = ["foo", "bar", "baz"]
+        self.assertEqual(list(flatten_iterable(items)), expected)
 
 
 class GetFooForModelTest(TestCase):

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -393,6 +393,21 @@ def flatten_dict(d, prefix="", separator="."):
     return ret
 
 
+def flatten_iterable(iterable):
+    """
+    Flatten a nested iterable such as a list of lists, keeping strings intact.
+
+    :param iterable: The iterable to be flattened
+    :returns: generator
+    """
+    for i in iterable:
+        if hasattr(i, '__iter__') and not isinstance(i, str):
+            for j in flatten_iterable(i):
+                yield j
+        else:
+            yield i
+
+
 # Taken from django.utils.functional (<3.0)
 def curry(_curried_func, *args, **kwargs):
     def _curried(*moreargs, **morekwargs):

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -401,7 +401,7 @@ def flatten_iterable(iterable):
     :returns: generator
     """
     for i in iterable:
-        if hasattr(i, '__iter__') and not isinstance(i, str):
+        if hasattr(i, "__iter__") and not isinstance(i, str):
             for j in flatten_iterable(i):
                 yield j
         else:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2513 
# What's Changed

- `NaturalKeyOrPKMultipleChoiceFilter.get_filter_predicate()` has been revised to only return a filter for a single value, and for slugs it wil always be a nested lookup.
- `TreeNodeMultipleChoiceFilter.filter()` was revised to always return a flattened list of objects in the event that there may sometimes be a nested a list of `QuerySets`
 - Implemented a new `flatten_iterable` utility to smartly flatten nested lists while skipping strings that is used in `TreeNodeMultipleChoiceFilter.filter()` to flatten nested lists/`QuerySets` before returned.
 - `DynamicGroup.members` will now return group queryset only if it has child groups, otherwise just uses its own filter directly.
 - `DynamicGroup.count` now calls `members.count()` for consistency.

`Region`
![image](https://user-images.githubusercontent.com/138052/197053017-67ee8370-e9bb-463f-891a-738dd152ef23.png)

`Location`
![image](https://user-images.githubusercontent.com/138052/197053048-740d411b-4045-49cb-b892-940ce4be99f4.png)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
