### PR TITLE
Port metric extensibility approach from capacity-metrics.

### DIFF
--- a/changes/766.added
+++ b/changes/766.added
@@ -1,1 +1,1 @@
-Add Prometheus metric extensibility capability.
+Added option for apps to extend Nautobot's Prometheus metrics, based on `nautobot_capacity_metrics`.

--- a/changes/766.added
+++ b/changes/766.added
@@ -1,0 +1,1 @@
+Add Prometheus metric extensibility capability.

--- a/examples/example_plugin/example_plugin/metrics.py
+++ b/examples/example_plugin/example_plugin/metrics.py
@@ -1,9 +1,9 @@
 from prometheus_client.metrics_core import GaugeMetricFamily
 
-from example_plugin.models import ExampleModel
-
 
 def metric_example():
+    from example_plugin.models import ExampleModel
+
     gauges = GaugeMetricFamily("nautobot_example_metric_count", "Nautobot Example Count Metric", labels=["name"])
 
     # This is very slow on larger tables. Shouldn't matter for the example plugin.

--- a/examples/example_plugin/example_plugin/metrics.py
+++ b/examples/example_plugin/example_plugin/metrics.py
@@ -1,15 +1,20 @@
 from prometheus_client.metrics_core import GaugeMetricFamily
 
+from example_plugin.models import ExampleModel
+
 
 def metric_example():
-    from example_plugin.models import ExampleModel
 
     gauges = GaugeMetricFamily("nautobot_example_metric_count", "Nautobot Example Count Metric", labels=["name"])
 
     # This is very slow on larger tables. Shouldn't matter for the example plugin.
     example_model_instance = ExampleModel.objects.order_by("?").first()
 
-    gauges.add_metric(labels=[example_model_instance.name], value=example_model_instance.number)
+    if example_model_instance:
+        gauges.add_metric(labels=[example_model_instance.name], value=example_model_instance.number)
+    else:
+        # If no model instance is there, provide an empty metric.
+        gauges.add_metric(labels=[], value=0)
     yield gauges
 
 

--- a/examples/example_plugin/example_plugin/metrics.py
+++ b/examples/example_plugin/example_plugin/metrics.py
@@ -1,0 +1,16 @@
+from prometheus_client.metrics_core import GaugeMetricFamily
+
+from example_plugin.models import ExampleModel
+
+
+def metric_example():
+    gauges = GaugeMetricFamily("nautobot_example_metric_count", "Nautobot Example Count Metric", labels=["name"])
+
+    # This is very slow on larger tables. Shouldn't matter for the example plugin.
+    example_model_instance = ExampleModel.objects.order_by("?").first()
+
+    gauges.add_metric(labels=[example_model_instance.name], value=example_model_instance.number)
+    yield gauges
+
+
+metrics = [metric_example]

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -46,3 +46,6 @@ TEST_USE_FACTORIES = True
 TEST_FACTORY_SEED = "Nautobot"
 # File in which all performance-specifc test baselines are stored
 TEST_PERFORMANCE_BASELINE_FILE = "nautobot/core/tests/performance_baselines.yml"
+
+# Metrics need to enabled in this config as overriding them with override_settings will not actually enable them
+METRICS_ENABLED = True

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -6,6 +6,7 @@ from django.test.utils import override_script_prefix
 from django.urls import get_script_prefix, reverse
 from prometheus_client.parser import text_string_to_metric_families
 
+from nautobot.extras.registry import registry
 from nautobot.utilities.testing import TestCase
 
 
@@ -280,10 +281,16 @@ class MetricsViewTestCase(TestCase):
 
     def test_metrics_extensibility(self):
         """Assert that the example metric from the example plugin shows up _exactly_ when the plugin is enabled."""
+        test_metric_name = "nautobot_example_metric_count"
         metrics_with_plugin = self.query_and_parse_metrics()
         metric_names_with_plugin = {metric.name for metric in metrics_with_plugin}
-        self.assertIn("nautobot_example_metric_count", metric_names_with_plugin)
-        with override_settings(PLUGINS_ENABLED=[]):
+        self.assertIn(test_metric_name, metric_names_with_plugin)
+        with override_settings(PLUGINS=[]):
+            # Clear out the app metric registry because it is not updated when settings are changed but Nautobot is not
+            # restarted.
+            registry["app_metrics"].clear()
             metrics_without_plugin = self.query_and_parse_metrics()
             metric_names_without_plugin = {metric.name for metric in metrics_without_plugin}
-            self.assertNotIn("nautobot_example_metric_count", metric_names_without_plugin)
+            self.assertNotIn(test_metric_name, metric_names_without_plugin)
+        metric_names_with_plugin.remove(test_metric_name)
+        self.assertSetEqual(metric_names_with_plugin, metric_names_without_plugin)

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -4,6 +4,7 @@ import urllib.parse
 from django.test import override_settings
 from django.test.utils import override_script_prefix
 from django.urls import get_script_prefix, reverse
+from prometheus_client.parser import text_string_to_metric_families
 
 from nautobot.utilities.testing import TestCase
 
@@ -268,3 +269,21 @@ class LoginUI(TestCase):
         self.client.logout()
         sso_login_search_result = self.make_request()
         self.assertIsNotNone(sso_login_search_result)
+
+
+class MetricsViewTestCase(TestCase):
+    def query_and_parse_metrics(self):
+        response = self.client.get(reverse("metrics"))
+        self.assertHttpStatus(response, 200, msg="/metrics should return a 200 HTTP status code.")
+        page_content = response.content.decode(response.charset)
+        return text_string_to_metric_families(page_content)
+
+    def test_metrics_extensibility(self):
+        """Assert that the example metric from the example plugin shows up _exactly_ when the plugin is enabled."""
+        metrics_with_plugin = self.query_and_parse_metrics()
+        metric_names_with_plugin = {metric.name for metric in metrics_with_plugin}
+        self.assertIn("nautobot_example_metric_count", metric_names_with_plugin)
+        with override_settings(PLUGINS_ENABLED=[]):
+            metrics_without_plugin = self.query_and_parse_metrics()
+            metric_names_without_plugin = {metric.name for metric in metrics_without_plugin}
+            self.assertNotIn("nautobot_example_metric_count", metric_names_without_plugin)

--- a/nautobot/core/urls.py
+++ b/nautobot/core/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import include
 from django.urls import path
 from django.views.static import serve
 
-from nautobot.core.views import CustomGraphQLView, HomeView, StaticMediaFailureView, SearchView
+from nautobot.core.views import CustomGraphQLView, HomeView, StaticMediaFailureView, SearchView, custom_app_metric_view
 from nautobot.extras.plugins.urls import (
     plugin_admin_patterns,
     plugin_patterns,
@@ -62,7 +62,7 @@ if settings.DEBUG:
 
 if settings.METRICS_ENABLED:
     urlpatterns += [
-        path("", include("django_prometheus.urls")),
+        path("metrics/", custom_app_metric_view),
     ]
 
 handler404 = "nautobot.core.views.resource_not_found"

--- a/nautobot/core/urls.py
+++ b/nautobot/core/urls.py
@@ -62,7 +62,7 @@ if settings.DEBUG:
 
 if settings.METRICS_ENABLED:
     urlpatterns += [
-        path("metrics/", custom_app_metric_view),
+        path("metrics/", custom_app_metric_view, name="metrics"),
     ]
 
 handler404 = "nautobot.core.views.resource_not_found"

--- a/nautobot/core/urls.py
+++ b/nautobot/core/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import include
 from django.urls import path
 from django.views.static import serve
 
-from nautobot.core.views import CustomGraphQLView, HomeView, StaticMediaFailureView, SearchView, custom_app_metric_view
+from nautobot.core.views import CustomGraphQLView, HomeView, StaticMediaFailureView, SearchView, nautobot_metrics_view
 from nautobot.extras.plugins.urls import (
     plugin_admin_patterns,
     plugin_patterns,
@@ -62,7 +62,7 @@ if settings.DEBUG:
 
 if settings.METRICS_ENABLED:
     urlpatterns += [
-        path("metrics/", custom_app_metric_view, name="metrics"),
+        path("metrics/", nautobot_metrics_view, name="metrics"),
     ]
 
 handler404 = "nautobot.core.views.resource_not_found"

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -258,7 +258,11 @@ def custom_app_metric_view(request):
     # Instantiate and register the collector. Note that this has to be done every time this view is accessed, because
     # the registry for multiprocess metrics is also instantiated every time this view is accessed. As a result, the
     # same goes for the registration of the collector to the registry.
-    nb_app_collector = NautobotAppMetricsCollector()
-    prometheus_registry.register(nb_app_collector)
+    try:
+        nb_app_collector = NautobotAppMetricsCollector()
+        prometheus_registry.register(nb_app_collector)
+    except ValueError:
+        # Collector already registered, we are running without multiprocessing
+        pass
     metrics_page = prometheus_client.generate_latest(prometheus_registry)
     return HttpResponse(metrics_page, content_type=prometheus_client.CONTENT_TYPE_LATEST)

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -243,7 +243,7 @@ class NautobotAppMetricsCollector(Collector):
         yield gauge
 
 
-def custom_app_metric_view(request):
+def nautobot_metrics_view(request):
     """Exports /metrics.
 
     This overwrites the default django_prometheus view to inject metrics from Nautobot apps.

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -235,8 +235,8 @@ class NautobotAppMetricsCollector(Collector):
     def collect(self):
         """Collect metrics from plugins."""
         start = time.time()
-        for metric in registry["app_metrics"]:
-            yield from metric()
+        for metric_generator in registry["app_metrics"]:
+            yield from metric_generator()
         gauge = GaugeMetricFamily("nautobot_app_metrics_processing_ms", "Time in ms to generate the app metrics")
         duration = time.time() - start
         gauge.add_metric([], format(duration * 1000, ".5f"))

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -235,7 +235,7 @@ class NautobotAppMetricsCollector(Collector):
     def collect(self):
         """Collect metrics from plugins."""
         start = time.time()
-        for metric in registry["plugin_metrics"]:
+        for metric in registry["app_metrics"]:
             yield from metric()
         gauge = GaugeMetricFamily("nautobot_app_metrics_processing_ms", "Time in ms to generate the app metrics")
         duration = time.time() - start

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -1370,6 +1370,32 @@ except ImportError:
     pass
 ```
 
+## Prometheus Metrics
+
++++ 1.5.?
+
+It is possible for Nautobot apps to provide their own Prometheus metrics. There are two general ways to achieve this:
+
+1. Use the prometheus_client library directly in your app code. Depending on whether that code runs in the web server or the worker context, the metric will show up in the respective `/metrics` endpoint(s).
+2. If the metric cannot be generated alongside existing code, a mechanism similar to that of Jobs in apps can be used. A list called `metrics` residing in a file called `metrics.py` can be provided at the root of the app. Nautobot will automatically read these and expose them via its `/metrics` endpoint. The following code snippet shows an example metric defined this way:
+
+```python
+# metrics.py
+from prometheus_client.metrics_core import GaugeMetricFamily
+
+from nautobot_animal_sounds.models import Animal
+
+
+def metric_animals():
+    gauges = GaugeMetricFamily("nautobot_noisy_animals_count", "Nautobot Example Count Metric", labels=[])
+    screaming_animal_count = Animal.objects.filter(loudness="noisy").count()
+    gauges.add_metric(labels=[], value=screaming_animal_count)
+    yield gauges
+
+
+metrics = [metric_example]
+```
+
 ## Testing Apps
 
 In general apps can be tested like other Django apps. In most cases you'll want to run your automated tests via the `nautobot-server test <app_module>` command or, if using the `coverage` Python library, `coverage run --module nautobot.core.cli test <app_module>`.

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -1377,7 +1377,7 @@ except ImportError:
 It is possible for Nautobot apps to provide their own [Prometheus metrics](../additional-features/prometheus-metrics.md). There are two general ways to achieve this:
 
 1. Use the `prometheus_client` library directly in your app code. Depending on whether that code runs in the web server or the worker context, the metric will show up in the respective `/metrics` endpoint(s) (i.e. metrics generated in the worker context show up in the worker's endpoint and those generated in the web application's context show up in the web application's endpoint).
-2. If the metric cannot be generated alongside existing code, apps can implement individual metric generator functions and register them into a list called `metrics` in a file named `metrics.py`at the root of the app. Nautobot will automatically read these and expose them via its `/metrics` endpoint. The following code snippet shows an example metric defined this way:
+2. If the metric cannot be generated alongside existing code, apps can implement individual metric generator functions and register them into a list called `metrics` in a file named `metrics.py` at the root of the app. Nautobot will automatically read these and expose them via its `/metrics` endpoint. The following code snippet shows an example metric defined this way:
 
 ```python
 # metrics.py

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -1374,10 +1374,10 @@ except ImportError:
 
 +++ 1.5.?
 
-It is possible for Nautobot apps to provide their own Prometheus metrics. There are two general ways to achieve this:
+It is possible for Nautobot apps to provide their own [Prometheus metrics](../additional-features/prometheus-metrics.md). There are two general ways to achieve this:
 
-1. Use the prometheus_client library directly in your app code. Depending on whether that code runs in the web server or the worker context, the metric will show up in the respective `/metrics` endpoint(s).
-2. If the metric cannot be generated alongside existing code, a mechanism similar to that of Jobs in apps can be used. A list called `metrics` residing in a file called `metrics.py` can be provided at the root of the app. Nautobot will automatically read these and expose them via its `/metrics` endpoint. The following code snippet shows an example metric defined this way:
+1. Use the `prometheus_client` library directly in your app code. Depending on whether that code runs in the web server or the worker context, the metric will show up in the respective `/metrics` endpoint(s).
+2. If the metric cannot be generated alongside existing code, apps can implement individual metric generator functions and register them into a list called `metrics` in a file named `metrics.py`at the root of the app. Nautobot will automatically read these and expose them via its `/metrics` endpoint. The following code snippet shows an example metric defined this way:
 
 ```python
 # metrics.py

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -1387,7 +1387,7 @@ from nautobot_animal_sounds.models import Animal
 
 
 def metric_animals():
-    gauges = GaugeMetricFamily("nautobot_noisy_animals_count", "Nautobot Example Count Metric", labels=[])
+    gauges = GaugeMetricFamily("nautobot_noisy_animals_count", "Nautobot Noisy Animals Count", labels=[])
     screaming_animal_count = Animal.objects.filter(loudness="noisy").count()
     gauges.add_metric(labels=[], value=screaming_animal_count)
     yield gauges

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -1376,7 +1376,7 @@ except ImportError:
 
 It is possible for Nautobot apps to provide their own [Prometheus metrics](../additional-features/prometheus-metrics.md). There are two general ways to achieve this:
 
-1. Use the `prometheus_client` library directly in your app code. Depending on whether that code runs in the web server or the worker context, the metric will show up in the respective `/metrics` endpoint(s).
+1. Use the `prometheus_client` library directly in your app code. Depending on whether that code runs in the web server or the worker context, the metric will show up in the respective `/metrics` endpoint(s) (i.e. metrics generated in the worker context show up in the worker's endpoint and those generated in the web application's context show up in the web application's endpoint).
 2. If the metric cannot be generated alongside existing code, apps can implement individual metric generator functions and register them into a list called `metrics` in a file named `metrics.py`at the root of the app. Nautobot will automatically read these and expose them via its `/metrics` endpoint. The following code snippet shows an example metric defined this way:
 
 ```python

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -721,12 +721,14 @@ def register_override_views(override_views, plugin):
 
 
 def discover_metrics(sender, *, apps, metrics, **kwargs):
-    """Callback to discover metrics.
+    """
+    Callback to discover metrics.
 
     This is necessary because we need to actually evaluate the metric generator fully to discover which metrics it
     provides. This allows us to give an accurate overview on the plugin detail page. However, because the metrics might
     import models themselves, they can only be run after migrations have taken place. This is ensured by connecting
-    this signal handler to the nautobot_database_ready signal for each app."""
+    this signal handler to the nautobot_database_ready signal for each app.
+    """
     if not metrics:
         return
     for metric in metrics:

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -153,7 +153,15 @@ class NautobotAppConfig(NautobotConfig):
         metrics = import_object(f"{self.__module__}.{self.metrics}")
         if metrics is not None:
             register_metrics(metrics)
-            self.features["metrics"] = metrics
+            self.features["metrics"] = []
+            for metric in metrics:
+                # Iterate over all the metric instances in this metric. This is done because a single callable might
+                # return multiple metrics with different names. Note: If a metric is _always_ returned from its
+                # callable, there would be inconsistency in the 'features' dict. This would however be a bad practice on
+                # the metric definition side, as any metric that _could_ exist _should_ always also exist, even if set
+                # to some initial value (ref: https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics).
+                for metric_instance in metric():
+                    self.features["metrics"].append(metric_instance.name)
 
         # Register plugin navigation menu items (if defined)
         menu_items = import_object(f"{self.__module__}.{self.menu_items}")

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -1,5 +1,6 @@
 import collections
 import inspect
+from functools import partial
 from importlib import import_module
 from logging import getLogger
 
@@ -18,6 +19,7 @@ from nautobot.core.apps import (
     register_menu_items,
     register_homepage_panels,
 )
+from nautobot.core.signals import nautobot_database_ready
 from nautobot.extras.choices import BannerClassChoices
 from nautobot.extras.registry import registry, register_datasource_contents
 from nautobot.extras.plugins.exceptions import PluginImproperlyConfigured
@@ -153,15 +155,10 @@ class NautobotAppConfig(NautobotConfig):
         metrics = import_object(f"{self.__module__}.{self.metrics}")
         if metrics is not None:
             register_metrics(metrics)
-            self.features["metrics"] = []
-            for metric in metrics:
-                # Iterate over all the metric instances in this metric. This is done because a single callable might
-                # return multiple metrics with different names. Note: If a metric is _always_ returned from its
-                # callable, there would be inconsistency in the 'features' dict. This would however be a bad practice on
-                # the metric definition side, as any metric that _could_ exist _should_ always also exist, even if set
-                # to some initial value (ref: https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics).
-                for metric_instance in metric():
-                    self.features["metrics"].append(metric_instance.name)
+            self.features["metrics"] = []  # Initialize as empty, to be filled by the signal handler
+            # Inject the metrics to discover into the signal handler.
+            signal_callback = partial(discover_metrics, metrics=metrics)
+            nautobot_database_ready.connect(signal_callback, sender=self)
 
         # Register plugin navigation menu items (if defined)
         menu_items = import_object(f"{self.__module__}.{self.menu_items}")
@@ -721,3 +718,22 @@ def register_override_views(override_views, plugin):
         for pattern in app_resolver.url_patterns:
             if isinstance(pattern, URLPattern) and hasattr(pattern, "name") and pattern.name == view_name:
                 pattern.callback = view
+
+
+def discover_metrics(sender, *, apps, metrics, **kwargs):
+    """Callback to discover metrics.
+
+    This is necessary because we need to actually evaluate the metric generator fully to discover which metrics it
+    provides. This allows us to give an accurate overview on the plugin detail page. However, because the metrics might
+    import models themselves, they can only be run after migrations have taken place. This is ensured by connecting
+    this signal handler to the nautobot_database_ready signal for each app."""
+    if not metrics:
+        return
+    for metric in metrics:
+        # Iterate over all the metric instances in this metric. This is done because a single callable might
+        # return multiple metrics with different names. Note: If a metric is _always_ returned from its
+        # callable, there would be inconsistency in the 'features' dict. This would however be a bad practice on
+        # the metric definition side, as any metric that _could_ exist _should_ always also exist, even if set
+        # to some initial value (ref: https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics).
+        for metric_instance in metric():
+            sender.features["metrics"].append(metric_instance.name)

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -35,7 +35,7 @@ registry["plugin_custom_validators"] = collections.defaultdict(list)
 registry["plugin_graphql_types"] = []
 registry["plugin_jobs"] = []
 registry["plugin_template_extensions"] = collections.defaultdict(list)
-registry["plugin_metrics"] = []
+registry["app_metrics"] = []
 
 
 #
@@ -439,7 +439,7 @@ def register_metrics(function_list):
     for metric in function_list:
         if not callable(metric):
             raise TypeError(f"{metric} is not a callable.")
-        registry["plugin_metrics"].append(metric)
+        registry["app_metrics"].append(metric)
 
 
 class FilterExtension:

--- a/nautobot/extras/templates/extras/plugin_detail.html
+++ b/nautobot/extras/templates/extras/plugin_detail.html
@@ -289,6 +289,20 @@
                                     {% endif %}
                                 </td>
                             </tr>
+                            <tr>
+                                <td>App Metrics</td>
+                                <td>
+                                    {% if features.metrics %}
+                                        <ul class="list-unstyled">
+                                            {% for metric in features.metrics %}
+                                                <li><code>{{ metric }}</code></li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% else %}
+                                        {{ False | render_boolean }}
+                                    {% endif %}
+                                </td>
+                            </tr>
                         {% endwith %}
                     </table>
                 </div>


### PR DESCRIPTION
# Relates to: #766 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

This ports the metric extensibility from capacity-metrics to this plugin as a first effort to move capacity-metrics into core. There is an example of what this does in the example plugin, here is what that looks like rendered:

```
# HELP nautobot_example_metric_count Nautobot Example Count Metric
# TYPE nautobot_example_metric_count gauge
nautobot_example_metric_count{name="Test"} 100.0
# HELP nautobot_app_metrics_processing_ms Time in ms to generate the app metrics
# TYPE nautobot_app_metrics_processing_ms gauge
nautobot_app_metrics_processing_ms 5.14007
```

I overwrote the `/metrics` view of `django_prometheus` in order to inject these custom app metrics and then copied the registry approach from the jobs, putting metrics into `$app.metrics.metrics`.

Of the two existing and one planned approaches in capacity-metrics to allow for custom metrics I chose to just implement the planned approach of auto-discovering from via path. I think since all the three ways (explicitly calling a function on the metric, configuring it in the app settings and discovering via path) are equally powerful, its best to go for the approach which mimics other app extensibility features such as jobs here.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
