### PR TITLE
Implement 'base_site' and 'subtree' filters on LocationFilterSet

### DIFF
--- a/changes/2518.added
+++ b/changes/2518.added
@@ -1,0 +1,1 @@
+Added `base_site` filter to `LocationFilterSet`, allowing for filtering Locations by their root ancestor's Site.

--- a/changes/2518.added
+++ b/changes/2518.added
@@ -1,1 +1,1 @@
-Added `base_site` filter to `LocationFilterSet`, allowing for filtering Locations by their root ancestor's Site.
+Added `base_site` and `subtree` filters to `LocationFilterSet`, allowing for filtering Locations by their root ancestor or its Site.

--- a/nautobot/dcim/filters.py
+++ b/nautobot/dcim/filters.py
@@ -348,7 +348,7 @@ class LocationFilterSet(NautobotFilterSet, StatusModelFilterSetMixin, TenancyFil
             max_depth = max(loc.tree_depth for loc in Location.objects.with_tree_fields())
             filter_name = "site__in"
             params = Q(**{filter_name: value})
-            for i in range(max_depth):
+            for _i in range(max_depth):
                 filter_name = f"parent__{filter_name}"
                 params |= Q(**{filter_name: value})
             return params

--- a/nautobot/dcim/filters.py
+++ b/nautobot/dcim/filters.py
@@ -340,7 +340,7 @@ class LocationFilterSet(NautobotFilterSet, StatusModelFilterSetMixin, TenancyFil
     def generate_query__base_site(self, value):
         """Helper method used by DynamicGroups and by _base_site() method."""
         if value:
-            max_depth = max(loc.tree_depth for loc in Location.objects.with_tree_fields())
+            max_depth = Location.objects.with_tree_fields().extra(order_by=["-__tree.tree_depth"]).first().tree_depth
             filter_name = "site__in"
             params = Q(**{filter_name: value})
             for _i in range(max_depth):
@@ -371,7 +371,7 @@ class LocationFilterSet(NautobotFilterSet, StatusModelFilterSetMixin, TenancyFil
     def generate_query__subtree(self, value):
         """Helper method used by DynamicGroups and by _subtree() method."""
         if value:
-            max_depth = max(loc.tree_depth for loc in Location.objects.with_tree_fields())
+            max_depth = Location.objects.with_tree_fields().extra(order_by=["-__tree.tree_depth"]).first().tree_depth
             params = Q(pk__in=[v.pk for v in value])
             filter_name = "in"
             for _i in range(max_depth):

--- a/nautobot/dcim/form_mixins.py
+++ b/nautobot/dcim/form_mixins.py
@@ -25,7 +25,7 @@ class LocatableModelFormMixin(forms.Form):
     location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         required=False,
-        # TODO: query_params={"base_site": "$site"},
+        query_params={"base_site": "$site"},
     )
 
     def __init__(self, *args, **kwargs):
@@ -63,7 +63,7 @@ class LocatableModelBulkEditFormMixin(forms.Form):
     location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         required=False,
-        # TODO: query_params={"base_site": "$site"},
+        query_params={"base_site": "$site"},
     )
 
     def __init__(self, *args, **kwargs):
@@ -136,5 +136,5 @@ class LocatableModelFilterFormMixin(forms.Form):
         to_field_name="slug",
         required=False,
         null_option="None",
-        # TODO query_params={"base_site": "$site"},
+        query_params={"base_site": "$site"},
     )

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -535,13 +535,14 @@ class LocationCSVForm(StatusModelCSVFormMixin, CustomFieldModelCSVForm):
 
 class LocationFilterForm(NautobotFilterForm, StatusModelFilterFormMixin, TenancyFilterForm):
     model = Location
-    field_order = ["q", "location_type", "parent", "base_site", "status", "tenant_group", "tenant", "tag"]
+    field_order = ["q", "location_type", "parent", "subtree", "base_site", "status", "tenant_group", "tenant", "tag"]
 
     q = forms.CharField(required=False, label="Search")
     location_type = DynamicModelMultipleChoiceField(
         queryset=LocationType.objects.all(), to_field_name="slug", required=False
     )
     parent = DynamicModelMultipleChoiceField(queryset=Location.objects.all(), to_field_name="slug", required=False)
+    subtree = DynamicModelMultipleChoiceField(queryset=Location.objects.all(), to_field_name="slug", required=False)
     base_site = DynamicModelMultipleChoiceField(queryset=Site.objects.all(), to_field_name="slug", required=False)
     tag = TagFilterField(model)
 

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -535,13 +535,14 @@ class LocationCSVForm(StatusModelCSVFormMixin, CustomFieldModelCSVForm):
 
 class LocationFilterForm(NautobotFilterForm, StatusModelFilterFormMixin, TenancyFilterForm):
     model = Location
-    field_order = ["q", "location_type", "parent", "status", "tenant_group", "tenant", "tag"]
+    field_order = ["q", "location_type", "parent", "base_site", "status", "tenant_group", "tenant", "tag"]
 
     q = forms.CharField(required=False, label="Search")
     location_type = DynamicModelMultipleChoiceField(
         queryset=LocationType.objects.all(), to_field_name="slug", required=False
     )
     parent = DynamicModelMultipleChoiceField(queryset=Location.objects.all(), to_field_name="slug", required=False)
+    base_site = DynamicModelMultipleChoiceField(queryset=Site.objects.all(), to_field_name="slug", required=False)
     tag = TagFilterField(model)
 
 


### PR DESCRIPTION
# Closes: #2518 
# What's Changed

- Implement `base_site` Location filter using a fairly naïve approach (filter on `site`, or on `parent__site`, or on `parent__parent__site`, etc. up to the maximum current depth of the Location tree). I tested UI filtering with about 2000 Locations (thanks #2540!) and it seems reasonably quick (a couple of seconds to apply), especially compared to alternate approaches I've tried. 
- Implement `subtree` Location filter using a similar approach.


### Showing the use of this filter in `query_params` to only show Locations that match the selected site, including descendants

![image](https://user-images.githubusercontent.com/5603551/197291105-2e609290-ad24-42f6-9709-b38062e2f89f.png)

![image](https://user-images.githubusercontent.com/5603551/197291139-64094a30-4c6e-4e3c-b15b-9b17b8a82df0.png)

![image](https://user-images.githubusercontent.com/5603551/197291179-8267f8a5-f429-495f-b17c-e0b2071c3a68.png)

### Filtering Locations table by multiple sites

![image](https://user-images.githubusercontent.com/5603551/197291407-51d1777c-a52f-4545-81b9-d6b71e739f3b.png)

![image](https://user-images.githubusercontent.com/5603551/197291480-4b7822ac-3369-4caf-8694-2f9e9ae74b93.png)



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
