### PR TITLE
Updates to Invoke and Docs on How to Serve Docs

### DIFF
--- a/changes/2819.fixed
+++ b/changes/2819.fixed
@@ -1,0 +1,1 @@
+Adds appropriate invoke task for running docs locally and adds how to run manually.

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -318,6 +318,18 @@ It may not always be convenient to enter into the virtual shell just to run prog
 $ poetry run mkdocs serve
 ```
 
+In order to serve docs on a Mac:
+
+- Install mkdocs via homebrew
+```bash
+brew install mkdocs
+```
+- Get the proper mkdocs themes installed
+```bash
+poetry shell
+poetry install
+```
+
 Check out the [Poetry usage guide](https://python-poetry.org/docs/basic-usage/) for more tips.
 
 #### Configuring Nautobot

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -312,17 +312,17 @@ Collecting ipython
   ...
 ```
 
-It may not always be convenient to enter into the virtual shell just to run programs. You may also execute a given command ad hoc within the project's virtual shell by using `poetry run`:
-
-```no-highlight
-$ poetry run mkdocs serve
-```
-
 * Install verify that you have the proper dependencies installed and are in the virtual environment via Poetry. This also ensures that you have the proper mkdocs themes installed.
 
 ```bash
 poetry shell
 poetry install
+```
+
+It may not always be convenient to enter into the virtual shell just to run programs. You may also execute a given command ad hoc within the project's virtual shell by using `poetry run`:
+
+```no-highlight
+$ poetry run mkdocs serve
 ```
 
 Check out the [Poetry usage guide](https://python-poetry.org/docs/basic-usage/) for more tips.

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -320,11 +320,14 @@ $ poetry run mkdocs serve
 
 In order to serve docs on a Mac:
 
-- Install mkdocs via homebrew
+* Install mkdocs via homebrew
+
 ```bash
 brew install mkdocs
 ```
-- Get the proper mkdocs themes installed
+
+* Get the proper mkdocs themes installed
+
 ```bash
 poetry shell
 poetry install

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -318,15 +318,7 @@ It may not always be convenient to enter into the virtual shell just to run prog
 $ poetry run mkdocs serve
 ```
 
-In order to serve docs on a Mac:
-
-* Install mkdocs via homebrew
-
-```bash
-brew install mkdocs
-```
-
-* Get the proper mkdocs themes installed
+* Install verify that you have the proper dependencies installed and are in the virtual environment via Poetry. This also ensures that you have the proper mkdocs themes installed.
 
 ```bash
 poetry shell

--- a/tasks.py
+++ b/tasks.py
@@ -591,12 +591,14 @@ def pylint(context, target=None, recursive=False):
         command += " ".join(target)
         run_command(context, command)
 
+
 @task
 def docs_local(context):
     """Runs local instance of mkdocs serve (ctrl-c to stop)."""
     command = "poetry run mkdocs serve"
     context.nautobot.local = True
     run_command(context, command)
+
 
 @task
 def hadolint(context):

--- a/tasks.py
+++ b/tasks.py
@@ -595,7 +595,7 @@ def pylint(context, target=None, recursive=False):
 @task
 def docs_local(context):
     """Runs local instance of mkdocs serve (ctrl-c to stop)."""
-    command = "poetry run mkdocs serve"
+    command = "mkdocs serve"
     context.nautobot.local = True
     run_command(context, command)
 

--- a/tasks.py
+++ b/tasks.py
@@ -591,6 +591,12 @@ def pylint(context, target=None, recursive=False):
         command += " ".join(target)
         run_command(context, command)
 
+@task
+def docs_local(context):
+    """Runs local instance of mkdocs serve (ctrl-c to stop)."""
+    command = "poetry run mkdocs serve"
+    context.nautobot.local = True
+    run_command(context, command)
 
 @task
 def hadolint(context):

--- a/tasks.py
+++ b/tasks.py
@@ -593,7 +593,7 @@ def pylint(context, target=None, recursive=False):
 
 
 @task
-def docs_local(context):
+def serve_docs(context):
     """Runs local instance of mkdocs serve (ctrl-c to stop)."""
     command = "mkdocs serve"
     context.nautobot.local = True


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2819
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

This adds documentation on how to get started running docs locally for Mac (indicating HomeBrew install) and adds an invoke task to execute the command to keep things consistent.

```no-highlight
❯ inv --list
Available tasks:

  black                  Check Python code style with Black.
  build                  Build Nautobot docker image.
  build-and-check-docs   Build docs for use within Nautobot.
  build-dependencies
  buildx                 Build Nautobot docker image using the experimental buildx docker functionality (multi-arch capability).
  check-migrations       Check for missing migrations.
  check-schema           Render the REST API schema and check for problems.
  cli                    Launch a bash shell inside the running Nautobot (or other) Docker container.
  createsuperuser        Create a new Nautobot superuser account (default: "admin"), will prompt for password.
  debug                  Start Nautobot and its dependencies in debug mode.
  destroy                Destroy all containers and volumes.
  docker-push            Tags and pushes docker images to the appropriate repos, intended for release use only.
  docs-local             Runs local instance of mkdocs serve (ctrl-c to stop).
  dumpdata               Dump data from database to db_output file.
  flake8                 Check for PEP8 compliance and other style issues.
  hadolint               Check Dockerfile for hadolint compliance and other style issues.
  integration-test       Run Nautobot integration tests.
  loaddata               Load data from file.
  makemigrations         Perform makemigrations operation in Django.
  markdownlint           Lint Markdown files.
  migrate                Perform migrate operation in Django.
  nbshell                Launch an interactive nbshell session.
  performance-test       Run Nautobot performance tests.
  post-upgrade           Performs Nautobot common post-upgrade operations using a single entrypoint.
  pylint                 Perform static analysis of Nautobot code.
  restart                Gracefully restart containers.
  start                  Start Nautobot and its dependencies in detached mode.
  stop                   Stop Nautobot and its dependencies.
  tests                  Run all linters and unit tests.
  unittest               Run Nautobot unit tests.
  unittest-coverage      Report on code test coverage as measured by 'invoke unittest'.
  vscode                 Launch Visual Studio Code with the appropriate Environment variables to run in a container.
```

```no-highlight
❯ inv docs-local
poetry run mkdocs serve
INFO     -  Building documentation...
INFO     -  Cleaning site directory
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
              - development/generic-views.md
              - installation/centos.md
              - installation/selinux-troubleshooting.md
              - installation/ubuntu.md
              - models/circuits/circuit.md
              - models/circuits/circuittermination.md
              - models/circuits/circuittype.md
              - models/circuits/provider.md
              - models/circuits/providernetwork.md
              - models/dcim/cable.md
              - models/dcim/consoleport.md
              - models/dcim/consoleporttemplate.md
              - models/dcim/consoleserverport.md
              - models/dcim/consoleserverporttemplate.md
              - models/dcim/device.md
              - models/dcim/devicebay.md
              - models/dcim/devicebaytemplate.md
              - models/dcim/deviceredundancygroup.md
              - models/dcim/devicerole.md
              - models/dcim/devicetype.md
              - models/dcim/frontport.md
              - models/dcim/frontporttemplate.md
              - models/dcim/interface.md
              - models/dcim/interfacetemplate.md
              - models/dcim/inventoryitem.md
              - models/dcim/location.md
              - models/dcim/locationtype.md
              - models/dcim/manufacturer.md
              - models/dcim/platform.md
              - models/dcim/powerfeed.md
              - models/dcim/poweroutlet.md
              - models/dcim/poweroutlettemplate.md
              - models/dcim/powerpanel.md
              - models/dcim/powerport.md
              - models/dcim/powerporttemplate.md
              - models/dcim/rack.md
              - models/dcim/rackgroup.md
              - models/dcim/rackreservation.md
              - models/dcim/rackrole.md
              - models/dcim/rearport.md
              - models/dcim/rearporttemplate.md
              - models/dcim/region.md
              - models/dcim/site.md
              - models/dcim/virtualchassis.md
              - models/extras/configcontext.md
              - models/extras/configcontextschema.md
              - models/extras/graphqlquery.md
              - models/extras/imageattachment.md
              - models/extras/job.md
              - models/extras/joblogentry.md
              - models/extras/jobresult.md
              - models/extras/secret.md
              - models/extras/secretsgroup.md
              - models/ipam/aggregate.md
              - models/ipam/ipaddress.md
              - models/ipam/prefix.md
              - models/ipam/rir.md
              - models/ipam/role.md
              - models/ipam/routetarget.md
              - models/ipam/service.md
              - models/ipam/vlan.md
              - models/ipam/vlangroup.md
              - models/ipam/vrf.md
              - models/tenancy/tenant.md
              - models/tenancy/tenantgroup.md
              - models/users/objectpermission.md
              - models/users/token.md
              - models/virtualization/cluster.md
              - models/virtualization/clustergroup.md
              - models/virtualization/clustertype.md
              - models/virtualization/virtualmachine.md
              - models/virtualization/vminterface.md
INFO     -  Documentation built in 8.18 seconds
INFO     -  [07:25:49] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO     -  [07:25:49] Serving on http://127.0.0.1:8001/projects/core/en/stable/
INFO     -  [07:25:50] Browser connected: http://localhost:8001/projects/core/en/stable/development/
INFO     -  [07:25:57] Browser connected: http://localhost:8001/projects/core/en/stable/development/
```


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
