### PR TITLE
Update Select2 Widgets to Know if They Are in a Modal

### DIFF
--- a/changes/3018.fixed
+++ b/changes/3018.fixed
@@ -1,1 +1,1 @@
-Update Select2 widgets to know they are in a modal.
+Fixed rendering of Select2 widgets in modal dialogs.

--- a/changes/3018.fixed
+++ b/changes/3018.fixed
@@ -1,0 +1,1 @@
+Update Select2 widgets to know they are in a modal.

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -619,7 +619,7 @@ function initializeInputs(context) {
     initializeSelectAllForm(this_context)
     initializeMultiValueChar(this_context)
 
-    $(".modal").each(function() {
+    $(this_context).each(function() {
         this_modal = $(this)
         initializeStaticChoiceSelection(this_modal, this_modal)
         initializeColorPicker(this_modal, this_modal)

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -619,7 +619,7 @@ function initializeInputs(context) {
     initializeSelectAllForm(this_context)
     initializeMultiValueChar(this_context)
 
-    $(this_context).each(function() {
+    $(this_context).find(".modal").each(function() {
         this_modal = $(this)
         initializeStaticChoiceSelection(this_modal, this_modal)
         initializeColorPicker(this_modal, this_modal)

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -50,13 +50,14 @@ function colorPickerClassCopy(data, container) {
 */
 
 // Static choice selection
-function initializeStaticChoiceSelection(context){
+function initializeStaticChoiceSelection(context, dropdownParent=null){
     this_context = $(context);
     this_context.find('.nautobot-select2-static').select2({
         allowClear: true,
         placeholder: "---------",
         theme: "bootstrap",
-        width: "off"
+        width: "off",
+        dropdownParent: dropdownParent
     });
 }
 
@@ -139,7 +140,7 @@ function initializeBulkEditNullification(context){
 }
 
 // Color Picker
-function initializeColorPicker(context){
+function initializeColorPicker(context, dropdownParent=null){
     this_context = $(context);
     this_context.find('.nautobot-select2-color-picker').select2({
         allowClear: true,
@@ -147,18 +148,20 @@ function initializeColorPicker(context){
         theme: "bootstrap",
         templateResult: colorPickerClassCopy,
         templateSelection: colorPickerClassCopy,
-        width: "off"
+        width: "off",
+        dropdownParent: dropdownParent
     });
 }
 
 // Dynamic Choice Selection
-function initializeDynamicChoiceSelection(context){
+function initializeDynamicChoiceSelection(context, dropdownParent=null){
     this_context = $(context);
     this_context.find('.nautobot-select2-api').select2({
         allowClear: true,
         placeholder: "---------",
         theme: "bootstrap",
         width: "off",
+        dropdownParent: dropdownParent,
         ajax: {
             delay: 500,
 
@@ -328,7 +331,7 @@ function initializeDateTimePicker(context){
     });
 }
 
-function initializeTags(context){
+function initializeTags(context, dropdownParent=null){
     this_context = $(context);
     this_tag_field = this_context.find('#id_tags.tagfield')
     var tags = this_tag_field;
@@ -354,6 +357,7 @@ function initializeTags(context){
         placeholder: "Tags",
         theme: "bootstrap",
         width: "off",
+        dropdownParent: dropdownParent,
         ajax: {
             delay: 250,
             url: nautobot_api_path + "extras/tags/",
@@ -439,7 +443,7 @@ function initializeVLANModeSelection(context){
     }
 }
 
-function initializeMultiValueChar(context){
+function initializeMultiValueChar(context, dropdownParent=null){
     this_context = $(context);
     this_context.find('.nautobot-select2-multi-value-char').select2({
         allowClear: true,
@@ -447,6 +451,7 @@ function initializeMultiValueChar(context){
         theme: "bootstrap",
         placeholder: "---------",
         multiple: true,
+        dropdownParent: dropdownParent,
         width: "off",
         "language": {
             "noResults": function(){
@@ -613,6 +618,15 @@ function initializeInputs(context) {
     initializeDynamicFilterForm(this_context)
     initializeSelectAllForm(this_context)
     initializeMultiValueChar(this_context)
+
+    $(".modal").each(function() {
+        this_modal = $(this)
+        initializeStaticChoiceSelection(this_modal, this_modal)
+        initializeColorPicker(this_modal, this_modal)
+        initializeDynamicChoiceSelection(this_modal, this_modal)
+        initializeTags(this_modal, this_modal)
+        initializeMultiValueChar(this_modal, this_modal)
+    })
 }
 
 function jsify_form(context) {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3018
# What's Changed
- Add `dropdownParent` argument to Select2 initializers (defaults to null for legacy calls)
- Loop over modals to reinitialize their Select2 widgets to update the dropdownParent property

**Demo:**

https://user-images.githubusercontent.com/31187/208224990-b454b072-c5a3-447d-976a-1e66b8301532.mov



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [NA] Documentation Updates (when adding/changing features)
- [NA] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
