### PR TITLE
Aligned buttons on device component create page.

### DIFF
--- a/changes/3155.fixed
+++ b/changes/3155.fixed
@@ -1,0 +1,1 @@
+Aligned buttons on device component create page.

--- a/nautobot/dcim/templates/dcim/device_component_add.html
+++ b/nautobot/dcim/templates/dcim/device_component_add.html
@@ -26,7 +26,7 @@
             </div>
             {% include 'inc/extras_features_edit_form_fields.html' with form=model_form %}
             <div class="form-group">
-                <div class="col-md-9 col-md-offset-3">
+                <div class="col-md-9 col-md-offset-3 text-right">
                     <button type="submit" name="_create" class="btn btn-primary">Create</button>
                     <button type="submit" name="_addanother" class="btn btn-primary">Create and Add More</button>
                     <a href="{{ return_url }}" class="btn btn-default">Cancel</a>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3155 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
It turns out that the misalignment occurs in the `device_component_add.html`. So changing that fixes the issue.

<img width="1730" alt="Screen Shot 2023-01-24 at 3 54 42 PM" src="https://user-images.githubusercontent.com/46973263/214413296-f52ad643-9ab6-4ee4-bb9e-e4536121327f.png">

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
