### PR TITLE
Fixed an issue when filtering on nested related fields for Dynamic Groups.

### DIFF
--- a/changes/2824.fixed
+++ b/changes/2824.fixed
@@ -1,0 +1,1 @@
+Fixed an issue when filtering on nested related fields for Dynamic Groups.

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -497,7 +497,7 @@ class DynamicGroup(OrganizationalModel):
             # reconstructed from saved filters, lists of slugs are common e.g. (`{"site": ["ams01",
             # "ams02"]}`, the value being a list of site slugs (`["ams01", "ams02"]`).
             if value and isinstance(value, list) and isinstance(value[0], str):
-                model_field = self.model._meta.get_field(filter_field.field_name)
+                model_field = django_filters.utils.get_model_field(self._model, filter_field.field_name)
                 related_model = model_field.related_model
                 lookup_kwargs = {f"{to_field_name}__in": value}
                 gq_value = related_model.objects.filter(**lookup_kwargs)

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -634,8 +634,13 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         # test a regression w/ nested slug-related values such as `DeviceFilterSet.region` which
         # filters on `site__region`.
         parent_region = Region.objects.filter(children__isnull=False).first()
-        group.set_filter({"region": [parent_region.slug]})
+        nested_value = [parent_region.slug]
+        group.set_filter({"region": nested_value})
         group.validated_save()
+        nested_query = group.generate_query_for_filter(filter_field=fs.filters["region"], value=nested_value)
+        nested_qs = queryset.filter(nested_query)
+        region_qs = Device.objects.filter(site__region__slug__in=nested_value)
+        self.assertQuerySetEqual(nested_qs, region_qs)
 
     def test_generate_query_for_group(self):
         """Test `DynamicGroup.generate_query_for_group()`."""

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -637,6 +637,10 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         nested_value = [parent_region.slug]
         group.set_filter({"region": nested_value})
         group.validated_save()
+
+        # We are making sure the filterset generated from the slug as an argument results in the same
+        # filtered queryset, and more importantly that the nested filter expression `site__region`
+        # is automatically used to get the related model name without failing.
         nested_query = group.generate_query_for_filter(filter_field=fs.filters["region"], value=nested_value)
         nested_qs = queryset.filter(nested_query)
         region_qs = Device.objects.filter(site__region__slug__in=nested_value)

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -17,6 +17,7 @@ from nautobot.dcim.models import (
     LocationType,
     Manufacturer,
     RearPort,
+    Region,
     Site,
 )
 from nautobot.extras.choices import DynamicGroupOperatorChoices
@@ -628,6 +629,13 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         solo_qs = queryset.filter(solo_query)
         serial_qs = Device.objects.filter(serial__iexact=solo_value)
         self.assertQuerySetEqual(solo_qs, serial_qs)
+
+        # Test that a nested field_name w/ `generate_query` works as expected. This is explicitly to
+        # test a regression w/ nested slug-related values such as `DeviceFilterSet.region` which
+        # filters on `site__region`.
+        parent_region = Region.objects.filter(children__isnull=False).first()
+        group.set_filter({"region": [parent_region.slug]})
+        group.validated_save()
 
     def test_generate_query_for_group(self):
         """Test `DynamicGroup.generate_query_for_group()`."""


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2824 
# What's Changed
- This fixes the `FieldDoesNotExist` error when attempting to filter on a nested field such as `Device.site__region` as published by the `DeviceFilterSet.region` field.
- This fix addresses this case where any natural-key multiple-choice filter was accessing a related model field using a nested field name in a filter expression.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
