### PR TITLE
[WIP] Added polymorphic response API serializer for `DynamicGroup.members` detail endpoint.

### DIFF
--- a/changes/2876.added
+++ b/changes/2876.added
@@ -1,0 +1,1 @@
+Added polymorphic response API serializer for `DynamicGroup.members` detail endpoint.

--- a/changes/2876.fixed
+++ b/changes/2876.fixed
@@ -1,0 +1,1 @@
+Fixed a bug in `get_serializer_for_model` that would sometimes result in an `AttributeError`.

--- a/nautobot/utilities/api.py
+++ b/nautobot/utilities/api.py
@@ -4,11 +4,11 @@ import sys
 from django.conf import settings
 from django.http import JsonResponse
 from django.urls import reverse
+from django.utils.module_loading import import_string
 from rest_framework import status
 from rest_framework.utils import formatting
 
 from nautobot.core.api.exceptions import SerializerNotFound
-from .utils import dynamic_import
 
 
 def get_serializer_for_model(model, prefix=""):
@@ -23,7 +23,7 @@ def get_serializer_for_model(model, prefix=""):
     if app_name not in settings.PLUGINS:
         serializer_name = f"nautobot.{serializer_name}"
     try:
-        return dynamic_import(serializer_name)
+        return import_string(serializer_name)
     except AttributeError:
         raise SerializerNotFound(f"Could not determine serializer for {app_name}.{model_name} with prefix '{prefix}'")
 

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -151,6 +151,8 @@ def lighten_color(r, g, b, factor):
     ]
 
 
+# 2.2 TODO: Remove this entirely as it is inferior and untested compared to
+# `django.utils.module_loading.import_string`.
 def dynamic_import(name):
     """
     Dynamically import a class from an absolute path string


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #<ISSUE NUMBER GOES HERE>
# What's Changed
- This is so that response for the `members` detail endpoint is no longer untyped.
- Also fix a minor bug in `get_serializer_for_model` using the `dynamic_import` function that should no longer be used, replacing it with Django's `import_string` function.
- Added a 2.2 TODO item to rip out `dynamic_import` in v2.2.

Schema now shows response schemas based on the group's `content_type`:

![image](https://user-images.githubusercontent.com/138052/202552392-23e5f9d9-4de9-4fd9-93af-e9c751c10613.png)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
