### PR TITLE
Prevent Git repository from providing Jobs if not marked as such

### DIFF
--- a/changes/2601.fixed
+++ b/changes/2601.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where a Git repository could provide Jobs even if not marked as a provider of Jobs.

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -913,7 +913,7 @@ def delete_git_config_context_schemas(repository_record, job_result, preserve=()
 def refresh_git_jobs(repository_record, job_result, delete=False):
     """Callback function for GitRepository updates - refresh all Job records managed by this repository."""
     installed_jobs = []
-    if not delete:
+    if "extras.job" in repository_record.provided_contents and not delete:
         jobs_path = os.path.join(repository_record.filesystem_path, "jobs")
         if os.path.isdir(jobs_path):
             for job_info in jobs_in_directory(jobs_path, report_errors=True):


### PR DESCRIPTION

# Closes: #2601 
# What's Changed

Add missing logic to `refresh_git_jobs` to ensure that a Git repository can only add Job records if it's been marked as a provider of Jobs. Verified through manual testing.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
