### PR TITLE
Removed `CeleryTestCase` and associated calling code.

### DIFF
--- a/nautobot/extras/tests/integration/test_plugins.py
+++ b/nautobot/extras/tests/integration/test_plugins.py
@@ -24,12 +24,7 @@ from example_plugin.models import ExampleModel
 class PluginWebhookTest(SeleniumTestCase):
     """
     This test case proves that plugins can use the webhook functions when making changes on a model.
-
-    Because webhooks use celery a class variable is set to True called `requires_celery`. This starts
-    a celery instance in a separate thread.
     """
-
-    requires_celery = True
 
     def setUp(self):
         super().setUp()
@@ -65,12 +60,10 @@ class PluginWebhookTest(SeleniumTestCase):
         """
         Test that webhooks are correctly triggered by a plugin model create.
         """
-        self.clear_worker()
         self.update_headers("test_plugin_webhook_create")
         # Make change to model
         with web_request_context(self.user):
             ExampleModel.objects.create(name="foo", number=100)
-        self.wait_on_active_tasks()
         self.assertTrue(os.path.exists(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_create")))
         os.remove(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_create"))
 
@@ -79,7 +72,6 @@ class PluginWebhookTest(SeleniumTestCase):
         """
         Test that webhooks are correctly triggered by a plugin model update.
         """
-        self.clear_worker()
         self.update_headers("test_plugin_webhook_update")
         obj = ExampleModel.objects.create(name="foo", number=100)
 
@@ -87,7 +79,6 @@ class PluginWebhookTest(SeleniumTestCase):
         with web_request_context(self.user):
             obj.number = 200
             obj.validated_save()
-        self.wait_on_active_tasks()
         self.assertTrue(os.path.exists(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_update")))
         os.remove(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_update"))
 
@@ -96,14 +87,12 @@ class PluginWebhookTest(SeleniumTestCase):
         """
         Test that webhooks are correctly triggered by a plugin model delete.
         """
-        self.clear_worker()
         self.update_headers(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_delete"))
         obj = ExampleModel.objects.create(name="foo", number=100)
 
         # Make change to model
         with web_request_context(self.user):
             obj.delete()
-        self.wait_on_active_tasks()
         self.assertTrue(os.path.exists(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_delete")))
         os.remove(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_delete"))
 
@@ -112,7 +101,6 @@ class PluginWebhookTest(SeleniumTestCase):
         """
         Verify that webhook body_template is correctly used.
         """
-        self.clear_worker()
         self.update_headers("test_plugin_webhook_with_body")
 
         self.webhook.body_template = '{"message": "{{ event }}"}'
@@ -122,7 +110,6 @@ class PluginWebhookTest(SeleniumTestCase):
         with web_request_context(self.user):
             ExampleModel.objects.create(name="bar", number=100)
 
-        self.wait_on_active_tasks()
         self.assertTrue(os.path.exists(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_with_body")))
         with open(os.path.join(tempfile.gettempdir(), "test_plugin_webhook_with_body"), "r") as f:
             self.assertEqual(json.loads(f.read()), {"message": "created"})


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed

Now that we have `CELERY_TASK_ALWAYS_EAGER = True` in our test config, we no longer need this. Celery tasks/Jobs can be tested without the need for a single-threaded background worker so long as they are in a `TransactionTestCase`.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
