### PR TITLE
Fix `LocationForm.parent` auto-fill (again), by revamping `prepare_value` yet again

### DIFF
--- a/changes/3347.fixed
+++ b/changes/3347.fixed
@@ -1,0 +1,1 @@
+Fixed (again) `Location.parent` not populating correctly in the form when editing an existing Location.

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -414,7 +414,7 @@ class ObjectEditView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
     def get(self, request, *args, **kwargs):
         obj = self.alter_obj(self.get_object(kwargs), request, args, kwargs)
 
-        initial_data = normalize_querydict(request.GET)
+        initial_data = normalize_querydict(request.GET, form_class=self.model_form)
         form = self.model_form(instance=obj, initial=initial_data)
         restrict_form_fields(form, request.user)
 

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -170,7 +170,7 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
             elif view.action == "destroy":
                 form = form_class(initial=request.GET)
             elif view.action in ["create", "update"]:
-                initial_data = normalize_querydict(request.GET)
+                initial_data = normalize_querydict(request.GET, form_class=form_class)
                 form = form_class(instance=instance, initial=initial_data)
                 restrict_form_fields(form, request.user)
             elif view.action == "bulk_destroy":

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1073,28 +1073,31 @@ class JobView(ObjectPermissionRequiredMixin, View):
     def get(self, request, class_path=None, slug=None):
         job_model = self._get_job_model_or_404(class_path, slug)
 
-        initial = normalize_querydict(request.GET)
-        if "kwargs_from_job_result" in initial:
-            job_result_pk = initial.pop("kwargs_from_job_result")
-            try:
-                job_result = job_model.results.get(pk=job_result_pk)
-                # Allow explicitly specified arg values in request.GET to take precedence over the saved job_kwargs,
-                # for example "?kwargs_from_job_result=<UUID>&integervar=22&_commit=False"
-                explicit_initial = initial
-                initial = job_result.job_kwargs.get("data", {}).copy()
-                commit = job_result.job_kwargs.get("commit")
-                if commit is not None:
-                    initial.setdefault("_commit", commit)
-                task_queue = job_result.job_kwargs.get("task_queue")
-                if task_queue is not None:
-                    initial.setdefault("_task_queue", task_queue)
-                initial.update(explicit_initial)
-            except JobResult.DoesNotExist:
-                messages.warning(request, f"JobResult {job_result_pk} not found, cannot use it to pre-populate inputs.")
-
-        template_name = "extras/job.html"
         try:
             job_class = job_model.job_class()
+            initial = normalize_querydict(request.GET, form_class=job_class.as_form_class())
+            if "kwargs_from_job_result" in initial:
+                job_result_pk = initial.pop("kwargs_from_job_result")
+                try:
+                    job_result = job_model.results.get(pk=job_result_pk)
+                    # Allow explicitly specified arg values in request.GET to take precedence over the saved job_kwargs,
+                    # for example "?kwargs_from_job_result=<UUID>&integervar=22&_commit=False"
+                    explicit_initial = initial
+                    initial = job_result.job_kwargs.get("data", {}).copy()
+                    commit = job_result.job_kwargs.get("commit")
+                    if commit is not None:
+                        initial.setdefault("_commit", commit)
+                    task_queue = job_result.job_kwargs.get("task_queue")
+                    if task_queue is not None:
+                        initial.setdefault("_task_queue", task_queue)
+                    initial.update(explicit_initial)
+                except JobResult.DoesNotExist:
+                    messages.warning(
+                        request,
+                        f"JobResult {job_result_pk} not found, cannot use it to pre-populate inputs.",
+                    )
+
+            template_name = "extras/job.html"
             job_form = job_class.as_form(initial=initial)
             if hasattr(job_class, "template_name"):
                 try:

--- a/nautobot/utilities/tests/test_forms.py
+++ b/nautobot/utilities/tests/test_forms.py
@@ -17,6 +17,7 @@ from nautobot.ipam.models import IPAddress, Prefix, VLANGroup
 from nautobot.utilities.filters import MultiValueCharFilter
 from nautobot.utilities.forms.fields import (
     CSVDataField,
+    DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,
     JSONField,
     MultiMatchModelMultipleChoiceField,
@@ -456,33 +457,48 @@ class CSVDataFieldTest(TestCase):
             self.field.clean(input_)
 
 
+class DynamicModelChoiceFieldTest(TestCase):
+    """Tests for DynamicModelChoiceField."""
+
+    def setUp(self):
+        self.field = DynamicModelChoiceField(queryset=IPAddress.objects.all())
+        self.field_with_to_field_name = DynamicModelChoiceField(
+            queryset=IPAddress.objects.all(), to_field_name="address"
+        )
+
+    def test_prepare_value_invalid_uuid(self):
+        """A nonexistent UUID PK value should be handled gracefully."""
+        value = "c671a001-4c17-4ca1-80fd-fe1609bcadec"
+        self.assertEqual(self.field.prepare_value(value), value)
+        self.assertEqual(self.field_with_to_field_name.prepare_value(value), value)
+
+    def test_prepare_value_valid_uuid(self):
+        """A UUID PK referring to an actual object should be handled correctly."""
+        address = IPAddress.objects.create(address="10.1.1.1/24")
+        self.assertEqual(self.field.prepare_value(address.pk), address.pk)
+        self.assertEqual(self.field_with_to_field_name.prepare_value(address.pk), address.address)
+
+    def test_prepare_value_valid_object(self):
+        """An object reference should be handled correctly."""
+        address = IPAddress.objects.create(address="10.1.1.1/24")
+        self.assertEqual(self.field.prepare_value(address), address.pk)
+        self.assertEqual(self.field_with_to_field_name.prepare_value(address), address.address)
+
+
 class DynamicModelMultipleChoiceFieldTest(TestCase):
     """Tests for DynamicModelMultipleChoiceField."""
 
     def setUp(self):
         self.field = DynamicModelMultipleChoiceField(queryset=IPAddress.objects.all())
-
-    def test_prepare_value_single_str(self):
-        """A single string (UUID) value should be treated as a single-entry list."""
-        self.assertEqual(
-            self.field.prepare_value("c671a001-4c17-4ca1-80fd-fe1609bcadec"),
-            ["c671a001-4c17-4ca1-80fd-fe1609bcadec"],
+        self.field_with_to_field_name = DynamicModelMultipleChoiceField(
+            queryset=IPAddress.objects.all(), to_field_name="address"
         )
 
     def test_prepare_value_multiple_str(self):
         """A list of string (UUID) values should be handled as-is."""
-        self.assertEqual(
-            self.field.prepare_value(["c671a001-4c17-4ca1-80fd-fe1609bcadec", "097581e8-1fd5-444f-bbf4-46324e924826"]),
-            ["c671a001-4c17-4ca1-80fd-fe1609bcadec", "097581e8-1fd5-444f-bbf4-46324e924826"],
-        )
-
-    def test_prepare_value_single_object(self):
-        """A single object value should be translated to its corresponding PK."""
-        address = IPAddress.objects.create(address="10.1.1.1/24")
-        self.assertEqual(
-            self.field.prepare_value(address),
-            address.pk,
-        )
+        values = ["c671a001-4c17-4ca1-80fd-fe1609bcadec", "097581e8-1fd5-444f-bbf4-46324e924826"]
+        self.assertEqual(self.field.prepare_value(values), values)
+        self.assertEqual(self.field_with_to_field_name.prepare_value(values), values)
 
     def test_prepare_value_multiple_object(self):
         """A list of object values should be translated to a list of PKs."""
@@ -491,6 +507,10 @@ class DynamicModelMultipleChoiceFieldTest(TestCase):
         self.assertEqual(
             self.field.prepare_value([address_1, address_2]),
             [address_1.pk, address_2.pk],
+        )
+        self.assertEqual(
+            self.field_with_to_field_name.prepare_value([address_1, address_2]),
+            [address_1.address, address_2.address],
         )
 
 

--- a/nautobot/virtualization/views.py
+++ b/nautobot/virtualization/views.py
@@ -208,7 +208,7 @@ class ClusterAddDevicesView(generic.ObjectEditView):
 
     def get(self, request, *args, **kwargs):
         cluster = get_object_or_404(self.queryset, pk=kwargs["pk"])
-        form = self.form(cluster, initial=normalize_querydict(request.GET))
+        form = self.form(cluster, initial=normalize_querydict(request.GET, form_class=self.form))
 
         return render(
             request,


### PR DESCRIPTION
# Closes: #3347 
# What's Changed

It turned out that #2773, in trying to fix #2470, did partially regress #2311, resulting in the filing of #3347.  Along the way, fixing this intersected with code introduced way back in #553 to address #512, resulting in me needing to rework that bit of code as well. Then manual testing to verify that I've fixed #3347/#2311 without reintroducing #2470 or #512. Wheeeee!

- The root of the issue in #512 was that `normalize_querydict` could only guess whether a given query parameter should be recorded as a single value or a list of values based on how many times it appeared in the query, meaning that a list parameter that was only used once in a given query would be incorrectly treated as a single value rather than a list with one entry. This would then cause problems in prepopulating an object form based on this incorrect treatment.
   - Solution then: add a special case in `DynamicModelMultipleChoiceField.prepare_value` to convert a single string value into a list value containing that single string.
       - The problem with this was, because of some Django internals involving rendering the individual `<option>` elements for the form field, that when provided a single *object* value (a model instance), it needed to stay as that single value, and *not* be converted to a list of a single object.
   - Solution now: remove the former code, and instead add an optional `form_class` parameter to `normalize_querydict` and update model views to provide this parameter as appropriate; when present, this parameter is used to check what form field a given query parameter corresponds to, and if the field is a multiple-choice field, correctly convert the single-valued parameter to a single-entry list.
   - This did require moving some code around in extras to support the `JobView` case, where the form class is generated on-the-fly from the selected Job, to make sure the form class was available at the time that the querydict is interpreted. This should have no functional impact.

- The underlying issue with #2311 and #2470 "feels" like a latent Django bug to me but I'm probably missing something. Basically what it boils down to is that with a baseline `ModelChoiceField` that defines a `to_field_name` value:
    - `prepare_value(object_instance)` returns the value of the instance's field corresponding to the `to_field_name` specified (or the instance's PK if no `to_field_name`), which correctly allows the rendered form to pre-select the appropriate `<option value="field_value">` in the HTML.
    - but `prepare_value(object_pk)` simply returns the provided PK,, *regardless of any `to_field_name`*, which doesn't match up with any `<option value="field_value">` in the HTML, resulting in no pre-selection in the rendered form.
    - So it *appears* that the fix here is to subclass the `prepare_value()` method and ensure that, when given a PK, it looks up the actual object instance (if any) and passes that instance through to the superclass for processing, ensuring correct form rendering in this case as well.


Cases manually tested:

- Look for regression of #512 by pressing the `Clone` button on object instances with zero, exactly one, or more than one Tag applied, (in other words, zero, one, and more than one occurrence of `tags=` in the GET query parameters) and verifying that in all three cases the form is correctly prepopulated with the appropriate tag selection:

![image](https://user-images.githubusercontent.com/5603551/224404611-d758bbf6-73b7-4ae5-8024-3d196407de8b.png)

![image](https://user-images.githubusercontent.com/5603551/224404655-d154b3d0-47db-4a54-a7d9-f4cf54d6e9da.png)

![image](https://user-images.githubusercontent.com/5603551/224404713-3759f6ba-4309-407d-83f7-5a76b255d022.png)

- Look for regression of #2311/#2470/#3347 by:
   - Editing an existing Location and confirming that the `parent` and all other model choice fields are correctly populated (this case was missed in testing #2773 it appears, resulting in #3347) and that slug autogeneration in the UI works correctly

![image](https://user-images.githubusercontent.com/5603551/224405551-d28a93fb-d6bf-4cba-8417-7d702db9b784.png)

   - Hitting the `Clone` button on an existing location and confirming that the `parent` and other appropriate model choice fields are correctly populated (this case was tested for in #2773) and that slug autogeneration in the UI works correctly

![image](https://user-images.githubusercontent.com/5603551/224405616-25d03fb3-2c74-446f-9975-10c6765bb6b1.png)

   - Hitting the `Add child` button on an existing location and confirming that the `parent` field is correctly populated and that slug autogeneration in the UI works correctly (this is functionally quite similar to the "Clone" case but with far fewer autopopulated selections)

![image](https://user-images.githubusercontent.com/5603551/224405727-a0b150d1-56e4-404e-b2b7-f338a24f718a.png)

**I have not spent time writing unit or integration test automation for the above cases because much of this functionality will likely change drastically in 2.0 rendering such tests irrelevant.**

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
