### PR TITLE
Update VLANFactory and test_bulk_edit_objects_with_constrained_permission

### DIFF
--- a/changes/3177.changed
+++ b/changes/3177.changed
@@ -1,0 +1,1 @@
+Updated VLANFactory to generate longer and more "realistic" VLAN names.

--- a/changes/3177.fixed
+++ b/changes/3177.fixed
@@ -1,0 +1,1 @@
+Fixed a spurious failure in BulkEditObjectsViewTestCase.test_bulk_edit_objects_with_constrained_permission.

--- a/nautobot/ipam/factory.py
+++ b/nautobot/ipam/factory.py
@@ -339,23 +339,27 @@ class VLANFactory(PrimaryModelFactory):
     # As with VLANGroup, with fully random names and vids, non-uniqueness is unlikely but possible,
     # and we might want to consider intentionally reusing non-unique values for test purposes?
     vid = factory.Faker("pyint", min_value=1, max_value=4094)
+    # Generate names like "vlan__0001__purple__GROUP__Floor-1__242_Vasquez_Freeway" or "vlan__1234__easy",
+    # depending on which of (group, location, site) are defined, if any.
     name = factory.LazyAttribute(
         lambda o: "__".join(
             [
                 str(x)
-                for x in filter(
+                for x in filter(  # Filter out Nones from the tuple so name isn't "vlan__1234__easy__None__None__None"
                     None,
                     (
                         "vlan",
-                        f"{o.vid:04d}",
+                        f"{o.vid:04d}",  # "0001" rather than "1", for more consistent names
                         faker.Faker().word(part_of_speech="adjective"),
-                        o.group,
-                        o.location,
-                        str(o.site).replace(" ", "_"),
+                        o.group,  # may be None
+                        o.location,  # may be None
+                        str(o.site).replace(" ", "_") if o.site else None,  # may be None
                     ),
                 )
             ]
-        )[:255]
+        )[
+            :255
+        ]  # truncate to max VLAN.name length just to be safe
     )
 
     status = random_instance(lambda: Status.objects.get_for_model(VLAN), allow_null=False)

--- a/nautobot/ipam/factory.py
+++ b/nautobot/ipam/factory.py
@@ -339,11 +339,23 @@ class VLANFactory(PrimaryModelFactory):
     # As with VLANGroup, with fully random names and vids, non-uniqueness is unlikely but possible,
     # and we might want to consider intentionally reusing non-unique values for test purposes?
     vid = factory.Faker("pyint", min_value=1, max_value=4094)
-    name = factory.LazyFunction(
-        lambda: (
-            faker.Faker().word(part_of_speech="adjective").capitalize()
-            + faker.Faker().word(part_of_speech="noun").capitalize()
-        )
+    name = factory.LazyAttribute(
+        lambda o: "__".join(
+            [
+                str(x)
+                for x in filter(
+                    None,
+                    (
+                        "vlan",
+                        f"{o.vid:04d}",
+                        faker.Faker().word(part_of_speech="adjective"),
+                        o.group,
+                        o.location,
+                        str(o.site).replace(" ", "_"),
+                    ),
+                )
+            ]
+        )[:255]
     )
 
     status = random_instance(lambda: Status.objects.get_for_model(VLAN), allow_null=False)

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -1061,42 +1061,47 @@ class ViewTestCases:
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
         def test_bulk_edit_objects_with_constrained_permission(self):
-            pk_list = list(self._get_queryset().values_list("pk", flat=True)[:3])
-            data = {
-                "pk": pk_list,
-                "_apply": True,  # Form button
-            }
-
-            # Append the form data to the request
-            data.update(post_data(self.bulk_edit_data))
-
-            # Dynamically determine a constraint that will *not* be matched by the updated objects.
+            # Select some objects that are *not* already set to match the first value in self.bulk_edit_data
             attr_name = list(self.bulk_edit_data.keys())[0]
-            field = self.model._meta.get_field(attr_name)
-            value = field.value_from_object(
-                self._get_queryset().exclude(**{attr_name: self.bulk_edit_data[attr_name]}).first()
-            )
+            objects = self._get_queryset().exclude(**{attr_name: self.bulk_edit_data[attr_name]})[:3]
+            self.assertEqual(objects.count(), 3)
+            pk_list = list(objects.values_list("pk", flat=True))
 
-            # Assign constrained permission
+            # Define a permission that permits the above objects, but will not permit them after updating them.
+            field = self.model._meta.get_field(attr_name)
+            values = [field.value_from_object(obj) for obj in objects]
             obj_perm = ObjectPermission(
                 name="Test permission",
-                constraints={attr_name: value},
+                constraints={f"{attr_name}__in": values},
                 actions=["change"],
             )
             obj_perm.save()
             obj_perm.users.add(self.user)
             obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
 
+            # Build form data
+            data = {
+                "pk": pk_list,
+                "_apply": True,  # Form button
+            }
+            data.update(post_data(self.bulk_edit_data))
+
             # Attempt to bulk edit permitted objects into a non-permitted state
             response = self.client.post(self._get_url("bulk_edit"), data)
+            # 200 because we're sent back to the edit form to try again; if the update were successful it'd be a 302
             self.assertHttpStatus(response, 200)
+            # Assert that the objects are NOT updated
+            for instance in self._get_queryset().filter(pk__in=pk_list):
+                self.assertIn(field.value_from_object(instance), values)
+                self.assertNotEqual(field.value_from_object(instance), self.bulk_edit_data[attr_name])
 
-            # Update permission constraints
+            # Update permission constraints to permit all objects
             obj_perm.constraints = {"pk__gt": 0}
             obj_perm.save()
 
-            # Bulk edit permitted objects
+            # Bulk edit permitted objects and expect a redirect back to the list view
             self.assertHttpStatus(self.client.post(self._get_url("bulk_edit"), data), 302)
+            # Assert that the objects were all updated correctly
             for instance in self._get_queryset().filter(pk__in=pk_list):
                 self.assertInstanceEqual(instance, self.bulk_edit_data)
 


### PR DESCRIPTION
# Closes: #N/A
# What's Changed

- Update VLANFactory to use longer and more "realistic" names (originally implemented as part of, but then backed out of #3173)
- This factory change to the test data uncovered a failure case in `BulkEditObjectsViewTestCase.test_bulk_edit_objects_with_constrained_permission` - namely, if the objects that it selects to bulk-edit *already have an attribute set to the bulk-edit target value for this attribute*, then the permission constraint that it defines will forbid editing these objects, causing the test to fail.
   - I've revised the test so that it now explicitly selects objects that are *not* set to the bulk-edit target value, and ensures that *all* of these objects are included in the permission constraint as permitted.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
