### PR TITLE
Move Upstream Test `continue-on-error` to Job Group Level, not Specific Matrix Job

### DIFF
--- a/.github/workflows/plugin_upstream_testing_base.yml
+++ b/.github/workflows/plugin_upstream_testing_base.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   unittest:
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -45,5 +46,4 @@ jobs:
       - name: "Copy credentials"
         run: "cp development/creds.example.env development/creds.env"
       - name: "Run Tests"
-        continue-on-error: true
         run: "INVOKE_${{ inputs.invoke_context_name }}_NAUTOBOT_VER=${{ matrix.nautobot-version }} INVOKE_${{ inputs.invoke_context_name }}_PYTHON_VER=${{ env.PYTHON_VERSION }} poetry run invoke unittest --failfast --keepdb"

--- a/changes/2878.changed
+++ b/changes/2878.changed
@@ -1,0 +1,1 @@
+Changed Upstream Workflow Job to continue on error for group, not each specific job.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
- Moved `continue-on-error` up to Job level so the specific failure of a branch test gives a useful status but the overall workflow succeeds. This helps in making API calls to get pass/fail of test without having to introspect the logs.

See:

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/31187/202729213-d4253db7-40a2-4472-a502-e98c8c22a3fc.png">

VS

<img width="1468" alt="image" src="https://user-images.githubusercontent.com/31187/202729503-c7c0695b-cd9e-460a-8ae4-8dd87a46c53b.png">



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- NA Unit, Integration Tests
- NA Documentation Updates (when adding/changing features)
- NA Example Plugin Updates (when adding/changing features)
- NA Outline Remaining Work, Constraints from Design
