### PR TITLE
Fix Filter on custom field (selection) can't be changed once filter is configured

### DIFF
--- a/changes/3335.fixed
+++ b/changes/3335.fixed
@@ -1,1 +1,1 @@
-Fix Filter on custom field (selection) can't be changed once filter is configured.
+Fixed inability to change filtering on custom field (selection) once filter is configured.

--- a/changes/3335.fixed
+++ b/changes/3335.fixed
@@ -1,0 +1,1 @@
+Fix Filter on custom field (selection) can't be changed once filter is configured.

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -266,7 +266,28 @@
                 }
             }
         }
+    })
+    // On change of input field in default filter form
+    // Replicate that change into dynamic filter form and vice-versa
+    $("#default-filter form input, #advanced-filter input").on("change", function (e){
+        let field_name = $(this).attr("name");
+        let field_value = $(this).val();
+        let form_id = $(this).parents("form").attr("id");
+        let default_filters_field_dom = $(`#default-filter form input[name=${field_name}]`);
+        let advanced_filters_field_dom = $(`#advanced-filter #filterform-table tbody tr td input[name=${field_name}]`);
 
+        // Only apply logic if fields with same name attr are on both advanced and default filter form
+        if(default_filters_field_dom.length && advanced_filters_field_dom.length){
+            // Only change field value if both fields do not have equal values
+            if (default_filters_field_dom.val() !== advanced_filters_field_dom.val()){
+                if(form_id === "dynamic-filter-form"){
+                    default_filters_field_dom.val(field_value);
+                }
+                else {
+                    advanced_filters_field_dom.val(field_value);
+                }
+            }
+        }
     })
 </script>
 {% endblock %}

--- a/nautobot/core/tests/integration/test_filters.py
+++ b/nautobot/core/tests/integration/test_filters.py
@@ -22,6 +22,7 @@ class ListViewFilterTestCase(SeleniumTestCase):
         self.user.is_superuser = True
         self.user.save()
 
+        # TODO(timizuo): changing these from name to slug when resolving issue #824
         self.cf_text_field_name = "text_field"
         self.cf_integer_field_name = "integer_field"
         self.cf_select_field_name = "select_field"
@@ -128,7 +129,6 @@ class ListViewFilterTestCase(SeleniumTestCase):
         """Assert that a filter input/select field on Dynamic Filter Form updates if same field is updated."""
         self.browser.visit(f'{self.live_server_url}{reverse("dcim:site_list")}')
 
-        # TODO(timizuo): changing these from name to slug when resolving issue #824
         text_field_name = "cf_" + self.cf_text_field_name
         integer_field_name = "cf_" + self.cf_integer_field_name
         select_field_name = "cf_" + self.cf_select_field_name

--- a/nautobot/core/tests/integration/test_filters.py
+++ b/nautobot/core/tests/integration/test_filters.py
@@ -34,7 +34,7 @@ class ListViewFilterTestCase(SeleniumTestCase):
             custom_field.content_types.set([ContentType.objects.get_for_model(Site)])
 
         for x in ["A", "B", "C"]:
-            CustomFieldChoice.objects.create(field=self.custom_fields[2], value=f"fOption {x}")
+            CustomFieldChoice.objects.create(field=self.custom_fields[2], value=f"Option {x}")
 
     def tearDown(self):
         self.logout()
@@ -103,39 +103,70 @@ class ListViewFilterTestCase(SeleniumTestCase):
         # assert the filter UI element is gone
         self.assertTrue(self.browser.is_element_not_present_by_xpath("//div[@class='filters-applied']"))
 
+    def change_field_value(self, field_name, value, field_type="input", idx=0, select2_field_name=None):
+        """Change the value of an input or select field.
+
+        Args:
+            field_name (str): The name of the input or select field.
+            value (str or int): The value to fill in the input field or select from the select field.
+            field_type (str, optional): The type of the field, either "input" or "select".
+            idx (int, optional): The index of the field in case there are multiple fields with the same name.
+            select2_field_name (str, optional): The name of the select2 field in case it is different from the input field name.
+        """
+        if field_type == "input":
+            self.browser.find_by_name(field_name)[idx].fill(value)
+        else:
+            self.browser.find_by_xpath(f"//select[@name='{field_name}']//following-sibling::span")[idx].click()
+            select2_field_name = select2_field_name or field_name
+            select_field_xpath = (
+                f"//ul[@id='select2-id_{select2_field_name}-results']/li[contains(@class,"
+                f"'select2-results__option')  and contains(text(),'{value}')]"
+            )
+            self.browser.find_by_xpath(select_field_xpath).click()
+
     def test_input_field_gets_updated(self):
         """Assert that a filter input/select field on Dynamic Filter Form updates if same field is updated."""
         self.browser.visit(f'{self.live_server_url}{reverse("dcim:site_list")}')
 
         # TODO(timizuo): changing these from name to slug when resolving issue #824
         text_field_name = "cf_" + self.cf_text_field_name
-        text_integer_field_name = "cf_" + self.cf_integer_field_name
-        text_select_field_name = "cf_" + self.cf_select_field_name
+        integer_field_name = "cf_" + self.cf_integer_field_name
+        select_field_name = "cf_" + self.cf_select_field_name
+        apply_btn_xpath = "//div[@id='default-filter']//button[@type='submit']"
 
         # Open the filter modal, configure filter and apply filter
         self.browser.find_by_id("id__filterbtn").click()
-        self.browser.find_by_name(text_field_name).first.fill("example-text")
-        self.browser.find_by_name(text_integer_field_name).first.fill(4356)
-        self.browser.find_by_xpath("//div[@id='default-filter']//button[@type='submit']").click()
+        self.change_field_value(text_field_name, "example-text")
+        self.change_field_value(integer_field_name, 4356)
+        self.change_field_value(select_field_name, "Option A", field_type="select")
+        self.browser.find_by_xpath(apply_btn_xpath).click()  # Click on apply filter button
         self.assertTrue(self.browser.is_text_present("example-text"))
         self.assertTrue(self.browser.is_text_present("4356"))
+        self.assertTrue(self.browser.is_text_present("Option A"))
 
         # Assert on update of field in Default Filter the update is replicated on Advanced Filter
         self.browser.find_by_id("id__filterbtn").click()
-        self.browser.find_by_name(text_field_name)[1].fill("test new")
-        self.browser.find_by_name(text_integer_field_name)[1].fill(1111)
-        self.browser.find_by_xpath("//a[@href='#advanced-filter']").click()  # *
+        self.change_field_value(text_field_name, "test new", idx=1)
+        self.change_field_value(integer_field_name, 1111, idx=1)
+        self.change_field_value(select_field_name, "Option B", field_type="select")
+        self.browser.find_by_xpath("//a[@href='#advanced-filter']").click()
         self.assertEqual(self.browser.find_by_name(text_field_name)[2].value, "test new")
-        self.assertEqual(self.browser.find_by_name(text_integer_field_name)[2].value, "1111")
+        self.assertEqual(self.browser.find_by_name(integer_field_name)[2].value, "1111")
+        self.assertEqual(self.browser.find_by_name(select_field_name)[2].value, "Option B")
 
         # Assert on update of field in Advanced Filter the update is replicated on Default Filter
-        self.browser.find_by_name(text_field_name)[2].fill("test new update")
-        self.browser.find_by_name(text_integer_field_name)[2].fill(8888)
+        self.change_field_value(text_field_name, "test new update", idx=2)
+        self.change_field_value(integer_field_name, 8888, idx=2)
+        self.change_field_value(
+            select_field_name, "Option C", field_type="select", idx=1, select2_field_name="form-1-lookup_value"
+        )
         self.browser.find_by_xpath("//a[@href='#default-filter']").click()
         self.assertEqual(self.browser.find_by_name(text_field_name)[1].value, "test new update")
-        self.assertEqual(self.browser.find_by_name(text_integer_field_name)[1].value, "8888")
+        self.assertEqual(self.browser.find_by_name(integer_field_name)[1].value, "8888")
+        self.assertEqual(self.browser.find_by_name(select_field_name)[1].value, "Option C")
 
         # Assert on update of filter, the new filter is applied
-        self.browser.find_by_xpath("//div[@id='default-filter']//button[@type='submit']").click()
+        self.browser.find_by_xpath(apply_btn_xpath).click()  # Click on apply filter button
         self.assertTrue(self.browser.is_text_present("test new update"))
         self.assertTrue(self.browser.is_text_present("8888"))
+        self.assertTrue(self.browser.is_text_present("Option C"))

--- a/nautobot/extras/filters/__init__.py
+++ b/nautobot/extras/filters/__init__.py
@@ -78,6 +78,7 @@ __all__ = (
     "ComputedFieldFilterSet",
     "ConfigContextFilterSet",
     "ContentTypeFilterSet",
+    "ContentTypeMultipleChoiceFilter",
     "CreatedUpdatedFilterSet",
     "CreatedUpdatedModelFilterSetMixin",
     "CustomFieldBooleanFilter",

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -847,7 +847,7 @@ def get_filterset_parameter_form_field(model, parameter):
     Return the relevant form field instance for a filterset parameter e.g DynamicModelMultipleChoiceField, forms.IntegerField e.t.c
     """
     # Avoid circular import
-    from nautobot.extras.filters import ContentTypeMultipleChoiceFilter, StatusFilter
+    from nautobot.extras.filters import ContentTypeMultipleChoiceFilter, CustomFieldFilterMixin, StatusFilter
     from nautobot.extras.models import Status, Tag
     from nautobot.extras.utils import ChangeLoggedModelsQuery, TaggableClassesQuery
     from nautobot.utilities.forms import (
@@ -869,7 +869,9 @@ def get_filterset_parameter_form_field(model, parameter):
     form_field = field.field
 
     # TODO(Culver): We are having to replace some widgets here because multivalue_field_factory that generates these isn't smart enough
-    if isinstance(field, NumberFilter):
+    if isinstance(field, CustomFieldFilterMixin):
+        form_field = field.custom_field.to_form_field()
+    elif isinstance(field, NumberFilter):
         form_field = forms.IntegerField()
     elif isinstance(field, filters.ModelMultipleChoiceFilter):
         related_model = Status if isinstance(field, StatusFilter) else field.extra["queryset"].model


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3196 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Because the custom field(selection) on the Default filter form and the DynamicFilterForm had different field types, the DynamicFilterForm field did not update when the choice field on the Default filter form did. The correct field type for DefaultFilter is a choice field, whereas the field type for DynaicFilterForm is a multichar field.

- Previously, this updating of fields on DynamicFilterForm and DefualtFilterForm was only performed on select fields. Added JavaScript logic to update on input fields also.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
