### PR TITLE
Resolves #3480 - IPAddress ProgrammingError on constrained permission

### DIFF
--- a/changes/3480.fixed
+++ b/changes/3480.fixed
@@ -1,0 +1,1 @@
+Resolved issues with ProgrammingError when constraint is applied to an IPAddress to limit access based on `IPAddress.host__net_host_contained`.

--- a/nautobot/ipam/api/views.py
+++ b/nautobot/ipam/api/views.py
@@ -308,12 +308,16 @@ class PrefixViewSet(StatusViewSetMixin, NautobotModelViewSet):
     update=extend_schema(responses={"200": serializers.IPAddressSerializerLegacy}, versions=["1.2"]),
 )
 class IPAddressViewSet(StatusViewSetMixin, NautobotModelViewSet):
-    queryset = IPAddress.objects.select_related(
+    # Resolves issue #3480
+    queryset = IPAddress.objects.prefetch_related(
+        "assigned_object",
         "nat_inside",
+        "nat_outside_list",
         "status",
+        "tags",
         "tenant",
         "vrf__tenant",
-    ).prefetch_related("tags", "assigned_object", "nat_outside_list")
+    )
     serializer_class = serializers.IPAddressSerializer
     filterset_class = filters.IPAddressFilterSet
 

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -619,7 +619,8 @@ class IPAddressListView(generic.ObjectListView):
 
 
 class IPAddressView(generic.ObjectView):
-    queryset = IPAddress.objects.select_related("vrf__tenant", "tenant")
+    # Resolves issue #3480
+    queryset = IPAddress.objects.prefetch_related("vrf__tenant", "tenant")
 
     def get_extra_context(self, request, instance):
         # Parent prefixes table


### PR DESCRIPTION
# Closes: #3480
# What's Changed

Resolved issues with ProgrammingError when constraint is applied to an IPAddress to limit access based on `IPAddress.host__net_host_contained`.
