### PR TITLE
Possibly fix flaky integration test

### DIFF
--- a/changes/3153.fixed
+++ b/changes/3153.fixed
@@ -1,0 +1,1 @@
+Made integration test `CableConnectFormTestCase.test_js_functionality` more resilient and less prone to erroneous failures.

--- a/nautobot/dcim/tests/integration/test_cable_connect_form.py
+++ b/nautobot/dcim/tests/integration/test_cable_connect_form.py
@@ -80,6 +80,7 @@ class CableConnectFormTestCase(SeleniumTestCase):
         # Change Device selection to "Device 2"
         self.browser.find_by_xpath("//label[@for='id_termination_b_device']").click()
         self.browser.driver.switch_to.active_element.click()
+        time.sleep(0.2)
         self.browser.find_by_xpath(
             "//ul[@id='select2-id_termination_b_device-results']/li[contains(@class,'select2-results__option') and contains(text(),'Device 2')]"
         ).click()


### PR DESCRIPTION
# Closes: #N/A
# What's Changed

Earlier in this test case, after clicking on the Select2 dropdown, we have a `time.sleep(0.2)` before looking for the populated menu options. There was no such sleep here; I'm adding it to see if it makes this test pass more consistently.

If this works, we should probably also backport this fix to `develop`.

# TODO
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
