### PR TITLE
Fix weekly scheduled job executing a day early

### DIFF
--- a/changes/2426.fixed
+++ b/changes/2426.fixed
@@ -1,0 +1,1 @@
+Fixed weekly scheduled job executing a day early.

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -1004,7 +1004,7 @@ class ScheduledJob(BaseModel):
         elif self.interval == JobExecutionType.TYPE_DAILY:
             return schedules.crontab(minute=t.minute, hour=t.hour)
         elif self.interval == JobExecutionType.TYPE_WEEKLY:
-            return schedules.crontab(minute=t.minute, hour=t.hour, day_of_week=t.weekday())
+            return schedules.crontab(minute=t.minute, hour=t.hour, day_of_week=t.strftime("%w"))
         elif self.interval == JobExecutionType.TYPE_CUSTOM:
             return self.get_crontab(self.crontab)
         raise ValueError(f"I do not know to convert {self.interval} to a Cronjob!")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2426
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Fix mismatch in crontab day of week and `datetime` day of week causing scheduled jobs to run a day early (Scheduled for Sunday but runs on Saturday, bug details discussed in #2426)
- Write test to test this

Test failure before fix applied:
```
======================================================================
FAIL: test_weekly_interval (nautobot.extras.tests.test_jobs.ScheduledJobIntervalTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/source/nautobot/extras/tests/test_jobs.py", line 758, in test_weekly_interval
    self.assertEqual(scheduled_job_weekday, requested_weekday)
AssertionError: 'Wednesday' != 'Thursday'
- Wednesday
+ Thursday


----------------------------------------------------------------------
Ran 1 test in 0.029s
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
