### PR TITLE
Revert "Fixed confusing ORM interface validating Dynamic Group char filters."

### DIFF
--- a/changes/2713.fixed
+++ b/changes/2713.fixed
@@ -1,1 +1,0 @@
-Fixed confusing ORM interface validating Dynamic Group char filters.

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -440,7 +440,9 @@ class DynamicGroup(OrganizationalModel):
             raise ValidationError({"filter": "Filter requires a `content_type` to be set"})
 
         # Validate against the filterset's internal form validation.
-        self.set_filter(self.filter)
+        filterset = self.filterset_class(self.filter)
+        if not filterset.is_valid():
+            raise ValidationError(filterset.errors)
 
     def delete(self, *args, **kwargs):
         """Check if we're a child and attempt to block delete if we are."""


### PR DESCRIPTION
Reverts nautobot/nautobot#2743

Causing test failures in Golden Config we'd much rather ensure are non-breaking before keeping this in.