### PR TITLE
fix custom field regex validation bugs #2489 and #2494

### DIFF
--- a/changes/2489.fixed
+++ b/changes/2489.fixed
@@ -1,0 +1,1 @@
+Fixed custom field regex validation always anchored to beginning of string.

--- a/changes/2494.fixed
+++ b/changes/2494.fixed
@@ -1,0 +1,1 @@
+Fixed custom field regex validation not being enforced on URL custom fields.

--- a/nautobot/docs/models/extras/customfield.md
+++ b/nautobot/docs/models/extras/customfield.md
@@ -51,6 +51,7 @@ When creating a custom field, if "Move to Advanced tab" is checked, this custom 
 Nautobot supports limited custom validation for custom field values. Following are the types of validation enforced for each field type:
 
 * Text: Regular expression (optional)
+* URL: Regular expression (optional)
 * Integer: Minimum and/or maximum value (optional)
 * JSON: If not empty, this field must contain valid JSON data
 * Selection: Must exactly match one of the prescribed choices

--- a/nautobot/extras/choices.py
+++ b/nautobot/extras/choices.py
@@ -62,6 +62,13 @@ class CustomFieldTypeChoices(ChoiceSet):
         (TYPE_JSON, "JSON"),
     )
 
+    REGEX_TYPES = (
+        TYPE_TEXT,
+        TYPE_URL,
+        TYPE_SELECT,
+        TYPE_MULTISELECT,
+    )
+
 
 #
 # CustomLinks

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -385,14 +385,8 @@ class CustomField(BaseModel, ChangeLoggedModel, NotesMixin):
         if self.validation_maximum is not None and self.type != CustomFieldTypeChoices.TYPE_INTEGER:
             raise ValidationError({"validation_maximum": "A maximum value may be set only for numeric fields"})
 
-        # Regex validation can be set only for text fields
-        regex_types = (
-            CustomFieldTypeChoices.TYPE_TEXT,
-            CustomFieldTypeChoices.TYPE_URL,
-            CustomFieldTypeChoices.TYPE_SELECT,
-            CustomFieldTypeChoices.TYPE_MULTISELECT,
-        )
-        if self.validation_regex and self.type not in regex_types:
+        # Regex validation can be set only for text, url, select and multi-select fields
+        if self.validation_regex and self.type not in CustomFieldTypeChoices.REGEX_TYPES:
             raise ValidationError(
                 {"validation_regex": "Regular expression validation is supported only for text, URL and select fields"}
             )
@@ -461,13 +455,13 @@ class CustomField(BaseModel, ChangeLoggedModel, NotesMixin):
         elif self.type == CustomFieldTypeChoices.TYPE_DATE:
             field = forms.DateField(required=required, initial=initial, widget=DatePicker())
 
-        # URL
-        elif self.type == CustomFieldTypeChoices.TYPE_URL:
-            field = LaxURLField(required=required, initial=initial)
+        # Text and URL
+        elif self.type in (CustomFieldTypeChoices.TYPE_URL, CustomFieldTypeChoices.TYPE_TEXT):
+            if self.type == CustomFieldTypeChoices.TYPE_URL:
+                field = LaxURLField(required=required, initial=initial)
+            elif self.type == CustomFieldTypeChoices.TYPE_TEXT:
+                field = forms.CharField(max_length=255, required=required, initial=initial)
 
-        # Text
-        elif self.type == CustomFieldTypeChoices.TYPE_TEXT:
-            field = forms.CharField(max_length=255, required=required, initial=initial)
             if self.validation_regex:
                 field.validators = [
                     RegexValidator(
@@ -527,12 +521,12 @@ class CustomField(BaseModel, ChangeLoggedModel, NotesMixin):
         if value not in [None, "", []]:
 
             # Validate text field
-            if self.type == CustomFieldTypeChoices.TYPE_TEXT:
+            if self.type in (CustomFieldTypeChoices.TYPE_TEXT, CustomFieldTypeChoices.TYPE_URL):
 
                 if not isinstance(value, str):
                     raise ValidationError("Value must be a string")
 
-                if self.validation_regex and not re.match(self.validation_regex, value):
+                if self.validation_regex and not re.search(self.validation_regex, value):
                     raise ValidationError(f"Value must match regex '{self.validation_regex}'")
 
             # Validate integer
@@ -625,7 +619,7 @@ class CustomFieldChoice(BaseModel, ChangeLoggedModel):
         if self.field.type not in (CustomFieldTypeChoices.TYPE_SELECT, CustomFieldTypeChoices.TYPE_MULTISELECT):
             raise ValidationError("Custom field choices can only be assigned to selection fields.")
 
-        if not re.match(self.field.validation_regex, self.value):
+        if not re.search(self.field.validation_regex, self.value):
             raise ValidationError(f"Value must match regex {self.field.validation_regex} got {self.value}.")
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2489, Closes: #2494
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Add regex validation to URL custom fields
- Change regex validation from `re.match` to `re.search` to properly match the [`RegexValidator`](https://docs.djangoproject.com/en/3.2/ref/validators/#regexvalidator) used in the form and to allow the regex to match anywhere on the string instead of anchored at the beginning.
- Add more testing for regex validation on the `CustomField` and `CustomFieldChoice` models.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
