### PR TITLE
Add support for netutils in Django templates and add test coverage

### DIFF
--- a/changes/3290.fixed
+++ b/changes/3290.fixed
@@ -1,0 +1,1 @@
+Fixed an issue preventing the inclusion of `netutils` functions in Django templates.

--- a/nautobot/docs/additional-features/template-filters.md
+++ b/nautobot/docs/additional-features/template-filters.md
@@ -7,17 +7,20 @@ Nautobot uses 2 template engines internally, Django Template and Jinja2. Django 
 !!! note
     Jinja2 and Django Template are very similar, the main difference between them is the syntax of the template. Historically, Django Template has been the go-to solution to generate webpage in Django and Jinja2 is the industry standard outside of Django.
 
-Both Django Template and Jinja2 can be extended with a library of functions, called `filters`, that apply formatting or transformations to a provided input. Nautobot provides many built-in `filters`, including network specific `filters` from the [netutils library](https://netutils.readthedocs.io/en/latest/index.html).
+Both Django Template and Jinja2 can be extended with a library of functions, called `filters`, that apply formatting or transformations to a provided input. Nautobot provides many built-in `filters`, including network specific `filters` from the [netutils library](https://netutils.readthedocs.io/en/latest/).
 
 ## Netutils Filters
 
 +++ 1.2.0
 
-[Netutils](https://netutils.readthedocs.io/en/latest/) is an external library, maintained by Network to Code, that is focusing on providing a collection of functions for common network automation tasks.
+[Netutils](https://netutils.readthedocs.io/en/latest/) is an external library, maintained by Network to Code, that is focusing on providing a collection of functions for common network automation tasks. Please [check the netutils documentation](https://netutils.readthedocs.io/en/latest/) to see the list of available functions.
 
-Please [check the netutils documentation](https://netutils.readthedocs.io/en/latest/netutils/index.html) to see the list of available functions.
+These functions are available automatically in Jinja2 rendered by Nautobot. For example you could define a [computed field](../models/extras/computedfield.md) on Circuit objects, using the Netutils `bits_to_name` function, to display the "Commit Rate" as a human-readable value by using the template code `{{ (obj.commit_rate * 1000) | bits_to_name }}`. (This particular example is contrived, as the Nautobot UI already humanizes the raw `commit_rate` value for display, but it demonstrates the kinds of things that these filters can be used for.)
 
-All functions in Netutils are available in Nautobot in both Jinja2 filters and Django Template.
+In general the syntax for using a netutils filter in a Jinja2 template is something like `{{ arg1 | function_name }}` for functions that take a single argument, and `{{ arg1 | function_name(arg_name2=arg2, arg_name3=arg3) }}` for functions that take multiple arguments.
+
++++ 1.5.11
+    Netutils functions are also available in Django templates after using the `{% load netutils %}` directive in a template. The syntax to use these functions is then generally `{% function_name arg_name1=arg1 arg_name2=arg2 %}`.
 
 ## Nautobot Built-In Filters
 

--- a/nautobot/utilities/apps.py
+++ b/nautobot/utilities/apps.py
@@ -7,17 +7,10 @@ class UtilitiesConfig(NautobotConfig):
     def ready(self):
         super().ready()
 
-        # Register netutils jinja2 filters in django_jinja and Django Template
+        # Register netutils jinja2 filters in django_jinja
         from netutils.utils import jinja2_convenience_function
         from django_jinja import library
-
-        from django import template
-
-        register = template.Library()
 
         for name, func in jinja2_convenience_function().items():
             # Register in django_jinja
             library.filter(name=name, fn=func)
-
-            # Register in Django Template
-            register.filter(name, func)

--- a/nautobot/utilities/templatetags/netutils.py
+++ b/nautobot/utilities/templatetags/netutils.py
@@ -1,0 +1,9 @@
+from django import template
+from netutils.utils import jinja2_convenience_function
+
+register = template.Library()
+
+for name, func in jinja2_convenience_function().items():
+    # Register as a simple_tag in Django Template context.
+    # We use simple_tag() rather than filter() because many netutils functions take more than one arg.
+    register.simple_tag(func, name=name)

--- a/nautobot/utilities/tests/test_templatetags_netutils.py
+++ b/nautobot/utilities/tests/test_templatetags_netutils.py
@@ -1,0 +1,52 @@
+import inspect
+
+from django.template import Context, Engine
+from django.template.exceptions import TemplateSyntaxError
+from django.test import TestCase
+
+from netutils.utils import jinja2_convenience_function
+
+
+class NautobotTemplateTagsNetutilsTest(TestCase):
+    """Test the use of netutils functions as Django template filters."""
+
+    def test_netutils_filters_in_django(self):
+        """Verify that each function is at least available as a filter."""
+        engine = Engine.get_default()
+        context = Context({})
+        for filter_name, filter_func in jinja2_convenience_function().items():
+            with self.subTest(f'Testing filter "{filter_name}"'):
+                template_string = "{% load netutils %}{% " + filter_name
+                signature = inspect.signature(filter_func)
+                i = 1
+                for param_name, param in signature.parameters.items():
+                    template_string += f" {param_name}="
+                    if param.annotation == str:
+                        template_string += f'"{i}"'
+                    elif param.annotation == bool:
+                        template_string += "True"
+                    elif param.annotation in (int, float):
+                        template_string += str(i)
+                    elif param.annotation in (list, tuple):
+                        template_string += "[]"
+                    elif param.annotation == dict:
+                        template_string += "{}"
+                    else:
+                        template_string += "None"
+                    i += 1
+                template_string += " %}"
+                template = engine.from_string(template_string)
+                try:
+                    template.render(context)
+                except TemplateSyntaxError as exc:
+                    # Django doesn't see this as a valid template-tag, or similar - shouldn't happen
+                    self.fail(str(exc))
+                except (AttributeError, KeyError, TypeError, ValueError):
+                    # We didn't pass "valid" params to the function, but at least Django saw it as a template tag.
+                    pass
+                except ConnectionError:
+                    # Yes, some netutils functions such as tcp_ping actually make network calls when invoked. Eeek.
+                    pass
+                except Exception:
+                    # Catch-all - at least it wasn't a TemplateSyntaxError, so good enough for now.
+                    pass


### PR DESCRIPTION

# Closes: #3290 
# What's Changed

- The way support for netutils was implemented way back in #1083 worked for Jinja2 templates (computed fields, webhooks, export templates, etc) but was wrong for Django. We didn't catch this at the time because #1083 only added automated test coverage for the Jinja2 case.
- Fix the Django case by explicitly importing the netutils functions as a `netutils` templatetags library, making it possible to do `{% load netutils %}` in a Django template then call the netutils functions as template tags.
- Add unit test coverage.
- Update docs.

Example that I hacked in to `site.html` for manual testing purposes:

```django
        {% load netutils %}
        FYI, according to Netutils, 1234567890 bits per second is {% bits_to_name 1234567890 %}
        or {% bits_to_name 1234567890 nbr_decimal=3 %}.
```

Screenshot:

![image](https://user-images.githubusercontent.com/5603551/218505648-2a2ab324-76f0-4ccb-a827-965c598b0d87.png)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
