### PR TITLE
Rack Elevation Improvements

### DIFF
--- a/changes/1768.added
+++ b/changes/1768.added
@@ -1,0 +1,1 @@
+Added the display of half-depth rack items from the rear face.

--- a/changes/2966.added
+++ b/changes/2966.added
@@ -1,1 +1,1 @@
-Fixed device name legibility on rack elevation with images.
+Added device name to rack elevation with images.

--- a/changes/2966.added
+++ b/changes/2966.added
@@ -1,0 +1,1 @@
+Fixed device name legibility on rack elevation with images.

--- a/changes/2967.fixed
+++ b/changes/2967.fixed
@@ -1,0 +1,1 @@
+Fixed inverted device images in dark mode.

--- a/nautobot/dcim/elevations.py
+++ b/nautobot/dcim/elevations.py
@@ -107,6 +107,18 @@ class RackElevationSVG:
         link.set_desc(self._get_device_description(device))
         link.add(drawing.rect(start, end, style=f"fill: #{color}", class_="slot"))
         hex_color = f"#{foreground_color(color)}"
+
+        # Embed front device type image if one exists
+        if self.include_images and device.device_type.front_image:
+            image = drawing.image(
+                href=device.device_type.front_image.url,
+                insert=start,
+                size=end,
+                class_="device-image",
+            )
+            image.fit(scale="slice")
+            link.add(image)
+
         link.add(
             drawing.text(
                 device_fullname,
@@ -124,17 +136,6 @@ class RackElevationSVG:
             )
         )
 
-        # Embed front device type image if one exists
-        if self.include_images and device.device_type.front_image:
-            image = drawing.image(
-                href=device.device_type.front_image.url,
-                insert=start,
-                size=end,
-                class_="device-image",
-            )
-            image.fit(scale="slice")
-            link.add(image)
-
     def _draw_device_rear(self, drawing, device, start, end, text):
         rect = drawing.rect(start, end, class_="slot blocked")
         rect.set_desc(self._get_device_description(device))
@@ -143,6 +144,18 @@ class RackElevationSVG:
         device_shortname = settings.UI_RACK_VIEW_TRUNCATE_FUNCTION(str(device))
 
         drawing.add(rect)
+
+        # Embed rear device type image if one exists
+        if self.include_images and device.device_type.rear_image:
+            image = drawing.image(
+                href=device.device_type.rear_image.url,
+                insert=start,
+                size=end,
+                class_="device-image",
+            )
+            image.fit(scale="slice")
+            drawing.add(image)
+
         drawing.add(
             drawing.text(
                 device_fullname, insert=text, class_=f"rack-device-fullname{'' if self.display_fullname else ' hidden'}"
@@ -155,17 +168,6 @@ class RackElevationSVG:
                 class_=f"rack-device-shortname{' hidden' if self.display_fullname else ''}",
             )
         )
-
-        # Embed rear device type image if one exists
-        if self.include_images and device.device_type.rear_image:
-            image = drawing.image(
-                href=device.device_type.rear_image.url,
-                insert=start,
-                size=end,
-                class_="device-image",
-            )
-            image.fit(scale="slice")
-            drawing.add(image)
 
     @staticmethod
     def _draw_empty(drawing, rack, start, end, text, id_, face_id, class_, reservation):

--- a/nautobot/dcim/elevations.py
+++ b/nautobot/dcim/elevations.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils.http import urlencode
 
-from nautobot.utilities.utils import foreground_color
 from .choices import DeviceFaceChoices
 from .constants import RACK_ELEVATION_BORDER_WIDTH
 
@@ -106,7 +105,6 @@ class RackElevationSVG:
         )
         link.set_desc(self._get_device_description(device))
         link.add(drawing.rect(start, end, style=f"fill: #{color}", class_="slot"))
-        hex_color = f"#{foreground_color(color)}"
 
         # Embed front device type image if one exists
         if self.include_images and device.device_type.front_image:
@@ -123,7 +121,8 @@ class RackElevationSVG:
             drawing.text(
                 device_fullname,
                 insert=text,
-                fill=hex_color,
+                fill="white",
+                style="text-shadow: 1px 1px 3px black;",
                 class_=f"rack-device-fullname{'' if self.display_fullname else ' hidden'}",
             )
         )
@@ -131,7 +130,8 @@ class RackElevationSVG:
             drawing.text(
                 device_shortname,
                 insert=text,
-                fill=hex_color,
+                fill="white",
+                style="text-shadow: 1px 1px 3px black;",
                 class_=f"rack-device-shortname{' hidden' if self.display_fullname else ''}",
             )
         )
@@ -158,13 +158,19 @@ class RackElevationSVG:
 
         drawing.add(
             drawing.text(
-                device_fullname, insert=text, class_=f"rack-device-fullname{'' if self.display_fullname else ' hidden'}"
+                device_fullname,
+                insert=text,
+                fill="white",
+                style="text-shadow: 1px 1px 3px black;",
+                class_=f"rack-device-fullname{'' if self.display_fullname else ' hidden'}",
             )
         )
         drawing.add(
             drawing.text(
                 device_shortname,
                 insert=text,
+                fill="white",
+                style="text-shadow: 1px 1px 3px black;",
                 class_=f"rack-device-shortname{' hidden' if self.display_fullname else ''}",
             )
         )

--- a/nautobot/dcim/elevations.py
+++ b/nautobot/dcim/elevations.py
@@ -62,6 +62,16 @@ class RackElevationSVG:
         drawing.defs.add(gradient)
 
     @staticmethod
+    def _add_filters(drawing):
+        new_filter = drawing.filter(id="darkmodeinvert")
+        fct = new_filter.feComponentTransfer(color_interpolation_filters="sRGB", result="inverted")
+        fct.feFuncR("table", tableValues="1,0")
+        fct.feFuncG("table", tableValues="1,0")
+        fct.feFuncB("table", tableValues="1,0")
+        new_filter.feColorMatrix(type_="hueRotate", values="180", in_="inverted")
+        drawing.defs.add(new_filter)
+
+    @staticmethod
     def _setup_drawing(width, height):
         drawing = svgwrite.Drawing(size=(width, height))
 
@@ -73,6 +83,7 @@ class RackElevationSVG:
         RackElevationSVG._add_gradient(drawing, "reserved", "#c7c7ff")
         RackElevationSVG._add_gradient(drawing, "occupied", "#d7d7d7")
         RackElevationSVG._add_gradient(drawing, "blocked", "#ffc0c0")
+        RackElevationSVG._add_filters(drawing)
 
         return drawing
 

--- a/nautobot/project-static/css/rack_elevation.css
+++ b/nautobot/project-static/css/rack_elevation.css
@@ -56,6 +56,13 @@ text {
 .blocked:hover+.add-device {
     fill: none;
 }
+.blocked_partial {
+    fill: url(#blocked_partial);
+}
+.blocked_partial:hover {
+    fill: url(#blocked_partial);
+}
+
 .unit {
     margin: 0;
     padding: 5px 0px;

--- a/nautobot/project-static/js/theme.js
+++ b/nautobot/project-static/js/theme.js
@@ -95,7 +95,11 @@ function setDarkTheme() {
     for (let obj of document.getElementsByTagName('object')) {
         obj.addEventListener('load', (event) => {
             if (event.target.contentDocument) {
-                for (let rack_image of event.target.contentDocument.getElementsByTagName('image')) {
+                images = event.target.contentDocument.getElementsByTagName('image');
+                short_names = event.target.contentDocument.getElementsByClassName('rack-device-shortname');
+                full_names = event.target.contentDocument.getElementsByClassName('rack-device-fullname');
+                all = [].concat(Array.from(images), Array.from(short_names), Array.from(full_names))
+                for (let rack_image of all) {
                     rack_image.setAttribute('filter', 'url(#darkmodeinvert)')
                 }
             }

--- a/nautobot/project-static/js/theme.js
+++ b/nautobot/project-static/js/theme.js
@@ -91,6 +91,16 @@ function setDarkTheme() {
     //  Nautobot initially loads in as light theme, then any page refresh or new page will load in dark theme
     // This line prevents that initial light screen load, with an initial, one-time "flash" from light to dark
     darkElement.disabled = undefined;
+
+    for (let obj of document.getElementsByTagName('object')) {
+        obj.addEventListener('load', (event) => {
+            if (event.target.contentDocument) {
+                for (let rack_image of event.target.contentDocument.getElementsByTagName('image')) {
+                    rack_image.setAttribute('filter', 'url(#darkmodeinvert)')
+                }
+            }
+        });
+    }
 }
 
 function setLightTheme() {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #1768, #2966, #2967
# What's Changed
- Device images on rack elevation are no longer inverted in dark mode:
    - <img width="1683" alt="image" src="https://user-images.githubusercontent.com/31187/207770019-725c1286-5ccc-4a02-88b8-1bcee2e33725.png">
- Device names are now overlayed on top of the device images:
    - <img width="314" alt="image" src="https://user-images.githubusercontent.com/31187/207768572-aeac5857-e58f-4b46-9037-022eac618966.png">
- When a half-depth device is present but viewed from the rear "face" it's presence is hinted at:
    - <img width="815" alt="image" src="https://user-images.githubusercontent.com/31187/207770295-308c86ff-99ba-4fd7-ad28-737c757f8ec0.png">
    - User can still assign a device to these locations individually, even if the half-depth device is multi-U



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [NA] Documentation Updates (when adding/changing features)
- [NA] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
