### PR TITLE
cleanup select2 widget form query_params after collapsing site_id, re…

### DIFF
--- a/nautobot/dcim/form_mixins.py
+++ b/nautobot/dcim/form_mixins.py
@@ -20,7 +20,7 @@ class LocatableModelFormMixin(forms.Form):
     )
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
-        query_params={"region_id": "$region"},
+        query_params={"region": "$region"},
     )
     location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
@@ -58,7 +58,7 @@ class LocatableModelBulkEditFormMixin(forms.Form):
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
         required=False,
-        query_params={"region_id": "$region"},
+        query_params={"region": "$region"},
     )
     location = DynamicModelChoiceField(
         queryset=Location.objects.all(),

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -583,21 +583,21 @@ class IPAddressForm(NautobotModelForm, TenancyForm, ReturnURLForm, AddressFieldM
         queryset=Site.objects.all(),
         required=False,
         label="Site",
-        query_params={"region_id": "$nat_region"},
+        query_params={"region": "$nat_region"},
     )
     nat_rack = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
         required=False,
         label="Rack",
         null_option="None",
-        query_params={"site_id": "$site"},
+        query_params={"site": "$site"},
     )
     nat_device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
         required=False,
         label="Device",
         query_params={
-            "site_id": "$site",
+            "site": "$site",
             "rack_id": "$nat_rack",
         },
     )

--- a/nautobot/virtualization/forms.py
+++ b/nautobot/virtualization/forms.py
@@ -188,7 +188,7 @@ class ClusterAddDevicesForm(BootstrapMixin, forms.Form):
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
         required=False,
-        query_params={"region_id": "$region"},
+        query_params={"region": "$region"},
     )
     location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
@@ -200,15 +200,15 @@ class ClusterAddDevicesForm(BootstrapMixin, forms.Form):
         required=False,
         null_option="None",
         query_params={
-            "site_id": "$site",
-            "location_id": "$location",
+            "site": "$site",
+            "location": "$location",
         },
     )
     devices = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         query_params={
-            "site_id": "$site",
-            "location_id": "$location",
+            "site": "$site",
+            "location": "$location",
             "rack_id": "$rack",
             "cluster_id": "null",
         },


### PR DESCRIPTION
cleanup select2 widget form query_params after collapsing site_id, region_id and location_id filters

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #<ISSUE NUMBER GOES HERE>
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
