### PR TITLE
Add prometheus metrics for health check results.

### DIFF
--- a/changes/2759.added
+++ b/changes/2759.added
@@ -1,0 +1,1 @@
+Add prometheus metrics for health check results

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -34,3 +34,5 @@ LOGGING["loggers"]["nautobot"]["level"] = LOG_LEVEL  # noqa: F405
 PLUGINS = [
     "example_plugin",
 ]
+
+METRICS_ENABLED = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ django-jinja = "~2.10.2"
 django-mptt = "~0.14.0"
 # Prometheus metrics for Django
 django-prometheus = "~2.2.0"
+# Custom prometheus metrics
+prometheus-client = "~0.14.1"
 # Redis cache for Django used for distributed locking
 django-redis = "~5.2.0"
 # RQ (Redis Queueing) for background handling of webhooks, jobs, etc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ django-mptt = "~0.14.0"
 # Prometheus metrics for Django
 django-prometheus = "~2.2.0"
 # Custom prometheus metrics
-prometheus-client = "~0.15.0"
+prometheus-client = "~0.14.1"
 # Redis cache for Django used for distributed locking
 django-redis = "~5.2.0"
 # RQ (Redis Queueing) for background handling of webhooks, jobs, etc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ django-mptt = "~0.14.0"
 # Prometheus metrics for Django
 django-prometheus = "~2.2.0"
 # Custom prometheus metrics
-prometheus-client = "~0.14.1"
+prometheus-client = "~0.15.0"
 # Redis cache for Django used for distributed locking
 django-redis = "~5.2.0"
 # RQ (Redis Queueing) for background handling of webhooks, jobs, etc.


### PR DESCRIPTION
# Closes: DNE
# What's Changed
Exposes metrics for the health check results under `/metrics` as follows:

```
# HELP health_check_database_info Multiprocess metric
# TYPE health_check_database_info gauge
health_check_database_info 1.0
# HELP health_check_cache_ops_redis_info Multiprocess metric
# TYPE health_check_cache_ops_redis_info gauge
health_check_cache_ops_redis_info 0.0
# HELP health_check_redis_backend_info Multiprocess metric
# TYPE health_check_redis_backend_info gauge
health_check_redis_backend_info 1.0
```

I have defaulted to enabling the metrics endpoint in the development configuration. I am happy to change this back if you want.

I have explicitly added
```
# Custom prometheus metrics
prometheus-client = "~0.14.1"
```
to `pyproject.toml`. This is a transitive dependency through `django-prometheus`, so it is not technically a new dependency, 


# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
