### PR TITLE
Fix bug preventing filters from being removed from list views

### DIFF
--- a/changes/3104.fixed
+++ b/changes/3104.fixed
@@ -1,0 +1,1 @@
+Fixed bug preventing filters from being removed from list views.

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -56,29 +56,29 @@
 {% if filter_params %}
 <div class="filters-applied">
     <b>Filters:</b>
-    {% for field, values in filter_params %}
+    {% for field in filter_params %}
     <span class="filter-container" dir="ltr">
         <span
                 class="filter-selection">
-            <b>{{ field }}:</b>
+            <b>{{ field.display }}:</b>
             <span
                     class="remove-filter-param"
                     title="Remove all items"
                     data-field-type="parent"
-                    data-field-value={{ field }}
+                    data-field-value={{ field.name }}
             >×</span>
             <ul class="filter-selection-rendered">
-                {% for value in values %}
+                {% for value in field.values %}
                 <li
                         class="filter-selection-choice"
-                        title="{{ value }}"
+                        title="{{ value.name }}"
                 >
                     <span
                             class="filter-selection-choice-remove remove-filter-param"
                             data-field-type="child"
-                            data-field-parent={{ field }}
-                            data-field-value={{ value }}
-                    >×</span>{{ value }}
+                            data-field-parent={{ field.name }}
+                            data-field-value={{ value.name }}
+                    >×</span>{{ value.display }}
                 </li>
                 {% endfor %}
             </ul>
@@ -160,7 +160,7 @@
     clipboard.on('success', function (e) {});
 
     clipboard.on('error', function (e) {});
-    
+
     $('.formset_row-dynamic-filterform').formset({
         addText: '<span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add another Filter',
         addCssClass: 'btn btn-primary add-row',

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -40,7 +40,7 @@
         <button type="button" class="btn btn-default" data-toggle="modal" data-target="#ObjectTable_config" title="Configure table"><i class="mdi mdi-cog"></i> Configure</button>
     {% endif %}
     {% if filter_form or dynamic_filter_form %}
-        <button type="button" class="btn btn-default" data-toggle="modal" data-target="#FilterForm_modal" title="Add filters"><i class="mdi mdi-filter"></i> Filter</button>
+        <button type="button" class="btn btn-default" data-toggle="modal" data-target="#FilterForm_modal" title="Add filters" id="id__filterbtn"><i class="mdi mdi-filter"></i> Filter</button>
     {% endif %}
     {% if permissions.add and 'add' in action_buttons %}
         {% add_button content_type.model_class|validated_viewname:"add" %}

--- a/nautobot/core/tests/integration/test_filters.py
+++ b/nautobot/core/tests/integration/test_filters.py
@@ -1,0 +1,84 @@
+from django.urls import reverse
+
+from nautobot.dcim.models import Region
+from nautobot.utilities.testing.integration import SeleniumTestCase
+
+
+class ListViewFilterTestCase(SeleniumTestCase):
+    """Integration test for the list view filter ui."""
+
+    fixtures = ["user-data.json"]
+
+    def setUp(self):
+        super().setUp()
+        self.login(self.user.username, self.password)
+
+    def tearDown(self):
+        self.logout()
+        super().tearDown()
+
+    def test_list_view_filter(self):
+        """
+        Test adding a filter with the list view filter modal and then
+        removing the filter with the list view "filters" ui element.
+        """
+        # set test user to admin
+        self.user.is_superuser = True
+        self.user.save()
+
+        # retrieve site list view
+        self.browser.visit(f"{self.live_server_url}{reverse('dcim:site_list')}")
+        filter_modal = self.browser.find_by_id("FilterForm_modal", wait_time=3)
+        self.assertFalse(filter_modal.visible)
+
+        # click on filter button to open the filter modal
+        filter_button = self.browser.find_by_id("id__filterbtn", wait_time=3)
+        filter_button.click()
+
+        # assert the filter modal has appeared
+        self.assertTrue(filter_modal.visible)
+
+        # start typing a region into select2
+        region = Region.objects.first()
+        region_select = filter_modal.find_by_xpath(
+            "//label[@for='id_region']/..//input[@class='select2-search__field']", wait_time=3
+        )
+        for _ in region_select.type(f"{region.name[:4]}", slowly=True):
+            pass
+
+        # click region option in select2
+        region_option_xpath = f"//ul[@id='select2-id_region-results']//li[text()='{region.name}']"
+        region_option = self.browser.find_by_xpath(region_option_xpath, wait_time=3)
+        region_option.click()
+
+        # click apply button in filter modal
+        apply_button = filter_modal.find_by_xpath("//div[@id='default-filter']//button[@type='submit']", wait_time=3)
+        apply_button.click()
+
+        # assert the url has changed to add the filter param
+        filtered_sites_url = self.browser.url
+        self.assertIn("region=", filtered_sites_url)
+
+        # find and click the remove all filter X button
+        remove_all_filters = self.browser.find_by_xpath(
+            "//div[@class='filters-applied']//span[@class='filter-selection']//span[@class='remove-filter-param']",
+            wait_time=3,
+        )
+        remove_all_filters.click()
+
+        # assert the filter param has been removed from the url
+        self.assertNotIn("region=", self.browser.url)
+
+        # navigate back to the filter page and try the individual filter remove X button
+        self.browser.visit(filtered_sites_url)
+        remove_single_filter = self.browser.find_by_xpath(
+            "//div[@class='filters-applied']//span[@class='filter-selection']//span[@class='filter-selection-choice-remove remove-filter-param']",
+            wait_time=3,
+        )
+        remove_single_filter.click()
+
+        # assert the filter has been removed from the url
+        self.assertNotIn("region=", self.browser.url)
+
+        # assert the filter UI element is gone
+        self.assertTrue(self.browser.is_element_not_present_by_xpath("//div[@class='filters-applied']"))

--- a/nautobot/core/tests/test_utilities.py
+++ b/nautobot/core/tests/test_utilities.py
@@ -16,7 +16,11 @@ class CheckFilterForDisplayTest(TestCase):
         device_filter_set_filters = DeviceFilterSet().get_filters()
 
         with self.subTest("Test invalid filter case (field_name not found)"):
-            expected_output = ["fake_field_name", ["example_field_value"]]
+            expected_output = {
+                "name": "fake_field_name",
+                "display": "fake_field_name",
+                "values": [{"name": "example_field_value", "display": "example_field_value"}],
+            }
 
             self.assertEqual(
                 check_filter_for_display(device_filter_set_filters, "fake_field_name", ["example_field_value"]),
@@ -24,7 +28,11 @@ class CheckFilterForDisplayTest(TestCase):
             )
 
         with self.subTest("Test values are converted to list"):
-            expected_output = ["fake_field_name", ["example_field_value"]]
+            expected_output = {
+                "name": "fake_field_name",
+                "display": "fake_field_name",
+                "values": [{"name": "example_field_value", "display": "example_field_value"}],
+            }
 
             self.assertEqual(
                 check_filter_for_display(device_filter_set_filters, "fake_field_name", "example_field_value"),
@@ -32,14 +40,22 @@ class CheckFilterForDisplayTest(TestCase):
             )
 
         with self.subTest("Test get field label, none exists (fallback)"):
-            expected_output = ["id", ["example_field_value"]]
+            expected_output = {
+                "name": "id",
+                "display": "id",
+                "values": [{"name": "example_field_value", "display": "example_field_value"}],
+            }
 
             self.assertEqual(
                 check_filter_for_display(device_filter_set_filters, "id", ["example_field_value"]), expected_output
             )
 
         with self.subTest("Test get field label, exists"):
-            expected_output = ["Has interfaces", ["example_field_value"]]
+            expected_output = {
+                "name": "has_interfaces",
+                "display": "Has interfaces",
+                "values": [{"name": "example_field_value", "display": "example_field_value"}],
+            }
 
             self.assertEqual(
                 check_filter_for_display(device_filter_set_filters, "has_interfaces", ["example_field_value"]),
@@ -50,7 +66,11 @@ class CheckFilterForDisplayTest(TestCase):
             "Test get value display, falls back to string representation (also NaturalKeyOrPKMultipleChoiceFilter)"
         ):
             example_obj = DeviceRedundancyGroup.objects.first()
-            expected_output = ["Device Redundancy Groups (slug or ID)", [str(example_obj)]]
+            expected_output = {
+                "name": "device_redundancy_group",
+                "display": "Device Redundancy Groups (slug or ID)",
+                "values": [{"name": str(example_obj.pk), "display": str(example_obj)}],
+            }
 
             self.assertEqual(
                 check_filter_for_display(device_filter_set_filters, "device_redundancy_group", [str(example_obj.pk)]),
@@ -59,7 +79,11 @@ class CheckFilterForDisplayTest(TestCase):
 
         with self.subTest("Test get value display (also legacy filter ModelMultipleChoiceFilter)"):
             example_obj = DeviceType.objects.first()
-            expected_output = ["Device type (ID)", [example_obj.display]]
+            expected_output = {
+                "name": "device_type_id",
+                "display": "Device type (ID)",
+                "values": [{"name": str(example_obj.pk), "display": example_obj.display}],
+            }
 
             self.assertEqual(
                 check_filter_for_display(device_filter_set_filters, "device_type_id", [str(example_obj.pk)]),
@@ -67,7 +91,11 @@ class CheckFilterForDisplayTest(TestCase):
             )
 
         with self.subTest("Test skip non-UUID value display (legacy, ex: ModelMultipleChoiceFilter)"):
-            expected_output = ["Manufacturer (slug)", ["fake_slug"]]
+            expected_output = {
+                "name": "manufacturer",
+                "display": "Manufacturer (slug)",
+                "values": [{"name": "fake_slug", "display": "fake_slug"}],
+            }
 
             self.assertEqual(
                 check_filter_for_display(device_filter_set_filters, "manufacturer", ["fake_slug"]), expected_output

--- a/nautobot/core/utilities.py
+++ b/nautobot/core/utilities.py
@@ -13,22 +13,32 @@ def check_filter_for_display(filters, field_name, values):
         values (list[str]): List of strings that may be PKs to look up
 
     Returns:
-        (list): A two item list containing:
-            - [0]: (str) Resolved field name, whether that's a field label of fallback to inputted `field_name` if label unavailable
-            - [1]: (list) Resolved field values, the return of `.display` property of the object, or the original inputted value
+        (dict): A dict containing:
+            - name: (str) Field name
+            - display: (str) Resolved field name, whether that's a field label of fallback to inputted `field_name` if label unavailable
+            - values: (list) List of dictionaries with the same `name` and `display` keys
     """
     values = values if isinstance(values, (list, tuple)) else [values]
 
-    if field_name not in filters.keys():
-        return [field_name, values]
+    resolved_filter = {
+        "name": field_name,
+        "display": field_name,
+        "values": [{"name": value, "display": value} for value in values],
+    }
 
-    label = filters[field_name].label if filters[field_name].label else field_name
+    if field_name not in filters.keys():
+        return resolved_filter
+
+    resolved_filter["display"] = filters[field_name].label or field_name
     if len(values) == 0 or not hasattr(filters[field_name], "queryset") or not is_uuid(values[0]):
-        return [label, values]
+        return resolved_filter
     else:
         try:
-            filtered_results = filters[field_name].queryset.filter(pk__in=values)
-            new_values = [result.display if hasattr(result, "display") else str(result) for result in filtered_results]
-            return [label, new_values]
+            new_values = []
+            for value in filters[field_name].queryset.filter(pk__in=values):
+                new_values.append({"name": str(value), "display": getattr(value, "display", str(value))})
+            resolved_filter["values"] = new_values
         except (FieldError, AttributeError):
-            return [label, values]
+            pass
+
+    return resolved_filter

--- a/nautobot/core/utilities.py
+++ b/nautobot/core/utilities.py
@@ -36,7 +36,7 @@ def check_filter_for_display(filters, field_name, values):
         try:
             new_values = []
             for value in filters[field_name].queryset.filter(pk__in=values):
-                new_values.append({"name": str(value), "display": getattr(value, "display", str(value))})
+                new_values.append({"name": str(value.pk), "display": getattr(value, "display", str(value))})
             resolved_filter["values"] = new_values
         except (FieldError, AttributeError):
             pass

--- a/nautobot/core/utilities.py
+++ b/nautobot/core/utilities.py
@@ -15,7 +15,7 @@ def check_filter_for_display(filters, field_name, values):
     Returns:
         (dict): A dict containing:
             - name: (str) Field name
-            - display: (str) Resolved field name, whether that's a field label of fallback to inputted `field_name` if label unavailable
+            - display: (str) Resolved field name, whether that's a field label or fallback to inputted `field_name` if label unavailable
             - values: (list) List of dictionaries with the same `name` and `display` keys
     """
     values = values if isinstance(values, (list, tuple)) else [values]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3104 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Fix bug in `nautobot.core.utilities.check_filter_for_display()` and update `object_list.html` to use the new `dict` format of the view's `filter_params` context variable. 
- Add an integration test to prevent this from happening going forward

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
