### PR TITLE
Add profiling functionality to jobs.

### DIFF
--- a/changes/3484.added
+++ b/changes/3484.added
@@ -1,0 +1,1 @@
+Added job profiling option to job execution when in DEBUG mode.

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -744,7 +744,7 @@ class MyJobTestCase(TransactionTestCase):
 
 Debugging the performance of Nautobot jobs can be tricky, because they are executed in the worker context. In order to gain extra visibility, [cProfile](https://docs.python.org/3/library/profile.html) can be used to profile the job execution.
 
-The 'profile' form field on jobs is automatically available when the `DEBUG` settings is `True`. When you select that checkbox, a profiling report in the pstats format will be written to the file system of the worker instance - the path will be logged in the job.
+The 'profile' form field on jobs is automatically available when the `DEBUG` settings is `True`. When you select that checkbox, a profiling report in the pstats format will be written to the file system of the environment where the job runs. Normally, this is on the file system of the worker process, but if you are using the `nautobot-server runjob` command with `--local`, it will end up in the file system of the web application itself. The path of the written file will be logged in the job.
 
 !!! note
     If you need to run this in an environment where `DEBUG` is `False`, you have the option of using `nautobot-server runjob` with the `--profile` flag. According to the docs, `cProfile` should have minimal impact on the performance of the job; still, proceed with caution when using this in a production environment.

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -738,6 +738,28 @@ class MyJobTestCase(TransactionTestCase):
         populate_status_choices(apps, None)
 ```
 
+## Debugging job performance
+
+Debugging the performance of Nautobot jobs can be tricky, because they are executed in the worker context. In order to gain extra visibility, [cProfile](https://docs.python.org/3/library/profile.html) can be used to profile the job execution.
+
+The 'profile' form field on jobs is automatically available when the `DEBUG` settings is `True`. When you select that checkbox, a profiling report in the pstats format will be written to the file system of the worker instance - the path will be logged in the job.
+
+!!! note
+    If you need to run this in an environment with `DEBUG` set to `True` you have to option of using `nautobot-server runjob` with the `--profile` flag. According to the docs, `cProfile` should have minimal impact on the performance of the job, still - proceed with caution when using this in a production environment.
+
+### Reading profiling reports
+
+A full description on how to deal with the output of `cProfile` can be found in the [Instant's users manual](https://docs.python.org/3/library/profile.html#instant-user-s-manual), but here is something to get you started:
+
+```python
+import pstats
+job_result_uuid = "66b70231-002f-412b-8cc4-1cc9609c2c9b"
+stats = pstats.Stats(f"/tmp/{job_result_uuid}.pstats")
+stats.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(10)
+```
+
+This will print the 10 function that the job execution spent their most time in - adapt this to your needs!
+
 ## Example Jobs
 
 ### Creating objects for a planned site

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -740,7 +740,7 @@ class MyJobTestCase(TransactionTestCase):
 
 ## Debugging job performance
 
-+++ 1.5.15
++++ 1.5.17
 
 Debugging the performance of Nautobot jobs can be tricky, because they are executed in the worker context. In order to gain extra visibility, [cProfile](https://docs.python.org/3/library/profile.html) can be used to profile the job execution.
 

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -740,6 +740,8 @@ class MyJobTestCase(TransactionTestCase):
 
 ## Debugging job performance
 
++++ 1.5.15
+
 Debugging the performance of Nautobot jobs can be tricky, because they are executed in the worker context. In order to gain extra visibility, [cProfile](https://docs.python.org/3/library/profile.html) can be used to profile the job execution.
 
 The 'profile' form field on jobs is automatically available when the `DEBUG` settings is `True`. When you select that checkbox, a profiling report in the pstats format will be written to the file system of the worker instance - the path will be logged in the job.

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -756,7 +756,7 @@ A full description on how to deal with the output of `cProfile` can be found in 
 ```python
 import pstats
 job_result_uuid = "66b70231-002f-412b-8cc4-1cc9609c2c9b"
-stats = pstats.Stats(f"/tmp/{job_result_uuid}.pstats")
+stats = pstats.Stats(f"/tmp/job-result-{job_result_uuid}.pstats")
 stats.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(10)
 ```
 

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -745,7 +745,7 @@ Debugging the performance of Nautobot jobs can be tricky, because they are execu
 The 'profile' form field on jobs is automatically available when the `DEBUG` settings is `True`. When you select that checkbox, a profiling report in the pstats format will be written to the file system of the worker instance - the path will be logged in the job.
 
 !!! note
-    If you need to run this in an environment with `DEBUG` set to `True` you have to option of using `nautobot-server runjob` with the `--profile` flag. According to the docs, `cProfile` should have minimal impact on the performance of the job, still - proceed with caution when using this in a production environment.
+    If you need to run this in an environment where `DEBUG` is `False`, you have the option of using `nautobot-server runjob` with the `--profile` flag. According to the docs, `cProfile` should have minimal impact on the performance of the job; still, proceed with caution when using this in a production environment.
 
 ### Reading profiling reports
 

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -749,7 +749,7 @@ The 'profile' form field on jobs is automatically available when the `DEBUG` set
 
 ### Reading profiling reports
 
-A full description on how to deal with the output of `cProfile` can be found in the [Instant's users manual](https://docs.python.org/3/library/profile.html#instant-user-s-manual), but here is something to get you started:
+A full description on how to deal with the output of `cProfile` can be found in the [Instant User's Manual](https://docs.python.org/3/library/profile.html#instant-user-s-manual), but here is something to get you started:
 
 ```python
 import pstats

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -758,7 +758,7 @@ stats = pstats.Stats(f"/tmp/{job_result_uuid}.pstats")
 stats.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(10)
 ```
 
-This will print the 10 function that the job execution spent their most time in - adapt this to your needs!
+This will print the 10 functions that the job execution spent the most time in - adapt this to your needs!
 
 ## Example Jobs
 

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -762,7 +762,7 @@ class JobForm(BootstrapMixin, forms.Form):
         required=False,
         initial=False,
         label="Profile job execution",
-        help_text="Profiles the job execution using cProfile",
+        help_text="Profiles the job execution using cProfile and outputs a report to /tmp/",
     )
     _task_queue = forms.ChoiceField(
         required=False,

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -758,6 +758,12 @@ class JobForm(BootstrapMixin, forms.Form):
         label="Commit changes",
         help_text="Commit changes to the database (uncheck for a dry-run)",
     )
+    _profile = forms.BooleanField(
+        required=False,
+        initial=False,
+        label="Profile job execution",
+        help_text="Profiles the job execution using cProfile",
+    )
     _task_queue = forms.ChoiceField(
         required=False,
         help_text="The task queue to route this job to",
@@ -767,11 +773,10 @@ class JobForm(BootstrapMixin, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Move _task_queue and _commit to the end of the form
-        task_queue = self.fields.pop("_task_queue")
-        self.fields["_task_queue"] = task_queue
-        commit = self.fields.pop("_commit")
-        self.fields["_commit"] = commit
+        # Move special fields to the end of the form
+        for field in ["_task_queue", "_commit", "_profile"]:
+            value = self.fields.pop(field)
+            self.fields[field] = value
 
     @property
     def requires_input(self):

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -345,6 +345,9 @@ class BaseJob:
         # Update task queue choices
         form.fields["_task_queue"].choices = task_queues_as_choices(task_queues)
 
+        if not settings.DEBUG:
+            form.fields["_profile"].widget = forms.HiddenInput()
+
         # https://github.com/PyCQA/pylint/issues/3484
         if self.field_order:  # pylint: disable=using-constant-test
             form.order_fields(self.field_order)
@@ -1078,7 +1081,7 @@ def get_job(class_path):
 
 
 @nautobot_task
-def run_job(data, request, job_result_pk, commit=True, *args, **kwargs):
+def run_job(data, request, job_result_pk, commit=True, profile=False, *args, **kwargs):
     """
     Helper function to call the "run()", "test_*()", and "post_run" methods on a Job.
 
@@ -1211,7 +1214,22 @@ def run_job(data, request, job_result_pk, commit=True, *args, **kwargs):
             with transaction.atomic():
                 # Script-like behavior
                 job.active_test = "run"
-                output = job.run(data=data, commit=commit)
+                if profile:
+                    import cProfile
+
+                    # TODO: This should probably be available as a file download rather than dumped to the hard drive.
+                    # Pending this: https://github.com/nautobot/nautobot/issues/3352
+                    profiling_path = f"/tmp/{job_result_pk}.pstats"
+
+                    # TODO: Context manager for this is added in 3.8
+                    profiler = cProfile.Profile()
+                    profiler.enable()
+                    output = job.run(data=data, commit=commit)
+                    profiler.disable()
+                    profiler.dump_stats(profiling_path)
+                    job.log_info(obj=None, message=f"Wrote profiling information to {profiling_path}.")
+                else:
+                    output = job.run(data=data, commit=commit)
                 if output:
                     job.results["output"] += "\n" + str(output)
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1219,7 +1219,7 @@ def run_job(data, request, job_result_pk, commit=True, profile=False, *args, **k
 
                     # TODO: This should probably be available as a file download rather than dumped to the hard drive.
                     # Pending this: https://github.com/nautobot/nautobot/issues/3352
-                    profiling_path = f"/tmp/{job_result_pk}.pstats"
+                    profiling_path = f"/tmp/nautobot-jobresult-{job_result_pk}.pstats"
 
                     # TODO: Context manager for this is added in 3.8
                     profiler = cProfile.Profile()

--- a/nautobot/extras/management/commands/runjob.py
+++ b/nautobot/extras/management/commands/runjob.py
@@ -25,6 +25,11 @@ class Command(BaseCommand):
             help="Commit changes to DB (defaults to dry-run if unset). --username is mandatory if using this argument",
         )
         parser.add_argument(
+            "--profile",
+            action="store_true",
+            help="Run cProfile on the job execution and write the result to the disk under /tmp (use --local to run the job locally, writing to the local filesystem).",
+        )
+        parser.add_argument(
             "-u",
             "--username",
             help="User account to impersonate as the requester of this job",
@@ -88,6 +93,7 @@ class Command(BaseCommand):
                 data=data,
                 request=copy_safe_request(request) if request else None,
                 commit=options["commit"],
+                profile=options["profile"],
                 job_result_pk=job_result.pk,
             )
             job_result.refresh_from_db()
@@ -101,6 +107,7 @@ class Command(BaseCommand):
                 data=data,
                 request=copy_safe_request(request) if request else None,
                 commit=options["commit"],
+                profile=options["profile"],
             )
 
             # Wait on the job to finish

--- a/nautobot/extras/management/commands/runjob.py
+++ b/nautobot/extras/management/commands/runjob.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--profile",
             action="store_true",
-            help="Run cProfile on the job execution and write the result to the disk under /tmp (use --local to run the job locally, writing to the local filesystem).",
+            help="Run cProfile on the job execution and write the result to the disk under /tmp.",
         )
         parser.add_argument(
             "-u",

--- a/nautobot/extras/tests/example_jobs/test_profiling.py
+++ b/nautobot/extras/tests/example_jobs/test_profiling.py
@@ -20,5 +20,4 @@ class TestProfilingJob(Job):
         return []
 
     def post_run(self):
-        # This serves as the 'assert' for the test - it shouldn't fail
-        pstats.Stats(f"/tmp/{self.job_result.id}.pstats")
+        pstats.Stats(f"/tmp/nautobot-jobresult-{self.job_result.id}.pstats")

--- a/nautobot/extras/tests/example_jobs/test_profiling.py
+++ b/nautobot/extras/tests/example_jobs/test_profiling.py
@@ -1,0 +1,24 @@
+import pstats
+
+from nautobot.extras.jobs import Job
+
+
+class TestProfilingJob(Job):
+    """
+    Job to have profiling tested.
+    """
+
+    description = "Test profiling"
+
+    def run(self, data, commit):
+        """
+        Job function.
+        """
+
+        self.log_success(obj=None, message="Profiling test.")
+
+        return []
+
+    def post_run(self):
+        # This serves as the 'assert' for the test - it shouldn't fail
+        pstats.Stats(f"/tmp/{self.job_result.id}.pstats")

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -4,6 +4,7 @@ import logging
 import re
 import uuid
 from io import StringIO
+from pathlib import Path
 from unittest import mock
 
 from django.contrib.auth import get_user_model
@@ -438,7 +439,17 @@ class JobTest(TransactionTestCase):
         name = "TestProfilingJob"
 
         # The job itself contains the 'assert' by loading the resulting profiling file from the workers filesystem
-        create_job_result_and_run_job(module, name)
+        job_result = create_job_result_and_run_job(module, name, profile=True)
+
+        self.assertEqual(
+            job_result.status,
+            JobResultStatusChoices.STATUS_COMPLETED,
+            msg="Profiling test job errored, this indicates that either no profiling file was created or it is malformed.",
+        )
+
+        profiling_result = Path(f"/tmp/nautobot-jobresult-{job_result.pk}.pstats")
+        self.assertTrue(profiling_result.exists())
+        profiling_result.unlink()
 
 
 class JobFileUploadTest(TransactionTestCase):

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -46,12 +46,12 @@ def get_job_class_and_model(module, name):
     return (job_class, job_model)
 
 
-def create_job_result_and_run_job(module, name, *, data=None, commit=True, request=None):
+def create_job_result_and_run_job(module, name, *, data=None, commit=True, profile=False, request=None):
     """Test helper function to call get_job_class_and_model() then and call run_job_for_testing()."""
     if data is None:
         data = {}
     _job_class, job_model = get_job_class_and_model(module, name)
-    job_result = run_job_for_testing(job=job_model, data=data, commit=commit, request=request)
+    job_result = run_job_for_testing(job=job_model, data=data, commit=commit, profile=profile, request=request)
     job_result.refresh_from_db()
     return job_result
 
@@ -428,6 +428,13 @@ class JobTest(TransactionTestCase):
             <span class="helptext">Commit changes to the database (uncheck for a dry-run)</span></td></tr>""",
             form.as_table(),
         )
+
+    def test_job_profiling(self):
+        module = "test_profiling"
+        name = "TestProfilingJob"
+
+        # The job itself contains the 'assert' by loading the resulting profiling file from the workers filesystem
+        create_job_result_and_run_job(module, name)
 
 
 class JobFileUploadTest(TransactionTestCase):

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -161,7 +161,9 @@ class JobTest(TransactionTestCase):
         name = "TestFieldOrder"
         job_class = get_job(f"local/{module}/{name}")
         form = job_class().as_form()
-        self.assertSequenceEqual(list(form.fields.keys()), ["var1", "var2", "var23", "_task_queue", "_commit"])
+        self.assertSequenceEqual(
+            list(form.fields.keys()), ["var1", "var2", "var23", "_task_queue", "_commit", "_profile"]
+        )
 
     def test_no_field_order(self):
         """
@@ -171,7 +173,7 @@ class JobTest(TransactionTestCase):
         name = "TestNoFieldOrder"
         job_class = get_job(f"local/{module}/{name}")
         form = job_class().as_form()
-        self.assertSequenceEqual(list(form.fields.keys()), ["var23", "var2", "_task_queue", "_commit"])
+        self.assertSequenceEqual(list(form.fields.keys()), ["var23", "var2", "_task_queue", "_commit", "_profile"])
 
     def test_no_field_order_inherited_variable(self):
         """
@@ -183,7 +185,7 @@ class JobTest(TransactionTestCase):
         form = job_class().as_form()
         self.assertSequenceEqual(
             list(form.fields.keys()),
-            ["testvar1", "b_testvar2", "a_testvar3", "_task_queue", "_commit"],
+            ["testvar1", "b_testvar2", "a_testvar3", "_task_queue", "_commit", "_profile"],
         )
 
     def test_read_only_job_pass(self):
@@ -400,7 +402,8 @@ class JobTest(TransactionTestCase):
             <span class="helptext">The task queue to route this job to</span></td></tr>
             <tr><th><label for="id__commit">Commit changes:</label></th>
             <td><input type="checkbox" name="_commit" placeholder="Commit changes" id="id__commit" checked><br>
-            <span class="helptext">Commit changes to the database (uncheck for a dry-run)</span></td></tr>""",
+            <span class="helptext">Commit changes to the database (uncheck for a dry-run)</span>
+            <input type="hidden" name="_profile" value="False" id="id__profile"></td></tr>""",
             form.as_table(),
         )
 
@@ -425,7 +428,8 @@ class JobTest(TransactionTestCase):
             </select><br><span class="helptext">The task queue to route this job to</span></td></tr>
             <tr><th><label for="id__commit">Commit changes:</label></th>
             <td><input type="checkbox" name="_commit" placeholder="Commit changes" id="id__commit" checked><br>
-            <span class="helptext">Commit changes to the database (uncheck for a dry-run)</span></td></tr>""",
+            <span class="helptext">Commit changes to the database (uncheck for a dry-run)</span>
+            <input type="hidden" name="_profile" value="False" id="id__profile"></td></tr>""",
             form.as_table(),
         )
 
@@ -678,7 +682,9 @@ class JobButtonReceiverTest(TransactionTestCase):
         name = "TestJobButtonReceiverSimple"
         job_class, _job_model = get_job_class_and_model(module, name)
         form = job_class().as_form()
-        self.assertSequenceEqual(list(form.fields.keys()), ["object_pk", "object_model_name", "_task_queue", "_commit"])
+        self.assertSequenceEqual(
+            list(form.fields.keys()), ["object_pk", "object_model_name", "_task_queue", "_commit", "_profile"]
+        )
 
     def test_hidden(self):
         module = "test_job_button_receiver"
@@ -735,7 +741,7 @@ class JobHookReceiverTest(TransactionTestCase):
         name = "TestJobHookReceiverLog"
         job_class, _job_model = get_job_class_and_model(module, name)
         form = job_class().as_form()
-        self.assertSequenceEqual(list(form.fields.keys()), ["object_change", "_task_queue", "_commit"])
+        self.assertSequenceEqual(list(form.fields.keys()), ["object_change", "_task_queue", "_commit", "_profile"])
 
     def test_hidden(self):
         module = "test_job_hook_receiver"

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1154,6 +1154,7 @@ class JobView(ObjectPermissionRequiredMixin, View):
         elif job_form is not None and job_form.is_valid() and schedule_form.is_valid():
             # Run the job. A new JobResult is created.
             commit = job_form.cleaned_data.pop("_commit")
+            profile = job_form.cleaned_data.pop("_profile")
             schedule_type = schedule_form.cleaned_data["_schedule_type"]
 
             if job_model.approval_required or schedule_type in JobExecutionType.SCHEDULE_CHOICES:
@@ -1229,6 +1230,7 @@ class JobView(ObjectPermissionRequiredMixin, View):
                     data=job_model.job_class.serialize_data(job_form.cleaned_data),
                     request=copy_safe_request(request),
                     commit=commit,
+                    profile=profile,
                     task_queue=job_form.cleaned_data.get("_task_queue", None),
                 )
 

--- a/nautobot/utilities/testing/__init__.py
+++ b/nautobot/utilities/testing/__init__.py
@@ -98,7 +98,7 @@ def run_job_for_testing(job, data=None, commit=True, profile=False, username="te
                 yield ctx_request
 
     with _web_request_context(user=user_instance) as wrapped_request:
-        run_job(data=data, request=wrapped_request, commit=commit, job_result_pk=job_result.pk)
+        run_job(data=data, request=wrapped_request, commit=commit, job_result_pk=job_result.pk, profile=profile)
     return job_result
 
 

--- a/nautobot/utilities/testing/__init__.py
+++ b/nautobot/utilities/testing/__init__.py
@@ -50,13 +50,14 @@ __all__ = (
 User = get_user_model()
 
 
-def run_job_for_testing(job, data=None, commit=True, username="test-user", request=None):
+def run_job_for_testing(job, data=None, commit=True, profile=False, username="test-user", request=None):
     """Provide a common interface to run Nautobot jobs as part of unit tests.
 
     Args:
       job (Job): Job model instance (not Job class) to run
       data (dict): Input data values for any Job variables.
       commit (bool): Whether to commit changes to the database or rollback when done.
+      profile (bool): Whether to profile the job execution.
       username (str): Username of existing or to-be-created User account to own the JobResult. Ignored if `request.user`
         exists.
       request (HttpRequest): Existing request (if any) to own the JobResult.
@@ -81,7 +82,7 @@ def run_job_for_testing(job, data=None, commit=True, username="test-user", reque
         )
     job_result = JobResult.objects.create(
         name=job.class_path,
-        job_kwargs={"data": data, "commit": commit},
+        job_kwargs={"data": data, "commit": commit, "profile": profile},
         obj_type=get_job_content_type(),
         user=user_instance,
         job_model=job,


### PR DESCRIPTION
# Closes: #DNE - discussed verbally
# What's Changed

Add `cProfile` profiling flag to jobs when `DEBUG` is set in the config. Example output:

```
# nautobot-server runjob plugins/example_plugin.jobs/ExampleLoggingJob --data '{"interval": 2}' --profile --local
[15:57:31] Running plugins/example_plugin.jobs/ExampleLoggingJob...
15:57:31.012 INFO    nautobot.jobs.ExampleLoggingJob jobs.py                                run_job() :
  Running job (commit=False)
15:57:31.019 INFO    nautobot.jobs.ExampleLoggingJob jobs.py                                    log() :
  Running for 2 seconds.
15:57:32.021 INFO    nautobot.jobs.ExampleLoggingJob jobs.py                                    log() :
  Step 1
15:57:33.039 INFO    nautobot.jobs.ExampleLoggingJob jobs.py                                    log() :
  Step 2
15:57:33.049 INFO    nautobot.jobs.ExampleLoggingJob jobs.py                                    log() :
  None
15:57:33.059 INFO    nautobot.jobs.ExampleLoggingJob jobs.py                                    log() :
  Wrote profiling information to /tmp/5c4bc8c1-5fe8-4a67-9116-70d4d943e944.pstats.
15:57:33.059 INFO    nautobot.jobs.ExampleLoggingJob jobs.py                               _run_job() :
  job completed successfully
15:57:33.061 INFO    nautobot.jobs.ExampleLoggingJob jobs.py                                    log() :
  Database changes have been reverted automatically.
15:57:33.065 INFO    nautobot.jobs.ExampleLoggingJob jobs.py                               _run_job() :
  Job completed in 0 minutes, 2.06 seconds
        run: 1 success, 4 info, 0 warning, 0 failure
                default: Running for 2 seconds.
                info: Step 1
                info: Step 2
                success: None
                info: Wrote profiling information to /tmp/5c4bc8c1-5fe8-4a67-9116-70d4d943e944.pstats.
                info: Database changes have been reverted automatically.

Ran for 2 seconds
[15:57:33] plugins/example_plugin.jobs/ExampleLoggingJob: SUCCESS
[15:57:33] plugins/example_plugin.jobs/ExampleLoggingJob: Duration 0 minutes, 2.06 seconds
[15:57:33] Finished
# python
>>> import pstats
>>> stats = pstats.Stats("/tmp/5c4bc8c1-5fe8-4a67-9116-70d4d943e944.pstats")
>>> stats.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(10)
Fri Mar 24 15:57:33 2023    /tmp/5c4bc8c1-5fe8-4a67-9116-70d4d943e944.pstats

         5860 function calls (5718 primitive calls) in 2.036 seconds

   Ordered by: cumulative time
   List reduced from 438 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    2.036    2.036 /source/examples/example_plugin/example_plugin/jobs.py:46(run)
        2    2.006    1.003    2.006    1.003 {built-in method time.sleep}
        4    0.000    0.000    0.029    0.007 /source/nautobot/extras/jobs.py:531(_log)
        4    0.000    0.000    0.029    0.007 /source/nautobot/extras/models/jobs.py:769(log)
        4    0.000    0.000    0.026    0.006 /usr/local/lib/python3.7/site-packages/django/db/models/base.py:685(save)
        4    0.000    0.000    0.025    0.006 /usr/local/lib/python3.7/site-packages/django/db/models/base.py:743(save_base)
        4    0.000    0.000    0.024    0.006 /usr/local/lib/python3.7/site-packages/django/db/models/base.py:822(_save_table)
        4    0.000    0.000    0.024    0.006 /usr/local/lib/python3.7/site-packages/django/db/models/base.py:914(_do_insert)
        4    0.000    0.000    0.024    0.006 /usr/local/lib/python3.7/site-packages/django/db/models/manager.py:84(manager_method)
        4    0.000    0.000    0.024    0.006 /usr/local/lib/python3.7/site-packages/django/db/models/query.py:1260(_insert)


<pstats.Stats object at 0xffffbb207e90>
>>> 

```

# Open questions

- Should I make this available via
  - the API endpoint for running jobs?
  - the management command for running jobs?
  - the running of scheduled jobs?
- Is the way I'm outputting this to disk okay? Should it be configurable as to what the path is? I wanted to keep it as simple as possible. 

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
