### PR TITLE
Update site_url for mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,9 +3,7 @@ dev_addr: "127.0.0.1:8001"
 edit_uri: "edit/main/nautobot/docs"
 site_dir: "nautobot/project-static/docs"
 site_name: "Nautobot Documentation"
-site_url: "https://docs.nautobot.com/en/stable/"
-# TODO: replace when switching domain
-# site_url: "https://docs.nautobot.com/projects/core/en/stable/"
+site_url: "https://docs.nautobot.com/projects/core/en/stable/"
 repo_url: "https://github.com/nautobot/nautobot"
 copyright: "Copyright &copy; The Authors"
 theme:


### PR DESCRIPTION
# Closes: #n/a
# What's Changed

docs.nautobot.com URL has changed. This was mostly updated in #2712 but this one needs to be updated too - the main noticeable symptom is that 404 pages under this project (e.g. https://docs.nautobot.com/projects/core/en/stable/foobar) get rendered incorrectly.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
