### PR TITLE
Fix test failing when version number contains alpha characters

### DIFF
--- a/changes/2682.fixed
+++ b/changes/2682.fixed
@@ -1,0 +1,1 @@
+Fixed test failing when version number contains alpha characters.

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -85,7 +85,7 @@ class HomeViewTestCase(TestCase):
         response = self.client.get(url)
         response_content = response.content.decode(response.charset).replace("\n", "")
 
-        footer_hostname_version_pattern = re.compile('<p class="text-muted">\\s+\\S+\\s+\\(v[\\d.]+\\)\\s+<\\/p>')
+        footer_hostname_version_pattern = re.compile(r'<p class="text-muted">\s+\S+\s+\(v1\.2\.3\)\s+</p>')
         self.assertRegex(response_content, footer_hostname_version_pattern)
 
         self.client.logout()

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -79,6 +79,7 @@ class HomeViewTestCase(TestCase):
         self.assertIsNotNone(nav_search_bar_result)
         self.assertIsNotNone(body_search_bar_result)
 
+    @override_settings(VERSION="1.2.3")
     def test_footer_version_visible_authenticated_users_only(self):
         url = reverse("home")
         response = self.client.get(url)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Related to: #2682
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Override `settings.VERSION` to `1.2.3` for test `nautobot.core.tests.test_views.HomeViewTestCase.test_footer_version_visible_authenticated_users_only` so that this test isn't affected by changes to settings in `pyproject.toml`.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
