### PR TITLE
Fixed ObjectListViewMixin's filtering when exporting objects in NautobotUIViewSet.

### DIFF
--- a/changes/3274.fixed
+++ b/changes/3274.fixed
@@ -1,0 +1,1 @@
+Fixed ObjectListViewMixin's filtering when exporting objects in NautobotUIViewSet.

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -442,11 +442,10 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
         "sort",  # table sorting
     )
 
-    def filter_queryset(self):
+    def filter_queryset(self, queryset):
         """
         Filter a query with request querystrings.
         """
-        queryset = self.get_queryset()
         if self.filterset_class is not None:
             filter_params = self.get_filter_params(self.request)
             filterset = self.filterset_class(filter_params, queryset)
@@ -461,7 +460,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
 
     def check_for_export(self, request, model, content_type):
         # Check for export template rendering
-        queryset = self.filter_queryset()
+        queryset = self.filter_queryset(self.get_queryset())
         if request.GET.get("export"):
             et = get_object_or_404(
                 ExportTemplate,
@@ -496,7 +495,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
         """
         Export the queryset of objects as concatenated YAML documents.
         """
-        queryset = self.filter_queryset()
+        queryset = self.filter_queryset(self.get_queryset())
         yaml_data = [obj.to_yaml() for obj in queryset]
 
         return "---\n".join(yaml_data)
@@ -505,7 +504,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
         """
         Export the queryset of objects as comma-separated value (CSV), using the model's to_csv() method.
         """
-        queryset = self.filter_queryset()
+        queryset = self.filter_queryset(self.get_queryset())
         csv_data = []
         custom_fields = []
         # Start with the column headers

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -450,9 +450,9 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
         We have to do it here in the ObjectListViewMixin class.
         """
         queryset = self.get_queryset()
-        filter_params = self.get_filter_params(self.request)
         if self.filterset_class is not None:
-            filterset = self.filterset_class(filter_params, self.queryset)
+            filter_params = self.get_filter_params(self.request)
+            filterset = self.filterset_class(filter_params, queryset)
             queryset = filterset.qs
             if not filterset.is_valid():
                 messages.error(

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -25,7 +25,6 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from drf_spectacular.utils import extend_schema
-
 from nautobot.core.api.views import BulkCreateModelMixin, BulkDestroyModelMixin, BulkUpdateModelMixin
 from nautobot.extras.models import CustomField, ExportTemplate
 from nautobot.extras.forms import NoteForm
@@ -443,11 +442,9 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
         "sort",  # table sorting
     )
 
-    def get_filtered_queryset_for_export(self):
+    def filter_queryset(self):
         """
-        Helper method for NautobotUIViewSet to recognize request's filter_params when exporting.
-        Since the export response cannot be captured from NautobotHTMLRenderer,
-        We have to do it here in the ObjectListViewMixin class.
+        Filter a query with request querystrings.
         """
         queryset = self.get_queryset()
         if self.filterset_class is not None:
@@ -464,7 +461,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
 
     def check_for_export(self, request, model, content_type):
         # Check for export template rendering
-        queryset = self.get_filtered_queryset_for_export()
+        queryset = self.filter_queryset()
         if request.GET.get("export"):
             et = get_object_or_404(
                 ExportTemplate,
@@ -499,7 +496,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
         """
         Export the queryset of objects as concatenated YAML documents.
         """
-        queryset = self.get_filtered_queryset_for_export()
+        queryset = self.filter_queryset()
         yaml_data = [obj.to_yaml() for obj in queryset]
 
         return "---\n".join(yaml_data)
@@ -508,7 +505,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
         """
         Export the queryset of objects as comma-separated value (CSV), using the model's to_csv() method.
         """
-        queryset = self.get_filtered_queryset_for_export()
+        queryset = self.filter_queryset()
         csv_data = []
         custom_fields = []
         # Start with the column headers

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -157,8 +157,8 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
             form = data["form"]
         else:
             if view.action == "list":
-                filter_params = view.get_filter_params(request)
                 if view.filterset_class is not None:
+                    filter_params = view.get_filter_params(request)
                     filterset = view.filterset_class(filter_params, view.queryset)
                     filterset_filters = filterset.get_filters()
                     view.queryset = filterset.qs

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -22,7 +22,6 @@ from nautobot.utilities.templatetags.helpers import bettertitle, validated_viewn
 from nautobot.utilities.utils import (
     convert_querydict_to_factory_formset_acceptable_querydict,
     normalize_querydict,
-    get_filterable_params_from_filter_params,
 )
 
 
@@ -33,11 +32,6 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
 
     # Log error messages within NautobotHTMLRenderer
     logger = logging.getLogger(__name__)
-
-    def get_filter_params(self, view, request):
-        """Helper function - take request.GET and discard any parameters that are not used for queryset filtering."""
-        filter_params = request.GET.copy()
-        return get_filterable_params_from_filter_params(filter_params, view.non_filter_params, view.filterset_class)
 
     def get_dynamic_filter_form(self, view, request, *args, filterset_class=None, **kwargs):
         """
@@ -163,7 +157,7 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
             form = data["form"]
         else:
             if view.action == "list":
-                filter_params = self.get_filter_params(view, request)
+                filter_params = view.get_filter_params(request)
                 if view.filterset_class is not None:
                     filterset = view.filterset_class(filter_params, view.queryset)
                     filterset_filters = filterset.get_filters()

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -157,13 +157,11 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
         else:
             if view.action == "list":
                 if view.filterset_class is not None:
-                    view.queryset = view.filter_queryset(view.queryset)
-                    filter_params = view.get_filter_params(request)
-                    filterset = view.filterset_class(filter_params, view.queryset)
-                    filterset_filters = filterset.get_filters()
+                    view.queryset = view.filter_queryset(view.get_queryset())
+                    filterset_filters = view.filterset.get_filters()
                     display_filter_params = [
                         check_filter_for_display(filterset_filters, field_name, values)
-                        for field_name, values in filter_params.items()
+                        for field_name, values in view.filter_params.items()
                     ]
                     if view.filterset_form_class is not None:
                         filter_form = view.filterset_form_class(request.GET, label_suffix="")

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -3,7 +3,6 @@ import logging
 from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
-from django.utils.safestring import mark_safe
 from django_tables2 import RequestConfig
 from rest_framework import renderers
 

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -158,17 +158,10 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
         else:
             if view.action == "list":
                 if view.filterset_class is not None:
+                    view.queryset = view.filter_queryset(view.queryset)
                     filter_params = view.get_filter_params(request)
                     filterset = view.filterset_class(filter_params, view.queryset)
                     filterset_filters = filterset.get_filters()
-                    view.queryset = filterset.qs
-                    if not filterset.is_valid():
-                        messages.error(
-                            request,
-                            mark_safe(f"Invalid filters were specified: {filterset.errors}"),
-                        )
-                        view.queryset = view.queryset.none()
-
                     display_filter_params = [
                         check_filter_for_display(filterset_filters, field_name, values)
                         for field_name, values in filter_params.items()

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -627,7 +627,7 @@ class Interface(CableTermination, PathEndpoint, ComponentModel, BaseInterface):
             self.enabled,
             self.mac_address,
             self.mtu,
-            self.mgmt_only,
+            str(self.mgmt_only),
             self.description,
             self.get_mode_display(),
             self.get_status_display(),
@@ -1034,6 +1034,6 @@ class InventoryItem(MPTTModel, ComponentModel):
             self.part_id,
             self.serial,
             self.asset_tag,
-            self.discovered,
+            str(self.discovered),
             self.description,
         )

--- a/nautobot/dcim/models/racks.py
+++ b/nautobot/dcim/models/racks.py
@@ -400,7 +400,7 @@ class Rack(PrimaryModel, StatusModel):
             self.asset_tag,
             self.width,
             self.u_height,
-            self.desc_units,
+            str(self.desc_units),
             self.outer_width,
             self.outer_depth,
             self.outer_unit,

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -106,6 +106,7 @@ class GitRepository(PrimaryModel):
             self.slug,
             self.remote_url,
             self.branch,
+            self.secrets_group.name if self.secrets_group else None,
             self.provided_contents,
         )
 

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -113,7 +113,7 @@ class VRF(PrimaryModel):
             self.name,
             self.rd,
             self.tenant.name if self.tenant else None,
-            self.enforce_unique,
+            str(self.enforce_unique),
             self.description,
         )
 
@@ -214,7 +214,7 @@ class RIR(OrganizationalModel):
         return (
             self.name,
             self.slug,
-            self.is_private,
+            str(self.is_private),
             self.description,
         )
 
@@ -626,7 +626,7 @@ class Prefix(PrimaryModel, StatusModel):
             self.vlan.vid if self.vlan else None,
             self.get_status_display(),
             self.role.name if self.role else None,
-            self.is_pool,
+            str(self.is_pool),
             self.description,
         )
 
@@ -974,7 +974,7 @@ class IPAddress(PrimaryModel, StatusModel):
             self.get_role_display(),
             obj_type,
             self.assigned_object_id,
-            is_primary,
+            str(is_primary),
             self.dns_name,
             self.description,
         )

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -798,32 +798,33 @@ class ViewTestCases:
         @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
         def test_queryset_to_csv(self):
             # Built-in CSV export
-            if hasattr(self.model, "csv_headers"):
-                response = self.client.get(f"{self._get_url('list')}?export")
-                self.assertHttpStatus(response, 200)
-                self.assertEqual(response.get("Content-Type"), "text/csv")
-                instance1 = self._get_queryset().first()
-                # With filtering
-                response = self.client.get(f"{self._get_url('list')}?export&id={instance1.pk}")
-                self.assertHttpStatus(response, 200)
-                self.assertEqual(response.get("Content-Type"), "text/csv")
-                response_body = response.content.decode(response.charset)
-                reader = csv.DictReader(StringIO(response_body))
-                print(response_body)
-                data = [dict(row) for row in reader][0]
-                print(data)
-                instance1_csv_data = [str(x) if x is not None else "" for x in instance1.to_csv()]
-                # append instance
-                instance1_cf_values = [
-                    "" if value is None else value for value in instance1.get_custom_fields().values()
-                ]
-                instance1_csv_data += instance1_cf_values
-                # Since values in `data` are all in str; cast all values in instance1_csv_data to str
-                instance1_csv_data = [str(val) for val in instance1_csv_data]
-                instance1_cf_headers = ["cf_" + str(cf.slug) for cf in instance1.get_custom_fields().keys()]
-                instance1_csv_headers = list(getattr(self.model, "csv_headers")) + instance1_cf_headers
-                self.assertEquals(instance1_csv_headers, list(data.keys()))
-                self.assertEquals(instance1_csv_data, list(data.values()))
+            if not hasattr(self.model, "csv_headers"):
+                self.skip(f"{self.model} has no csv_headers attribute?")
+            response = self.client.get(f"{self._get_url('list')}?export")
+            self.assertHttpStatus(response, 200)
+            self.assertEqual(response.get("Content-Type"), "text/csv")
+            instance1 = self._get_queryset().first()
+            # With filtering
+            response = self.client.get(f"{self._get_url('list')}?export&id={instance1.pk}")
+            self.assertHttpStatus(response, 200)
+            self.assertEqual(response.get("Content-Type"), "text/csv")
+            response_body = response.content.decode(response.charset)
+            reader = csv.DictReader(StringIO(response_body))
+            # This line will make data a dictionary with csv headers as keys and corresponding csv values as values.
+            # For example:
+            # {'name': 'AFRINIC', 'slug': 'afrinic', 'is_private': '', 'description': ...'}
+            data = [dict(row) for row in reader][0]
+
+            instance1_csv_data = [str(x) if x is not None else "" for x in instance1.to_csv()]
+            # append instance
+            instance1_cf_values = ["" if value is None else value for value in instance1.get_custom_fields().values()]
+            instance1_csv_data += instance1_cf_values
+            # Since values in `data` are all in str; cast all values in instance1_csv_data to str
+            instance1_csv_data = [str(val) for val in instance1_csv_data]
+            instance1_cf_headers = ["cf_" + str(cf.slug) for cf in instance1.get_custom_fields().keys()]
+            instance1_csv_headers = list(self.model.csv_headers) + instance1_cf_headers
+            self.assertEqual(instance1_csv_headers, list(data.keys()))
+            self.assertEqual(instance1_csv_data, list(data.values()))
 
     class CreateMultipleObjectsViewTestCase(ModelViewTestCase):
         """

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -815,6 +815,7 @@ class ViewTestCases:
                     # x might be None, in that case use an empty sting
                     instance1_csv_data = [str(x) if x is not None else "" for x in instance1.to_csv()]
                     for header in csv_headers:
+                        # ignore "", None and etc, we only want "name", "slug" or similar identifiers
                         if entry[header]:
                             self.assertIn(entry[header], instance1_csv_data)
 

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -799,7 +799,7 @@ class ViewTestCases:
         def test_queryset_to_csv(self):
             # Built-in CSV export
             if not hasattr(self.model, "csv_headers"):
-                self.skip(f"{self.model} has no csv_headers attribute?")
+                self.skipTest(f"{self.model} has no csv_headers attribute?")
             response = self.client.get(f"{self._get_url('list')}?export")
             self.assertHttpStatus(response, 200)
             self.assertEqual(response.get("Content-Type"), "text/csv")

--- a/nautobot/utilities/testing/views.py
+++ b/nautobot/utilities/testing/views.py
@@ -811,12 +811,12 @@ class ViewTestCases:
                 reader = csv.DictReader(StringIO(response_body))
                 data = [dict(row) for row in reader]
                 csv_headers = getattr(self.model, "csv_headers")
-                for i in range(len(data)):
+                for _, entry in enumerate(data):
                     # x might be None, in that case use an empty sting
                     instance1_csv_data = [str(x) if x is not None else "" for x in instance1.to_csv()]
                     for header in csv_headers:
-                        if data[i][header] is not None:
-                            self.assertIn(data[i][header], instance1_csv_data)
+                        if entry[header]:
+                            self.assertIn(entry[header], instance1_csv_data)
 
     class CreateMultipleObjectsViewTestCase(ModelViewTestCase):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3274
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Moved `get_filter_params()` from `renders.py` to `mixins.py` so that the export feature will respect the filters applied from the request.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
