### PR TITLE
Fix change log not displaying correctly when missing object_data_v2 field

### DIFF
--- a/changes/2795.fixed
+++ b/changes/2795.fixed
@@ -1,0 +1,1 @@
+Fixed changelog diff ui to fall back to `object_data` when `object_data_v2` is not present for both ObjectChange instances.

--- a/changes/2795.fixed
+++ b/changes/2795.fixed
@@ -1,1 +1,1 @@
-Fixed changelog diff ui to fall back to `object_data` when `object_data_v2` is not present for both ObjectChange instances.
+Fixed changelog diff data to fall back to `object_data` when `object_data_v2` is not present for both `ObjectChange` instances.

--- a/nautobot/extras/models/change_logging.py
+++ b/nautobot/extras/models/change_logging.py
@@ -214,16 +214,12 @@ class ObjectChange(BaseModel):
         prechange = None
         postchange = None
 
-        prior_change = ObjectChange.objects.filter(
-            changed_object_type=self.changed_object_type,
-            changed_object_id=self.changed_object_id,
-            time__lt=self.time,
-        )
+        prior_change = self.get_prev_change()
 
-        if self.action != ObjectChangeActionChoices.ACTION_CREATE and prior_change.exists():
-            prechange = prior_change.first().object_data_v2
+        if self.action != ObjectChangeActionChoices.ACTION_CREATE and prior_change is not None:
+            prechange = prior_change.object_data_v2
             if prechange is None:
-                prechange = prior_change.first().object_data
+                prechange = prior_change.object_data
 
         if self.action != ObjectChangeActionChoices.ACTION_DELETE:
             postchange = self.object_data_v2
@@ -231,8 +227,8 @@ class ObjectChange(BaseModel):
                 postchange = self.object_data
 
         if prechange and postchange:
-            if self.object_data_v2 is None or prior_change.first().object_data_v2 is None:
-                prechange = prior_change.first().object_data
+            if self.object_data_v2 is None or prior_change.object_data_v2 is None:
+                prechange = prior_change.object_data
                 postchange = self.object_data
             diff_added = shallow_compare_dict(prechange, postchange, exclude=["last_updated"])
             diff_removed = {x: prechange.get(x) for x in diff_added}


### PR DESCRIPTION
# Closes: #2795 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Falls back to `object_data` if `object_data_v2` is not present for both the before and after `ObjectChange` objects.

## Before

![image](https://user-images.githubusercontent.com/75227981/202299601-b971cb56-cf39-4e0b-8635-139e679193dc.png)

## After

![image](https://user-images.githubusercontent.com/75227981/202299639-6addf2de-b361-410a-9f71-3d3385403a21.png)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
