### PR TITLE
Add 'q' to ContentTypeFilterSet

### DIFF
--- a/changes/2684.fixed
+++ b/changes/2684.fixed
@@ -1,0 +1,1 @@
+Fixed "The results could not be loaded" when filtering `ContentTypes` in the UI.

--- a/nautobot/extras/filters.py
+++ b/nautobot/extras/filters.py
@@ -416,6 +416,13 @@ class ConfigContextSchemaFilterSet(BaseFilterSet):
 
 
 class ContentTypeFilterSet(BaseFilterSet):
+    q = SearchFilter(
+        filter_predicates={
+            "app_label": "icontains",
+            "model": "icontains",
+        },
+    )
+
     class Meta:
         model = ContentType
         fields = ["id", "app_label", "model"]

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
 
 from nautobot.dcim.filters import DeviceFilterSet
 from nautobot.dcim.models import (
@@ -24,6 +25,7 @@ from nautobot.extras.constants import HTTP_CONTENT_TYPE_JSON
 from nautobot.extras.filters import (
     ComputedFieldFilterSet,
     ConfigContextFilterSet,
+    ContentTypeFilterSet,
     CustomLinkFilterSet,
     ExportTemplateFilterSet,
     GitRepositoryFilterSet,
@@ -310,6 +312,29 @@ class ConfigContextTestCase(FilterTestCases.FilterTestCase):
         value = self.queryset.values_list("pk", flat=True)[0]
         params = {"q": value}
         self.assertEqual(self.filterset(params, self.queryset).qs.values_list("pk", flat=True)[0], value)
+
+
+class ContentTypeFilterSetTestCase(FilterTestCases.FilterTestCase):
+    queryset = ContentType.objects.order_by("app_label", "model")
+    filterset = ContentTypeFilterSet
+
+    def test_app_label(self):
+        params = {"app_label": ["dcim"]}
+        self.assertQuerysetEqual(self.filterset(params, self.queryset).qs, ContentType.objects.filter(app_label="dcim"))
+
+    def test_model(self):
+        params = {"model": ["device", "virtualmachine"]}
+        self.assertQuerysetEqual(
+            self.filterset(params, self.queryset).qs,
+            ContentType.objects.filter(model__in=["device", "virtualmachine"]),
+        )
+
+    def test_search(self):
+        params = {"q": "circ"}
+        self.assertQuerysetEqual(
+            self.filterset(params, self.queryset).qs,
+            ContentType.objects.filter(Q(app_label__icontains="circ") | Q(model__icontains="circ")),
+        )
 
 
 class CustomLinkTestCase(FilterTestCases.FilterTestCase):

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -320,20 +320,19 @@ class ContentTypeFilterSetTestCase(FilterTestCases.FilterTestCase):
 
     def test_app_label(self):
         params = {"app_label": ["dcim"]}
-        self.assertQuerysetEqual(self.filterset(params, self.queryset).qs, ContentType.objects.filter(app_label="dcim"))
+        self.assertQuerysetEqual(self.filterset(params, self.queryset).qs, self.queryset.filter(app_label="dcim"))
 
     def test_model(self):
         params = {"model": ["device", "virtualmachine"]}
         self.assertQuerysetEqual(
-            self.filterset(params, self.queryset).qs,
-            ContentType.objects.filter(model__in=["device", "virtualmachine"]),
+            self.filterset(params, self.queryset).qs, self.queryset.filter(model__in=["device", "virtualmachine"])
         )
 
     def test_search(self):
         params = {"q": "circ"}
         self.assertQuerysetEqual(
             self.filterset(params, self.queryset).qs,
-            ContentType.objects.filter(Q(app_label__icontains="circ") | Q(model__icontains="circ")),
+            self.queryset.filter(Q(app_label__icontains="circ") | Q(model__icontains="circ")),
         )
 
 


### PR DESCRIPTION
# Closes: #2684 
# What's Changed

- Add `q` SearchFilter to ContentTypeFilterSet, resolving #2684.
- Add test coverage for this filterset.

![image](https://user-images.githubusercontent.com/5603551/199766912-6d2ef26e-e976-44ad-a545-09a432f00d54.png)

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
