### PR TITLE
Fixed filtering by tree node objects in nested Dynamic Groups.

### DIFF
--- a/changes/2693.fixed
+++ b/changes/2693.fixed
@@ -1,0 +1,1 @@
+Fixed filtering by tree node objects in nested Dynamic Groups.

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -278,7 +278,7 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         device2.location = loc_site
         device2.validated_save()
 
-        names = [device1.name, device2.name]
+        expected = sorted([device1.name, device2.name])
 
         # Create the Dynamic Group filtering on Location A
         group = DynamicGroup.objects.create(
@@ -292,7 +292,25 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         # that have a Location whose parent is "Location A".
         self.assertEqual(
             sorted(m.name for m in group.members),
-            sorted(names),
+            expected,
+        )
+
+        # Now also test that an advancted (nested) dynamic group, also reports
+        # the same number of members.
+        parent_group = DynamicGroup.objects.create(
+            name="Parent of Devices Location",
+            slug="parent-devices-location",
+            content_type=self.device_ct,
+            filter={},
+        )
+        parent_group.add_child(
+            child=group,
+            operator=DynamicGroupOperatorChoices.OPERATOR_INTERSECTION,
+            weight=10,
+        )
+        self.assertEqual(
+            sorted(m.name for m in parent_group.members),
+            expected,
         )
 
     def test_count(self):

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -351,9 +351,9 @@ class MappedPredicatesFilterMixin:
         super().__init__(*args, **kwargs)
 
         # Generate the query with a sentinel value to validate it and surface parse errors.
-        self.generate_query(self.filter_predicates, value="")
+        self.generate_query(value="", filter_predicates=self.filter_predicates)
 
-    def generate_query(self, filter_predicates, value, **kwargs):
+    def generate_query(self, value, filter_predicates=None, **kwargs):
         """
         Given a mapping of `filter_predicates` and a `value`, return a `Q` object for 2-tuple of
         predicate=value.
@@ -401,7 +401,7 @@ class MappedPredicatesFilterMixin:
             return qs
 
         # Evaluate the query and stash it for later use (such as introspection or debugging)
-        query = self.generate_query(filter_predicates=self.filter_predicates, value=value)
+        query = self.generate_query(value=value, filter_predicates=self.filter_predicates)
         qs = self.get_method(qs)(query)
         self._most_recent_query = query
         return qs.distinct()
@@ -519,9 +519,12 @@ class TreeNodeMultipleChoiceFilter(NaturalKeyOrPKMultipleChoiceFilter):
         return query
 
     def filter(self, qs, value):
+        if value in EMPTY_VALUES:
+            return qs
+
         # Fetch the generated Q object and filter the incoming qs with it before passing it along.
         query = self.generate_query(value)
-        return qs.filter(query)
+        return self.get_method(qs)(query)
 
 
 #

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -508,6 +508,8 @@ class TreeNodeMultipleChoiceFilter(NaturalKeyOrPKMultipleChoiceFilter):
         for obj in value:
             # Try to get the `to_field_name` (e.g. `slug`) or just pass the object through.
             val = getattr(obj, self.field.to_field_name, obj)
+            if val == self.null_value:
+                val = None
             predicates.append(self.get_filter_predicate(val))
 
         # Construct a nested OR query from the list of filter predicates derived from the flattened

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -353,7 +353,7 @@ class MappedPredicatesFilterMixin:
         # Generate the query with a sentinel value to validate it and surface parse errors.
         self.generate_query(self.filter_predicates, value="")
 
-    def generate_query(self, filter_predicates, value):
+    def generate_query(self, filter_predicates, value, **kwargs):
         """
         Given a mapping of `filter_predicates` and a `value`, return a `Q` object for 2-tuple of
         predicate=value.
@@ -401,7 +401,7 @@ class MappedPredicatesFilterMixin:
             return qs
 
         # Evaluate the query and stash it for later use (such as introspection or debugging)
-        query = self.generate_query(self.filter_predicates, value)
+        query = self.generate_query(filter_predicates=self.filter_predicates, value=value)
         qs = self.get_method(qs)(query)
         self._most_recent_query = query
         return qs.distinct()
@@ -486,7 +486,10 @@ class TreeNodeMultipleChoiceFilter(NaturalKeyOrPKMultipleChoiceFilter):
     would match both "Athens" and "Durham".
     """
 
-    def filter(self, qs, value):
+    def generate_query(self, value, qs=None, **kwargs):
+        """
+        Given a filter value, return a `Q` object that accounts for nested tree node descendants.
+        """
         if value:
             if any(isinstance(node, TreeNode) for node in value):
                 # django-tree-queries
@@ -499,7 +502,26 @@ class TreeNodeMultipleChoiceFilter(NaturalKeyOrPKMultipleChoiceFilter):
 
         # This new_value is going to be a list of querysets that needs to be flattened.
         value = list(flatten_iterable(value))
-        return super().filter(qs, value)
+
+        # Construct a list of filter predicates that will be used to generate the Q object.
+        predicates = []
+        for obj in value:
+            # Try to get the `to_field_name` (e.g. `slug`) or just pass the object through.
+            val = getattr(obj, self.field.to_field_name, obj)
+            predicates.append(self.get_filter_predicate(val))
+
+        # Construct a nested OR query from the list of filter predicates derived from the flattened
+        # listed of descendant objects.
+        query = models.Q()
+        for predicate in predicates:
+            query |= models.Q(**predicate)
+
+        return query
+
+    def filter(self, qs, value):
+        # Fetch the generated Q object and filter the incoming qs with it before passing it along.
+        query = self.generate_query(value)
+        return qs.filter(query)
 
 
 #


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2693 
# What's Changed

- `TreeNodeMultipleChoiceFilter.filter()` refactored to call a new `generate_filter()` method that returns a `Q` objectthat includes filter predicates for all descendants.
- `DynamicGroup.generate_query_for_filter()` has been extended to look for `generate_query()` methods on filters and call that to include the generated `Q` object in group filters.

Proof that it works for Locations:

![image](https://user-images.githubusercontent.com/138052/198411946-753944f2-7e04-4c37-8ac1-c9cef28550e6.png)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
