### PR TITLE
Removed  `block sidebar` from aggregate_list.html and objectchange_list.html.

### DIFF
--- a/changes/3384.changed
+++ b/changes/3384.changed
@@ -1,0 +1,2 @@
+Moved extra information stored previously in `block sidebar` to `block header_extra` in page templates (`aggregate_list.html` and `objectchange_list.html`).
+Documented `block header_extra` in `docs/development/templates.md`.

--- a/changes/3384.removed
+++ b/changes/3384.removed
@@ -1,2 +1,2 @@
-Removed `block sidebar` from aggregate_list.html and objectchange_list.html.
-Removed documenation about `block sidebar` from docs/development/templates.md.
+Removed all remaining instances of `block sidebar` from page templates (`aggregate_list.html` and `objectchange_list.html`).
+Removed documentation about `block sidebar` from `docs/development/templates.md`.

--- a/changes/3384.removed
+++ b/changes/3384.removed
@@ -1,0 +1,2 @@
+Removed `block sidebar` from aggregate_list.html and objectchange_list.html.
+Removed documenation about `block sidebar` from docs/development/templates.md.

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -53,7 +53,7 @@
     {% endif %}
 </div>
 <h1>{% block title %}{{ title }}{% endblock %}</h1>
-{% block extras %}{% endblock %}
+{% block header_extra %}{% endblock %}
 {% if filter_params %}
 <div class="filters-applied">
     <b>Filters:</b>

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -53,6 +53,7 @@
     {% endif %}
 </div>
 <h1>{% block title %}{{ title }}{% endblock %}</h1>
+{% block extras %}{% endblock %}
 {% if filter_params %}
 <div class="filters-applied">
     <b>Filters:</b>

--- a/nautobot/docs/development/templates.md
+++ b/nautobot/docs/development/templates.md
@@ -47,7 +47,7 @@ The base template for listing objects is `generic/object_list.html`, with the fo
   left of the table configuration button.
 * `bulk_buttons`: may be a set of buttons at the bottom of the table, to the
   left of potential bulk edit or delete buttons.
-* `extras`: may provide extra information to display just above the table,
+* `header_extra`: may provide extra information to display just above the table,
   to the left.
 
 ## Object Edit

--- a/nautobot/docs/development/templates.md
+++ b/nautobot/docs/development/templates.md
@@ -45,7 +45,6 @@ The base template for listing objects is `generic/object_list.html`, with the fo
 
 * `buttons`: may provide a set of buttons at the top right of the page, to the
   left of the table configuration button.
-* `sidebar`: may implement a sidebar below the search form on the right.
 * `bulk_buttons`: may be a set of buttons at the bottom of the table, to the
   left of potential bulk edit or delete buttons.
 

--- a/nautobot/docs/development/templates.md
+++ b/nautobot/docs/development/templates.md
@@ -47,6 +47,8 @@ The base template for listing objects is `generic/object_list.html`, with the fo
   left of the table configuration button.
 * `bulk_buttons`: may be a set of buttons at the bottom of the table, to the
   left of potential bulk edit or delete buttons.
+* `extras`: may provide extra information to display just above the table,
+  to the left.
 
 ## Object Edit
 

--- a/nautobot/extras/templates/extras/objectchange_list.html
+++ b/nautobot/extras/templates/extras/objectchange_list.html
@@ -3,7 +3,7 @@
 
 {% block title %}Change Log{% endblock %}
 
-{% block extras %}
+{% block header_extra %}
     <div class="text-muted">
         Change log retention:
         {% if "CHANGELOG_RETENTION"|settings_or_config %}

--- a/nautobot/extras/templates/extras/objectchange_list.html
+++ b/nautobot/extras/templates/extras/objectchange_list.html
@@ -3,8 +3,9 @@
 
 {% block title %}Change Log{% endblock %}
 
-{% block sidebar %}
-    <div class="text-muted">
+{% block content %}
+    {{ block.super }}
+    <div class="text-muted pull-right">
         Change log retention:
         {% if "CHANGELOG_RETENTION"|settings_or_config %}
             {{ "CHANGELOG_RETENTION"|settings_or_config }} days

--- a/nautobot/extras/templates/extras/objectchange_list.html
+++ b/nautobot/extras/templates/extras/objectchange_list.html
@@ -3,9 +3,8 @@
 
 {% block title %}Change Log{% endblock %}
 
-{% block content %}
-    {{ block.super }}
-    <div class="text-muted pull-right">
+{% block extras %}
+    <div class="text-muted">
         Change log retention:
         {% if "CHANGELOG_RETENTION"|settings_or_config %}
             {{ "CHANGELOG_RETENTION"|settings_or_config }} days

--- a/nautobot/ipam/templates/ipam/aggregate_list.html
+++ b/nautobot/ipam/templates/ipam/aggregate_list.html
@@ -1,9 +1,8 @@
 {% extends 'generic/object_list.html' %}
 {% load humanize %}
 
-{% block content %}
-    {{ block.super }}
-    <div class="panel panel-default pull-right" style="width: 20%;">
+{% block extras %}
+    <div class="panel panel-default">
         <div class="panel-heading">
             <strong><i class="mdi mdi-chart-areaspline"></i> Statistics</strong>
         </div>

--- a/nautobot/ipam/templates/ipam/aggregate_list.html
+++ b/nautobot/ipam/templates/ipam/aggregate_list.html
@@ -1,7 +1,7 @@
 {% extends 'generic/object_list.html' %}
 {% load humanize %}
 
-{% block extras %}
+{% block header_extra %}
     <div class="panel panel-default">
         <div class="panel-heading">
             <strong><i class="mdi mdi-chart-areaspline"></i> Statistics</strong>

--- a/nautobot/ipam/templates/ipam/aggregate_list.html
+++ b/nautobot/ipam/templates/ipam/aggregate_list.html
@@ -2,13 +2,6 @@
 {% load humanize %}
 
 {% block header_extra %}
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <strong><i class="mdi mdi-chart-areaspline"></i> Statistics</strong>
-        </div>
-        <ul class="list-group">
-            <li class="list-group-item">Total IPv4 IPs <span class="badge">{{ ipv4_total|intcomma }}</span></li>
-            <li class="list-group-item">Total IPv6 /64s <span class="badge">{{ ipv6_total|intcomma }}</span></li>
-        </ul>
-    </div>
-{% endblock %}
+   Total IPv4 IPs: <span class="badge">{{ ipv4_total|intcomma }}</span>
+   Total IPv6 /64s: <span class="badge">{{ ipv6_total|intcomma }}</span>
+{% endblock header_extra %}

--- a/nautobot/ipam/templates/ipam/aggregate_list.html
+++ b/nautobot/ipam/templates/ipam/aggregate_list.html
@@ -1,8 +1,9 @@
 {% extends 'generic/object_list.html' %}
 {% load humanize %}
 
-{% block sidebar %}
-    <div class="panel panel-default">
+{% block content %}
+    {{ block.super }}
+    <div class="panel panel-default pull-right" style="width: 20%;">
         <div class="panel-heading">
             <strong><i class="mdi mdi-chart-areaspline"></i> Statistics</strong>
         </div>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3384 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
AggregateListView
![Screen Shot 2023-03-22 at 11 06 26 AM](https://user-images.githubusercontent.com/46973263/226948356-881d26f3-6061-4e01-811e-5eaed475d5dd.png)

ObjectChangeListView
![Screen Shot 2023-03-22 at 11 06 21 AM](https://user-images.githubusercontent.com/46973263/226948301-52b15af1-d0c6-45e9-aae5-1867a29c4e22.png)


I do not want the template to lose any information that was originally placed in the sidebar. But I do not know if there is a better place to place them other than the sidebar. Lmk if these changes are acceptable.
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
