### PR TITLE
Add change logging for relationship changes

### DIFF
--- a/changes/2951.added
+++ b/changes/2951.added
@@ -1,0 +1,1 @@
+Added change logging when relationships are changed.

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -2,10 +2,11 @@ import uuid
 from contextlib import contextmanager
 
 from django.contrib.auth import get_user_model
-from django.db.models.signals import m2m_changed, pre_delete, post_save
+from django.db.models.signals import m2m_changed, post_delete, post_save, pre_delete
 from django.test.client import RequestFactory
 
 from nautobot.extras.choices import ObjectChangeEventContextChoices
+from nautobot.extras.models import RelationshipAssociation
 from nautobot.extras.signals import _handle_changed_object, _handle_deleted_object
 from nautobot.utilities.utils import curry
 
@@ -92,6 +93,7 @@ def change_logging(change_context):
     post_save.connect(handle_changed_object, dispatch_uid="handle_changed_object")
     m2m_changed.connect(handle_changed_object, dispatch_uid="handle_changed_object")
     pre_delete.connect(handle_deleted_object, dispatch_uid="handle_deleted_object")
+    post_delete.connect(handle_deleted_object, dispatch_uid="handle_deleted_object", sender=RelationshipAssociation)
 
     yield
 
@@ -100,6 +102,7 @@ def change_logging(change_context):
     post_save.disconnect(handle_changed_object, dispatch_uid="handle_changed_object")
     m2m_changed.disconnect(handle_changed_object, dispatch_uid="handle_changed_object")
     pre_delete.disconnect(handle_deleted_object, dispatch_uid="handle_deleted_object")
+    post_delete.disconnect(handle_deleted_object, dispatch_uid="handle_deleted_object", sender=RelationshipAssociation)
 
 
 @contextmanager

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -315,6 +315,8 @@ def _handle_relationship_association_change(change_context, sender, instance, **
     from .jobs import enqueue_job_hooks  # avoid circular import
 
     for related_object in [instance.source, instance.destination]:
+        if related_object is None:
+            continue
         if hasattr(related_object, "to_objectchange"):
             updated_objectchange = related_object.to_objectchange(ObjectChangeActionChoices.ACTION_UPDATE)
             related_changes = ObjectChange.objects.filter(

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -1430,11 +1430,10 @@ class RelationshipChangeLoggingTest(TestCase):
 
             # ensure diff only contains added relationship
             snapshots = object_change.get_snapshots()
-            expected_diff = copy.deepcopy(base_diff)
-            expected_diff["relationships"][self.site_ip_relationship.slug].pop("source")
-            self.assertEqual(snapshots["differences"]["removed"], expected_diff)
-
-            expected_diff["relationships"][self.site_ip_relationship.slug]["destination"]["objects"] = [
+            removed_diff = copy.deepcopy(base_diff)
+            removed_diff["relationships"][self.site_ip_relationship.slug].pop("source")
+            added_diff = copy.deepcopy(removed_diff)
+            added_diff["relationships"][self.site_ip_relationship.slug]["destination"]["objects"] = [
                 {
                     "id": str(self.ip.pk),
                     "url": "http://testserver" + reverse("ipam-api:ipaddress-detail", kwargs={"pk": self.ip.pk}),
@@ -1443,7 +1442,8 @@ class RelationshipChangeLoggingTest(TestCase):
                     "family": self.ip.family,
                 }
             ]
-            self.assertEqual(snapshots["differences"]["added"], expected_diff)
+            self.assertEqual(snapshots["differences"]["removed"], removed_diff)
+            self.assertEqual(snapshots["differences"]["added"], added_diff)
 
         with self.subTest("Destination object change was generated"):
             self.assertEqual(get_changes_for_model(self.ip).count(), 2)
@@ -1452,11 +1452,10 @@ class RelationshipChangeLoggingTest(TestCase):
 
             # ensure diff only contains added relationship
             snapshots = object_change.get_snapshots()
-            expected_diff = copy.deepcopy(base_diff)
-            expected_diff["relationships"][self.site_ip_relationship.slug].pop("destination")
-            self.assertEqual(snapshots["differences"]["removed"], expected_diff)
-
-            expected_diff["relationships"][self.site_ip_relationship.slug]["source"]["objects"] = [
+            removed_diff = copy.deepcopy(base_diff)
+            removed_diff["relationships"][self.site_ip_relationship.slug].pop("destination")
+            added_diff = copy.deepcopy(removed_diff)
+            added_diff["relationships"][self.site_ip_relationship.slug]["source"]["objects"] = [
                 {
                     "id": str(self.site.pk),
                     "url": "http://testserver" + reverse("dcim-api:site-detail", kwargs={"pk": self.site.pk}),
@@ -1465,7 +1464,8 @@ class RelationshipChangeLoggingTest(TestCase):
                     "slug": self.site.slug,
                 }
             ]
-            self.assertEqual(snapshots["differences"]["added"], expected_diff)
+            self.assertEqual(snapshots["differences"]["removed"], removed_diff)
+            self.assertEqual(snapshots["differences"]["added"], added_diff)
 
     def test_change_logging_with_object_save(self):
         """

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -32,6 +32,7 @@ from django_filters import (
     NumberFilter,
 )
 from django_filters.utils import verbose_lookup_expr
+from rest_framework.test import APIRequestFactory
 from taggit.managers import _TaggableManager
 
 from nautobot.dcim.choices import CableLengthUnitChoices
@@ -230,7 +231,9 @@ def serialize_object_v2(obj):
     # Try serializing obj(model instance) using its API Serializer
     try:
         serializer_class = get_serializer_for_model(obj.__class__)
-        data = serializer_class(obj, context={"request": None}).data
+        request = APIRequestFactory().get("/", {"include": ["relationships"]})
+        request.version = settings.REST_FRAMEWORK_VERSION
+        data = serializer_class(obj, context={"request": request}).data
     except SerializerNotFound:
         # Fall back to generic JSON representation of obj
         data = serialize_object(obj)

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -231,6 +231,7 @@ def serialize_object_v2(obj):
     # Try serializing obj(model instance) using its API Serializer
     try:
         serializer_class = get_serializer_for_model(obj.__class__)
+        # create a fake request to include opt-in `relationships` field if available
         request = APIRequestFactory().get("/", {"include": ["relationships"]})
         request.version = settings.REST_FRAMEWORK_VERSION
         data = serializer_class(obj, context={"request": request}).data


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #2951 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Changes to `RelationshipAssociation` objects will now trigger an `ObjectChange` to be created for the `source` and `destination` related objects

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
