### PR TITLE
Add missing fields to component BulkCreateForms and add unit test coverage

### DIFF
--- a/changes/2999.fixed
+++ b/changes/2999.fixed
@@ -1,0 +1,1 @@
+Fixed several missing fields in the UI when bulk-adding components to a list of devices.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -2360,7 +2360,7 @@ class ConsolePortCreateForm(ComponentCreateForm):
     )
 
 
-class ConsolePortBulkCreateForm(form_from_model(ConsolePort, ["type"]), DeviceBulkAddComponentForm):
+class ConsolePortBulkCreateForm(form_from_model(ConsolePort, ["type", "tags"]), DeviceBulkAddComponentForm):
     field_order = ("name_pattern", "label_pattern", "type", "description", "tags")
 
 
@@ -2427,7 +2427,7 @@ class ConsoleServerPortCreateForm(ComponentCreateForm):
     )
 
 
-class ConsoleServerPortBulkCreateForm(form_from_model(ConsoleServerPort, ["type"]), DeviceBulkAddComponentForm):
+class ConsoleServerPortBulkCreateForm(form_from_model(ConsoleServerPort, ["type", "tags"]), DeviceBulkAddComponentForm):
     field_order = ("name_pattern", "label_pattern", "type", "description", "tags")
 
 
@@ -2501,7 +2501,7 @@ class PowerPortCreateForm(ComponentCreateForm):
 
 
 class PowerPortBulkCreateForm(
-    form_from_model(PowerPort, ["type", "maximum_draw", "allocated_draw"]),
+    form_from_model(PowerPort, ["type", "maximum_draw", "allocated_draw", "tags"]),
     DeviceBulkAddComponentForm,
 ):
     field_order = (
@@ -2600,7 +2600,7 @@ class PowerOutletCreateForm(ComponentCreateForm):
         self.fields["power_port"].queryset = PowerPort.objects.filter(device=device)
 
 
-class PowerOutletBulkCreateForm(form_from_model(PowerOutlet, ["type", "feed_leg"]), DeviceBulkAddComponentForm):
+class PowerOutletBulkCreateForm(form_from_model(PowerOutlet, ["type", "feed_leg", "tags"]), DeviceBulkAddComponentForm):
     field_order = (
         "name_pattern",
         "label_pattern",
@@ -2879,17 +2879,29 @@ class InterfaceCreateForm(ComponentCreateForm, InterfaceCommonForm):
 
 
 class InterfaceBulkCreateForm(
-    form_from_model(Interface, ["type", "enabled", "mtu", "mgmt_only"]),
+    form_from_model(Interface, ["enabled", "mtu", "mgmt_only", "mode", "tags"]),
     DeviceBulkAddComponentForm,
 ):
+    type = forms.ChoiceField(
+        choices=InterfaceTypeChoices,
+        widget=StaticSelect2(),
+    )
+    status = DynamicModelChoiceField(
+        required=True,
+        queryset=Status.objects.all(),
+        query_params={"content_types": Interface._meta.label_lower},
+    )
+
     field_order = (
         "name_pattern",
         "label_pattern",
+        "status",
         "type",
         "enabled",
         "mtu",
         "mgmt_only",
         "description",
+        "mode",
         "tags",
     )
 
@@ -3292,7 +3304,7 @@ class RearPortCreateForm(ComponentCreateForm):
     )
 
 
-class RearPortBulkCreateForm(form_from_model(RearPort, ["type", "positions"]), DeviceBulkAddComponentForm):
+class RearPortBulkCreateForm(form_from_model(RearPort, ["type", "positions", "tags"]), DeviceBulkAddComponentForm):
     field_order = (
         "name_pattern",
         "label_pattern",
@@ -3377,7 +3389,7 @@ class PopulateDeviceBayForm(BootstrapMixin, forms.Form):
         ).exclude(pk=device_bay.device.pk)
 
 
-class DeviceBayBulkCreateForm(DeviceBulkAddComponentForm):
+class DeviceBayBulkCreateForm(form_from_model(DeviceBay, ["tags"]), DeviceBulkAddComponentForm):
     field_order = ("name_pattern", "label_pattern", "description", "tags")
 
 
@@ -3505,7 +3517,7 @@ class InventoryItemCSVForm(CustomFieldModelCSVForm):
 
 
 class InventoryItemBulkCreateForm(
-    form_from_model(InventoryItem, ["manufacturer", "part_id", "serial", "asset_tag", "discovered"]),
+    form_from_model(InventoryItem, ["manufacturer", "part_id", "serial", "asset_tag", "discovered", "tags"]),
     DeviceBulkAddComponentForm,
 ):
     field_order = (

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+import unittest
 
 import pytz
 import yaml
@@ -1850,6 +1851,15 @@ class PowerOutletTestCase(ViewTestCases.DeviceComponentViewTestCase):
             "tags": [t.pk for t in Tag.objects.get_for_model(PowerOutlet)],
         }
 
+        cls.bulk_add_data = {
+            "device": device.pk,
+            "name_pattern": "Power Outlet [4-6]",
+            "type": PowerOutletTypeChoices.TYPE_IEC_C13,
+            "feed_leg": PowerOutletFeedLegChoices.FEED_LEG_B,
+            "description": "A power outlet",
+            "tags": [t.pk for t in Tag.objects.get_for_model(PowerOutlet)],
+        }
+
         cls.bulk_edit_data = {
             "type": PowerOutletTypeChoices.TYPE_IEC_C15,
             "power_port": powerports[1].pk,
@@ -1910,6 +1920,7 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.bulk_create_data = {
             "device": device.pk,
             "name_pattern": "Interface [4-6]",
+            "label_pattern": "Interface Number [4-6]",
             "type": InterfaceTypeChoices.TYPE_1GE_GBIC,
             "enabled": False,
             "bridge": interfaces[4].pk,
@@ -1917,12 +1928,26 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             "mac_address": EUI("01:02:03:04:05:06"),
             "mtu": 2000,
             "mgmt_only": True,
-            "description": "A front port",
+            "description": "An Interface",
             "mode": InterfaceModeChoices.MODE_TAGGED,
             "untagged_vlan": vlans[0].pk,
             "tagged_vlans": [v.pk for v in vlans[1:4]],
             "tags": [t.pk for t in Tag.objects.get_for_model(Interface)],
             "status": status_active.pk,
+        }
+
+        cls.bulk_add_data = {
+            "device": device.pk,
+            "name_pattern": "Interface [4-6]",
+            "label_pattern": "Interface Number [4-6]",
+            "status": status_active.pk,
+            "type": InterfaceTypeChoices.TYPE_1GE_GBIC,
+            "enabled": True,
+            "mtu": 1500,
+            "mgmt_only": False,
+            "description": "An Interface",
+            "mode": InterfaceModeChoices.MODE_TAGGED,
+            "tags": [],
         }
 
         cls.bulk_edit_data = {
@@ -1997,6 +2022,10 @@ class FrontPortTestCase(ViewTestCases.DeviceComponentViewTestCase):
             "Device 1,Front Port 5,8p8c,Rear Port 5,1",
             "Device 1,Front Port 6,8p8c,Rear Port 6,1",
         )
+
+    @unittest.skip("No DeviceBulkAddFrontPortView exists at present")
+    def test_bulk_add_component(self):
+        pass
 
 
 class RearPortTestCase(ViewTestCases.DeviceComponentViewTestCase):

--- a/nautobot/virtualization/forms.py
+++ b/nautobot/virtualization/forms.py
@@ -762,11 +762,17 @@ class VirtualMachineBulkAddComponentForm(CustomFieldModelBulkEditFormMixin, Boot
 
 
 class VMInterfaceBulkCreateForm(
-    form_from_model(VMInterface, ["enabled", "mtu", "description", "mode"]),
+    form_from_model(VMInterface, ["enabled", "mtu", "description", "mode", "tags"]),
     VirtualMachineBulkAddComponentForm,
 ):
+    status = DynamicModelChoiceField(
+        queryset=Status.objects.all(),
+        query_params={"content_types": VMInterface._meta.label_lower},
+    )
+
     field_order = (
         "name_pattern",
+        "status",
         "enabled",
         "mtu",
         "description",

--- a/nautobot/virtualization/tests/test_views.py
+++ b/nautobot/virtualization/tests/test_views.py
@@ -340,6 +340,18 @@ class VMInterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             "tags": [t.pk for t in Tag.objects.get_for_model(VMInterface)],
         }
 
+        cls.bulk_add_data = {
+            "virtual_machine": virtualmachines[1].pk,
+            "name_pattern": "Interface [4-6]",
+            "enabled": True,
+            "status": status_active.pk,
+            "mtu": 1500,
+            "description": "New Description",
+            "mode": InterfaceModeChoices.MODE_TAGGED,
+            "custom_field_1": "Custom field data",
+            "tags": [],
+        }
+
         cls.csv_data = (
             "virtual_machine,name,status",
             "Virtual Machine 2,Interface 4,active",


### PR DESCRIPTION
# Closes: #2999 
# What's Changed

- When bulk-adding Interfaces to a list of Devices, or VMInterfaces to a list of VirtualMachines, the UI form was missing a `status` field; after #1753, this meant that component creation would fail validation. I've added this missing field to both forms.
- Additionally, when bulk-adding Interfaces, the `type` field was incorrectly marked as optional rather than mandatory. I've fixed this.
- All of the DeviceBulkAddComponentForm subclasses were missing a `tags` field (it was removed inadvertently in #1505) so I've added it back in to these forms.
- I also added `mode` as a field on `InterfaceBulkCreateForm` as this field was present on `VMInterfaceBulkCreateForm` but missing here for no apparent reason.

Before:

![image](https://user-images.githubusercontent.com/5603551/207918675-d7971bee-4a61-4df9-9cb1-89092a0114c6.png)

After:

![image](https://user-images.githubusercontent.com/5603551/207918772-1bd4bd18-2284-4117-9f25-c39fae9bc86d.png)

Additionally, as far as I can tell, there was **no** existing unit test automation for this set of views/forms; I've added a generic test case to the `DeviceComponentViewTestCase` base class to provide basic success-path coverage for these views.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
