### PR TITLE
Fixed inheritance and `RoleField` definition on `Role` model mixins.

### DIFF
--- a/changes/3291.fixed
+++ b/changes/3291.fixed
@@ -1,0 +1,1 @@
+Fixed inheritance and `RoleField` definition on `Role` model mixins.

--- a/nautobot/extras/models/roles.py
+++ b/nautobot/extras/models/roles.py
@@ -47,13 +47,13 @@ class RoleModelMixin(models.Model):
     Abstract base class for any model which may have roles.
     """
 
-    role = RoleField()
+    role = RoleField(null=True, blank=True)
 
     class Meta:
         abstract = True
 
 
-class RoleRequiredRoleModelMixin(RoleModelMixin):
+class RoleRequiredRoleModelMixin(models.Model):
     """
     Abstract base class for any model which may have roles with role field required.
     """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3291 
# What's Changed

- Updated `RoleModelMixin` to make `RoleField` null and blank explicitly
- Updated `RoleRequiredRoleMixin` base to inherit from `models.Model` and not subclass `RoleModelMixin`

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
