### PR TITLE
Disallow changing the parent of an in-use LocationType

### DIFF
--- a/changes/2669.changed
+++ b/changes/2669.changed
@@ -1,0 +1,1 @@
+Blocked changing the parent of a LocationType when it already has Locations using it.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2669 
# What's Changed

Changing the `parent` of a `LocationType` that already has associated `Locations` would invalidate the parentage of those `Locations`, so we should block the user from making this change in that situation.

![image](https://user-images.githubusercontent.com/5603551/199837727-c9cacc3d-20dd-4d83-b2a3-9ad31bb01d4c.png)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
