### PR TITLE
Added support for search, custom fields, and relationships to Dynamic Groups

### DIFF
--- a/changes/3219.added
+++ b/changes/3219.added
@@ -1,0 +1,1 @@
+Added support for custom fields to Dynamic Groups.

--- a/changes/3220.added
+++ b/changes/3220.added
@@ -1,0 +1,1 @@
+Added support for relationships to Dynamic Groups.

--- a/changes/3353.fixed
+++ b/changes/3353.fixed
@@ -1,0 +1,2 @@
+Fixed a bug in `nautobot.extras.forms.mixins.CustomFieldModelFilterFormMixin` where the list of custom field names were not being stored on `self.custom_fields`.
+Fixed a bug in `nautobot.utilities.filters.MappedPredicatesFilterMixin` (from which `SearchFilter` inherits) that was preventing `q` fields from being used in Dynamic Group filters.

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -70,6 +70,7 @@ class CustomFieldModelFilterFormMixin(forms.Form):
         custom_fields = CustomField.objects.filter(content_types=self.obj_type).exclude(
             filter_logic=CustomFieldFilterLogicChoices.FILTER_DISABLED
         )
+        self.custom_fields = []
         for cf in custom_fields:
             # 2.0 TODO: #824 cf.name to cf.slug throughout
             field_name = f"cf_{cf.name}"
@@ -79,6 +80,7 @@ class CustomFieldModelFilterFormMixin(forms.Form):
                 )
             else:
                 self.fields[field_name] = cf.to_form_field(set_initial=False, enforce_required=False)
+            self.custom_fields.append(field_name)
 
 
 class CustomFieldModelFormMixin(forms.ModelForm):

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -69,6 +69,11 @@ class DynamicGroup(OrganizationalModel):
     #
     # Currently this means skipping "computed fields" and "comments".
     #
+    # - Computed fields are skipped because they are generated at call time and
+    #   therefore cannot be queried
+    # - Comments are skipped because they are TextFields that require an exact
+    #   match and are better covered by the search (`q`) field.
+    #
     # Type: tuple
     exclude_filter_fields = ("cpf_", "comments")  # Must be a tuple
 

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -64,17 +64,13 @@ class DynamicGroup(OrganizationalModel):
 
     clone_fields = ["content_type", "filter"]
 
-    # This is used as a `startswith` check on field names, so these can be
-    # explicit fields or just substrings.
+    # This is used as a `startswith` check on field names, so these can be explicit fields or just
+    # substrings.
     #
-    # Currently this means skipping "search", custom fields, and custom relationships.
-    #
-    # FIXME(jathan): As one example, `DeviceFilterSet.q` filter searches in `comments`. The issue
-    # really being that this field renders as a textarea and it's not cute in the UI. Might be able
-    # to dynamically change the widget if we decide we do want to support this field.
+    # Currently this means skipping "computed fields" and "comments".
     #
     # Type: tuple
-    exclude_filter_fields = ("q", "cf_", "cr_", "cpf_", "comments")  # Must be a tuple
+    exclude_filter_fields = ("cpf_", "comments")  # Must be a tuple
 
     class Meta:
         ordering = ["content_type", "name"]

--- a/nautobot/extras/templates/extras/dynamicgroup_edit.html
+++ b/nautobot/extras/templates/extras/dynamicgroup_edit.html
@@ -27,17 +27,41 @@
                 <div class="tab-pane active" id="filter-form">
                     {% if filter_form %}
                     <span class="help-block">
-			Select the filtering criteria to determine membership of objects matching
-			the Content Type for this Dynamic Group. Fields that are not a dropdown are
-			expected to have string inputs and do not support multiple values.
+                        Select the filtering criteria to determine membership of objects matching
+                        the Content Type for this Dynamic Group. Fields that are not a dropdown are
+                        expected to have string inputs and do not support multiple values.
                     </span>
                     {% else %}
                     <span class="help-block">
-			Filtering criteria will be available after initially saving this group and
-			returning to this page.
+                        Filtering criteria will be available after initially saving this group and
+                        returning to this page.
                     </span>
                     {% endif %}
-                    {% render_form filter_form %}
+
+                    <div class="panel panel-default">
+                      <div class="panel-heading"><strong>Object Fields</strong></div>
+                      <div class="panel-body">
+                        {% render_form filter_form %}
+                      </div>
+                    </div>
+
+                    {% if filter_form.custom_fields %}
+                    <div class="panel panel-default">
+                      <div class="panel-heading"><strong>Custom Fields</strong></div>
+                      <div class="panel-body">
+                        {% render_custom_fields filter_form %}
+                      </div>
+                    </div>
+                    {% endif %}
+
+                    {% if filter_form.relationships %}
+                    <div class="panel panel-default">
+                      <div class="panel-heading"><strong>Relationships</strong></div>
+                      <div class="panel-body">
+                        {% render_relationships filter_form %}
+                      </div>
+                    </div>
+                    {% endif %}
                 </div>
                 <div class="tab-pane" id="children-form">
                     {% if children.errors %}

--- a/nautobot/extras/templates/extras/dynamicgroup_edit.html
+++ b/nautobot/extras/templates/extras/dynamicgroup_edit.html
@@ -31,36 +31,37 @@
                         the Content Type for this Dynamic Group. Fields that are not a dropdown are
                         expected to have string inputs and do not support multiple values.
                     </span>
+
+                        <div class="panel panel-default">
+                          <div class="panel-heading"><strong>Object Fields</strong></div>
+                          <div class="panel-body">
+                            {% render_form filter_form %}
+                          </div>
+                        </div>
+
+                        {% if filter_form.custom_fields %}
+                        <div class="panel panel-default">
+                          <div class="panel-heading"><strong>Custom Fields</strong></div>
+                          <div class="panel-body">
+                            {% render_custom_fields filter_form %}
+                          </div>
+                        </div>
+                        {% endif %}
+
+                        {% if filter_form.relationships %}
+                        <div class="panel panel-default">
+                          <div class="panel-heading"><strong>Relationships</strong></div>
+                          <div class="panel-body">
+                            {% render_relationships filter_form %}
+                          </div>
+                        </div>
+                        {% endif %}
+
                     {% else %}
                     <span class="help-block">
                         Filtering criteria will be available after initially saving this group and
                         returning to this page.
                     </span>
-                    {% endif %}
-
-                    <div class="panel panel-default">
-                      <div class="panel-heading"><strong>Object Fields</strong></div>
-                      <div class="panel-body">
-                        {% render_form filter_form %}
-                      </div>
-                    </div>
-
-                    {% if filter_form.custom_fields %}
-                    <div class="panel panel-default">
-                      <div class="panel-heading"><strong>Custom Fields</strong></div>
-                      <div class="panel-body">
-                        {% render_custom_fields filter_form %}
-                      </div>
-                    </div>
-                    {% endif %}
-
-                    {% if filter_form.relationships %}
-                    <div class="panel panel-default">
-                      <div class="panel-heading"><strong>Relationships</strong></div>
-                      <div class="panel-body">
-                        {% render_relationships filter_form %}
-                      </div>
-                    </div>
                     {% endif %}
                 </div>
                 <div class="tab-pane" id="children-form">

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -410,7 +410,7 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         # Test that it's a dict with or without certain key fields.
         self.assertIsInstance(fields, dict)
         self.assertNotEqual(fields, {})
-        self.assertNotIn("q", fields)
+        self.assertNotIn("comments", fields)
         self.assertIn("name", fields)
         # See if a CharField is properly converted to a MultiValueCharField In DynamicGroupEditForm.
         self.assertIsInstance(fields["name"], MultiValueCharField)
@@ -512,7 +512,7 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         filter_fields = group.get_filter_fields()
         self.assertIsInstance(filter_fields, dict)
         self.assertNotEqual(filter_fields, {})
-        self.assertNotIn("q", filter_fields)
+        self.assertNotIn("comments", filter_fields)
         self.assertIn("name", filter_fields)
 
     def test_generate_filter_form(self):

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -20,9 +20,21 @@ from nautobot.dcim.models import (
     Region,
     Site,
 )
-from nautobot.extras.choices import DynamicGroupOperatorChoices
+from nautobot.extras.choices import (
+    CustomFieldFilterLogicChoices,
+    CustomFieldTypeChoices,
+    DynamicGroupOperatorChoices,
+    RelationshipTypeChoices,
+)
 from nautobot.extras.filters import DynamicGroupFilterSet, DynamicGroupMembershipFilterSet
-from nautobot.extras.models import DynamicGroup, DynamicGroupMembership, Status
+from nautobot.extras.models import (
+    CustomField,
+    DynamicGroup,
+    DynamicGroupMembership,
+    Relationship,
+    RelationshipAssociation,
+    Status,
+)
 from nautobot.ipam.models import Prefix
 from nautobot.utilities.forms.fields import MultiValueCharField
 from nautobot.utilities.forms.widgets import MultiValueCharInput
@@ -827,6 +839,107 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         # Clear the deeply nested child's parents then delete it!
         self.nested_child.parents.clear()
         self.nested_child.delete()
+
+    def test_filter_relationships(self):
+        """Test that relationships can be used in filters."""
+        prefix_ct = ContentType.objects.get_for_model(Prefix)
+
+        device = self.devices[0]
+        prefix = Prefix.objects.first()
+
+        relationship = Relationship(
+            name="Device to Prefix",
+            slug="device_to_prefix",
+            source_type=self.device_ct,
+            source_label="My Prefixes",
+            source_filter=None,
+            destination_type=prefix_ct,
+            destination_label="My Devices",
+            type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
+        )
+        relationship.validated_save()
+
+        ra = RelationshipAssociation(
+            relationship=relationship,
+            source=device,
+            destination=prefix,
+        )
+        ra.validated_save()
+
+        dg = DynamicGroup(
+            name="relationships",
+            slug="relationships",
+            description="I filter on relationships.",
+            filter={"cr_device_to_prefix__destination": [prefix.pk]},
+            content_type=self.device_ct,
+        )
+        dg.validated_save()
+
+        # These should be the same length.
+        self.assertEqual(dg.count, 1)
+
+        # And have the same members...
+        self.assertIn(device, dg.members)
+        expected = [str(device)]
+        self.assertEqual(sorted(dg.members.values_list("name", flat=True)), expected)
+
+    def test_filter_custom_fields(self):
+        """Test that relationships can be used in filters."""
+
+        device = self.devices[0]
+
+        cf = CustomField.objects.create(
+            name="favorite_food",
+            type=CustomFieldTypeChoices.TYPE_TEXT,
+            filter_logic=CustomFieldFilterLogicChoices.FILTER_LOOSE,
+        )
+        cf.content_types.add(self.device_ct)
+
+        device._custom_field_data = {"favorite_food": "bacon"}
+        device.validated_save()
+        device.refresh_from_db()
+
+        dg = DynamicGroup(
+            name="custom_fields",
+            slug="custom_fields",
+            description="I filter on custom fields.",
+            filter={"cf_favorite_food": "bacon"},
+            content_type=self.device_ct,
+        )
+        dg.validated_save()
+
+        # These should be the same length.
+        self.assertEqual(dg.count, 1)
+
+        # And have the same members...
+        self.assertIn(device, dg.members)
+        expected = [str(device)]
+        self.assertEqual(sorted(dg.members.values_list("name", flat=True)), expected)
+
+    def test_filter_search(self):
+        """Test that search (`q` filter) can be used in filters."""
+
+        # Rename the device to explicitly match on search.
+        device = self.devices[0]
+        device.name = "pizza-party-machine"
+        device.save()
+
+        dg = DynamicGroup(
+            name="custom_fields",
+            slug="custom_fields",
+            description="I filter on the q field",
+            filter={"q": "party"},  # Let's party! 🎉
+            content_type=self.device_ct,
+        )
+        dg.validated_save()
+
+        # These should be the same length.
+        self.assertEqual(dg.count, 1)
+
+        # And have the same members...
+        self.assertIn(device, dg.members)
+        expected = [str(device)]
+        self.assertEqual(sorted(dg.members.values_list("name", flat=True)), expected)
 
 
 class DynamicGroupMembershipModelTest(DynamicGroupTestBase):

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -499,6 +499,31 @@ class DynamicGroupTestCase(
             "dynamic_group_memberships-MAX_NUM_FORMS": "1000",
         }
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_edit_saved_filter(self):
+        """Test that editing a filter works using the edit view."""
+        self.add_permissions("extras.add_dynamicgroup", "extras.change_dynamicgroup")
+
+        # Create the object first.
+        data = self.form_data.copy()
+        request = {
+            "path": self._get_url("add"),
+            "data": post_data(data),
+        }
+        self.assertHttpStatus(self.client.post(**request), 302)
+
+        # Now update it.
+        instance = self._get_queryset().get(name=data["name"])
+        data["filter-serial"] = "abc123"
+        request = {
+            "path": self._get_url("edit", instance),
+            "data": post_data(data),
+        }
+        self.assertHttpStatus(self.client.post(**request), 302)
+
+        instance.refresh_from_db()
+        self.assertEqual(instance.filter, {"serial": data["filter-serial"]})
+
 
 class ExportTemplateTestCase(
     ViewTestCases.CreateObjectViewTestCase,

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -352,12 +352,12 @@ class MappedPredicatesFilterMixin:
         super().__init__(*args, **kwargs)
 
         # Generate the query with a sentinel value to validate it and surface parse errors.
-        self.generate_query(value="", filter_predicates=self.filter_predicates)
+        self.generate_query(value="")
 
-    def generate_query(self, value, filter_predicates=None, **kwargs):
+    def generate_query(self, value, **kwargs):
         """
-        Given a mapping of `filter_predicates` and a `value`, return a `Q` object for 2-tuple of
-        predicate=value.
+        Given a `value`, return a `Q` object for 2-tuple of `predicate=value`. Filter predicates are
+        read from the instance filter. Any `kwargs` are ignored.
         """
 
         def noop(v):
@@ -365,7 +365,7 @@ class MappedPredicatesFilterMixin:
             return v
 
         query = models.Q()
-        for field_name, lookup_info in filter_predicates.items():
+        for field_name, lookup_info in self.filter_predicates.items():
             # Unless otherwise specified, set the default prepreprocssor
             if isinstance(lookup_info, str):
                 lookup_expr = lookup_info
@@ -402,7 +402,7 @@ class MappedPredicatesFilterMixin:
             return qs
 
         # Evaluate the query and stash it for later use (such as introspection or debugging)
-        query = self.generate_query(value=value, filter_predicates=self.filter_predicates)
+        query = self.generate_query(value=value)
         qs = self.get_method(qs)(query)
         self._most_recent_query = query
         return qs.distinct()


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3219 
# Closes: #3220
# What's Changed

## This version is for the `develop` branch

**Once this is approved and merged, a follow up will be made for merge into `next` since some minor changes need to be made with import paths**

- This unblocks fields starting with `cf`, `cr_`, and `q` from being used in filters for Dynamic Groups
- Augmented the Dynamic Group edit view to break fields down by "Object Fields", "Custom Fields", and "Relationships"
- The "search" field now shows up in the "Object Fields"
- Fixed a bug in `nautobot.extras.forms.mixins.CustomFieldModelFilterFormMixin` where the list of custom field names were not being stored on `self.custom_fields`
- Fixed a bug in `nautobot.utilities.filters.MappedPredicatesFilterMixin` (from which `SearchFilter` inherits) that was preventing `q` fields from being used in Dynamic Group filters.

## Screenshots

Field sections
![image](https://user-images.githubusercontent.com/138052/220759601-08d6faa7-3b29-476f-9024-53ff822e0634.png)

Custom Fields in a DG

![image](https://user-images.githubusercontent.com/138052/220759466-37cbe2dd-8b0d-44c2-a4a4-f93bda96ea20.png)

Relationships in a DG
![Cursor_and_relationships_-_Nautobot](https://user-images.githubusercontent.com/138052/220759530-05b87090-9242-469f-bfd9-3951a3a69330.png)

"Search" field in "Object Fields" section
![image](https://user-images.githubusercontent.com/138052/220759737-6426a000-26f1-48b8-b421-5da327928331.png)

Search value in a filter on a DG
![image](https://user-images.githubusercontent.com/138052/220759820-9146da6c-7aad-4690-a844-5e13714e84a4.png)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
