### PR TITLE
Restore Delete Function on NautobotUIViewSet

### DIFF
--- a/changes/2946.fixed
+++ b/changes/2946.fixed
@@ -1,0 +1,1 @@
+Fixed NautobotUIViewSet views not being able to delete objects.

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -20,7 +20,7 @@ from django.utils.safestring import mark_safe
 from django.views.generic.edit import FormView
 
 from rest_framework import mixins, exceptions
-from rest_framework.parsers import MultiPartParser
+from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
@@ -72,7 +72,7 @@ class NautobotViewSetMixin(GenericViewSet, AccessMixin, GetReturnURLMixin, FormV
     filterset_class = None
     filterset_form_class = None
     form_class = None
-    parser_classes = [MultiPartParser]
+    parser_classes = [FormParser, MultiPartParser]
     queryset = None
     # serializer_class has to be specified to eliminate the need to override retrieve() in the RetrieveModelMixin for now.
     serializer_class = None


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2936
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
- Added `x-www-form-urlencoded` Parser to `NautobotUIViewSet`
    - This is how the web form deletes work
- Added Test Case for `x-www-form-urlencoded` for `DeleteObjectViewTestCase`
    - Previous tests were submitting as `multipart/form-data` which is not how the web UI actually submits the form:
    - <img width="819" alt="image" src="https://user-images.githubusercontent.com/31187/205390654-9b3b6ce8-eca7-4c8d-a938-08161f1156ab.png">



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- NA Documentation Updates (when adding/changing features)
- NA Example Plugin Updates (when adding/changing features)
- NA Outline Remaining Work, Constraints from Design
