### PR TITLE
Fix interface status missing when creating a device with a device role associated to a InterfaceTemplate

### DIFF
--- a/changes/2419.fixed
+++ b/changes/2419.fixed
@@ -1,0 +1,1 @@
+Fixed the null device interface status when a device is created with a device_role associated to an InterfaceTemplate.

--- a/nautobot/dcim/models/device_component_templates.py
+++ b/nautobot/dcim/models/device_component_templates.py
@@ -10,12 +10,13 @@ from nautobot.dcim.choices import (
     PowerOutletTypeChoices,
     PowerOutletFeedLegChoices,
     InterfaceTypeChoices,
+    InterfaceStatusChoices,
     PortTypeChoices,
 )
 
 from nautobot.core.models import BaseModel
 from nautobot.dcim.constants import REARPORT_POSITIONS_MAX, REARPORT_POSITIONS_MIN
-from nautobot.extras.models import ChangeLoggedModel, CustomField, CustomFieldModel, RelationshipModel
+from nautobot.extras.models import ChangeLoggedModel, CustomField, CustomFieldModel, RelationshipModel, Status
 from nautobot.extras.utils import extras_features
 from nautobot.utilities.fields import NaturalOrderingField
 from nautobot.utilities.ordering import naturalize_interface
@@ -258,11 +259,16 @@ class InterfaceTemplate(ComponentTemplateModel):
         unique_together = ("device_type", "name")
 
     def instantiate(self, device):
+        try:
+            status = Status.objects.get_for_model(Interface).get(slug=InterfaceStatusChoices.STATUS_ACTIVE)
+        except Status.DoesNotExist:
+            status = Status.objects.get_for_model(Interface).first()
         return self.instantiate_model(
             model=Interface,
             device=device,
             type=self.type,
             mgmt_only=self.mgmt_only,
+            status=status,
         )
 
 

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -172,7 +172,22 @@ class InterfaceTemplateTestCase(TestCase):
             site=site,
         )
 
-        self.assertEqual(device_1.interfaces.get(name="Test_Template_1").status.slug, "active")
+        active_status = Status.objects.get(slug="active")
+        self.assertEqual(device_1.interfaces.get(name="Test_Template_1").status, active_status)
+
+        # Assert that a different status is picked if active status is not found for interface
+        interface_ct = ContentType.objects.get_for_model(Interface)
+        active_status.content_types.remove(interface_ct)
+
+        device_2 = Device.objects.create(
+            device_type=device_type,
+            device_role=device_role,
+            status=statuses[0],
+            name="Test Device 2",
+            site=site,
+        )
+        first_status = Status.objects.get_for_model(Interface).first()
+        self.assertIsNotNone(device_2.interfaces.get(name="Test_Template_1").status, first_status)
 
 
 class RackGroupTestCase(TestCase):

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -147,6 +147,34 @@ class InterfaceTemplateCustomFieldTestCase(TestCase):
         self.assertEqual(Interface.objects.get(pk=interfaces[1].pk).cf["field_3"], "value_3")
 
 
+class InterfaceTemplateTestCase(TestCase):
+    def test_interface_template_sets_interface_status(self):
+        """
+        When a device is created with a device type associated with the template,
+        assert interface templates sets the interface status.
+        """
+        statuses = Status.objects.get_for_model(Device)
+        site = Site.objects.create(name="Site 1", slug="site-1")
+        manufacturer = Manufacturer.objects.create(name="Acme", slug="acme")
+        device_role = DeviceRole.objects.create(name="Device Role 1", slug="device-role-1", color="ff0000")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="FrameForwarder 2048", slug="ff2048")
+        InterfaceTemplate.objects.create(
+            device_type=device_type,
+            name="Test_Template_1",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            mgmt_only=True,
+        )
+        device_1 = Device.objects.create(
+            device_type=device_type,
+            device_role=device_role,
+            status=statuses[0],
+            name="Test Device 1",
+            site=site,
+        )
+
+        self.assertEqual(device_1.interfaces.get(name="Test_Template_1").status.slug, "active")
+
+
 class RackGroupTestCase(TestCase):
     def setUp(self):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2419 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
