### PR TITLE
Added support for relationships in Dynamic Groups.

### DIFF
--- a/changes/3220.added
+++ b/changes/3220.added
@@ -1,0 +1,1 @@
+Added support for relationships in Dynamic Groups.

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -75,7 +75,7 @@ class DynamicGroup(OrganizationalModel):
     # to dynamically change the widget if we decide we do want to support this field.
     #
     # Type: tuple
-    exclude_filter_fields = ("q", "cf_", "cr_", "cpf_", "comments")  # Must be a tuple
+    exclude_filter_fields = ("q", "cpf_", "comments")  # Must be a tuple
 
     class Meta:
         ordering = ["content_type", "name"]

--- a/nautobot/extras/templates/extras/dynamicgroup_edit.html
+++ b/nautobot/extras/templates/extras/dynamicgroup_edit.html
@@ -44,22 +44,25 @@
                         {% render_form filter_form %}
                       </div>
                     </div>
-		    {% if filter_form.custom_fields %}
+
+                    {% if filter_form.custom_fields %}
                     <div class="panel panel-default">
                       <div class="panel-heading"><strong>Custom Fields</strong></div>
                       <div class="panel-body">
                         {% render_custom_fields filter_form %}
                       </div>
                     </div>
-		    {% endif %}
-		    {% if filter_form.relationships %}
+                    {% endif %}
+
+                    {% if filter_form.relationships %}
                     <div class="panel panel-default">
                       <div class="panel-heading"><strong>Relationships</strong></div>
                       <div class="panel-body">
                         {% render_relationships filter_form %}
                       </div>
                     </div>
-		    {% endif %}
+                    {% endif %}
+
                 </div>
                 <div class="tab-pane" id="children-form">
                     {% if children.errors %}

--- a/nautobot/extras/templates/extras/dynamicgroup_edit.html
+++ b/nautobot/extras/templates/extras/dynamicgroup_edit.html
@@ -27,17 +27,39 @@
                 <div class="tab-pane active" id="filter-form">
                     {% if filter_form %}
                     <span class="help-block">
-			Select the filtering criteria to determine membership of objects matching
-			the Content Type for this Dynamic Group. Fields that are not a dropdown are
-			expected to have string inputs and do not support multiple values.
+                      Select the filtering criteria to determine membership of objects matching
+                      the Content Type for this Dynamic Group. Fields that are not a dropdown are
+                      expected to have string inputs and do not support multiple values.
                     </span>
                     {% else %}
                     <span class="help-block">
-			Filtering criteria will be available after initially saving this group and
-			returning to this page.
+                      Filtering criteria will be available after initially saving this group and
+                      returning to this page.
                     </span>
                     {% endif %}
-                    {% render_form filter_form %}
+
+                    <div class="panel panel-default">
+                      <div class="panel-heading"><strong>Object Fields</strong></div>
+                      <div class="panel-body">
+                        {% render_form filter_form %}
+                      </div>
+                    </div>
+		    {% if filter_form.custom_fields %}
+                    <div class="panel panel-default">
+                      <div class="panel-heading"><strong>Custom Fields</strong></div>
+                      <div class="panel-body">
+                        {% render_custom_fields filter_form %}
+                      </div>
+                    </div>
+		    {% endif %}
+		    {% if filter_form.relationships %}
+                    <div class="panel panel-default">
+                      <div class="panel-heading"><strong>Relationships</strong></div>
+                      <div class="panel-body">
+                        {% render_relationships filter_form %}
+                      </div>
+                    </div>
+		    {% endif %}
                 </div>
                 <div class="tab-pane" id="children-form">
                     {% if children.errors %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3220 
# What's Changed

## This is the version for the `next` branch

- This unblocks fields starting with `cr_` from being used in filters for Dynamic Groups
- Augmented the edit view to break fields down by "object fields", "custom fields" (not shown), and "relationships":

<img width="800" alt="image" src="https://user-images.githubusercontent.com/138052/220472258-22f5e62e-6388-4534-a666-a895ce6d1859.png">

<img width="1218" alt="image" src="https://user-images.githubusercontent.com/138052/220472283-9595ec31-6344-4d4e-9dd9-a67eda5d0e8b.png">


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
