### PR TITLE
add signals to log when user logs in and logs out

### DIFF
--- a/changes/2146.fixed
+++ b/changes/2146.fixed
@@ -1,0 +1,1 @@
+Add signals to log when a user logs in and logs out to fix a bug when SSO logins were not being logged.

--- a/changes/2146.fixed
+++ b/changes/2146.fixed
@@ -1,1 +1,1 @@
-Add signals to log when a user logs in and logs out to fix a bug where SSO logins were not being logged.
+Added signals to log when a user logs in and logs out to fix a bug where SSO logins were not being logged.

--- a/changes/2146.fixed
+++ b/changes/2146.fixed
@@ -1,1 +1,1 @@
-Add signals to log when a user logs in and logs out to fix a bug when SSO logins were not being logged.
+Add signals to log when a user logs in and logs out to fix a bug where SSO logins were not being logged.

--- a/nautobot/core/signals.py
+++ b/nautobot/core/signals.py
@@ -1,6 +1,8 @@
 """Custom signals and handlers for the core Nautobot application."""
+import logging
 
-from django.dispatch import Signal
+from django.contrib.auth.signals import user_logged_in, user_logged_out
+from django.dispatch import receiver, Signal
 
 
 nautobot_database_ready = Signal()
@@ -17,3 +19,17 @@ The intended purpose of this signal is for apps and plugins that need to populat
 (**not** the database schema itself!), for example to ensure the existence of certain CustomFields, Jobs,
 Relationships, etc.
 """
+
+
+@receiver(user_logged_in)
+def user_logged_in_signal(sender, request, user, **kwargs):
+    """Generate a log message when a user logs in through the web ui"""
+    logger = logging.getLogger("nautobot.auth.login")
+    logger.info(f"User {user} successfully authenticated")
+
+
+@receiver(user_logged_out)
+def user_logged_out_signal(sender, request, user, **kwargs):
+    """Generate a log message when a user logs out from the web ui"""
+    logger = logging.getLogger("nautobot.auth.logout")
+    logger.info(f"User {user} has logged out")

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -6,6 +6,7 @@ import logging
 from datetime import timedelta
 
 from cacheops.signals import cache_invalidated, cache_read
+from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -298,3 +299,18 @@ def refresh_job_models(sender, *, apps, **kwargs):
             )
             job_model.installed = False
             job_model.save()
+
+
+#
+# Authentication
+#
+
+
+@receiver(user_logged_in)
+def user_logged_in_signal(sender, request, user, **kwargs):
+    logger.info(f"User {user} successfully authenticated")
+
+
+@receiver(user_logged_out)
+def user_logged_out_signal(sender, request, user, **kwargs):
+    logger.info(f"User {user} has logged out")

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -6,7 +6,6 @@ import logging
 from datetime import timedelta
 
 from cacheops.signals import cache_invalidated, cache_read
-from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -299,18 +298,3 @@ def refresh_job_models(sender, *, apps, **kwargs):
             )
             job_model.installed = False
             job_model.save()
-
-
-#
-# Authentication
-#
-
-
-@receiver(user_logged_in)
-def user_logged_in_signal(sender, request, user, **kwargs):
-    logger.info(f"User {user} successfully authenticated")
-
-
-@receiver(user_logged_out)
-def user_logged_out_signal(sender, request, user, **kwargs):
-    logger.info(f"User {user} has logged out")

--- a/nautobot/users/views.py
+++ b/nautobot/users/views.py
@@ -70,7 +70,6 @@ class LoginView(View):
 
             # Authenticate user
             auth_login(request, form.get_user())
-            logger.info(f"User {request.user} successfully authenticated")
             messages.info(request, f"Logged in as {request.user}.")
 
             return self.redirect_to_next(request, logger)
@@ -106,12 +105,8 @@ class LogoutView(View):
     """
 
     def get(self, request):
-        logger = logging.getLogger("nautobot.auth.logout")
-
         # Log out the user
-        username = request.user
         auth_logout(request)
-        logger.info(f"User {username} has logged out")
         messages.info(request, "You have logged out.")
 
         # Delete session key cookie (if set) upon logout


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2146
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Add signals for `user_logged_in` and `user_logged_out` django signals to send messages to `logger` when the user logs in/out. Required for logging SSO login as described in #2146
- Remove login/logout messages from `LoginView` and `LogoutView` so messages aren't duplicated
- Tested against environment running SSO and environment only using local authentication

Test output:

```
### Local User

nautobot-nautobot-1        | 13:53:38.688 INFO    django.server :
nautobot-nautobot-1        |   "GET /login/?next=/ HTTP/1.1" 200 23335
nautobot-nautobot-1        | 13:53:41.451 INFO    django.server :
nautobot-nautobot-1        |   "GET /health/ HTTP/1.1" 200 11816
nautobot-nautobot-1        | 13:53:41.756 DEBUG   nautobot.auth.login  views.py                                  post() :
nautobot-nautobot-1        |   Login form validation was successful
nautobot-nautobot-1        | 13:53:41.769 INFO    nautobot.auth.login  signals.py               user_logged_in_signal() :
nautobot-nautobot-1        |   User admin successfully authenticated
nautobot-nautobot-1        | 13:53:41.778 DEBUG   nautobot.auth.login  views.py                      redirect_to_next() :
nautobot-nautobot-1        |   Redirecting user to /

nautobot-nautobot-1        | 13:54:42.777 INFO    nautobot.auth.logout signals.py              user_logged_out_signal() :
nautobot-nautobot-1        |   User admin has logged out
nautobot-nautobot-1        | 13:54:42.822 INFO    django.server :
nautobot-nautobot-1        |   "GET /logout/ HTTP/1.1" 302 0

### SSO User

nautobot-nautobot-1        | 14:12:37.545 INFO    nautobot.auth.login  signals.py               user_logged_in_signal() :
nautobot-nautobot-1        |   User nautobot_auditor successfully authenticated
nautobot-nautobot-1        | 14:12:37.561 INFO    nautobot.extras.signals signals.py               user_logged_in_signal() :
nautobot-nautobot-1        |   User nautobot_auditor successfully authenticated
nautobot-nautobot-1        | 14:12:37.784 INFO    django.server :
nautobot-nautobot-1        |   "GET /complete/keycloak/?state=<snip>&code=<snip> HTTP/1.1" 302 0
nautobot-nautobot-1        | 14:12:37.802 DEBUG   nautobot.auth.login  views.py                      redirect_to_next() :
nautobot-nautobot-1        |   Redirecting user to /
nautobot-nautobot-1        | 14:12:37.858 INFO    django.server :
nautobot-nautobot-1        |   "GET /login/?next=/ HTTP/1.1" 302 0
nautobot-nautobot-1        | 14:12:39.028 INFO    django.server :
nautobot-nautobot-1        |   "GET / HTTP/1.1" 200 143974

nautobot-nautobot-1        | 14:12:42.078 INFO    nautobot.auth.logout signals.py              user_logged_out_signal() :
nautobot-nautobot-1        |   User nautobot_auditor has logged out
nautobot-nautobot-1        | 14:12:42.079 INFO    nautobot.extras.signals signals.py              user_logged_out_signal() :
nautobot-nautobot-1        |   User nautobot_auditor has logged out
nautobot-nautobot-1        | 14:12:42.134 INFO    django.server :
nautobot-nautobot-1        |   "GET /logout/ HTTP/1.1" 302 0
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
