### PR TITLE
Fix Docker Prerelease Tag Syntax

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -86,6 +86,7 @@ jobs:
             latest=false
           tags: |
             type=semver,pattern={{version}}+py${{ matrix.python-version }}
+            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.7 }}
             type=raw,value={{version}}-py${{ matrix.python-version }}r
           labels: |
             org.opencontainers.image.title=Nautobot
@@ -113,6 +114,7 @@ jobs:
             latest=false
           tags: |
             type=semver,pattern={{version}}+py${{ matrix.python-version }}
+            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.7 }}
             type=raw,value={{version}}-py${{ matrix.python-version }}r
           labels: |
             org.opencontainers.image.title=Nautobot

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -85,8 +85,8 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern={{version}}-py${{ matrix.python-version }}
-            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.7 }}
+            type=semver,pattern={{version}}+py${{ matrix.python-version }}
+            type=raw,value={{version}}-py${{ matrix.python-version }}r
           labels: |
             org.opencontainers.image.title=Nautobot
       - name: "Build"
@@ -112,8 +112,8 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern={{version}}-py${{ matrix.python-version }}
-            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.7 }}
+            type=semver,pattern={{version}}+py${{ matrix.python-version }}
+            type=raw,value={{version}}-py${{ matrix.python-version }}r
           labels: |
             org.opencontainers.image.title=Nautobot
       - name: "Build Dev Containers"

--- a/changes/3206.fixed
+++ b/changes/3206.fixed
@@ -1,0 +1,1 @@
+Fixed Docker tag syntax on prerelease workflow.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3206
# What's Changed
**Changed to use `+` instead of `-` for Python version signifier when using the `semver` format tag**

Previously it was attempting `2.0.0-alpha.1-py3.7` which isn't valid [SemVer](https://semver.org). This label would have been reject and was confirmed in testing. In fact, our current syntax for our stable builds is incorrect. BNF on the SemVer site states that `-alphanum.num` is for pre-release signifiers. `+alphanum.num` is for build numbers which is more applicable for our Python-specific build signifier. We probably should publish `1.5.14+py3.7`. 

**Backup `raw` tag to take the literal value that is passed in, assuming something goes awry with the approach above.**

Suffixed with `r` _just_ in case `docker/build-push-action` or `docker/metadata-action` get sad with two tags that result in the same value.

Also:
- Removed the non-Python-version specific tag as it made discovery a bit opaque as to which tag was failing
- Didn't address https://github.com/nautobot/nautobot/issues/3206#issuecomment-1420663909 because it seems some are still experiencing `dist-info` problems: https://github.com/python-poetry/poetry/issues/6815


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [NA] Attached Screenshots, Payload Example
- [NA] Unit, Integration Tests
- [NA] Documentation Updates (when adding/changing features)
- [NA] Example Plugin Updates (when adding/changing features)
- [NA] Outline Remaining Work, Constraints from Design
