### PR TITLE
UI docker dev environment tweaks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,5 @@
 
 # Add specific exclusions
 **/__pycache__
+nautobot/ui/build
+nautobot/ui/node_modules

--- a/development/docker-compose.dev.yml
+++ b/development/docker-compose.dev.yml
@@ -29,12 +29,15 @@ services:
     ports:
       - "3000:3000"
     working_dir: /opt/node/nautobot
-    user: node
+    # user: node  # Best practice, but "nautobot" container currently uses root --> permission issues for shared volume
     volumes:
       - ../nautobot/ui/:/opt/node/nautobot
       - ../examples/:/opt/examples
       - ../:/source
-    command: >
-      bash -c "npm install && npm run start"  # TODO: running npm install every time is slow, can we persist a volume?
+      - node_modules:/opt/node/nautobot/node_modules
+    # Wait for nautobot container to be fully ready, meaning that it's already run `npm install/build` successfully
     depends_on:
-      - nautobot
+      nautobot:
+        condition: service_healthy
+    command: >
+      bash -c "npm run start"

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -21,13 +21,15 @@ services:
     healthcheck:
       interval: 5s
       timeout: 5s
-      start_period: 45s
+      start_period: 10m  # intentionally conservative upper bound for `npm install` time in a fresh setup
       retries: 3
       test:
         - "CMD"
         - "curl"
         - "-f"
         - "http://localhost:8080/health/"
+    volumes:
+      - node_modules:/source/nautobot/ui/node_modules
   celery_worker:
     image: "local/nautobot-dev:local-py${PYTHON_VER}"
     ports:
@@ -89,3 +91,5 @@ services:
     tty: true
     ports:
       - "8001:8001"
+volumes:
+  node_modules:

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -497,7 +497,10 @@ Quit the server with CONTROL-C.
 
 Please see the [official Django documentation on `runserver`](https://docs.djangoproject.com/en/stable/ref/django-admin/#runserver) for more information.
 
-You can connect to the development server at `localhost:8080`, but normally you'll want to connect to the NGINX server instead (see below).
+!!! note
+    When first started in Docker Compose, the Nautobot development server container will automatically install dependencies for building the React UI for Nautobot, then build this UI. This may take several minutes before the server becomes ready to accept web connections.
+
+You can connect to the development server at `localhost:8080`, but normally you'll want to connect to the Node.js server instead (see below).
 
 ### Starting the Node.js Server
 
@@ -507,17 +510,10 @@ In development, you should run a Node.js server instance as well. This will hand
 | ----------------------- | ------------------------------- |
 | `invoke start`          | `cd nautobot_ui; npm run start` |
 
-You can connect to the Node.js server at `localhost:3000`, but normally you'll want to connect to the NGINX server instead (see below).
+!!! note
+    In the Docker Compose workflow, the Node.js server will delay starting until the Nautobot development server has finished the initial UI build, which may take several minutes. This is normal.
 
-### Starting the NGINX Server
-
-In development, the NGINX server ties together the Nautobot development server and the Node.js server into a single unified frontend, similar to the unified server environment that you'd normally run in production.
-
-| Docker Compose Workflow | Virtual Environment Workflow |
-| ----------------------- | ---------------------------- |
-| `invoke start`          | `TODO`                       |
-
-You can connect to the NGINX server at `localhost:8888` and log in using the superuser account you created earlier.
+You can connect to the Node.js server at `localhost:3000`.
 
 ### Starting the Worker Server
 


### PR DESCRIPTION
# Closes: #n/a
# What's Changed

- Add some exclusions to `.dockerignore` so that the docker build context doesn't bloat with local `node_modules` and `build` files when switching between local and docker setups.
- Changed `build_ui` handling of npm commands to more verbose by default, but capturing stdout/stderr and only showing them to the user if a failure occurs
- Instead of mounting `nautobot/ui/node_modules` into the container, use a Docker volume for this purpose and share it between `nautobot` and `nodejs` containers.
   - Appears much faster when building from zero
   - Means that `invoke destroy` will blow away this volume, good for troubleshooting or returning to a clean slate
   - Since `nautobot` runs as the `root` user currently, I had to change the `nodejs` to also run as `root` rather than `node` because otherwise file permissions on `node_modules` became a problem.
- To avoid contention between both `nautobot` and `nodejs` containers trying to run `npm install` on startup, I changed it so that `nodejs` waits until `nautobot` is healthy (`build_ui` has completed successfully) before starting and no longer takes responsibility for running `npm install` itself.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- n/a Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
