### PR TITLE
Changed `DynamicGroup.objects.get_for_object()` to be a little more efficient

### DIFF
--- a/changes/3264.changed
+++ b/changes/3264.changed
@@ -1,0 +1,1 @@
+Changed `DynamicGroup.objects.get_for_object()` to be a little more efficient.

--- a/nautobot/extras/querysets.py
+++ b/nautobot/extras/querysets.py
@@ -175,7 +175,7 @@ class DynamicGroupQuerySet(RestrictedQuerySet):
         my_groups = []
         # TODO(jathan): 3 queries per DynamicGroup instance
         for dynamic_group in eligible_groups.iterator():
-            if obj.pk in dynamic_group.members.values_list("pk", flat=True):
+            if dynamic_group.members.filter(pk=obj.pk).values_list("pk", flat=True).exists():
                 my_groups.append(dynamic_group.pk)
 
         # TODO(jathan): 1 query


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3270 
# What's Changed
- Reverse membership query for an object to groups of which it may be a member will now always only be a single-row query vs an N-row query based on the number of members of a particular group.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
