### PR TITLE
Add to_field_name=slug on LocationForm.parent, update prepare_cloned_fields to handle it

### DIFF
--- a/changes/2470.fixed
+++ b/changes/2470.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect automatic generation of Location slugs in the UI.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -468,6 +468,7 @@ class LocationForm(NautobotModelForm, TenancyForm):
     parent = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         query_params={"child_location_type": "$location_type"},
+        to_field_name="slug",
         required=False,
     )
     site = DynamicModelChoiceField(queryset=Site.objects.all(), required=False)

--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -541,7 +541,7 @@ class DynamicModelChoiceMixin:
             filter_ = self.filter(field_name=field_name)
             try:
                 self.queryset = filter_.filter(self.queryset, data)
-            except TypeError:
+            except (TypeError, ValidationError):
                 # Catch any error caused by invalid initial data passed from the user
                 self.queryset = self.queryset.none()
         else:


### PR DESCRIPTION
# Closes: #2470 
# What's Changed

- Added `to_field_name="slug"` on the LocationForm `parent` field so that the slug, rather than the PK, of the parent Location is used when auto-generating a slug for the new/edited Location. (Fix #2470)
- By itself, this would reintroduce #2311, because `prepare_cloned_fields` (which is used to generate the query parameters that are used to pre-populate an edit form in various cases) always uses the PK of any foreign-key fields in the generated query parameters, and passing a PK in the query parameters when the form field expects a slug wouldn't work. Therefore, I extended `prepare_cloned_fields` to look up the associated edit form, and in the case where a FK model field has a form field with `to_field_name` defined, use that field from the related object instead of its PK.
- Added a bit more exception handling in `DynamicModelChoiceMixin.get_bound_field` because I tripped over a `ValidationError` when initially exploring this issue.
- Enhanced `get_related_class_for_model` to accept a model *instance* as a valid input.

![image](https://user-images.githubusercontent.com/5603551/200636609-b03ed5b3-c116-419f-8ea8-c9ee17db8ef3.png)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests - there are currently no tests that I see for `prepare_cloned_fields`; I'll see about adding some
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
