### PR TITLE
Bulk Create/Edit of Required Relationships

### DIFF
--- a/changes/2744.fixed
+++ b/changes/2744.fixed
@@ -1,0 +1,1 @@
+Enforced required Relationships when bulk editing (via API or UI) or bulk creating (via API) objects with required relationships.

--- a/changes/2744.fixed
+++ b/changes/2744.fixed
@@ -1,1 +1,1 @@
-Enforced required Relationships when bulk editing (via API or UI) or bulk creating (via API) objects with required relationships.
+Enforced required Relationships when bulk editing or creating objects that have required relationships. Bulk edit via API or UI. Bulk create via API.

--- a/nautobot/core/templates/generic/object_bulk_update.html
+++ b/nautobot/core/templates/generic/object_bulk_update.html
@@ -9,7 +9,12 @@
     <div class="panel panel-danger">
         <div class="panel-heading"><strong>Errors</strong></div>
         <div class="panel-body">
-            {{ form.errors }}
+            {{ form.non_field_errors }}
+            {% for field in form %}
+                {% if field.errors %}
+                    <strong class="panel-title">{{ field.label }}</strong>: {{ field.errors }}
+                {% endif %}
+            {% endfor %}
         </div>
     </div>
 {% endif %}
@@ -28,14 +33,6 @@
             </div>
         </div>
         <div class="col-md-4">
-            {% if form.non_field_errors %}
-                <div class="panel panel-danger">
-                    <div class="panel-heading"><strong>Errors</strong></div>
-                    <div class="panel-body">
-                        {{ form.non_field_errors }}
-                    </div>
-                </div>
-            {% endif %}
             <div class="panel panel-default">
                 <div class="panel-heading"><strong>{% block form_title %}Attributes{% endblock %}</strong></div>
                 <div class="panel-body">

--- a/nautobot/docs/models/extras/relationship.md
+++ b/nautobot/docs/models/extras/relationship.md
@@ -33,7 +33,7 @@ To mark a relationship as being required, select "Source objects MUST implement 
 * If "Destination objects MUST implement this relationship" is selected, objects of the type selected in "Destination Type" will enforce this relationship when they are created or edited.
 * If "Source objects MUST implement this relationship" is selected, objects of the type selected in "Source Type" will enforce this relationship when they are created or edited.
 
-Required relationships are enforced in the following scenarios: 
+Required relationships are enforced in the following scenarios:
 
 * Creating or editing an object via the API or the UI
 * Bulk creating objects via the API

--- a/nautobot/docs/models/extras/relationship.md
+++ b/nautobot/docs/models/extras/relationship.md
@@ -22,20 +22,22 @@ To create a relationship, from the top-level navigation menu select **Extensibil
 !!! note
     A symmetric many-to-many relationship can be, but is not necessarily, a _complete graph_ or _full mesh_. For example, in the routing topology example above, if Device _A_ and Device _B_ are peers, and Device _B_ and Device _C_ are peers, this does not automatically imply a relationship between Devices _A_ and _C_ -- they **might or might not** also be peers, depending on how you define and populate the specific associations for this relationship.
 
+## Required Relationships
+
 +++ 1.5.0
 
-    Relationships can be marked as being required. By default, relationships are not marked as being required.
+Relationships can be marked as being required. By default, relationships are not marked as being required.
 
-    To mark a relationship as being required, select "Source objects MUST implement this relationship" or conversely "Destination objects MUST implement this relationship" from the "Required on" field when editing or creating a relationship:
+To mark a relationship as being required, select "Source objects MUST implement this relationship" or conversely "Destination objects MUST implement this relationship" from the "Required on" field when editing or creating a relationship:
 
-    * If "Destination objects MUST implement this relationship" is selected, objects of the type selected in "Destination Type" will enforce this relationship when they are created or edited.
-    * If "Source objects MUST implement this relationship" is selected, objects of the type selected in "Source Type" will enforce this relationship when they are created or edited.
+* If "Destination objects MUST implement this relationship" is selected, objects of the type selected in "Destination Type" will enforce this relationship when they are created or edited.
+* If "Source objects MUST implement this relationship" is selected, objects of the type selected in "Source Type" will enforce this relationship when they are created or edited.
 
-    Required relationships are enforced in the following scenarios: 
+Required relationships are enforced in the following scenarios: 
 
-    * Creating or editing an object via the API or the UI
-    * Bulk creating objects via the API
-    * Bulk editing objects via the API or the UI
+* Creating or editing an object via the API or the UI
+* Bulk creating objects via the API
+* Bulk editing objects via the API or the UI
 
 ## Relationship Filters
 

--- a/nautobot/docs/models/extras/relationship.md
+++ b/nautobot/docs/models/extras/relationship.md
@@ -22,14 +22,20 @@ To create a relationship, from the top-level navigation menu select **Extensibil
 !!! note
     A symmetric many-to-many relationship can be, but is not necessarily, a _complete graph_ or _full mesh_. For example, in the routing topology example above, if Device _A_ and Device _B_ are peers, and Device _B_ and Device _C_ are peers, this does not automatically imply a relationship between Devices _A_ and _C_ -- they **might or might not** also be peers, depending on how you define and populate the specific associations for this relationship.
 
-## Requiring a Relationship
++++ 1.5.0
 
-Relationships can be marked as being required. By default, relationships are not marked as being required.
+    Relationships can be marked as being required. By default, relationships are not marked as being required.
 
-To mark a relationship as being required, select "Source objects MUST implement this relationship" or conversely "Destination objects MUST implement this relationship" from the "Required on" field when editing or creating a relationship:
+    To mark a relationship as being required, select "Source objects MUST implement this relationship" or conversely "Destination objects MUST implement this relationship" from the "Required on" field when editing or creating a relationship:
 
-* If "Destination objects MUST implement this relationship" is selected, objects of the type selected in "Destination Type" will enforce this relationship when they are created or edited.
-* If "Source objects MUST implement this relationship" is selected, objects of the type selected in "Source Type" will enforce this relationship when they are created or edited.
+    * If "Destination objects MUST implement this relationship" is selected, objects of the type selected in "Destination Type" will enforce this relationship when they are created or edited.
+    * If "Source objects MUST implement this relationship" is selected, objects of the type selected in "Source Type" will enforce this relationship when they are created or edited.
+
+    Required relationships are enforced in the following scenarios: 
+
+    * Creating or editing an object via the API or the UI
+    * Bulk creating objects via the API
+    * Bulk editing objects via the API or the UI
 
 ## Relationship Filters
 

--- a/nautobot/docs/release-notes/version-1.5.md
+++ b/nautobot/docs/release-notes/version-1.5.md
@@ -62,6 +62,12 @@ relationship:
 - If "Destination objects MUST implement this relationship" is selected, objects of the type selected in "Destination Type" will enforce this relationship when they are created or edited.
 - If "Source objects MUST implement this relationship" is selected, objects of the type selected in "Source Type" will enforce this relationship when they are created or edited.
 
+Required relationships are enforced in the following scenarios:
+
+- Creating or editing an object via the API or the UI
+- Bulk creating objects via the API
+- Bulk editing objects via the API or the UI
+
 ### Changed
 
 #### Database Query Caching is now Disabled by Default ([#1721](https://github.com/nautobot/nautobot/issues/1721))

--- a/nautobot/extras/api/relationships.py
+++ b/nautobot/extras/api/relationships.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError as CoreValidationError
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema_field
 from rest_framework.exceptions import PermissionDenied

--- a/nautobot/extras/api/relationships.py
+++ b/nautobot/extras/api/relationships.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError as CoreValidationError
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema_field
 from rest_framework.exceptions import PermissionDenied
@@ -271,10 +272,12 @@ class RelationshipModelSerializerMixin(ValidatedModelSerializer):
         )
         if required_relationships_errors:
             raise ValidationError(required_relationships_errors)
-
         instance = super().create(validated_data)
         if relationships_data:
-            self._save_relationships(instance, relationships_data)
+            try:
+                self._save_relationships(instance, relationships_data)
+            except CoreValidationError as error:
+                raise ValidationError(str(error))
         return instance
 
     def update(self, instance, validated_data):

--- a/nautobot/extras/api/relationships.py
+++ b/nautobot/extras/api/relationships.py
@@ -271,7 +271,7 @@ class RelationshipModelSerializerMixin(ValidatedModelSerializer):
             output_for="api", initial_data=relationships_data
         )
         if required_relationships_errors:
-            raise ValidationError(required_relationships_errors)
+            raise ValidationError({"relationships": required_relationships_errors})
         instance = super().create(validated_data)
         if relationships_data:
             try:
@@ -290,7 +290,7 @@ class RelationshipModelSerializerMixin(ValidatedModelSerializer):
             instance=instance,
         )
         if required_relationships_errors:
-            raise ValidationError(required_relationships_errors)
+            raise ValidationError({"relationships": required_relationships_errors})
 
         instance = super().update(instance, validated_data)
         if relationships_data:

--- a/nautobot/extras/api/relationships.py
+++ b/nautobot/extras/api/relationships.py
@@ -276,7 +276,7 @@ class RelationshipModelSerializerMixin(ValidatedModelSerializer):
         if relationships_data:
             try:
                 self._save_relationships(instance, relationships_data)
-            except CoreValidationError as error:
+            except DjangoValidationError as error:
                 raise ValidationError(str(error))
         return instance
 

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -411,7 +411,7 @@ class RelationshipModelBulkEditFormMixin(BulkEditForm):
             for editing in self.cleaned_data["pk"]:
                 editing_verbose_name = editing._meta.verbose_name
                 required_target_side = RelationshipSideChoices.OPPOSITE[relationship.required_on]
-                required_target_type = getattr(relationship, f'{required_target_side}_type')
+                required_target_type = getattr(relationship, f"{required_target_side}_type")
                 required_type_verbose_name = required_target_type.model_class()._meta.verbose_name
                 filter_kwargs = {
                     "relationship": relationship,

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -4,7 +4,6 @@ from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db.models import Q
-from django.utils.safestring import mark_safe
 
 from nautobot.extras.choices import (
     CustomFieldFilterLogicChoices,

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -472,8 +472,8 @@ class RelationshipModelFormMixin(forms.ModelForm):
                 self.fields[field_name] = relationship.to_form_field(side=side)
 
                 # HTML5 validation for required relationship field:
-                # if relationship.required_on == side:
-                #     self.fields[field_name].required = True
+                if relationship.required_on == side:
+                    self.fields[field_name].required = True
 
                 # if the object already exists, populate the field with existing values
                 if self.instance.present_in_database:

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -440,9 +440,7 @@ class RelationshipModelBulkEditFormMixin(BulkEditForm):
             if len(object_list) > 5:
                 self.add_error(None, f"{len(object_list)} {relationship_message}")
             else:
-                self.add_error(
-                    None, mark_safe(f"These {relationship_message}:<ul><li>{'</li><li>'.join(object_list)}</li></ul>")
-                )
+                self.add_error(None, f"These {relationship_message}: {', '.join(object_list)}")
 
         return super().clean()
 

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -348,7 +348,7 @@ class RelationshipModelBulkEditFormMixin(BulkEditForm):
     def clean(self):
 
         # Get any initial required relationship objects errors (i.e. non-existent required objects)
-        required_objects_errors = self.Meta().model.required_related_objects_errors(output_for="ui")
+        required_objects_errors = self.model.required_related_objects_errors(output_for="ui")
         already_invalidated_slugs = []
         for error_dict in required_objects_errors:
             for field, errors in error_dict.items():

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -350,11 +350,10 @@ class RelationshipModelBulkEditFormMixin(BulkEditForm):
         # Get any initial required relationship objects errors (i.e. non-existent required objects)
         required_objects_errors = self.model.required_related_objects_errors(output_for="ui")
         already_invalidated_slugs = []
-        for error_dict in required_objects_errors:
-            for field, errors in error_dict.items():
-                self.add_error(None, errors)
-                relationship_slug = field.split("__")[0][3:]
-                already_invalidated_slugs.append(relationship_slug)
+        for field, errors in required_objects_errors.items():
+            self.add_error(None, errors)
+            relationship_slug = field.split("__")[0][3:]
+            already_invalidated_slugs.append(relationship_slug)
 
         required_relationships = []
         # The following query excludes already invalidated relationships (this happened above
@@ -500,9 +499,8 @@ class RelationshipModelFormMixin(forms.ModelForm):
         required_relationships_errors = self.Meta().model.required_related_objects_errors(
             output_for="ui", initial_data=self.cleaned_data, instance=self.instance
         )
-        for error_dict in required_relationships_errors:
-            for field, errors in error_dict.items():
-                self.add_error(field, errors)
+        for field, errors in required_relationships_errors.items():
+            self.add_error(field, errors)
 
         for side, relationships in self.instance.get_relationships().items():
             for relationship in relationships:

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -236,7 +236,7 @@ class RelationshipModel(models.Model):
         """
 
         required_relationships = Relationship.objects.get_required_for_model(cls)
-        relationships_field_errors = []
+        relationships_field_errors = {}
         for relation in required_relationships:
 
             opposite_side = RelationshipSideChoices.OPPOSITE[relation.required_on]
@@ -320,7 +320,7 @@ class RelationshipModel(models.Model):
                         )
 
             if len(field_errors[field_key]) > 0:
-                relationships_field_errors.append(field_errors)
+                relationships_field_errors[field_key] = field_errors[field_key]
 
         return relationships_field_errors
 

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -310,7 +310,7 @@ class RelationshipModel(models.Model):
 
                 elif output_for == "api":
                     supplied_data = initial_data.get(relation, {}).get(opposite_side, {})
-                    if  not supplied_data:
+                    if not supplied_data:
                         missing_data = True
 
                 if missing_data:

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -310,7 +310,7 @@ class RelationshipModel(models.Model):
 
                 elif output_for == "api":
                     supplied_data = initial_data.get(relation, {}).get(opposite_side, {})
-                    if len(supplied_data) == 0:
+                    if  not supplied_data:
                         missing_data = True
 
                 if missing_data:

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -316,7 +316,7 @@ class RelationshipModel(models.Model):
                         )
                     elif output_for == "api":
                         field_errors[field_key].append(
-                            f'You need to specify relationships["{relation.slug}"]["{opposite_side}"]["objects"].'
+                            f'You need to specify ["relationships"]["{relation.slug}"]["{opposite_side}"]["objects"].'
                         )
 
             if len(field_errors[field_key]) > 0:

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -258,7 +258,7 @@ class RelationshipModel(models.Model):
                     and not relationships_key_specified
                 ):
                     filter_kwargs = {"relationship": relation, f"{relation.required_on}_id": instance.pk}
-                    if RelationshipAssociation.objects.filter(**filter_kwargs).count() > 0:
+                    if RelationshipAssociation.objects.filter(**filter_kwargs).exists():
                         continue
 
             required_model_class = getattr(relation, f"{opposite_side}_type").model_class()

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -301,19 +301,15 @@ class RelationshipModel(models.Model):
 
             if initial_data is not None:
 
-                missing_data = False
+                supplied_data = []
 
                 if output_for == "ui":
                     supplied_data = initial_data.get(field_key, [])
-                    if not supplied_data:
-                        missing_data = True
 
                 elif output_for == "api":
                     supplied_data = initial_data.get(relation, {}).get(opposite_side, {})
-                    if not supplied_data:
-                        missing_data = True
 
-                if missing_data:
+                if not supplied_data:
                     if output_for == "ui":
                         field_errors[field_key].append(
                             f"You need to select {num_required_verbose} {required_model_meta.verbose_name}."

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -2661,24 +2661,26 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase, RequiredRelationshipTes
         )
         self.assertHttpStatus(response, 400)
         self.assertEqual(
-            [
-                {
+            {
+                "relationships": {
                     "vlans-devices-m2m": [
                         "VLANs require at least one device, but no devices exist yet. "
                         "Create a device by posting to /api/dcim/devices/",
                         'You need to specify relationships["vlans-devices-m2m"]["source"]["objects"].',
                     ]
                 }
-            ],
+            },
             response.json(),
         )
 
         # Create test device for association
         device_for_association = test_views.create_test_device("VLAN Required Device")
         required_relationship_json = {"vlans-devices-m2m": {"source": {"objects": [str(device_for_association.id)]}}}
-        expected_error_json = [
-            {"vlans-devices-m2m": ['You need to specify relationships["vlans-devices-m2m"]["source"]["objects"].']}
-        ]
+        expected_error_json = {
+            "relationships": {
+                "vlans-devices-m2m": ['You need to specify relationships["vlans-devices-m2m"]["source"]["objects"].']
+            }
+        }
 
         # Test POST, PATCH and PUT
         for method in ["post", "patch", "put"]:

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -2678,7 +2678,9 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase, RequiredRelationshipTes
         required_relationship_json = {"vlans-devices-m2m": {"source": {"objects": [str(device_for_association.id)]}}}
         expected_error_json = {
             "relationships": {
-                "vlans-devices-m2m": ['You need to specify ["relationships"]["vlans-devices-m2m"]["source"]["objects"].']
+                "vlans-devices-m2m": [
+                    'You need to specify ["relationships"]["vlans-devices-m2m"]["source"]["objects"].'
+                ]
             }
         }
 

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -2666,7 +2666,7 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase, RequiredRelationshipTes
                     "vlans-devices-m2m": [
                         "VLANs require at least one device, but no devices exist yet. "
                         "Create a device by posting to /api/dcim/devices/",
-                        'You need to specify relationships["vlans-devices-m2m"]["source"]["objects"].',
+                        'You need to specify ["relationships"]["vlans-devices-m2m"]["source"]["objects"].',
                     ]
                 }
             },
@@ -2678,7 +2678,7 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase, RequiredRelationshipTes
         required_relationship_json = {"vlans-devices-m2m": {"source": {"objects": [str(device_for_association.id)]}}}
         expected_error_json = {
             "relationships": {
-                "vlans-devices-m2m": ['You need to specify relationships["vlans-devices-m2m"]["source"]["objects"].']
+                "vlans-devices-m2m": ['You need to specify ["relationships"]["vlans-devices-m2m"]["source"]["objects"].']
             }
         }
 

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -1194,14 +1194,14 @@ class RequiredRelationshipTestMixin(TestCase):
 
                 elif interact_with == "api":
                     self.assertHttpStatus(response, 400)
-                    expected_error_json = [
-                        {
+                    expected_error_json = {
+                        "relationships": {
                             related_field_name: [
                                 params["expected_errors"]["api"]["objects_nonexistent"],
                                 params["expected_errors"]["api"]["objects_not_specified"],
                             ]
                         }
-                    ]
+                    }
                     self.assertEqual(expected_error_json, response.json())
 
                 # Check that no object was created:
@@ -1223,9 +1223,11 @@ class RequiredRelationshipTestMixin(TestCase):
 
                 elif interact_with == "api":
                     self.assertHttpStatus(response, 400)
-                    expected_error_json = [
-                        {related_field_name: [params["expected_errors"]["api"]["objects_not_specified"]]}
-                    ]
+                    expected_error_json = {
+                        "relationships": {
+                            related_field_name: [params["expected_errors"]["api"]["objects_not_specified"]]
+                        }
+                    }
                     self.assertEqual(expected_error_json, response.json())
 
                 # Check that no object was created:
@@ -1295,9 +1297,11 @@ class RequiredRelationshipTestMixin(TestCase):
                         url_kwargs={"pk": newly_created_object.pk},
                     )
                     self.assertHttpStatus(response, 400)
-                    expected_error_json = [
-                        {related_field_name: [params["expected_errors"]["api"]["objects_not_specified"]]}
-                    ]
+                    expected_error_json = {
+                        "relationships": {
+                            related_field_name: [params["expected_errors"]["api"]["objects_not_specified"]]
+                        }
+                    }
                     self.assertEqual(expected_error_json, response.json())
 
                     # Object is updated with the required relationship data (succeeds)
@@ -1353,7 +1357,9 @@ class RequiredRelationshipTestMixin(TestCase):
                         url_kwargs={"pk": newly_created_object.pk},
                     )
                     self.assertHttpStatus(response, 400)
-                    expected_error_json = [
-                        {related_field_name: [params["expected_errors"]["api"]["objects_not_specified"]]}
-                    ]
+                    expected_error_json = {
+                        "relationships": {
+                            related_field_name: [params["expected_errors"]["api"]["objects_not_specified"]]
+                        }
+                    }
                     self.assertEqual(expected_error_json, response.json())

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -1099,7 +1099,7 @@ class RequiredRelationshipTestMixin(TestCase):
                     "api": {
                         "objects_nonexistent": "VLANs require at least one device, but no devices exist yet. "
                         "Create a device by posting to /api/dcim/devices/",
-                        "objects_not_specified": 'You need to specify relationships["vlans-devices-m2m"]'
+                        "objects_not_specified": 'You need to specify ["relationships"]["vlans-devices-m2m"]'
                         '["source"]["objects"].',
                     },
                     "ui": {
@@ -1121,7 +1121,7 @@ class RequiredRelationshipTestMixin(TestCase):
                     "api": {
                         "objects_nonexistent": "Platforms require at least one device, but no devices exist yet. "
                         "Create a device by posting to /api/dcim/devices/",
-                        "objects_not_specified": 'You need to specify relationships["platform-devices-o2m"]'
+                        "objects_not_specified": 'You need to specify ["relationships"]["platform-devices-o2m"]'
                         '["destination"]["objects"].',
                     },
                     "ui": {
@@ -1144,7 +1144,7 @@ class RequiredRelationshipTestMixin(TestCase):
                     "api": {
                         "objects_nonexistent": "Circuit types require a platform, but no platforms exist yet. "
                         "Create a platform by posting to /api/dcim/platforms/",
-                        "objects_not_specified": 'You need to specify relationships["circuittype-platform-o2o"]'
+                        "objects_not_specified": 'You need to specify ["relationships"]["circuittype-platform-o2o"]'
                         '["destination"]["objects"].',
                     },
                     "ui": {

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2011,13 +2011,12 @@ class RelationshipTestCase(
             reverse("ipam:vlan_bulk_edit"), data={"pk": [str(vlan.id) for vlan in vlans[:3]], "_apply": [""]}
         )
         self.assertContains(
-            response, 'These VLANs require a device for the required relationship "VLANs require at least one Device":'
+            response,
+            "These VLANs require a device for the required "
+            "relationship &quot;VLANs require at least one Device&quot;",
         )
         for vlan in vlans[:3]:
-            self.assertContains(
-                response,
-                f"<li>{str(vlan)}</li>",
-            )
+            self.assertContains(response, f"{str(vlan)}")
 
         # Try editing 6 VLANs and adding the required device (succeeds):
         response = self.client.post(


### PR DESCRIPTION
# Closes: #2744 
# What's Changed
UI bulk edit and API bulk edit/add now enforces required relationships.

# TODO
- [x] UI bulk edit check for existence of required objects
- [x] UI bulk edit check each object's required relationships data from form submission
- [x] UI bulk edit tests
- [x] API bulk edit
- [x] API bulk edit tests
- [x] API bulk create
- [x] API bulk create tests
- [x] Docs