### PR TITLE
Fixed confusing ORM interface validating Dynamic Group char filters.

### DIFF
--- a/changes/2713.fixed
+++ b/changes/2713.fixed
@@ -1,0 +1,1 @@
+Fixed confusing ORM interface validating Dynamic Group char filters.

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -440,9 +440,7 @@ class DynamicGroup(OrganizationalModel):
             raise ValidationError({"filter": "Filter requires a `content_type` to be set"})
 
         # Validate against the filterset's internal form validation.
-        filterset = self.filterset_class(self.filter)
-        if not filterset.is_valid():
-            raise ValidationError(filterset.errors)
+        self.set_filter(self.filter)
 
     def delete(self, *args, **kwargs):
         """Check if we're a child and attempt to block delete if we are."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2713 
# What's Changed
- Specifically this aligns model validation with the UI form view validation that is calling  `DynamicGroup.set_filter()`, now making `DynamicGroup.clean()` call `set_filter()` as well when `validated_save()` is called.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
