### PR TITLE
Fix kombu serialization error on jobs

### DIFF
--- a/changes/3295.fixed
+++ b/changes/3295.fixed
@@ -1,0 +1,1 @@
+Fixed kombu serialization error on `User` object that arose when `CELERY_RESULT_EXTENDED == True` or when `enqueue_job` was called from within an existing `Job`.

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -496,12 +496,10 @@ class NautobotFakeRequest:
         data = copy.deepcopy(self.__dict__)
         # We don't want to try to pickle/unpickle or serialize/deserialize the actual User object,
         # but make sure we do store its PK so that we can look it up on-demand after being deserialized.
+        user = data.pop("user")
+        data.pop("_cached_user", None)
         if "_user_pk" not in data:
-            # We have a user but haven't stored its PK yet, so look it up and store it
-            data["_user_pk"] = data.pop("user").pk
-        else:
-            # We already have stored the PK, and we need to AVOID actually resolving the lazy user reference.
-            data.pop("user")
+            data["_user_pk"] = user.pk
         return data
 
     @classmethod


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3295
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Resolves the `kombu.exceptions.EncodeError` raised when either `CELERY_RESULT_EXTENDED == True` or `enqueue_job` is called from within another `Job` and the existing Job's request is passed to `enqueue_job`.

Fix is implemented by ensuring `_cached_user` is removed from the request is present, which appears to occur when an existing Job's request is passed to `enqueue_job` (i.e. a `Job` that queues up another `Job`) or through some other scenario.

This also appears to fix the linked issue which details a similar bug when `CELERY_RESULT_EXTENDED == True`. The exact code-path leading to that bug was not investigated; however, testing was completed to confirm this resolves the issue.

This fix is a back-port of a fix already implemented in v2.0.0-alpha.1 ([original fix](https://github.com/nautobot/nautobot/commit/1b5d62dd861c0c0a0550d49802eb6ac356c02334#diff-75faa4e2846155ade0f3e2d35048efb5cf59dbee86c9a090c78b42b7350b7442))

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
