### PR TITLE
Hide version in footer for unauthenticated users

### DIFF
--- a/changes/2683.fixed
+++ b/changes/2683.fixed
@@ -1,0 +1,1 @@
+Fixed so that unauthenticated users don't see the version number for Nautobot in the footer.

--- a/nautobot/core/templates/inc/footer.html
+++ b/nautobot/core/templates/inc/footer.html
@@ -8,7 +8,7 @@
                 <div class="col-xs-4">
                     <p class="text-muted">
                         {% if settings.BRANDING_FILEPATHS.logo and settings.BRANDING_POWERED_BY_URL %}<a href="{{ settings.BRANDING_POWERED_BY_URL }}"><img src="{% static 'img/nautobot_logo.svg' %}" height="20" /> Powered</a> &middot;{% endif %}
-                        {{ settings.HOSTNAME }} (v{{ settings.VERSION }})
+                        {{ settings.HOSTNAME }} {% if request.user.is_authenticated %} (v{{ settings.VERSION }}) {% endif %}
                     </p>
                 </div>
                 <div class="col-xs-4 text-center">

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -86,7 +86,10 @@ class HomeViewTestCase(TestCase):
 
         footer_hostname_version_pattern = re.compile('<p class="text-muted">\\s+\\S+\\s+\\(v[\\d.]+\\)\\s+<\\/p>')
         self.assertRegex(response_content, footer_hostname_version_pattern)
+
         self.client.logout()
+        response = self.client.get(url)
+        response_content = response.content.decode(response.charset).replace("\n", "")
         self.assertNotRegex(response_content, footer_hostname_version_pattern)
 
 

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -79,6 +79,16 @@ class HomeViewTestCase(TestCase):
         self.assertIsNotNone(nav_search_bar_result)
         self.assertIsNotNone(body_search_bar_result)
 
+    def test_footer_version_visible_authenticated_users_only(self):
+        url = reverse("home")
+        response = self.client.get(url)
+        response_content = response.content.decode(response.charset).replace("\n", "")
+
+        footer_hostname_version_pattern = re.compile('<p class="text-muted">\\s+\\S+\\s+\\(v[\\d.]+\\)\\s+<\\/p>')
+        self.assertRegex(response_content, footer_hostname_version_pattern)
+        self.client.logout()
+        self.assertNotRegex(response_content, footer_hostname_version_pattern)
+
 
 class ForceScriptNameTestcase(TestCase):
     """Basic test to assert that `settings.FORCE_SCRIPT_NAME` works as intended."""


### PR DESCRIPTION
Closes: #2682

# What's Changed
- Nautbot version number is hidden from the footer for unauthenticated users

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example

> Note the version number being present next to the hostname in the `before`, but not in the `after`.

## Before
![before](https://user-images.githubusercontent.com/1125285/197773805-38ec5902-103b-4f1a-b7c4-20fb9b17cc15.png)

## After
![after](https://user-images.githubusercontent.com/1125285/197773830-0bb1c2c7-f3ad-4cbe-b6cd-a61d9e538a39.png)

