### PR TITLE
Add test helper method to `FilterTestCases` to find values suitable for testing multiple choice filters.

### DIFF
--- a/changes/2686.added
+++ b/changes/2686.added
@@ -1,0 +1,1 @@
+Added test helper method to `FilterTestCases` to find values suitable for testing multiple choice filters.

--- a/nautobot/utilities/tests/test_filters.py
+++ b/nautobot/utilities/tests/test_filters.py
@@ -995,7 +995,7 @@ class DynamicFilterLookupExpressionTest(TestCase):
 class GetFiltersetTestValuesTest(FilterTestCases.BaseFilterTestCase):
     """Tests for `BaseFilterTestCase.get_filterset_test_values()`."""
 
-    queryset = Site.objects.all()
+    queryset = Site.objects.filter(name__startswith="getfiltersettest")
     exception_message = "Cannot find valid test data for Site field description"
 
     @classmethod
@@ -1003,32 +1003,32 @@ class GetFiltersetTestValuesTest(FilterTestCases.BaseFilterTestCase):
         statuses = Status.objects.get_for_model(Site)
         cls.status_active = statuses.get(slug="active")
 
-        Site.objects.all().delete()
-
     def test_empty_queryset(self):
         with self.assertRaisesMessage(ValueError, self.exception_message):
             self.get_filterset_test_values("description")
 
     def test_object_return_count(self):
         for n in range(1, 11):
-            Site.objects.create(name=f"Site{n}", status=self.status_active, description=f"description {n}")
-        test_values = self.get_filterset_test_values("description", Site.objects.all())
-        self.assertNotEqual(test_values, 0)
-        self.assertNotEqual(test_values, Site.objects.count())
+            Site.objects.create(
+                name=f"getfiltersettestSite{n}", status=self.status_active, description=f"description {n}"
+            )
+        test_values = self.get_filterset_test_values("description", self.queryset)
+        self.assertNotEqual(len(test_values), 0)
+        self.assertNotEqual(len(test_values), self.queryset.count())
 
     def test_insufficient_unique_values(self):
-        Site.objects.create(name="UniqueSite", description="UniqueSite description")
+        Site.objects.create(name="getfiltersettestUniqueSite", description="UniqueSite description")
         with self.assertRaisesMessage(ValueError, self.exception_message):
             self.get_filterset_test_values("description")
-        Site.objects.create(name="Site1", status=self.status_active)
-        Site.objects.create(name="Site2", status=self.status_active)
+        Site.objects.create(name="getfiltersettestSite1", status=self.status_active)
+        Site.objects.create(name="getfiltersettestSite2", status=self.status_active)
         with self.assertRaisesMessage(ValueError, self.exception_message):
             self.get_filterset_test_values("description")
 
     def test_no_unique_values(self):
         for n in range(1, 11):
-            Site.objects.create(name=f"Site{n}", status=self.status_active)
-        for site in Site.objects.all():
+            Site.objects.create(name=f"getfiltersettestSite{n}", status=self.status_active)
+        for site in self.queryset:
             site.delete()
             with self.assertRaisesMessage(ValueError, self.exception_message):
                 self.get_filterset_test_values("description")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Add a helper method to `FilterTestCase` to find unique values for testing multiple choice filters. This will help with rewriting tests to use factory fixtures.

```py
        def get_filterset_test_values(self, field_name, queryset=None):
            """Returns a list of distinct values from the requested queryset field to use in filterset tests.

            Returns a list for use in testing multiple choice filters. The size of the returned list is random
            but will contain at minimum 2 unique values. The list of values will match at least 2 instances when
            passed to the queryset's filter(field_name__in=[]) method but will fail to match at least one instance.

            Args:
                field_name: The name of the field to retrieve test values from.
                queryset: The queryset to retrieve test values. Defaults to `self.queryset`.

            Returns:
                list: A list of unique values derived from the queryset.

            Raises:
                ValueError: Raised if unable to find a combination of 2 or more unique values
                    to filter the queryset to a subset of the total instances.
            """
```



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
