### PR TITLE
Bulk Create/Edit of Required Relationships

### DIFF
--- a/changes/2744.fixed
+++ b/changes/2744.fixed
@@ -1,0 +1,1 @@
+Enforced required Relationships when bulk editing (via API or UI) or bulk creating (via API) objects with required relationships.

--- a/changes/2744.fixed
+++ b/changes/2744.fixed
@@ -1,1 +1,1 @@
-Enforced required Relationships when bulk editing (via API or UI) or bulk creating (via API) objects with required relationships.
+Enforced required Relationships when bulk editing or creating objects that have required relationships. Bulk edit via API or UI. Bulk create via API.

--- a/nautobot/core/templates/generic/object_bulk_update.html
+++ b/nautobot/core/templates/generic/object_bulk_update.html
@@ -9,7 +9,12 @@
     <div class="panel panel-danger">
         <div class="panel-heading"><strong>Errors</strong></div>
         <div class="panel-body">
-            {{ form.errors }}
+            {{ form.non_field_errors }}
+            {% for field in form %}
+                {% if field.errors %}
+                    <strong class="panel-title">{{ field.label }}</strong>: {{ field.errors }}
+                {% endif %}
+            {% endfor %}
         </div>
     </div>
 {% endif %}
@@ -28,14 +33,6 @@
             </div>
         </div>
         <div class="col-md-4">
-            {% if form.non_field_errors %}
-                <div class="panel panel-danger">
-                    <div class="panel-heading"><strong>Errors</strong></div>
-                    <div class="panel-body">
-                        {{ form.non_field_errors }}
-                    </div>
-                </div>
-            {% endif %}
             <div class="panel panel-default">
                 <div class="panel-heading"><strong>{% block form_title %}Attributes{% endblock %}</strong></div>
                 <div class="panel-body">

--- a/nautobot/extras/api/relationships.py
+++ b/nautobot/extras/api/relationships.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError as CoreValidationError
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema_field
 from rest_framework.exceptions import PermissionDenied

--- a/nautobot/extras/api/relationships.py
+++ b/nautobot/extras/api/relationships.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError as CoreValidationError
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema_field
 from rest_framework.exceptions import PermissionDenied
@@ -271,10 +272,12 @@ class RelationshipModelSerializerMixin(ValidatedModelSerializer):
         )
         if required_relationships_errors:
             raise ValidationError(required_relationships_errors)
-
         instance = super().create(validated_data)
         if relationships_data:
-            self._save_relationships(instance, relationships_data)
+            try:
+                self._save_relationships(instance, relationships_data)
+            except CoreValidationError as error:
+                raise ValidationError(str(error))
         return instance
 
     def update(self, instance, validated_data):

--- a/nautobot/extras/api/relationships.py
+++ b/nautobot/extras/api/relationships.py
@@ -276,7 +276,7 @@ class RelationshipModelSerializerMixin(ValidatedModelSerializer):
         if relationships_data:
             try:
                 self._save_relationships(instance, relationships_data)
-            except CoreValidationError as error:
+            except DjangoValidationError as error:
                 raise ValidationError(str(error))
         return instance
 

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -411,7 +411,7 @@ class RelationshipModelBulkEditFormMixin(BulkEditForm):
             for editing in self.cleaned_data["pk"]:
                 editing_verbose_name = editing._meta.verbose_name
                 required_target_side = RelationshipSideChoices.OPPOSITE[relationship.required_on]
-                required_target_type = getattr(relationship, f'{required_target_side}_type')
+                required_target_type = getattr(relationship, f"{required_target_side}_type")
                 required_type_verbose_name = required_target_type.model_class()._meta.verbose_name
                 filter_kwargs = {
                     "relationship": relationship,

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -472,8 +472,8 @@ class RelationshipModelFormMixin(forms.ModelForm):
                 self.fields[field_name] = relationship.to_form_field(side=side)
 
                 # HTML5 validation for required relationship field:
-                # if relationship.required_on == side:
-                #     self.fields[field_name].required = True
+                if relationship.required_on == side:
+                    self.fields[field_name].required = True
 
                 # if the object already exists, populate the field with existing values
                 if self.instance.present_in_database:

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -348,7 +348,7 @@ class RelationshipModelBulkEditFormMixin(BulkEditForm):
     def clean(self):
 
         # Get any initial required relationship objects errors (i.e. non-existent required objects)
-        required_objects_errors = self.Meta().model.required_related_objects_errors(output_for="ui")
+        required_objects_errors = self.model.required_related_objects_errors(output_for="ui")
         already_invalidated_slugs = []
         for error_dict in required_objects_errors:
             for field, errors in error_dict.items():

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -310,7 +310,7 @@ class RelationshipModel(models.Model):
 
                 elif output_for == "api":
                     supplied_data = initial_data.get(relation, {}).get(opposite_side, {})
-                    if  not supplied_data:
+                    if not supplied_data:
                         missing_data = True
 
                 if missing_data:

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -310,7 +310,7 @@ class RelationshipModel(models.Model):
 
                 elif output_for == "api":
                     supplied_data = initial_data.get(relation, {}).get(opposite_side, {})
-                    if len(supplied_data) == 0:
+                    if  not supplied_data:
                         missing_data = True
 
                 if missing_data:

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -258,7 +258,7 @@ class RelationshipModel(models.Model):
                     and not relationships_key_specified
                 ):
                     filter_kwargs = {"relationship": relation, f"{relation.required_on}_id": instance.pk}
-                    if RelationshipAssociation.objects.filter(**filter_kwargs).count() > 0:
+                    if RelationshipAssociation.objects.filter(**filter_kwargs).exists():
                         continue
 
             required_model_class = getattr(relation, f"{opposite_side}_type").model_class()


### PR DESCRIPTION
# Closes: #2744 
# What's Changed
UI bulk edit and API bulk edit/add now enforces required relationships.

# TODO
- [x] UI bulk edit check for existence of required objects
- [x] UI bulk edit check each object's required relationships data from form submission
- [ ] UI bulk edit tests
- [x] API bulk edit
- [ ] API bulk edit tests
- [x] API bulk create
- [ ] API bulk create tests
- [ ] Docs
