### PR TITLE
ConfigContext data migration and make sure the SiteLocationType.content_types is set to allow all Location ContentTypes

### DIFF
--- a/changes/3222.added
+++ b/changes/3222.added
@@ -1,0 +1,1 @@
+Added Site and Region data migration for ConfigContext class and ensured that "Site" LocationType allows the correct ContentTypes.

--- a/nautobot/dcim/migrations/0030_migrate_region_and_site_data_to_locations.py
+++ b/nautobot/dcim/migrations/0030_migrate_region_and_site_data_to_locations.py
@@ -4,6 +4,7 @@ import logging
 
 from django.db import migrations
 from django.db.utils import IntegrityError
+from nautobot.extras.utils import FeatureQuery
 
 logger = logging.getLogger(__name__)
 
@@ -175,6 +176,18 @@ def migrate_site_and_region_data_to_locations(apps, schema_editor):
             exclude_lt="Site",
         )
 
+    # Reassign Region Models to Locations of Region LocationType
+    if Region.objects.exists():
+        ConfigContext = apps.get_model("extras", "configcontext")
+        ccs = ConfigContext.objects.filter(regions__isnull=False).prefetch_related("locations", "regions")
+        for cc in ccs:
+            region_name_list = list(cc.regions.all().values_list("name", flat=True))
+            region_locs = list(Location.objects.filter(name__in=region_name_list, location_type=region_lt))
+            original_locs = list(cc.locations.all())
+            locations = region_locs + original_locs
+            cc.locations.set(locations)
+            cc.save()
+
     # Reassign Site Models to Locations of Site LocationType
     if Site.objects.exists():  # Iff Site instances exist
         CircuitTermination = apps.get_model("circuits", "circuittermination")
@@ -182,15 +195,28 @@ def migrate_site_and_region_data_to_locations(apps, schema_editor):
         PowerPanel = apps.get_model("dcim", "powerpanel")
         RackGroup = apps.get_model("dcim", "rackgroup")
         Rack = apps.get_model("dcim", "rack")
+        ConfigContext = apps.get_model("extras", "configcontext")
         Prefix = apps.get_model("ipam", "prefix")
         VLANGroup = apps.get_model("ipam", "vlangroup")
         VLAN = apps.get_model("ipam", "vlan")
         Cluster = apps.get_model("virtualization", "cluster")
 
+        ContentType = apps.get_model("contenttypes", "ContentType")
+        site_lt.content_types.set(ContentType.objects.filter(FeatureQuery("locations").get_query()))
+
         cts = CircuitTermination.objects.filter(location__isnull=True).select_related("site")
         for ct in cts:
             ct.location = Location.objects.get(name=ct.site.name, location_type=site_lt)
         CircuitTermination.objects.bulk_update(cts, ["location"], 1000)
+
+        ccs = ConfigContext.objects.filter(sites__isnull=False).prefetch_related("locations", "sites")
+        for cc in ccs:
+            site_name_list = list(cc.sites.all().values_list("name", flat=True))
+            site_locs = list(Location.objects.filter(name__in=site_name_list, location_type=site_lt))
+            original_locs = list(cc.locations.all())
+            locations = site_locs + original_locs
+            cc.locations.set(site_locs + original_locs)
+            cc.save()
 
         devices = Device.objects.filter(location__isnull=True).select_related("site")
         for device in devices:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: N/A
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

1. Migrate ConfigContext regions and sites data to ConfigContext.locations.
2. Ensure the new "Site" LocationType allows all ContentTypes allowed by Location (FeatureQuery("locations").get_query()).
3. Tested thoroughly and did what it was intended.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
