### PR TITLE
Backport #3255 to develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ jobs/*
 htmlcov/*
 /nautobot/project-static/docs/
 /examples/example_plugin/example_plugin/static/example_plugin/docs/
+development/factory_dump.json

--- a/changes/3255.added
+++ b/changes/3255.added
@@ -1,0 +1,1 @@
+Added `--cache-test-fixtures` command line argument to Nautobot unit and integration tests.

--- a/invoke.yml.example
+++ b/invoke.yml.example
@@ -4,6 +4,7 @@ nautobot:
   local: False
   python_ver: "3.7"
   compose_dir: "/full/path/to/nautobot/development"
+  cache_test_fixtures: False
   compose_files:
     - "docker-compose.yml"
     - "docker-compose.postgres.yml"

--- a/nautobot/circuits/signals.py
+++ b/nautobot/circuits/signals.py
@@ -33,10 +33,12 @@ def rebuild_paths_circuits(obj):
 
 
 @receiver(post_save, sender=CircuitTermination)
-def update_circuit(instance, **kwargs):
+def update_circuit(instance, raw=False, **kwargs):
     """
     When a CircuitTermination has been modified, update its parent Circuit.
     """
+    if raw:
+        return
     if instance.term_side in CircuitTerminationSideChoices.values():
         termination_name = f"termination_{instance.term_side.lower()}"
         setattr(instance.circuit, termination_name, instance)
@@ -45,10 +47,12 @@ def update_circuit(instance, **kwargs):
 
 
 @receiver(post_save, sender=CircuitTermination)
-def update_connected_terminations(instance, **kwargs):
+def update_connected_terminations(instance, raw=False, **kwargs):
     """
     When a CircuitTermination has been modified, update the Cable Paths if the Circuit Termination has a peer.
     """
+    if raw:
+        return
     peer = instance.get_peer_termination()
     # Check if Circuit Termination has a peer
     if peer:

--- a/nautobot/core/management/commands/generate_test_data.py
+++ b/nautobot/core/management/commands/generate_test_data.py
@@ -158,7 +158,7 @@ Type 'yes' to continue, or 'no' to cancel: """
                     "--natural-primary",
                     indent=2,
                     format="json",
-                    exclude=["contenttypes", "auth.permission", "extras.job", "extras.customfield"],
+                    exclude=["contenttypes", "django_rq", "auth.permission", "extras.job", "extras.customfield"],
                     output=options["fixture_file"],
                 )
 

--- a/nautobot/core/management/commands/generate_test_data.py
+++ b/nautobot/core/management/commands/generate_test_data.py
@@ -1,3 +1,5 @@
+import os
+
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
@@ -23,8 +25,19 @@ class Command(BaseCommand):
             dest="interactive",
             help="Do NOT prompt the user for input or confirmation of any kind.",
         )
+        parser.add_argument(
+            "--cache-test-fixtures",
+            action="store_true",
+            help="Save test database to a json fixture file to re-use on subsequent tests.",
+        )
+        parser.add_argument(
+            "--fixture-file",
+            default="development/factory_dump.json",
+            help="Fixture file to use with --cache-test-fixtures.",
+        )
 
-    def handle(self, *args, **options):
+    def _generate_factory_data(self, seed):
+
         try:
             import factory.random
 
@@ -57,25 +70,8 @@ class Command(BaseCommand):
         except ImportError as err:
             raise CommandError('Unable to load data factories. Is the "factory-boy" package installed?') from err
 
-        if options["flush"]:
-            if options["interactive"]:
-                confirm = input(
-                    f"""\
-You have requested a flush of the database before generating new data.
-This will IRREVERSIBLY DESTROY all data in the "{connections[DEFAULT_DB_ALIAS].settings_dict['NAME']}" database,
-including all user accounts, and return each table to an empty state.
-Are you SURE you want to do this?
-
-Type 'yes' to continue, or 'no' to cancel: """
-                )
-                if confirm != "yes":
-                    self.stdout.write("Cancelled.")
-                    return
-
-            self.stdout.write(self.style.WARNING("Flushing all existing data from the database..."))
-            call_command("flush", "--no-input")
-
-        seed = options["seed"] or get_random_string(16)
+        if not seed:
+            seed = get_random_string(16)
         self.stdout.write(f'Seeding the pseudo-random number generator with seed "{seed}"...')
         factory.random.reseed_random(seed)
 
@@ -130,5 +126,42 @@ Type 'yes' to continue, or 'no' to cancel: """
         DeviceRedundancyGroupFactory.create_batch(10)
         self.stdout.write("Creating DeviceRoles...")
         DeviceRoleFactory.create_batch(10)
+
+    def handle(self, *args, **options):
+        if options["flush"]:
+            if options["interactive"]:
+                confirm = input(
+                    f"""\
+You have requested a flush of the database before generating new data.
+This will IRREVERSIBLY DESTROY all data in the "{connections[DEFAULT_DB_ALIAS].settings_dict['NAME']}" database,
+including all user accounts, and return each table to an empty state.
+Are you SURE you want to do this?
+
+Type 'yes' to continue, or 'no' to cancel: """
+                )
+                if confirm != "yes":
+                    self.stdout.write("Cancelled.")
+                    return
+
+            self.stdout.write(self.style.WARNING("Flushing all existing data from the database..."))
+            call_command("flush", "--no-input")
+
+        if options["cache_test_fixtures"] and os.path.exists(options["fixture_file"]):
+            call_command("loaddata", options["fixture_file"])
+        else:
+            self._generate_factory_data(options["seed"])
+
+            if options["cache_test_fixtures"]:
+                call_command(
+                    "dumpdata",
+                    "--natural-foreign",
+                    "--natural-primary",
+                    indent=2,
+                    format="json",
+                    exclude=["contenttypes", "auth.permission", "extras.job", "extras.customfield"],
+                    output=options["fixture_file"],
+                )
+
+                self.stdout.write(self.style.SUCCESS(f"Dumped factory data to {options['fixture_file']}"))
 
         self.stdout.write(self.style.SUCCESS("Database populated successfully!"))

--- a/nautobot/core/tests/runner.py
+++ b/nautobot/core/tests/runner.py
@@ -21,7 +21,10 @@ class NautobotTestRunner(DiscoverRunner):
 
     exclude_tags = ["integration"]
 
-    def __init__(self, **kwargs):
+    def __init__(self, cache_test_fixtures=False, **kwargs):
+
+        self.cache_test_fixtures = cache_test_fixtures
+
         # Assert "integration" hasn't been provided w/ --tag
         incoming_tags = kwargs.get("tags") or []
         # Assert "exclude_tags" hasn't been provided w/ --exclude-tag; else default to our own.
@@ -33,6 +36,15 @@ class NautobotTestRunner(DiscoverRunner):
             kwargs["exclude_tags"] = incoming_exclude_tags
 
         super().__init__(**kwargs)
+
+    @classmethod
+    def add_arguments(cls, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--cache-test-fixtures",
+            action="store_true",
+            help="Save test database to a json fixture file to re-use on subsequent tests.",
+        )
 
     def setup_test_environment(self, **kwargs):
         super().setup_test_environment(**kwargs)
@@ -47,6 +59,8 @@ class NautobotTestRunner(DiscoverRunner):
             command = ["generate_test_data", "--flush", "--no-input"]
             if settings.TEST_FACTORY_SEED is not None:
                 command += ["--seed", settings.TEST_FACTORY_SEED]
+            if self.cache_test_fixtures:
+                command += ["--cache-test-fixtures"]
             call_command(*command)
 
         return result

--- a/nautobot/dcim/signals.py
+++ b/nautobot/dcim/signals.py
@@ -57,7 +57,7 @@ def rebuild_paths(obj):
 
 
 @receiver(post_save, sender=RackGroup)
-def handle_rackgroup_site_location_change(instance, created, **kwargs):
+def handle_rackgroup_site_location_change(instance, created, raw=False, **kwargs):
     """
     Update child RackGroups, Racks, and PowerPanels if Site or Location assignment has changed.
 
@@ -68,6 +68,8 @@ def handle_rackgroup_site_location_change(instance, created, **kwargs):
     may or may not be permitted to contain Racks or PowerPanels. If it's not permitted, rather than trying to search
     through child locations to find the "right" one, the best we can do is simply to null out the location.
     """
+    if raw:
+        return
     if not created:
         if instance.location is not None:
             descendants = instance.location.descendants(include_self=True)
@@ -134,7 +136,7 @@ def handle_rackgroup_site_location_change(instance, created, **kwargs):
 
 
 @receiver(post_save, sender=Rack)
-def handle_rack_site_location_change(instance, created, **kwargs):
+def handle_rack_site_location_change(instance, created, raw=False, **kwargs):
     """
     Update child Devices if Site or Location assignment has changed.
 
@@ -142,6 +144,8 @@ def handle_rack_site_location_change(instance, created, **kwargs):
     may or may not be permitted to contain Devices. If it's not permitted, rather than trying to search
     through child locations to find the "right" one, the best we can do is simply to null out the location.
     """
+    if raw:
+        return
     if not created:
         if instance.location is not None:
             devices_permitted = (
@@ -172,10 +176,12 @@ def handle_rack_site_location_change(instance, created, **kwargs):
 
 
 @receiver(post_save, sender=VirtualChassis)
-def assign_virtualchassis_master(instance, created, **kwargs):
+def assign_virtualchassis_master(instance, created, raw=False, **kwargs):
     """
     When a VirtualChassis is created, automatically assign its master device (if any) to the VC.
     """
+    if raw:
+        return
     if created and instance.master:
         master = Device.objects.get(pk=instance.master.pk)
         master.virtual_chassis = instance

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -821,14 +821,18 @@ class ScheduledJobs(models.Model):
     objects = ExtendedManager()
 
     @classmethod
-    def changed(cls, instance, **kwargs):
+    def changed(cls, instance, raw=False, **kwargs):
         """This function acts as a signal handler to track changes to the scheduled job that is triggered before a change"""
+        if raw:
+            return
         if not instance.no_changes:
             cls.update_changed()
 
     @classmethod
-    def update_changed(cls, **kwargs):
+    def update_changed(cls, raw=False, **kwargs):
         """This function acts as a signal handler to track changes to the scheduled job that is triggered after a change"""
+        if raw:
+            return
         cls.objects.update_or_create(ident=1, defaults={"last_update": timezone.now()})
 
     @classmethod

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -45,11 +45,14 @@ def _get_user_if_authenticated(user, objectchange):
         return None
 
 
-def _handle_changed_object(change_context, sender, instance, **kwargs):
+def _handle_changed_object(change_context, sender, instance, raw=False, **kwargs):
     """
     Fires when an object is created or updated.
     """
     from .jobs import enqueue_job_hooks  # avoid circular import
+
+    if raw:
+        return
 
     object_m2m_changed = False
 
@@ -237,11 +240,13 @@ def dynamic_group_children_changed(sender, instance, action, reverse, model, pk_
         )
 
 
-def dynamic_group_membership_created(sender, instance, **kwargs):
+def dynamic_group_membership_created(sender, instance, raw=False, **kwargs):
     """
     Forcibly call `full_clean()` when a new `DynamicGroupMembership` object
     is manually created to prevent inadvertantly creating invalid memberships.
     """
+    if raw:
+        return
     instance.full_clean()
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -646,6 +646,7 @@ def check_schema(context, api_version=None):
 
 @task(
     help={
+        "cache_test_fixtures": "Save test database to a json fixture file to re-use on subsequent tests.",
         "keepdb": "Save and re-use test database between test runs for faster re-testing.",
         "label": "Specify a directory or module to test instead of running all Nautobot tests.",
         "failfast": "Fail as soon as a single test fails don't run the entire test suite.",
@@ -662,6 +663,7 @@ def check_schema(context, api_version=None):
 )
 def unittest(
     context,
+    cache_test_fixtures=False,
     keepdb=False,
     label="nautobot",
     failfast=False,
@@ -683,6 +685,8 @@ def unittest(
     command = f"coverage run{append_arg} --module nautobot.core.cli test {label}"
     command += " --config=nautobot/core/tests/nautobot_config.py"
     # booleans
+    if context.nautobot.get("cache_test_fixtures", False) or cache_test_fixtures:
+        command += " --cache-test-fixtures"
     if keepdb:
         command += " --keepdb"
     if failfast:
@@ -719,6 +723,7 @@ def unittest_coverage(context):
 
 @task(
     help={
+        "cache_test_fixtures": "Save test database to a json fixture file to re-use on subsequent tests",
         "keepdb": "Save and re-use test database between test runs for faster re-testing.",
         "label": "Specify a directory or module to test instead of running all Nautobot tests.",
         "failfast": "Fail as soon as a single test fails don't run the entire test suite.",
@@ -735,6 +740,7 @@ def unittest_coverage(context):
 )
 def integration_test(
     context,
+    cache_test_fixtures=False,
     keepdb=False,
     label="nautobot",
     failfast=False,
@@ -754,6 +760,7 @@ def integration_test(
 
     unittest(
         context,
+        cache_test_fixtures=cache_test_fixtures,
         keepdb=keepdb,
         label=label,
         failfast=failfast,
@@ -770,6 +777,7 @@ def integration_test(
 
 @task(
     help={
+        "cache_test_fixtures": "Save test database to a json fixture file to re-use on subsequent tests.",
         "keepdb": "Save and re-use test database between test runs for faster re-testing.",
         "label": "Specify a directory or module to test instead of running all Nautobot tests.",
         "failfast": "Fail as soon as a single test fails don't run the entire test suite.",
@@ -785,6 +793,7 @@ def integration_test(
 )
 def performance_test(
     context,
+    cache_test_fixtures=False,
     keepdb=False,
     label="nautobot",
     failfast=False,
@@ -806,6 +815,7 @@ def performance_test(
 
     unittest(
         context,
+        cache_test_fixtures=cache_test_fixtures,
         keepdb=keepdb,
         label=label,
         failfast=failfast,


### PR DESCRIPTION
# Closes: #n/a
# What's Changed

Backport of #3255. Only change compared to a5deb6390221e79c265c3d51764d133fdc550816 is to add `django_rq` to the exclusion list when dumping the test data since we still have django-rq in 1.5.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
