### PR TITLE
Fixed SiteFactory time_zone attribute to use only `pytz.common_timezones`.

### DIFF
--- a/changes/2774.fixed
+++ b/changes/2774.fixed
@@ -1,0 +1,1 @@
+fixed SiteFactory time_zone attribute to use only `pytz.common_timezones`.

--- a/nautobot/dcim/factory.py
+++ b/nautobot/dcim/factory.py
@@ -226,7 +226,7 @@ class SiteFactory(PrimaryModelFactory):
     tenant = factory.Maybe("has_tenant", random_instance(Tenant), None)
 
     has_time_zone = factory.Faker("pybool")
-    time_zone = factory.Maybe("has_time_zone", factory.LazyFunction(lambda: pytz.timezone(Faker().timezone())), None)
+    time_zone = factory.Faker("random_element", elements=pytz.common_timezones)
 
     has_physical_address = factory.Faker("pybool")
     physical_address = factory.Maybe("has_physical_address", factory.Faker("address"))


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2774 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
