### PR TITLE
fix bug preventing scheduled job from running

### DIFF
--- a/changes/3457.fixed
+++ b/changes/3457.fixed
@@ -1,0 +1,1 @@
+Fixed bug preventing scheduled job from running.

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -30,7 +30,7 @@ class NautobotScheduleEntry(ModelEntry):
             logger.exception("Removing schedule %s for argument deserialization error: %s", self.name, exc)
             self._disable(model)
         try:
-            self.schedule = model.scheduled_job
+            self.schedule = model.schedule
         except model.DoesNotExist:
             logger.error(
                 "Disabling schedule %s that was removed from database",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3457
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

A typo in `core/celery/schedulers.py` was causing an exception to be raised when beat would try to run a scheduled job

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))

