### PR TITLE
Fixed 500 error when combining filtering on relationships with concrete fields.

### DIFF
--- a/changes/2963.fixed
+++ b/changes/2963.fixed
@@ -1,0 +1,1 @@
+Fixed 500 error when combining filtering on relationships with concrete fields.

--- a/nautobot/extras/filters/mixins.py
+++ b/nautobot/extras/filters/mixins.py
@@ -193,8 +193,11 @@ class RelationshipFilter(django_filters.ModelMultipleChoiceFilter):
                 ).values_list("source_id", flat=True)
 
                 values = list(destinations) + list(sources)
-            qs &= self.get_method(self.qs)(Q(**{"id__in": values}))
-            return qs
+
+            # ModelMultipleChoiceFilters always have `distinct=True` so we must make sure that the
+            # unioned queryset is also distinct. Ref: https://github.com/nautobot/nautobot/issues/2963
+            union_qs = self.get_method(self.qs)(Q(**{"id__in": values})).distinct()
+            return qs & union_qs
 
 
 class RelationshipModelFilterSetMixin(django_filters.FilterSet):

--- a/nautobot/extras/filters/mixins.py
+++ b/nautobot/extras/filters/mixins.py
@@ -195,8 +195,13 @@ class RelationshipFilter(django_filters.ModelMultipleChoiceFilter):
                 values = list(destinations) + list(sources)
 
             # ModelMultipleChoiceFilters always have `distinct=True` so we must make sure that the
-            # unioned queryset is also distinct. Ref: https://github.com/nautobot/nautobot/issues/2963
-            union_qs = self.get_method(self.qs)(Q(**{"id__in": values})).distinct()
+            # unioned queryset is also distinct. We also need to conditionally check if the incoming
+            # `qs` is distinct in the case that a caller is manually passing in a queryset that may
+            # not be distinct. (Ref: https://github.com/nautobot/nautobot/issues/2963)
+            union_qs = self.get_method(self.qs)(Q(**{"id__in": values}))
+            if qs.query.distinct:
+                union_qs = union_qs.distinct()
+
             return qs & union_qs
 
 

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -1269,7 +1269,7 @@ class RelationshipModelFilterSetTestCase(FilterTestCases.FilterTestCase):
 
     def test_regression_distinct_2963(self):
         """
-        Regression tests for issue #2963 u address `AssertionError`error when combining filtering on
+        Regression tests for issue #2963 to  address `AssertionError` error when combining filtering on
         relationships with concrete fields.
 
         Ref: https://github.com/nautobot/nautobot/issues/2963

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -1267,6 +1267,26 @@ class RelationshipModelFilterSetTestCase(FilterTestCases.FilterTestCase):
             2,
         )
 
+    def test_regression_distinct_2963(self):
+        """
+        Regression tests for issue #2963 u address `AssertionError`error when combining filtering on
+        relationships with concrete fields.
+
+        Ref: https://github.com/nautobot/nautobot/issues/2963
+        """
+        self.queryset = Device.objects.all()
+        self.filterset = DeviceFilterSet
+        self.assertEqual(
+            self.filterset(
+                {
+                    f"cr_{self.relationships[0].slug}__destination": [self.vlans[0].pk, self.vlans[1].pk],
+                    "manufacturer": ["manufacturer-1"],
+                },
+                self.queryset,
+            ).qs.count(),
+            2,
+        )
+
 
 class SecretTestCase(FilterTestCases.NameSlugFilterTestCase):
     queryset = Secret.objects.all()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2963 
# What's Changed
- This makes `RelationshipFilter` always call `distinct()` on the unioned queryset.

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/138052/206598290-93575156-2354-460b-bbf6-cc0a6ff534fe.png">

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
