### PR TITLE
Fix web UI footer margin and swagger UI authorization box size

### DIFF
--- a/changes/2789.fixed
+++ b/changes/2789.fixed
@@ -1,0 +1,1 @@
+Fixed web UI footer margin and swagger UI authorization box size.

--- a/nautobot/core/templates/admin/base.html
+++ b/nautobot/core/templates/admin/base.html
@@ -150,6 +150,7 @@
     </div>
 
     {% block footer %}<footer id="footer"></footer>{% endblock %}
+    <div class="push"></div>
     {% if "BANNER_BOTTOM"|settings_or_config %}
         <div class="alert alert-info text-center banner-bottom" role="alert">
                 {{ "BANNER_BOTTOM"|settings_or_config|safe }}

--- a/nautobot/core/templates/base.html
+++ b/nautobot/core/templates/base.html
@@ -34,6 +34,7 @@
         {% endfor %}
         {% block header %}{% endblock header %}
         {% block content %}{% endblock content %}
+        <div class="push"></div>
         {% if "BANNER_BOTTOM"|settings_or_config %}
             <div class="alert alert-info text-center banner-bottom" role="alert">
                 {{ "BANNER_BOTTOM"|settings_or_config|safe }}

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -24,6 +24,7 @@ body {
     height: 48px; /* .push must be the same height as .footer */
 }
 .footer {
+    background-color: #f5f5f5;
     border-top: 1px solid #d0d0d0;
 }
 .footer .row {

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -12,10 +12,16 @@ body {
     padding-top: 70px;
 }
 .wrapper {
-    min-height: calc(100vh - 110px);
+    min-height: 100%;
+    height: auto !important;
+    margin: 0 auto -48px; /* the bottom margin is the negative value of the footer's height */
+    padding-bottom: 30px;
 }
 .navbar-brand {
     padding: 12px 15px 8px;
+}
+.footer, .push {
+    height: 48px; /* .push must be the same height as .footer */
 }
 .footer {
     border-top: 1px solid #d0d0d0;
@@ -360,7 +366,7 @@ table.report th a {
     white-space: nowrap;
 }
 .banner-bottom {
-    margin: 48px 0 50px;
+    margin-bottom: 50px;
 }
 .panel table {
     margin-bottom: 0;

--- a/nautobot/project-static/css/dark.css
+++ b/nautobot/project-static/css/dark.css
@@ -36,6 +36,7 @@ html[data-theme="dark"] .container-fluid.wrapper {
 
 /* Lighter than the background */
 html[data-theme="dark"] .navbar,                          /* Top menu navbar */
+html[data-theme="dark"] .footer,                          /* Bottom footer bar */
 html[data-theme="dark"] .footer .row {                    /* Bottom footer bar */
   background-color: rgb(209, 216, 221) !important;
 }


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2789 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Fix swagger UI authorization box vertical size being too large
- Fix footer margin that was no longer working
- Fix tiny white line underneath the footer on dark mode when the viewport is wide

Tested against home page, list view with over 50 objects, graphql ui and swagger api on wide and narrow viewports in light mode and dark mode.

![image](https://user-images.githubusercontent.com/75227981/200895295-893ae439-8fa7-406c-ac66-d38ea754da17.png)

![image](https://user-images.githubusercontent.com/75227981/200895465-4274c950-cba9-462f-a31d-451f0d46b4c6.png)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
