### PR TITLE
Fix to ensure django_filters.NumberFilter is treated as a single choice field

### DIFF
--- a/changes/2837.fixed
+++ b/changes/2837.fixed
@@ -1,1 +1,1 @@
-Changed nautobot.utilities.utils.is_single_choice_field to check if field is an instance MultipleChoiceFilter.
+Fixed incorrect logic in `nautobot.utilities.utils.is_single_choice_field` that was causing valid filters to report as invalid.

--- a/changes/2837.fixed
+++ b/changes/2837.fixed
@@ -1,1 +1,1 @@
-Added NumberFilter to nautobot.utilities.utils.is_single_choice_field check list, fixing the filter globally.
+Changed nautobot.utilities.utils.is_single_choice_field to check if field is an instance MultipleChoiceFilter.

--- a/changes/2837.fixed
+++ b/changes/2837.fixed
@@ -1,0 +1,1 @@
+Added NumberFilter to nautobot.utilities.utils.is_single_choice_field check list, fixing the filter globally.

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -934,7 +934,7 @@ def convert_querydict_to_factory_formset_acceptable_querydict(request_querydict,
 def is_single_choice_field(filterset_class, field_name):
     # Some filter parameters do not accept multiple values, e.g DateTime, Boolean, Int fields and the q field, etc.
     field = get_filterset_field(filterset_class, field_name)
-    return not isinstance(field, django_filters.MultipleChoiceFilter) or field_name == "q"
+    return not isinstance(field, django_filters.MultipleChoiceFilter)
 
 
 def get_filterable_params_from_filter_params(filter_params, non_filter_params, filterset_class):

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -933,7 +933,7 @@ def convert_querydict_to_factory_formset_acceptable_querydict(request_querydict,
 def is_single_choice_field(filterset_class, field_name):
     # Some filter parameters do not accept multiple values, e.g DateTime fields, boolean fields, q field etc.
     field = get_filterset_field(filterset_class, field_name)
-    return isinstance(field, (DateFilter, DateTimeFilter, TimeFilter, BooleanFilter)) or field_name == "q"
+    return isinstance(field, (DateFilter, DateTimeFilter, NumberFilter, TimeFilter, BooleanFilter)) or field_name == "q"
 
 
 def get_filterable_params_from_filter_params(filter_params, non_filter_params, filterset_class):

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -8,6 +8,7 @@ from collections import OrderedDict, namedtuple
 from itertools import count, groupby
 from decimal import Decimal
 
+import django_filters
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -931,9 +932,9 @@ def convert_querydict_to_factory_formset_acceptable_querydict(request_querydict,
 
 
 def is_single_choice_field(filterset_class, field_name):
-    # Some filter parameters do not accept multiple values, e.g DateTime fields, boolean fields, q field etc.
+    # Some filter parameters do not accept multiple values, e.g DateTime, Boolean, Int fields and the q field, etc.
     field = get_filterset_field(filterset_class, field_name)
-    return isinstance(field, (DateFilter, DateTimeFilter, NumberFilter, TimeFilter, BooleanFilter)) or field_name == "q"
+    return not isinstance(field, django_filters.MultipleChoiceFilter) or field_name == "q"
 
 
 def get_filterable_params_from_filter_params(filter_params, non_filter_params, filterset_class):


### PR DESCRIPTION
# Closes: #2837 
# What's Changed

`django_filters.NumberFilter` is now treated a single choice field which fixes this filter globally. Before, we would get the following with any uses of `django_filters.NumberFilter`:

```
Invalid filters were specified:
Enter a number.
```

# TODO
- [x] Explanation of Change(s)
- [ ] Unit, Integration Tests