### PR TITLE
UI 2.0: Cleanup Router Links, Import Font as Source

### DIFF
--- a/nautobot/ui/package-lock.json
+++ b/nautobot/ui/package-lock.json
@@ -11,6 +11,8 @@
         "@chakra-ui/react": "^2.5.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
+        "@fontsource/ubuntu": "^4.5.11",
+        "@fontsource/ubuntu-mono": "^4.5.11",
         "@fortawesome/fontawesome-svg-core": "^6.2.1",
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
@@ -3641,6 +3643,16 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@fontsource/ubuntu": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/ubuntu/-/ubuntu-4.5.11.tgz",
+      "integrity": "sha512-c+B8A8r31hJLk8Ek7Svoz4GwjtInhc60LFM6XTr5TKtZbcct8TPNxJuKX4+hnqoWgcvy8s0Gj4mde4TcK/SgDQ=="
+    },
+    "node_modules/@fontsource/ubuntu-mono": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/ubuntu-mono/-/ubuntu-mono-4.5.11.tgz",
+      "integrity": "sha512-IqqJKgp9Xc8tFeCIHPQuFbiKZC8tBU2hdIllwX2pryYfkl8/w4DuScFq9fPMfy1Mp4raFVcJALvOMOfRXkLp/w=="
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.3.0",

--- a/nautobot/ui/package.json
+++ b/nautobot/ui/package.json
@@ -7,6 +7,8 @@
     "@chakra-ui/react": "^2.5.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@fontsource/ubuntu": "^4.5.11",
+    "@fontsource/ubuntu-mono": "^4.5.11",
     "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/react-fontawesome": "^0.2.0",

--- a/nautobot/ui/src/App.js
+++ b/nautobot/ui/src/App.js
@@ -5,6 +5,16 @@ import { NautobotUIProvider } from "@nautobot/nautobot-ui"
 import Layout from '@components/layouts/Layout';
 import NautobotRouter from "src/router"
 
+import { extendTheme } from '@chakra-ui/react'
+
+const theme = {
+  fonts: {
+    heading: `'Ubuntu', sans-serif`,
+    body: `'Ubuntu', sans-serif`,
+    mono: `'Ubuntu Mono', monospace`,
+  },
+}
+
 // TODO: See if we can/need to continue this pattern:
 // Global API pattern needs these arguments passed through:
 //   { updateStore, globalApi }
@@ -12,7 +22,7 @@ import NautobotRouter from "src/router"
 
 function App() {
   return (
-    <NautobotUIProvider>
+    <NautobotUIProvider theme={theme}>
       <BrowserRouter>
         <Layout>
           <NautobotRouter />

--- a/nautobot/ui/src/App.js
+++ b/nautobot/ui/src/App.js
@@ -5,8 +5,6 @@ import { NautobotUIProvider } from "@nautobot/nautobot-ui"
 import Layout from '@components/layouts/Layout';
 import NautobotRouter from "src/router"
 
-import { extendTheme } from '@chakra-ui/react'
-
 const theme = {
   fonts: {
     heading: `'Ubuntu', sans-serif`,

--- a/nautobot/ui/src/components/common/ObjectListTable.jsx
+++ b/nautobot/ui/src/components/common/ObjectListTable.jsx
@@ -3,6 +3,7 @@ import {
   Frame,
 } from "@nautobot/nautobot-ui";
 import { Link } from "./RouterLink";
+import { RouterButton } from "./RouterButton"
 import { ButtonGroup } from "@chakra-ui/react";
 import * as Icon from "react-icons/tb";
 import { useLocation } from "react-router-dom";
@@ -15,18 +16,16 @@ export default function ObjectListTable({ tableData, tableHeader, totalCount, ac
   let location = useLocation();
   return (
     <Frame>
-      <ButtonGroup>
-        <Button>
-          <Link to={`${location.pathname}add`}>
-            <Icon.TbPlus /> Add
-          </Link>
-        </Button>{" "}
-        <Button variant="secondary">
+      <ButtonGroup pb={2}>
+        <RouterButton to={`${location.pathname}add`} mr={2}>
+          <Icon.TbPlus /> Add
+        </RouterButton>
+        <RouterButton to="#" variant="secondary" mr={2}>
           <Icon.TbDatabaseImport /> Import
-        </Button>{" "}
-        <Button variant="secondary">
+        </RouterButton>
+        <RouterButton to="#" variant="secondary" mr={2}>
           <Icon.TbDatabaseExport /> Export
-        </Button>{" "}
+        </RouterButton>
       </ButtonGroup>
       <NautobotTable data={tableData} headers={tableHeader} />
       <Paginator

--- a/nautobot/ui/src/components/common/RouterButton.jsx
+++ b/nautobot/ui/src/components/common/RouterButton.jsx
@@ -1,0 +1,13 @@
+import { Button as UIButton } from "@nautobot/nautobot-ui"
+import { Link as ReactRouterLink } from "react-router-dom";
+
+// This provides a standard Link object we can use that marries the Button UI component with the ReactRouter Link
+export function RouterButton(props) {
+
+    return (
+        <UIButton as={ReactRouterLink} {...props}></UIButton>
+    )
+}
+
+export const Button = RouterButton
+export default RouterButton

--- a/nautobot/ui/src/components/common/SidebarNav.jsx
+++ b/nautobot/ui/src/components/common/SidebarNav.jsx
@@ -1,5 +1,6 @@
-import { Accordion, AccordionButton, AccordionItem, AccordionPanel, Heading, SidebarButton } from "@nautobot/nautobot-ui"
-import RouterLink from "@components/common/RouterLink"
+import { Accordion, AccordionButton, AccordionItem, AccordionPanel, AccordionIcon, Heading, SidebarButton  } from "@nautobot/nautobot-ui"
+import { LinkOverlay, LinkBox } from "@chakra-ui/react";
+import { Link as ReactRouterLink } from "react-router-dom";
 
 import { useGetUIMenuQuery } from "@utils/api";
 
@@ -14,36 +15,33 @@ export default function SidebarNav() {
   return (
     <Accordion allowMultiple variant="sidebarLevel0">
       {
-        menuInfo.map((item, idx) => (
-          <AccordionItem key={idx}>
-            <Heading><AccordionButton isLast>
-              {item.name}
-            </AccordionButton></Heading>
-
+        menuInfo.map((item, idx, arr) => (
+          <AccordionItem key={item.name}>
+            <Heading>
+              <AccordionButton isLast={idx == arr.length - 1}>
+                {item.name}
+                <AccordionIcon />
+              </AccordionButton>
+            </Heading>
             <AccordionPanel>
               {
-                Object.entries(item.properties.groups).map((group, group_idx) => (
-                <Accordion
-                    allowMultiple
-                    variant="sidebarLevel1"
-                    key={group_idx}
-                  >
-                    <AccordionItem>
-                        <Heading>
-                            <AccordionButton isLast>
-                            {group[0]}
-                            </AccordionButton>
-                        </Heading>
-                        <AccordionPanel>
+                Object.entries(item.properties.groups).map((group, group_idx, group_arr) => (
+                <Accordion allowMultiple variant="sidebarLevel1" key={group[0]}>
+                  <AccordionItem>
+                    <Heading>
+                      <AccordionButton isLast={group_idx == group_arr.length - 1}>
+                        {group[0]}
+                        <AccordionIcon />
+                      </AccordionButton>
+                    </Heading>
+                    <AccordionPanel>
                     {
-                    Object.entries(group[1].items).map((menu, menu_idx) => (
-                        <SidebarButton key={menu_idx} level={2}>
-                            <RouterLink to={menu[0]}>{menu[1].name}</RouterLink>
-                        </SidebarButton>
+                    Object.entries(group[1].items).map((menu, menu_idx, menu_arr) => (
+                      <SidebarButton as={ReactRouterLink} key={menu_idx} level={2} to={menu[0]} isLast={menu_idx == menu_arr.length - 1}>{menu[1].name}</SidebarButton>
                     ))
                     }
-                        </AccordionPanel>
-                    </AccordionItem>
+                    </AccordionPanel>
+                  </AccordionItem>
                 </Accordion>
                 ))
               }

--- a/nautobot/ui/src/components/layouts/Layout.jsx
+++ b/nautobot/ui/src/components/layouts/Layout.jsx
@@ -9,7 +9,7 @@ import {
   Text,
   Button
 } from "@nautobot/nautobot-ui";
-import { useLocation } from "react-router-dom";
+import { Link as ReactRouterLink, useLocation } from "react-router-dom";
 import {
   GLOBAL_GRID_GAP,
   GLOBAL_PADDING_RIGHT,
@@ -20,6 +20,7 @@ import RouterLink from "@components/common/RouterLink";
 import LoadingWidget from "@components/common/LoadingWidget";
 
 import { useGetSessionQuery, useGetUIMenuQuery } from "@utils/api";
+import RouterButton from "@components/common/RouterButton";
 
 export default function Layout({ children }) {
   const location = useLocation();
@@ -70,14 +71,10 @@ export default function Layout({ children }) {
             {sessionInfo && sessionInfo.logged_in ? (
               <>
                 <SidebarNav />
-                <Button m={3}>
-                  <RouterLink to="/logout/">Log Out</RouterLink>
-                </Button>
+                <RouterButton m={3} to="/logout/">Log Out</RouterButton>
               </>
             ) : (
-              <Button m={3}>
-                <RouterLink to="/login/">Log In</RouterLink>
-              </Button>
+              <RouterButton m={3} to="/login/">Log In</RouterButton>
             )}
           </Sidebar>
         </Box>

--- a/nautobot/ui/src/index.js
+++ b/nautobot/ui/src/index.js
@@ -8,7 +8,9 @@ import { persistStore } from 'redux-persist'
 import reportWebVitals from "src/reportWebVitals"
 import App from './App';
 
-import "src/styles/globals.css"
+import '@fontsource/ubuntu/400.css'
+import '@fontsource/ubuntu/500.css'
+import '@fontsource/ubuntu-mono/400.css'
 
 const dev = process.env.NODE_ENV !== "production"
 const container = document.getElementById('root')

--- a/nautobot/ui/src/styles/globals.css
+++ b/nautobot/ui/src/styles/globals.css
@@ -1,8 +1,0 @@
-/* Font should be pulled in earlier to prevent jumpy experience */
-@import url('https://fonts.googleapis.com/css2?family=Ubuntu+Mono&family=Ubuntu:wght@400;500&display=swap');
-
-html,
-body {
-  font-family: 'Ubuntu', sans-serif;
-  background-color: #f1f1f1;
-}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: DNE
# What's Changed
- UI font included as a package instead of Google Fonts
  - Because of where Nautobot runs we shouldn't be pulling from CDNs
  - Prevents jumpy loading
- Fix Accordion rendering
- Introduce `RouterButton` like `RouterLink` to auto-wire `Link` from React Router

<img width="1275" alt="image" src="https://user-images.githubusercontent.com/31187/227519716-66331c89-ee89-4a06-8461-5081f7b63494.png">


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
