### PR TITLE
Fix data mismatch in ScheduledJob causing celery worker to fail

### DIFF
--- a/changes/3169.fixed
+++ b/changes/3169.fixed
@@ -1,0 +1,1 @@
+Fixed data mismatch in ScheduledJob causing celery workers to fail.

--- a/changes/3169.fixed
+++ b/changes/3169.fixed
@@ -1,1 +1,1 @@
-Fixed data mismatch in ScheduledJob causing celery workers to fail.
+Fixed data mismatch in `ScheduledJob` causing celery workers to fail when running scheduled jobs created in versions prior to `v1.5.8`. ⚠ **NOTE**: If your celery workers are failing on startup after upgrading to `v1.5.8`, you may need to purge the celery queue with `nautobot-server celery purge` or `nautobot-server celery purge -Q <queues>` to purge custom queues.

--- a/nautobot/extras/migrations/0054_scheduledjob_kwargs_request_user_change.py
+++ b/nautobot/extras/migrations/0054_scheduledjob_kwargs_request_user_change.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+def rename_scheduled_job_kwargs_request_user(apps, schema_editor):
+    ScheduledJob = apps.get_model("extras", "ScheduledJob")
+    for sj in ScheduledJob.objects.all():
+        if "request" in sj.kwargs and sj.kwargs["request"].get("user", None) is not None:
+            sj.kwargs["request"].setdefault("_user_pk", sj.kwargs["request"].pop("user"))
+            sj.save()
+
+
+def reverse_rename_scheduled_job_kwargs_request_user(apps, schema_editor):
+    ScheduledJob = apps.get_model("extras", "ScheduledJob")
+    for sj in ScheduledJob.objects.all():
+        if "request" in sj.kwargs and sj.kwargs["request"].get("_user_pk", None) is not None:
+            sj.kwargs["request"].setdefault("user", sj.kwargs["request"].pop("_user_pk"))
+            sj.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("extras", "0053_relationship_required_on"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rename_scheduled_job_kwargs_request_user, reverse_code=reverse_rename_scheduled_job_kwargs_request_user
+        ),
+    ]

--- a/nautobot/extras/migrations/0054_scheduledjob_kwargs_request_user_change.py
+++ b/nautobot/extras/migrations/0054_scheduledjob_kwargs_request_user_change.py
@@ -2,18 +2,23 @@ from django.db import migrations
 
 
 def rename_scheduled_job_kwargs_request_user(apps, schema_editor):
+    """
+    Rename ScheduledJob.kwargs["request"]["user"] to ScheduledJob.kwargs["request"]["_user_pk"]
+    to support https://github.com/nautobot/nautobot/pull/3105 and prevent an AttributeError exception
+    when the scheduled job runs.
+    """
     ScheduledJob = apps.get_model("extras", "ScheduledJob")
     for sj in ScheduledJob.objects.all():
-        if "request" in sj.kwargs and sj.kwargs["request"].get("user", None) is not None:
-            sj.kwargs["request"].setdefault("_user_pk", sj.kwargs["request"].pop("user"))
+        if "request" in sj.kwargs:
+            sj.kwargs["request"].setdefault("_user_pk", sj.kwargs["request"].pop("user", None))
             sj.save()
 
 
 def reverse_rename_scheduled_job_kwargs_request_user(apps, schema_editor):
     ScheduledJob = apps.get_model("extras", "ScheduledJob")
     for sj in ScheduledJob.objects.all():
-        if "request" in sj.kwargs and sj.kwargs["request"].get("_user_pk", None) is not None:
-            sj.kwargs["request"].setdefault("user", sj.kwargs["request"].pop("_user_pk"))
+        if "request" in sj.kwargs:
+            sj.kwargs["request"].setdefault("user", sj.kwargs["request"].pop("_user_pk", None))
             sj.save()
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3169
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Add data migration to rename `ScheduledJob.kwargs["request"]["user"]` to `ScheduledJob.kwargs["request"]["_user_pk"]`

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
