### PR TITLE
Fix #2675 by adding NAUTOBOT_REDIS_SCHEME to support unix socket connections

### DIFF
--- a/changes/2675.added
+++ b/changes/2675.added
@@ -1,0 +1,1 @@
+Added the ability to configure Redis Unix socket connections

--- a/changes/2675.added
+++ b/changes/2675.added
@@ -1,1 +1,1 @@
-Added the ability to configure Redis Unix socket connections
+Added the ability to configure Redis Unix socket connections.

--- a/nautobot/core/settings_funcs.py
+++ b/nautobot/core/settings_funcs.py
@@ -72,7 +72,9 @@ def parse_redis_connection(redis_database):
     """
     # The following `_redis_*` variables are used to generate settings based on
     # environment variables.
-    redis_scheme = "rediss" if is_truthy(os.getenv("NAUTOBOT_REDIS_SSL", "false")) else "redis"
+    redis_scheme = os.getenv("NAUTOBOT_REDIS_SCHEME")
+    if redis_scheme is None:
+        redis_scheme = "rediss" if is_truthy(os.getenv("NAUTOBOT_REDIS_SSL", "false")) else "redis"
     redis_host = os.getenv("NAUTOBOT_REDIS_HOST", "localhost")
     redis_port = int(os.getenv("NAUTOBOT_REDIS_PORT", "6379"))
     redis_username = os.getenv("NAUTOBOT_REDIS_USERNAME", "")
@@ -85,4 +87,7 @@ def parse_redis_connection(redis_database):
     if redis_username or redis_password:
         redis_creds = f"{redis_username}:{redis_password}@"
 
-    return f"{redis_scheme}://{redis_creds}{redis_host}:{redis_port}/{redis_database}"
+    if redis_scheme == "unix":
+        return f"{redis_scheme}://{redis_creds}{redis_host}?db={redis_database}"
+    else:
+        return f"{redis_scheme}://{redis_creds}{redis_host}:{redis_port}/{redis_database}"

--- a/nautobot/docs/configuration/required-settings.md
+++ b/nautobot/docs/configuration/required-settings.md
@@ -290,6 +290,7 @@ RQ_QUEUES = {
 
 The following environment variables may also be set for some of the above values:
 
+* `NAUTOBOT_REDIS_SCHEME`
 * `NAUTOBOT_REDIS_HOST`
 * `NAUTOBOT_REDIS_PORT`
 * `NAUTOBOT_REDIS_PASSWORD`


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2675
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Added support for Unix socket connections by adding the environment variable NAUTOBOT_REDIS_SCHEME 

e.g. setting
```
NAUTOBOT_REDIS_SCHEME=unix
NAUTOBOT_REDIS_HOST=/var/run/redis.sock
````
will allow redis connections to the unix socket

