### PR TITLE
Fix get_route_for_model for ContentTypes

### DIFF
--- a/changes/3341.fixed
+++ b/changes/3341.fixed
@@ -1,0 +1,1 @@
+Fix the issue with the ContentType reverse return, i.e get_route_for_model(ContentType, api=True...).

--- a/nautobot/utilities/tests/test_utils.py
+++ b/nautobot/utilities/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pickle
 
 from django import forms
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.http import QueryDict
@@ -231,6 +232,8 @@ class GetFooForModelTest(TestCase):
         self.assertEqual(get_route_for_model(Device, "list", api=True), "dcim-api:device-list")
         self.assertEqual(get_route_for_model("dcim.site", "detail", api=True), "dcim-api:site-detail")
         self.assertEqual(get_route_for_model(Site, "detail", api=True), "dcim-api:site-detail")
+        self.assertEqual(get_route_for_model(ContentType, "list", api=True), "extras-api:contenttype-list")
+        self.assertEqual(get_route_for_model(ContentType, "detail", api=True), "extras-api:contenttype-detail")
         self.assertEqual(
             get_route_for_model("example_plugin.examplemodel", "list", api=True),
             "plugins-api:example_plugin-api:examplemodel-list",

--- a/nautobot/utilities/tests/test_utils.py
+++ b/nautobot/utilities/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pickle
 
 from django import forms
+from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db.models import Q
@@ -234,6 +235,8 @@ class GetFooForModelTest(TestCase):
         self.assertEqual(get_route_for_model(Site, "detail", api=True), "dcim-api:site-detail")
         self.assertEqual(get_route_for_model(ContentType, "list", api=True), "extras-api:contenttype-list")
         self.assertEqual(get_route_for_model(ContentType, "detail", api=True), "extras-api:contenttype-detail")
+        self.assertEqual(get_route_for_model(Group, "list", api=True), "users-api:group-list")
+        self.assertEqual(get_route_for_model(Group, "detail", api=True), "users-api:group-detail")
         self.assertEqual(
             get_route_for_model("example_plugin.examplemodel", "list", api=True),
             "plugins-api:example_plugin-api:examplemodel-list",

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -105,8 +105,8 @@ def get_route_for_model(model, action, api=False):
         model = get_model_from_name(model)
 
     suffix = "" if not api else "-api"
-    # Because ContentType is not a core model in nautobot, running a 'ContentType. meta.app label'
-    # would return "contenttypes" rather than "extras".
+    # The `contenttypes` app doesn't provide REST API endpoints,
+    # but Nautobot provides one for the ContentType model in our `extras` app.
     if model is ContentType:
         app_label = "extras"
     else:

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -12,6 +12,7 @@ import django_filters
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.serializers import serialize
@@ -105,10 +106,12 @@ def get_route_for_model(model, action, api=False):
         model = get_model_from_name(model)
 
     suffix = "" if not api else "-api"
-    # The `contenttypes` app doesn't provide REST API endpoints,
-    # but Nautobot provides one for the ContentType model in our `extras` app.
+    # The `contenttypes` and `auth` app doesn't provide REST API endpoints,
+    # but Nautobot provides one for the ContentType model in our `extras` and Group model in `users` app.
     if model is ContentType:
         app_label = "extras"
+    elif model is Group:
+        app_label = "users"
     else:
         app_label = model._meta.app_label
     prefix = f"{app_label}{suffix}:{model._meta.model_name}"

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -105,7 +105,13 @@ def get_route_for_model(model, action, api=False):
         model = get_model_from_name(model)
 
     suffix = "" if not api else "-api"
-    prefix = f"{model._meta.app_label}{suffix}:{model._meta.model_name}"
+    # Because ContentType is not a core model in nautobot, running a 'ContentType. meta.app label'
+    # would return "contenttypes" rather than "extras".
+    if model is ContentType:
+        app_label = "extras"
+    else:
+        app_label = model._meta.app_label
+    prefix = f"{app_label}{suffix}:{model._meta.model_name}"
     sep = "_" if not api else "-"
     viewname = f"{prefix}{sep}{action}"
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3080 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Running `get_route_for_model(ConentType, api=True...)` would yield `content-types-api:contenttype-list` rather than the newly created endpoint for contenttypes because `ContentType` is not a core model in nautobot (`extras-api:contenttype-list`)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
