### PR TITLE
Fix incorrect data in Note API test

### DIFF
--- a/changes/3277.fixed
+++ b/changes/3277.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect test data in `nautobot.extras.tests.test_api.NoteTest`.

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -2447,17 +2447,17 @@ class NoteTest(APIViewTestCases.APIViewTestCase):
             {
                 "note": "This is a test.",
                 "assigned_object_id": site1.pk,
-                "assigned_object_type": f"{ct._meta.app_label}.{ct._meta.model_name}",
+                "assigned_object_type": "dcim.site",
             },
             {
                 "note": "This is a test.",
                 "assigned_object_id": site2.pk,
-                "assigned_object_type": f"{ct._meta.app_label}.{ct._meta.model_name}",
+                "assigned_object_type": "dcim.site",
             },
             {
                 "note": "This is a note on Site 1.",
                 "assigned_object_id": site1.pk,
-                "assigned_object_type": f"{ct._meta.app_label}.{ct._meta.model_name}",
+                "assigned_object_type": "dcim.site",
             },
         ]
         cls.bulk_update_data = {


### PR DESCRIPTION
# Closes: #n/a
# What's Changed

Something I stumbled across while working on a different issue. With the test data in the REST API `NoteTest`, we were passing `contenttypes.contenttype` as the `assigned_object_type` instead of `dcim.site`.

# TODO
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
