### PR TITLE
Fix incorrect permissions on /opt/nautobot/nautobot_config.py in final images

### DIFF
--- a/2758.changed
+++ b/2758.changed
@@ -1,0 +1,1 @@
+Changed console logging back to disabled by default when running `nautobot-server test ...`.

--- a/changes/2755.fixed
+++ b/changes/2755.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect file permissions on `/opt/nautobot/nautobot_config.py` in `final` Docker images.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -311,7 +311,7 @@ USER nautobot
 
 WORKDIR /opt/nautobot
 
-COPY --from=final-dev /opt/nautobot/nautobot_config.py /opt/nautobot/nautobot_config.py
+COPY --from=final-dev --chown=nautobot /opt/nautobot/nautobot_config.py /opt/nautobot/nautobot_config.py
 
 # Run Nautobot server under uwsgi by default
 EXPOSE 8080 8443

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import re
+import sys
 
 from django.contrib.messages import constants as messages
 import django.forms
@@ -283,40 +284,49 @@ DATETIME_FORMAT = os.getenv("NAUTOBOT_DATETIME_FORMAT", "N j, Y g:i a")
 DEBUG = is_truthy(os.getenv("NAUTOBOT_DEBUG", "False"))
 INTERNAL_IPS = ("127.0.0.1", "::1")
 FORCE_SCRIPT_NAME = None
+
+TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
+
 LOG_LEVEL = "DEBUG" if DEBUG else "INFO"
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "normal": {
-            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s :\n  %(message)s",
-            "datefmt": "%H:%M:%S",
+
+if TESTING:
+    # keep log quiet by default when running unit/integration tests
+    LOGGING = {}
+else:
+    LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "normal": {
+                "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s :\n  %(message)s",
+                "datefmt": "%H:%M:%S",
+            },
+            "verbose": {
+                "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s() :\n  %(message)s",
+                "datefmt": "%H:%M:%S",
+            },
         },
-        "verbose": {
-            "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s() :\n  %(message)s",
-            "datefmt": "%H:%M:%S",
+        "handlers": {
+            "normal_console": {
+                "level": "INFO",
+                "class": "logging.StreamHandler",
+                "formatter": "normal",
+            },
+            "verbose_console": {
+                "level": "DEBUG",
+                "class": "logging.StreamHandler",
+                "formatter": "verbose",
+            },
         },
-    },
-    "handlers": {
-        "normal_console": {
-            "level": "INFO",
-            "class": "logging.StreamHandler",
-            "formatter": "normal",
+        "loggers": {
+            "django": {"handlers": ["normal_console"], "level": "INFO"},
+            "nautobot": {
+                "handlers": ["verbose_console" if DEBUG else "normal_console"],
+                "level": LOG_LEVEL,
+            },
         },
-        "verbose_console": {
-            "level": "DEBUG",
-            "class": "logging.StreamHandler",
-            "formatter": "verbose",
-        },
-    },
-    "loggers": {
-        "django": {"handlers": ["normal_console"], "level": "INFO"},
-        "nautobot": {
-            "handlers": ["verbose_console" if DEBUG else "normal_console"],
-            "level": LOG_LEVEL,
-        },
-    },
-}
+    }
+
 MEDIA_ROOT = os.path.join(NAUTOBOT_ROOT, "media").rstrip("/")
 SESSION_COOKIE_AGE = int(os.getenv("NAUTOBOT_SESSION_COOKIE_AGE", "1209600"))  # 2 weeks, in seconds
 SESSION_FILE_PATH = os.getenv("NAUTOBOT_SESSION_FILE_PATH", None)

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -40,6 +40,3 @@ STORAGE_CONFIG = {
     "AWS_STORAGE_BUCKET_NAME": "nautobot",
     "AWS_S3_REGION_NAME": "us-west-1",
 }
-
-# Disable logging for tests
-LOGGING = {}

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -956,6 +956,9 @@ Default:
 }
 ```
 
++/- 1.4.10
+    While running unit or integration tests via `nautobot-server test ...`, LOGGING will be set to `{}` instead of the above defaults, as verbose logging to the console is typically not desirable while running tests.
+
 This translates to:
 
 * all messages from Django and from Nautobot of INFO severity or higher will be logged to the console.

--- a/tasks.py
+++ b/tasks.py
@@ -652,7 +652,8 @@ def unittest(
         build_and_check_docs(context)
 
     append_arg = " --append" if append else ""
-    command = f"coverage run{append_arg} --module nautobot.core.cli --config=nautobot/core/tests/nautobot_config.py test {label}"
+    command = f"coverage run{append_arg} --module nautobot.core.cli test {label}"
+    command += " --config=nautobot/core/tests/nautobot_config.py"
     # booleans
     if keepdb:
         command += " --keepdb"


### PR DESCRIPTION
# Closes: #2755 
# What's Changed

- Fix ownership of `/opt/nautobot/nautobot_config.py` in `final` images, a bug introduced by #2715.

Before:

```bash
nautobot@692f1c8a9a0d:~$ ls -l
total 32
-rw-r--r-- 1 nautobot nautobot  1980 Nov  4 21:36 nautobot.crt
-rw------- 1 nautobot nautobot  3276 Nov  4 21:36 nautobot.key
-rw-r--r-- 1 root     root     18818 Nov  4 21:36 nautobot_config.py
-rw-r--r-- 1 nautobot nautobot  2198 Nov  4 21:27 uwsgi.ini
```

After:

```bash
nautobot@89d310d03b6c:~$ ls -l
total 32
-rw-r--r-- 1 nautobot nautobot  1980 Nov  7 15:03 nautobot.crt
-rw------- 1 nautobot nautobot  3272 Nov  7 15:03 nautobot.key
-rw-r--r-- 1 nautobot nautobot 18818 Nov  7 15:03 nautobot_config.py
-rw-r--r-- 1 nautobot nautobot  2198 Oct  4 13:08 uwsgi.ini
```

- Fix a less severe issue also introduced by #2715 in which plugins running with the default `nautobot_config.py` using the `final-dev` image would have verbose console logging enabled by default during the tests, which is generally not desirable.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
