### PR TITLE
Fixed backwards-compatibility with changes made to `TreeNodeMultipleChoiceFilter`.

### DIFF
--- a/changes/2717.fixed
+++ b/changes/2717.fixed
@@ -1,0 +1,1 @@
+Fixed backwards-compatibility with changes made to `TreeNodeMultipleChoiceFilter`.

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -486,6 +486,10 @@ class TreeNodeMultipleChoiceFilter(NaturalKeyOrPKMultipleChoiceFilter):
     would match both "Athens" and "Durham".
     """
 
+    def __init__(self, *args, **kwargs):
+        kwargs.pop("lookup_expr", None)  # Disallow overloading of `lookup_expr`.
+        super().__init__(*args, **kwargs)
+
     def generate_query(self, value, qs=None, **kwargs):
         """
         Given a filter value, return a `Q` object that accounts for nested tree node descendants.

--- a/nautobot/utilities/tests/test_filters.py
+++ b/nautobot/utilities/tests/test_filters.py
@@ -144,6 +144,14 @@ class TreeNodeMultipleChoiceFilterTest(TestCase):
 
         self.assertCountEqual(list(qs), [self.site1])
 
+    def test_lookup_expr_param_ignored(self):
+        """
+        Test that the `lookup_expr` parameter is ignored when using this filter on filtersets.
+        """
+        # Since we deprecated `in` this should be ignored.
+        f = TreeNodeMultipleChoiceFilter(queryset=Region.objects.all(), lookup_expr="in")
+        self.assertEqual(f.lookup_expr, django_filters.conf.settings.DEFAULT_LOOKUP_EXPR)
+
 
 class NaturalKeyOrPKMultipleChoiceFilterTest(TestCase):
     class SiteFilterSet(BaseFilterSet):


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
- This addresses an issue that was fixed in #2665 that obviated the need to specify `lookup_expr="in"` when defining a `TreeNodeMultipleChoiceFilter` on a filterset but could result in a `ValidationError` in filtersets provided by plugins.
- If `lookup_expr` is passed to `TreeNodeMultipleChoiceFilter` on a filterset, this argument is now ignored.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
