### PR TITLE
[WIP] Update HTTP_ACCEPT header in test without api_version

### DIFF
--- a/nautobot/utilities/testing/api.py
+++ b/nautobot/utilities/testing/api.py
@@ -49,8 +49,7 @@ class APITestCase(ModelTestCase):
         super().setUpNautobot(client=False)
         self.token = Token.objects.create(user=self.user)
         self.header = {"HTTP_AUTHORIZATION": f"Token {self.token.key}"}
-        if self.api_version:
-            self.set_api_version(self.api_version)
+        self.set_api_version(self.api_version)
 
     def set_api_version(self, api_version):
         """Set or unset a specific API version for requests in this test case."""


### PR DESCRIPTION
the `set_api_version` is already taking care of having a null api_version, setting HTTP_ACCEPT header to "application/json". This is not a big deal because it's de the default for API calls, but it seems more easy to follow.

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #<ISSUE NUMBER GOES HERE>
# What's Changed

Explicitly using the `set_api_version` even no api_version is defined.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
