### PR TITLE
Fix an error when rendering a SecretsError with an unknown provider to string

### DIFF
--- a/changes/2962.fixed
+++ b/changes/2962.fixed
@@ -1,0 +1,1 @@
+Fixed an error raised when logging errors about a `Secret` with an invalid `provider`.

--- a/nautobot/extras/models/secrets.py
+++ b/nautobot/extras/models/secrets.py
@@ -88,7 +88,7 @@ class Secret(PrimaryModel):
         """
         provider = registry["secrets_providers"].get(self.provider)
         if not provider:
-            raise SecretProviderError(self, None, f'No registered provider "{self.provider}" is available')
+            raise SecretProviderError(self, self.provider, f'No registered provider "{self.provider}" is available')
 
         try:
             return provider.get_value_for_secret(self, obj=obj)

--- a/nautobot/extras/secrets/exceptions.py
+++ b/nautobot/extras/secrets/exceptions.py
@@ -7,14 +7,17 @@ class SecretError(Exception):
     def __init__(self, secret, provider_class, message, *args, **kwargs):
         super().__init__(message, *args, **kwargs)
         self.secret = secret
-        self.provider_class = provider_class
+        # provider_class can be a SecretsProvider class or just a descriptive string.
+        if isinstance(provider_class, type):
+            self.provider_class = provider_class
+            self.provider = provider_class.__name__
+        else:
+            self.provider_class = None
+            self.provider = str(provider_class)
         self.message = message
 
     def __str__(self):
-        return (
-            f"{self.__class__.__name__}: "
-            f'Secret "{self.secret}" (provider "{self.provider_class.__name__}"): {self.message}'
-        )
+        return f'{self.__class__.__name__}: Secret "{self.secret}" (provider "{self.provider}"): {self.message}'
 
 
 class SecretParametersError(SecretError):

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -931,46 +931,119 @@ class SecretTest(TestCase):
 
     def test_environment_variable_value_not_found(self):
         """Failure to retrieve an environment variable raises an exception."""
-        with self.assertRaises(SecretValueNotFoundError):
+        with self.assertRaises(SecretValueNotFoundError) as handler:
             self.environment_secret.get_value()
-        with self.assertRaises(SecretValueNotFoundError):
-            self.environment_secret.get_value(obj=None)
-        with self.assertRaises(SecretValueNotFoundError):
-            self.environment_secret.get_value(obj=self.site)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretValueNotFoundError: Secret "{self.environment_secret}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            'Undefined environment variable "NAUTOBOT_TEST_ENVIRONMENT_VARIABLE"!',
+        )
 
-        with self.assertRaises(SecretValueNotFoundError):
+        with self.assertRaises(SecretValueNotFoundError) as handler:
+            self.environment_secret.get_value(obj=None)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretValueNotFoundError: Secret "{self.environment_secret}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            'Undefined environment variable "NAUTOBOT_TEST_ENVIRONMENT_VARIABLE"!',
+        )
+
+        with self.assertRaises(SecretValueNotFoundError) as handler:
+            self.environment_secret.get_value(obj=self.site)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretValueNotFoundError: Secret "{self.environment_secret}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            'Undefined environment variable "NAUTOBOT_TEST_ENVIRONMENT_VARIABLE"!',
+        )
+
+        with self.assertRaises(SecretValueNotFoundError) as handler:
             self.environment_secret_templated.get_value(obj=self.site)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretValueNotFoundError: Secret "{self.environment_secret_templated}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            'Undefined environment variable "NAUTOBOT_TEST_NYC"!',
+        )
 
     def test_environment_variable_value_missing_parameters(self):
         """A mis-defined environment variable secret raises an exception on access."""
         self.environment_secret.parameters = {}
-        with self.assertRaises(SecretParametersError):
+
+        with self.assertRaises(SecretParametersError) as handler:
             self.environment_secret.get_value()
-        with self.assertRaises(SecretParametersError):
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretParametersError: Secret "{self.environment_secret}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            'The "variable" parameter is mandatory!',
+        )
+
+        with self.assertRaises(SecretParametersError) as handler:
             self.environment_secret.get_value(obj=None)
-        with self.assertRaises(SecretParametersError):
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretParametersError: Secret "{self.environment_secret}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            'The "variable" parameter is mandatory!',
+        )
+
+        with self.assertRaises(SecretParametersError) as handler:
             self.environment_secret.get_value(obj=self.site)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretParametersError: Secret "{self.environment_secret}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            'The "variable" parameter is mandatory!',
+        )
 
     def test_environment_variable_templated_missing_object(self):
         """A templated secret requires an object for context."""
         # Since we're not using Jinja2's StrictUndefined, it just renders as an empty string if obj is omitted or None,
         # For this secret it results in a rendered value of "", which is of course not a defined environment variable.
-        with self.assertRaises(SecretValueNotFoundError):
+        with self.assertRaises(SecretValueNotFoundError) as handler:
             self.environment_secret_templated.get_value()
-        with self.assertRaises(SecretValueNotFoundError):
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretValueNotFoundError: Secret "{self.environment_secret_templated}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            'Undefined environment variable "NAUTOBOT_TEST_"!',
+        )
+
+        with self.assertRaises(SecretValueNotFoundError) as handler:
             self.environment_secret_templated.get_value(obj=None)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretValueNotFoundError: Secret "{self.environment_secret_templated}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            'Undefined environment variable "NAUTOBOT_TEST_"!',
+        )
 
     def test_environment_variable_templated_bad_template(self):
         """Error handling."""
         # Malformed Jinja2
         self.environment_secret_templated.parameters["variable"] = "{{ obj."
-        with self.assertRaises(SecretParametersError):
+        with self.assertRaises(SecretParametersError) as handler:
             self.environment_secret_templated.get_value(obj=self.site)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretParametersError: Secret "{self.environment_secret_templated}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            "expected name or number",
+        )
+
         # Template references attribute not present on the provided obj
         # Since we're not using Jinja2's StrictUndefined, this just renders as an empty string
         self.environment_secret_templated.parameters["variable"] = "{{ obj.primary_ip4 }}"
-        with self.assertRaises(SecretValueNotFoundError):
+        with self.assertRaises(SecretValueNotFoundError) as handler:
             self.environment_secret_templated.get_value(obj=self.site)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretValueNotFoundError: Secret "{self.environment_secret_templated}" '
+            '(provider "EnvironmentVariableSecretsProvider"): '
+            'Undefined environment variable ""!',
+        )
 
     @mock.patch.dict(os.environ, {"NAUTOBOT_TEST_ENVIRONMENT_VARIABLE": "supersecretvalue"})
     def test_environment_variable_value_success(self):
@@ -1006,22 +1079,57 @@ class SecretTest(TestCase):
 
     def test_text_file_value_not_found(self):
         """Failure to retrieve a file raises an exception."""
-        with self.assertRaises(SecretValueNotFoundError):
+        path = self.text_file_secret.rendered_parameters(obj=None)["path"]
+        with self.assertRaises(SecretValueNotFoundError) as handler:
             self.text_file_secret.get_value()
-        with self.assertRaises(SecretValueNotFoundError):
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretValueNotFoundError: Secret "{self.text_file_secret}" (provider "TextFileSecretsProvider"): '
+            f'File "{path}" not found!',
+        )
+
+        with self.assertRaises(SecretValueNotFoundError) as handler:
             self.text_file_secret.get_value(obj=None)
-        with self.assertRaises(SecretValueNotFoundError):
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretValueNotFoundError: Secret "{self.text_file_secret}" (provider "TextFileSecretsProvider"): '
+            f'File "{path}" not found!',
+        )
+
+        with self.assertRaises(SecretValueNotFoundError) as handler:
             self.text_file_secret.get_value(obj=self.site)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretValueNotFoundError: Secret "{self.text_file_secret}" (provider "TextFileSecretsProvider"): '
+            f'File "{path}" not found!',
+        )
 
     def test_text_file_value_missing_parameters(self):
         """A mis-defined text file secret raises an exception."""
         self.text_file_secret.parameters = {}
-        with self.assertRaises(SecretParametersError):
+        with self.assertRaises(SecretParametersError) as handler:
             self.text_file_secret.get_value()
-        with self.assertRaises(SecretParametersError):
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretParametersError: Secret "{self.text_file_secret}" (provider "TextFileSecretsProvider"): '
+            'The "path" parameter is mandatory!',
+        )
+
+        with self.assertRaises(SecretParametersError) as handler:
             self.text_file_secret.get_value(obj=None)
-        with self.assertRaises(SecretParametersError):
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretParametersError: Secret "{self.text_file_secret}" (provider "TextFileSecretsProvider"): '
+            'The "path" parameter is mandatory!',
+        )
+
+        with self.assertRaises(SecretParametersError) as handler:
             self.text_file_secret.get_value(obj=self.site)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretParametersError: Secret "{self.text_file_secret}" (provider "TextFileSecretsProvider"): '
+            'The "path" parameter is mandatory!',
+        )
 
     def test_text_file_value_success(self):
         """Successful retrieval of a text file secret."""
@@ -1072,14 +1180,36 @@ class SecretTest(TestCase):
     def test_unknown_provider(self):
         """An unknown/unsupported provider raises an exception."""
         self.environment_secret.provider = "it-is-a-mystery"
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as handler:
             self.environment_secret.clean()
-        with self.assertRaises(SecretProviderError):
+        self.assertEqual(
+            str(handler.exception),
+            "{'provider': ['No registered provider \"it-is-a-mystery\" is available']}",
+        )
+
+        with self.assertRaises(SecretProviderError) as handler:
             self.environment_secret.get_value()
-        with self.assertRaises(SecretProviderError):
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretProviderError: Secret "{self.environment_secret}" (provider "it-is-a-mystery"): '
+            'No registered provider "it-is-a-mystery" is available',
+        )
+
+        with self.assertRaises(SecretProviderError) as handler:
             self.environment_secret.get_value(obj=None)
-        with self.assertRaises(SecretProviderError):
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretProviderError: Secret "{self.environment_secret}" (provider "it-is-a-mystery"): '
+            'No registered provider "it-is-a-mystery" is available',
+        )
+
+        with self.assertRaises(SecretProviderError) as handler:
             self.environment_secret.get_value(obj=self.site)
+        self.assertEqual(
+            str(handler.exception),
+            f'SecretProviderError: Secret "{self.environment_secret}" (provider "it-is-a-mystery"): '
+            'No registered provider "it-is-a-mystery" is available',
+        )
 
 
 class SecretsGroupTest(TestCase):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #TBD
# What's Changed

Fix a user-reported issue from public Slack:

```python
   File "/usr/local/lib/python3.9/site-packages/nautobot/extras/secrets/exceptions.py", line 16, in __str__
     f'Secret "{self.secret}" (provider "{self.provider_class.__name__}"): {self.message}'
 AttributeError: 'NoneType' object has no attribute '__name__'
```

This happens in the case where a `Secret` has a configured `provider` string that doesn't correspond to any registered `SecretsProvider` class; when attempting to get the value of this `Secret`, a `SecretProviderError` is raised with a `None` value for its `provider_class` attribute; when Nautobot attempts to log this error, the `SecretError.__str__()` function attempts to dereference `self.provider_class.__name__` which throws the above `AttributeError`.

To fix this issue, I've made the following changes:

- To make for slightly better string representation, allow a `SecretError` to store either a `provider_class` class reference (as before) or a raw `provider` string, and let the `__str__()` representation of the `SecretError` use either.
- Change the exception raised in the "no registered provider" case to pass the unknown `provider` string instead of `None` when constructing the `SecretProviderError`.

Additionally:

- Update the various test cases that test for `SecretError` to be raised so that they also now check the string representation of each such exception.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
