### PR TITLE
Use same nautobot_config.py in final and final-dev images

### DIFF
--- a/changes/2671.changed
+++ b/changes/2671.changed
@@ -1,0 +1,3 @@
+Changed the published `nautobot-dev` images to use the same default `nautobot_config.py` as the published `nautobot` images, instead of using the Nautobot core development `nautobot_config.py` file.
+Renamed `development/docker-compose.build.yml` to `development/docker-compose.final.yml` to better reflect its meaning.
+Changed the image labels used in the docker-compose development workflow to reduce ambiguity.

--- a/development/docker-compose.final-dev.yml
+++ b/development/docker-compose.final-dev.yml
@@ -1,0 +1,11 @@
+---
+version: "3.4"
+services:
+  nautobot:
+    build:
+      target: final-dev
+    image: "local/nautobot-final-dev:local-py${PYTHON_VER}"
+  celery_worker:
+    image: "local/nautobot-final-dev:local-py${PYTHON_VER}"
+  celery_beat:
+    image: "local/nautobot-final-dev:local-py${PYTHON_VER}"

--- a/development/docker-compose.final.yml
+++ b/development/docker-compose.final.yml
@@ -5,7 +5,7 @@ services:
   nautobot:
     build:
       target: final
-    image: "networktocode/nautobot-py${PYTHON_VER}:local"
+    image: "local/nautobot-final:local-py${PYTHON_VER}"
     ports:
       - 8443:8443
     healthcheck:
@@ -15,4 +15,6 @@ services:
         - "-fk"
         - "https://localhost:8443/health/"
   celery_worker:
-    image: "networktocode/nautobot-py${PYTHON_VER}:local"
+    image: "local/nautobot-final:local-py${PYTHON_VER}"
+  celery_beat:
+    image: "local/nautobot-final:local-py${PYTHON_VER}"

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
       target: dev
-    image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
+    image: "local/nautobot-dev:local-py${PYTHON_VER}"
     ports:
       - "8080:8080"
     depends_on:
@@ -29,7 +29,7 @@ services:
         - "-f"
         - "http://localhost:8080/health/"
   celery_worker:
-    image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
+    image: "local/nautobot-dev:local-py${PYTHON_VER}"
     entrypoint: "nautobot-server celery worker -l INFO"
     healthcheck:
       interval: 60s
@@ -48,7 +48,7 @@ services:
       - ./dev.env
     tty: true
   celery_beat:
-    image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
+    image: "local/nautobot-dev:local-py${PYTHON_VER}"
     entrypoint: "nautobot-server celery beat -l INFO"
     healthcheck:
       disable: true
@@ -80,7 +80,7 @@ services:
   mkdocs:
     profiles:
       - mkdocs
-    image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
+    image: "local/nautobot-dev:local-py${PYTHON_VER}"
     entrypoint: "mkdocs serve -a '0.0.0.0:8001'"
     healthcheck:
       disable: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -250,9 +250,6 @@ RUN npm install --global markdownlint-cli@0.31.1
 # /source from build-nautobot will include docs from build-docs as well
 COPY --from=build-nautobot /source /source
 
-# TODO Use nautobot init to generate the same config for all use cases
-COPY development/nautobot_config.py /opt/nautobot/nautobot_config.py
-
 # Run Nautobot development server by default
 EXPOSE 8080
 CMD ["nautobot-server", "runserver", "0.0.0.0:8080", "--insecure"]
@@ -269,12 +266,18 @@ RUN --mount=type=cache,target="/root/.cache/pip" \
     rm -rf /source && \
     rm -rf /tmp/tmp*
 
+COPY development/nautobot_config.py /opt/nautobot/nautobot_config.py
+
 ################################ Stage: final-dev (development environment for Nautobot plugins)
 
 FROM dependencies-dev as final-dev
 
 RUN pip install --no-deps --no-cache-dir /source/dist/*.whl && \
     rm -rf /source
+
+WORKDIR /opt/nautobot
+
+RUN nautobot-server init
 
 ################################ Stage: final (production-ready image)
 
@@ -308,7 +311,7 @@ USER nautobot
 
 WORKDIR /opt/nautobot
 
-RUN nautobot-server init
+COPY --from=final-dev /opt/nautobot/nautobot_config.py /opt/nautobot/nautobot_config.py
 
 # Run Nautobot server under uwsgi by default
 EXPOSE 8080 8443

--- a/nautobot/docs/development/docker-compose-advanced-use-cases.md
+++ b/nautobot/docs/development/docker-compose-advanced-use-cases.md
@@ -26,9 +26,10 @@ The files related to the Docker development environment can be found inside of t
 In this directory you'll find the following core files:
 
 - `docker-compose.yml` - Docker service containers and their relationships to the Nautobot container
-- `docker-compose.build.yml` - Docker compose override file used to start/build the production docker images for local testing.
 - `docker-compose.debug.yml` - Docker compose override file used to start the Nautobot container for use with [Visual Studio Code's dev container integration](#microsoft-visual-studio-code-integration).
 - `docker-compose.dev.yml` - Docker compose override file used to mount the Nautobot source code inside the container at `/source` and the `nautobot_config.py` from the same directory as `/opt/nautobot/nautobot_config.py` for the active configuration.
+- `docker-compose.final.yml` - Docker compose override file used to start/build the `final` (production) Docker images for local testing.
+- `docker-compose.final-dev.yml` - Docker compose override file used to start/build the `final-dev` (app development environment) Docker images for local testing.
 - `docker-compose.mysql.yml` - Docker compose override file used to add a MySQL container as the database backend for Nautobot.
 - `docker-compose.postgres.yml` - Docker compose override file used to add a Postgres container as the database backend for Nautobot.
 - `dev.env` - Environment variables used to setup the container services

--- a/nautobot/docs/development/release-checklist.md
+++ b/nautobot/docs/development/release-checklist.md
@@ -195,7 +195,8 @@ Test the images locally - to do this you need to set the following in your `invo
 nautobot:
   compose_files:
     - "docker-compose.yml"
-    - "docker-compose.build.yml"
+    - "docker-compose.postgres.yml"
+    - "docker-compose.final.yml"
 ```
 
 !!! warning

--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -58,7 +58,7 @@ Currently images are pushed for the following python versions:
 * 3.10
 
 !!! info
-    Developer images `networktocode/nautobot-dev:${TAG}` and `ghcr.io/nautobot/nautobot-dev:${TAG}` are also provided with the same tags as above. These images provide the development dependencies needed to build Nautobot; they can be used as a base for development to develop additional Nautobot plugins but should **NOT** be used in production.
+    Developer images `networktocode/nautobot-dev:${TAG}` and `ghcr.io/nautobot/nautobot-dev:${TAG}` are also provided with the same tags as above. These images provide the development dependencies needed to build Nautobot; they can be used as a base for development to develop your own Nautobot apps but should **NOT** be used in production.
 
 ## Getting Started
 
@@ -208,24 +208,25 @@ COPY nautobot_config.py /opt/nautobot/nautobot_config.py
 
 ## Building the Image
 
-If you have a [development environment](../development/getting-started.md#setting-up-your-development-environment) you can use invoke to build the docker images.  By default `invoke build` will build the development containers:
+If you have a [development environment](../development/getting-started.md#setting-up-your-development-environment) you can use `invoke` to build the Docker image.  By default `invoke build` will build the `dev` image:
 
 ```no-highlight
 $ invoke build
 ...
 $ docker images
-REPOSITORY                                                                TAG                    IMAGE ID       CREATED          SIZE
-networktocode/nautobot-dev                                                local                  25487d93fc1f   16 seconds ago   630MB
+REPOSITORY                                       TAG                              IMAGE ID       CREATED          SIZE
+local/nautobot-dev                               local-py3.7                      0d93eec7dfea   5 minutes ago    1.31GB
 ```
 
-If you need to build or test the final image, you must set your `invoke.yml` to use `docker-compose.build.yml` in place of `docker-compose.dev.yml`:
+If you need to build or test the `final` image, you must set your `invoke.yml` to use `docker-compose.final.yml` in place of `docker-compose.dev.yml`:
 
 ```yaml
 ---
 nautobot:
   compose_files:
     - "docker-compose.yml"
-    - "docker-compose.build.yml"
+    - "docker-compose.postgres.yml"
+    - "docker-compose.final.yml"
 ```
 
 Then you can re-run the `invoke build` command:
@@ -234,15 +235,11 @@ Then you can re-run the `invoke build` command:
 $ invoke build
 ...
 $ docker images
-REPOSITORY                                                                TAG                    IMAGE ID       CREATED          SIZE
-networktocode/nautobot                                                    local                  0a24d68da987   55 seconds ago   337MB
+REPOSITORY                                       TAG                              IMAGE ID       CREATED          SIZE
+local/nautobot-final                             local-py3.7                      e03e752fcc6b   27 minutes ago   629MB
 ```
 
-If you do not have a development environment created you can also build the container using the regular `docker build` command:
-
-```no-highlight
-$ docker build -t networktocode/nautobot -f ./docker/Dockerfile --build-arg PYTHON_VER=3.7 .
-```
+Similarly, you can use `docker-compose.final-dev.yml` if you wish to build and test the `final-dev` image.
 
 ## Docker Compose
 

--- a/tasks.py
+++ b/tasks.py
@@ -192,9 +192,10 @@ def run_command(context, command, **kwargs):
         "cache": "Whether to use Docker's cache when building the image. (Default: enabled)",
         "poetry_parallel": "Enable/disable poetry to install packages in parallel. (Default: True)",
         "pull": "Whether to pull Docker images when building the image. (Default: disabled)",
+        "skip_docs_build": "Skip (re)build of documentation after building the image.",
     }
 )
-def build(context, force_rm=False, cache=True, poetry_parallel=True, pull=False):
+def build(context, force_rm=False, cache=True, poetry_parallel=True, pull=False, skip_docs_build=False):
     """Build Nautobot docker image."""
     command = f"build --build-arg PYTHON_VER={context.nautobot.python_ver}"
 
@@ -211,8 +212,9 @@ def build(context, force_rm=False, cache=True, poetry_parallel=True, pull=False)
 
     docker_compose(context, command, env={"DOCKER_BUILDKIT": "1", "COMPOSE_DOCKER_CLI_BUILD": "1"})
 
-    # Build the docs so they are available.
-    build_nautobot_docs(context)
+    if not skip_docs_build:
+        # Build the docs so they are available. Skip if you're using a `final-dev` or `final` image instead of `dev`.
+        build_nautobot_docs(context)
 
 
 @task(
@@ -265,6 +267,8 @@ def buildx(
     print(f"Building Nautobot {target} target with Python {context.nautobot.python_ver} for {platforms}...")
     if tag is None:
         if target == "dev":
+            pass
+        if target == "final-dev":
             tag = f"networktocode/nautobot-dev-py{context.nautobot.python_ver}:local"
         elif target == "final":
             tag = f"networktocode/nautobot-py{context.nautobot.python_ver}:local"


### PR DESCRIPTION
# Closes: #2671 
# What's Changed

- Previously the `final-dev` images (published as `nautobot-dev`) were using the `development/nautobot_config.py` file as their default configuration. This caused failures in some downstream dev environments (such as `pynautobot`) that didn't provide their own `nautobot_config.py` overrides, because that config file enables the `example_plugin` in Nautobot, which isn't actually included in the `final-dev` image build. I've changed the Docker build for `final-dev` so that it now defaults to the same templated file (from `nautobot-server init`) as the `final` image, which should unblock these downstream dev environments. (TODO below - I want to actually try this image with the `pynautobot` dev environment)
- I found it repeatedly confusing that our local docker-compose dev environment defaults to building and using `dev` images with the label/tag `networktocode/nautobot-dev-py${PYTHON_VER}:local`, since these images shouldn't ever be published to dockerhub, and the label is confusing against the `networktocode/nautobot-dev:${VER}-py${PYTHON_VER}` images which actually **are** published. I changed the dev image label to instead be `local/nautobot-dev:local-py${PYTHON_VER}` to make its local purpose more clear.
- Similarly, I updated the `docker-compose.build.yml` that can be used for running with locally built `final` images to label these images as `local/nautobot-final:local-py${PYTHON_VER}` instead of `networktocode/nautobot-py${PYTHON_VER}:local`, which was also confusing against the actual published images on dockerhub at `networktocode/nautobot:${VER}-py${PYTHON_VER}`.
- I also renamed `development/docker-compose.build.yml` to `development/docker-compose.final.yml` and updated the docs accordingly.
- We didn't have a docker-compose file for building/testing with `final-dev` targets, so I've added `development/docker-compose.final-dev.yml`.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Test updated `final-dev` Docker image with `pynautobot` dev environment.
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
