### PR TITLE
Fix #1982

### DIFF
--- a/changes/1982.fixed
+++ b/changes/1982.fixed
@@ -1,0 +1,1 @@
+Fixed a UI presentation/validation issue with dynamic-groups using foreign-key filters that aren't explicitly defined in the corresponding FilterForm.

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -18,6 +18,7 @@ from nautobot.extras.choices import DynamicGroupOperatorChoices
 from nautobot.extras.querysets import DynamicGroupQuerySet, DynamicGroupMembershipQuerySet
 from nautobot.extras.utils import extras_features
 from nautobot.utilities.forms.constants import BOOLEAN_WITH_BLANK_CHOICES
+from nautobot.utilities.forms.fields import DynamicModelChoiceField
 from nautobot.utilities.forms.widgets import StaticSelect2
 from nautobot.utilities.utils import get_filterset_for_model, get_form_for_model
 
@@ -229,6 +230,9 @@ class DynamicGroup(OrganizationalModel):
             # Null boolean fields need a special widget that doesn't save `False` when unchecked.
             if isinstance(modelform_field, forms.NullBooleanField):
                 modelform_field.widget = StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES)
+
+            if isinstance(modelform_field, DynamicModelChoiceField):
+                modelform_field = filterset_field.field
 
             # Filter fields should never be required!
             modelform_field.required = False

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -23,8 +23,8 @@ from nautobot.extras.choices import DynamicGroupOperatorChoices
 from nautobot.extras.filters import DynamicGroupFilterSet, DynamicGroupMembershipFilterSet
 from nautobot.extras.models import DynamicGroup, DynamicGroupMembership, Status
 from nautobot.ipam.models import Prefix
-from nautobot.utilities.forms.fields import MultiValueCharField
-from nautobot.utilities.forms.widgets import MultiValueCharInput
+from nautobot.utilities.forms.fields import MultiMatchModelMultipleChoiceField, MultiValueCharField
+from nautobot.utilities.forms.widgets import APISelectMultiple, MultiValueCharInput
 from nautobot.utilities.testing import TestCase
 
 
@@ -414,6 +414,9 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         # See if a CharField is properly converted to a MultiValueCharField In DynamicGroupEditForm.
         self.assertIsInstance(fields["name"], MultiValueCharField)
         self.assertIsInstance(fields["name"].widget, MultiValueCharInput)
+        # See if a DynamicModelChoiceField is properly converted to a MultiMatchModelMultipleChoiceField
+        self.assertIsInstance(fields["rack"], MultiMatchModelMultipleChoiceField)
+        self.assertIsInstance(fields["rack"].widget, APISelectMultiple)
 
     def test_map_filter_fields_skip_missing(self):
         """
@@ -511,6 +514,7 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         self.assertNotEqual(filter_fields, {})
         self.assertNotIn("q", filter_fields)
         self.assertIn("name", filter_fields)
+        self.assertIn("rack", filter_fields)
 
     def test_generate_filter_form(self):
         """Test `DynamicGroup.generate_filter_form()`."""

--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -734,12 +734,15 @@ class NumericArrayField(SimpleArrayField):
         return super().to_python(value)
 
 
-class MultiMatchModelMultipleChoiceField(django_filters.fields.ModelMultipleChoiceField):
+class MultiMatchModelMultipleChoiceField(DynamicModelChoiceMixin, django_filters.fields.ModelMultipleChoiceField):
     """
     Filter field to support matching on the PK *or* `to_field_name` fields (defaulting to `slug` if not specified).
 
     Raises ValidationError if none of the fields match the requested value.
     """
+
+    filter = django_filters.ModelMultipleChoiceFilter
+    widget = widgets.APISelectMultiple
 
     def __init__(self, *args, **kwargs):
         self.natural_key = kwargs.setdefault("to_field_name", "slug")


### PR DESCRIPTION
# Closes: #1982
# What's Changed

With the new filters added to DeviceFilterSet in #2849, specifically the NaturalKeyOrPKMultipleChoiceField such as `rack`, `cluster`, and `device_type` that are not declared in the DeviceFilterForm, the dynamic-groups UI was broken:

1. The UI presented a single-choice model selection for each such filter, instead of the desired multi-choice selection.
2. If a value was selected for any of these filters, on form submission the form would fail validation with "Select a valid choice. That choice is not one of the available choices."

Solution:

- In DynamicGroup._map_filter_fields, replace any `DynamicModelChoiceField` provided by the model form with the correct field type provided by the filterset form.
- Make `MultiMatchModelMultipleChoiceField` inherit from the same `DynamicModelChoiceMixin` mixin class used in `DynamicModelChoiceField` and `DynamicModelMultipleChoiceField`.
  - I tried making `MultiMatchModelMultipleChoiceField` a direct subclass of `DynamicModelMultipleChoiceField`, but ran into issues because it expects to inherit from `django_filters.fields.ModelMultipleChoiceField` rather than the `django.forms.ModelMultipleChoiceField` that `DynamicModelMultipleChoiceField` has as its base class.

I still think in the long term it may be correct to merge `DynamicModelMultipleChoiceField` and `MultiMatchModelMultipleChoiceField` into a single class, but this gets us closer to that point and appears to address the issues I saw.

UI now allows appropriate multiple selections:

![image](https://user-images.githubusercontent.com/5603551/206530574-9440f580-1ce1-4f35-985f-1047e1b33498.png)

and the dynamic-group filter can now include these filters:

![image](https://user-images.githubusercontent.com/5603551/206530937-81680463-6a67-4671-9cb6-c0ddfd56454c.png)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design