### PR TITLE
fix: Format csv test expected data using csv_format

### DIFF
--- a/changes/3419.fixed
+++ b/changes/3419.fixed
@@ -1,0 +1,1 @@
+Fixed `test_queryset_to_csv` to format data fetched from the model.


### PR DESCRIPTION
# Closes: #3419

# What's Changed

Fixed `test_queryset_to_csv` to use `format_csv` on data fetched from the model.
