### PR TITLE
Override tags field in ConfigContextForm as DynamicModelMultipleChoiceField

### DIFF
--- a/changes/2663.changed
+++ b/changes/2663.changed
@@ -1,1 +1,1 @@
-Changed `tags` field in ConfigContextForm to `DynamicModelMultipleChoiceField`
+Changed `tags` field in ConfigContextForm to `DynamicModelMultipleChoiceField`.

--- a/changes/2663.changed
+++ b/changes/2663.changed
@@ -1,0 +1,1 @@
+Changed `tags` field in ConfigContextForm to `DynamicModelMultipleChoiceField`

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -220,6 +220,7 @@ class ConfigContextForm(BootstrapMixin, NoteModelFormMixin, forms.ModelForm):
     device_redundancy_groups = DynamicModelMultipleChoiceField(
         queryset=DeviceRedundancyGroup.objects.all(), required=False
     )
+    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
 
     data = JSONField(label="")
 

--- a/nautobot/extras/templates/extras/configcontext_edit.html
+++ b/nautobot/extras/templates/extras/configcontext_edit.html
@@ -26,9 +26,9 @@
             {% render_field form.tenant_groups %}
             {% render_field form.tenants %}
             {% render_field form.device_redundancy_groups %}
+            {% render_field form.tags %}
         </div>
     </div>
-    {% include 'inc/extras_features_edit_form_fields.html' %}
     <div class="panel panel-default">
         <div class="panel-heading"><strong>Data</strong></div>
         <div class="panel-body">

--- a/nautobot/extras/templates/extras/configcontext_edit.html
+++ b/nautobot/extras/templates/extras/configcontext_edit.html
@@ -26,9 +26,9 @@
             {% render_field form.tenant_groups %}
             {% render_field form.tenants %}
             {% render_field form.device_redundancy_groups %}
-            {% render_field form.tags %}
         </div>
     </div>
+    {% include 'inc/extras_features_edit_form_fields.html' %}
     <div class="panel panel-default">
         <div class="panel-heading"><strong>Data</strong></div>
         <div class="panel-body">


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2663 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

So all the `PrimaryModels` have their `tags` field defined as `TaggableManager` from `django-taggit`, whereas ConfigContext is the only one with `tags` defined as `models.ManyToManyField`. I wonder if we should change the tags field to`TaggableManager`. But for now I only override the tags field in the `ConfigContextForm` and it works as expected without a migration involved.

<img width="894" alt="Screen Shot 2022-12-06 at 11 03 18 AM" src="https://user-images.githubusercontent.com/46973263/205961885-20237fe3-409b-4738-a828-210659c4d11c.png">
<img width="870" alt="Screen Shot 2022-12-06 at 11 03 05 AM" src="https://user-images.githubusercontent.com/46973263/205961833-2160e31f-6681-4175-814d-a52b3932c450.png">



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
