### PR TITLE
Added a system task for handling Jobs where the hard `time_limit` is hit.

### DIFF
--- a/changes/633.fixed
+++ b/changes/633.fixed
@@ -1,0 +1,1 @@
+Added a system task for handling Jobs where the hard `time_limit` is hit.

--- a/nautobot/core/tasks.py
+++ b/nautobot/core/tasks.py
@@ -1,6 +1,6 @@
-import logging
-
 from cacheops.simple import CacheMiss, cache
+from celery.utils.log import get_task_logger
+from celery.exceptions import TimeLimitExceeded
 from django.conf import settings
 from packaging import version
 import requests
@@ -8,8 +8,9 @@ import requests
 from nautobot.core import celery
 from nautobot.core.utils import config
 
+
 # Get an instance of a logger
-logger = logging.getLogger("nautobot.releases")
+logger = get_task_logger(__name__)
 
 
 @celery.nautobot_task
@@ -53,3 +54,20 @@ def get_releases(pre_releases=False):
 
     # Since this is a Celery task, we can't return Version objects as they are not JSON serializable.
     return [(str(version), url) for version, url in releases]
+
+
+@celery.nautobot_task(ignore_result=True)
+def handle_time_limit_exceeded(task_id):
+    """
+    Handler for when a running `Job` hits its hard `time_limit` to ensure that
+    the `JobResult` is marked as a failure and the traceback is saved.
+    """
+    from nautobot.extras.choices import JobResultStatusChoices
+    from nautobot.extras.models import JobResult
+
+    jr = JobResult.objects.get(task_id=task_id)
+    # TODO(jathan): Assert this is the correct accessor for `time_limit`
+    time_limit = jr.job_model.time_limit
+    jr.set_status(JobResultStatusChoices.STATUS_FAILURE)
+    jr.traceback = str(TimeLimitExceeded(time_limit))
+    jr.save()


### PR DESCRIPTION



<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #633
# What's Changed
**Note: This is not testable because our unit test suite no longer uses `CeleryTestCase` and eager results don't use workers. Additionally, in the previous iteration they wouldn't be either because `CeleryTestCase` used a `solo` worker and time-limits are only supported on the pre-fork worker we use for production deployments.**

- This introduces a `NautobotRequest` for Celery that subclasses the core `Request` object to extend the `on_timeout` handler to fire off a `handle_time_limit_exceeded` task when the hard time limit is hit.
- The new `handle_time_limit_exceeded` task takes a `task_id` and sets the `JobResult.status` to `FAILURE` and also saves a `TimeLimitExceeded` exception as the `traceback`.

## Example job
This is the job I used to test this.

```python
# bunkjob.py
import time

from celery.exceptions import SoftTimeLimitExceeded

from nautobot.extras.jobs import Job


class BunkJob(Job):

    class Meta:
        soft_time_limit = 5
        time_limit = 10
        description = "I sleep for 30 seconds."

    def run(self, data, commit):
        try:
            time.sleep(30)
            self.log_info("Nap complete.")
        except SoftTimeLimitExceeded:
            self.log_warning("Time's up! About to crash.")
            time.sleep(30)
```

## Screenshots
Proof that the job failed after logging "Time's up! About to crash." That the job fails. 
![image](https://user-images.githubusercontent.com/138052/217114391-c30486bb-48bd-4ff0-adbc-2092c9b35958.png)

Traceback stored on the `JobResult`

![image](https://user-images.githubusercontent.com/138052/217114409-15aab307-52b7-4cf6-a09b-fb236f23ce9d.png)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
