### PR TITLE
IPAddress lookup fix

### DIFF
--- a/changes/3480.fixed
+++ b/changes/3480.fixed
@@ -1,0 +1,1 @@
+Fixed an error that could be seen in certain cases with IPAddress records.

--- a/nautobot/ipam/lookups.py
+++ b/nautobot/ipam/lookups.py
@@ -23,7 +23,6 @@ def _postgresql_varbin_to_broadcast(length):
 
 
 def _postgresql_varbin_to_integer(lhs, length, alias=None):
-    # alias = None
     if alias:
         return f"right({alias}.{lhs}::text, -1)::varbit::bit({length})"
     return f"right({lhs}::text, -1)::varbit::bit({length})"

--- a/nautobot/ipam/tests/test_querysets.py
+++ b/nautobot/ipam/tests/test_querysets.py
@@ -1,3 +1,4 @@
+import re
 from unittest import skipIf
 
 import netaddr
@@ -82,34 +83,50 @@ class IPAddressQuerySet(TestCase):
 
         cls.queryset.delete()
 
-        IPAddress.objects.create(address="10.0.0.1/24", vrf=None, tenant=None)
-        IPAddress.objects.create(address="10.0.0.2/24", vrf=None, tenant=None)
-        IPAddress.objects.create(address="10.0.0.3/24", vrf=None, tenant=None)
-        IPAddress.objects.create(address="10.0.0.4/24", vrf=None, tenant=None)
-        IPAddress.objects.create(address="10.0.0.1/25", vrf=None, tenant=None)
-        IPAddress.objects.create(address="2001:db8::1/64", vrf=None, tenant=None)
-        IPAddress.objects.create(address="2001:db8::2/64", vrf=None, tenant=None)
-        IPAddress.objects.create(address="2001:db8::3/64", vrf=None, tenant=None)
+        cls.ips = {
+            "10.0.0.1/24": IPAddress.objects.create(address="10.0.0.1/24", vrf=None, tenant=None),
+            "10.0.0.1/25": IPAddress.objects.create(address="10.0.0.1/25", vrf=None, tenant=None),
+            "10.0.0.2/24": IPAddress.objects.create(address="10.0.0.2/24", vrf=None, tenant=None),
+            "10.0.0.3/24": IPAddress.objects.create(address="10.0.0.3/24", vrf=None, tenant=None),
+            "10.0.0.4/24": IPAddress.objects.create(address="10.0.0.4/24", vrf=None, tenant=None),
+            "2001:db8::1/64": IPAddress.objects.create(address="2001:db8::1/64", vrf=None, tenant=None),
+            "2001:db8::2/64": IPAddress.objects.create(address="2001:db8::2/64", vrf=None, tenant=None),
+            "2001:db8::3/64": IPAddress.objects.create(address="2001:db8::3/64", vrf=None, tenant=None),
+        }
 
     def test_ip_family(self):
         self.assertEqual(self.queryset.ip_family(4).count(), 5)
         self.assertEqual(self.queryset.ip_family(6).count(), 3)
 
     def test_net_host_contained(self):
-        self.assertEqual(self.queryset.net_host_contained(netaddr.IPNetwork("10.0.0.0/24")).count(), 5)
-        self.assertEqual(self.queryset.net_host_contained(netaddr.IPNetwork("10.0.0.0/30")).count(), 4)
-        self.assertEqual(self.queryset.net_host_contained(netaddr.IPNetwork("10.0.0.0/31")).count(), 2)
-        self.assertEqual(self.queryset.net_host_contained(netaddr.IPNetwork("10.0.10.0/24")).count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            self.queryset.net_host_contained(netaddr.IPNetwork("10.0.0.0/24")),
+            [instance for ip, instance in self.ips.items() if "10.0" in ip],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            self.queryset.net_host_contained(netaddr.IPNetwork("10.0.0.0/30")),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.0\.0\.[0-3]/", ip)],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            self.queryset.net_host_contained(netaddr.IPNetwork("10.0.0.0/31")),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.0\.0\.[0-1]/", ip)],
+        )
+        self.assertQuerysetEqual(
+            self.queryset.net_host_contained(netaddr.IPNetwork("10.0.10.0/24")),
+            [],
+        )
 
     def test_net_in(self):
         args = ["10.0.0.1/24"]
-        self.assertEqual(self.queryset.net_in(args).count(), 1)
+        self.assertQuerysetEqualAndNotEmpty(self.queryset.net_in(args), [self.ips["10.0.0.1/24"]])
 
         args = ["10.0.0.1"]
-        self.assertEqual(self.queryset.net_in(args).count(), 2)
+        self.assertQuerysetEqualAndNotEmpty(
+            self.queryset.net_in(args), [self.ips["10.0.0.1/24"], self.ips["10.0.0.1/25"]]
+        )
 
         args = ["10.0.0.1/24", "10.0.0.1/25"]
-        self.assertEqual(self.queryset.net_in(args).count(), 2)
+        self.assertQuerysetEqualAndNotEmpty(self.queryset.net_in(args), [self.ips[arg] for arg in args])
 
     def test_get_by_address(self):
         address = self.queryset.net_in(["10.0.0.1/24"])[0]
@@ -194,107 +211,291 @@ class IPAddressQuerySet(TestCase):
             "fe80::": 0,
         }
         for term, cnt in search_terms.items():
+            # TODO refactor to be able to use assertQuerysetEqualAndNotEmpty()
             self.assertEqual(self.queryset.string_search(term).count(), cnt)
 
     def test_host_family(self):
-        self.assertEqual(IPAddress.objects.filter(host__family=4).count(), 5)
-        self.assertEqual(IPAddress.objects.filter(host__family=6).count(), 3)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__family=4),
+            [instance for ip, instance in self.ips.items() if "." in ip],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__family=6),
+            [instance for ip, instance in self.ips.items() if ":" in ip],
+        )
 
     def test_host_net_host(self):
-        self.assertEqual(IPAddress.objects.filter(host__net_host="10.0.0.1").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__net_host="10.0.0.2").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__net_host="10.0.0.50").count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__net_host="2001:db8::1").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__net_host="2001:db8::5").count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_host="10.0.0.1"),
+            [self.ips["10.0.0.1/24"], self.ips["10.0.0.1/25"]],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_host="10.0.0.2"),
+            [self.ips["10.0.0.2/24"]],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__net_host="10.0.0.50"), [])
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_host="2001:db8::1"),
+            [self.ips["2001:db8::1/64"]],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__net_host="2001:db8::5"), [])
+        # https://github.com/nautobot/nautobot/issues/3480
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.select_related("nat_inside").filter(host__net_host="10.0.0.1"),
+            [self.ips["10.0.0.1/24"], self.ips["10.0.0.1/25"]],
+        )
 
     def test_host_net_host_contained(self):
-        self.assertEqual(IPAddress.objects.filter(host__net_host_contained="10.0.0.0/24").count(), 5)
-        self.assertEqual(IPAddress.objects.filter(host__net_host_contained="10.0.0.0/30").count(), 4)
-        self.assertEqual(IPAddress.objects.filter(host__net_host_contained="10.0.0.0/31").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__net_host_contained="10.0.0.2/31").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__net_host_contained="10.0.10.0/24").count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__net_host_contained="2001:db8::/64").count(), 3)
-        self.assertEqual(IPAddress.objects.filter(host__net_host_contained="2222:db8::/64").count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_host_contained="10.0.0.0/24"),
+            [instance for ip, instance in self.ips.items() if "10.0.0" in ip],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_host_contained="10.0.0.0/30"),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.0\.0\.[0-3]/", ip)],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_host_contained="10.0.0.0/31"),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.0\.0\.[0-1]/", ip)],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_host_contained="10.0.0.2/31"),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.0\.0\.[2-3]/", ip)],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__net_host_contained="10.0.10.0/24"), [])
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_host_contained="2001:db8::/64"),
+            [instance for ip, instance in self.ips.items() if "2001:db8:" in ip],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__net_host_contained="2222:db8::/64"), [])
+        # https://github.com/nautobot/nautobot/issues/3480
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.select_related("nat_inside").filter(host__net_host_contained="10.0.0.0/24"),
+            [instance for ip, instance in self.ips.items() if "10.0.0" in ip],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.select_related("nat_inside").filter(host__net_host_contained="2001:db8::/64"),
+            [instance for ip, instance in self.ips.items() if "2001:db8:" in ip],
+        )
 
     def test_host_net_in(self):
-        self.assertEqual(IPAddress.objects.filter(host__net_in=["10.0.0.0/31", "10.0.0.2/31"]).count(), 4)
-        self.assertEqual(IPAddress.objects.filter(host__net_in=["10.0.0.0/24"]).count(), 5)
-        self.assertEqual(IPAddress.objects.filter(host__net_in=["172.16.0.0/24"]).count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__net_in=["2001:db8::/64"]).count(), 3)
-        self.assertEqual(IPAddress.objects.filter(host__net_in=["10.0.0.0/24", "2001:db8::/64"]).count(), 8)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_in=["10.0.0.0/31", "10.0.0.2/31"]),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.0\.0\.[0-3]/", ip)],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_in=["10.0.0.0/24"]),
+            [instance for ip, instance in self.ips.items() if "10.0.0" in ip],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__net_in=["172.16.0.0/24"]), [])
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_in=["2001:db8::/64"]),
+            [instance for ip, instance in self.ips.items() if "2001:db8::" in ip],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_in=["10.0.0.0/24", "2001:db8::/64"]),
+            self.ips.values(),
+        )
 
-        IPAddress.objects.create(address="192.168.0.1/24", vrf=None, tenant=None)
-        self.assertEqual(IPAddress.objects.filter(host__net_in=["192.168.0.0/31"]).count(), 1)
+        extra_ip = IPAddress.objects.create(address="192.168.0.1/24", vrf=None, tenant=None)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__net_in=["192.168.0.0/31"]),
+            [extra_ip],
+        )
+
+        # https://github.com/nautobot/nautobot/issues/3480
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.select_related("nat_inside").filter(host__net_in=["10.0.0.0/24"]),
+            [instance for ip, instance in self.ips.items() if "10.0.0" in ip],
+        )
 
     @skipIf(
         connection.vendor == "postgresql",
         "Not currently supported on postgresql",
     )
     def test_host_exact(self):
-        self.assertEqual(IPAddress.objects.filter(host__exact="10.0.0.1").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__exact="10.0.0.2").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__exact="10.0.0.10").count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__iexact="10.0.0.1").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__iexact="10.0.0.2").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__iexact="10.0.0.10").count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__exact="10.0.0.1"),
+            [instance for ip, instance in self.ips.items() if "10.0.0.1/" in ip],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__exact="10.0.0.2"),
+            [self.ips["10.0.0.2/24"]],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__exact="10.0.0.10"), [])
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__iexact="10.0.0.1"),
+            [instance for ip, instance in self.ips.items() if "10.0.0.1/" in ip],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__iexact="10.0.0.2"),
+            [self.ips["10.0.0.2/24"]],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__iexact="10.0.0.10"), [])
 
-        self.assertEqual(IPAddress.objects.filter(host__exact="2001:db8::1").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__exact="2001:db8::5").count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__iexact="2001:db8::1").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__iexact="2001:db8::5").count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__exact="2001:db8::1"),
+            [self.ips["2001:db8::1/64"]],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__exact="2001:db8::5"), [])
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__iexact="2001:db8::1"),
+            [self.ips["2001:db8::1/64"]],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__iexact="2001:db8::5"), [])
+
+        # https://github.com/nautobot/nautobot/issues/3480
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.select_related("nat_inside").filter(host__exact="10.0.0.1"),
+            [instance for ip, instance in self.ips.items() if "10.0.0.1/" in ip],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.select_related("nat_inside").filter(host__iexact="2001:db8::1"),
+            [self.ips["2001:db8::1/64"]],
+        )
 
     @skipIf(
         connection.vendor == "postgresql",
         "Not currently supported on postgresql",
     )
     def test_host_endswith(self):
-        self.assertEqual(IPAddress.objects.filter(host__endswith="0.2").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__endswith="0.1").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__endswith="0.50").count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__iendswith="0.2").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__iendswith="0.1").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__iendswith="0.50").count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__endswith="0.2"),
+            [instance for ip, instance in self.ips.items() if "0.2/" in ip],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__endswith="0.1"),
+            [instance for ip, instance in self.ips.items() if "0.1/" in ip],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__endswith="0.50"), [])
 
-        self.assertEqual(IPAddress.objects.filter(host__endswith="8::1").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__endswith="8::5").count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__iendswith="8::1").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__iendswith="8::5").count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__iendswith="0.2"),
+            [instance for ip, instance in self.ips.items() if "0.2/" in ip],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__iendswith="0.1"),
+            [instance for ip, instance in self.ips.items() if "0.1/" in ip],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__iendswith="0.50"), [])
+
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__endswith="8::1"),
+            [instance for ip, instance in self.ips.items() if "8::1/" in ip],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__endswith="8::5"), [])
+
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__iendswith="8::1"),
+            [instance for ip, instance in self.ips.items() if "8::1/" in ip],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__iendswith="8::5"), [])
+
+        # https://github.com/nautobot/nautobot/issues/3480
+        self.assertEqual(IPAddress.objects.select_related("nat_inside").filter(host__endswith="0.1").count(), 2)
+        self.assertEqual(IPAddress.objects.select_related("nat_inside").filter(host__iendswith="8::1").count(), 1)
 
     @skipIf(
         connection.vendor == "postgresql",
         "Not currently supported on postgresql",
     )
     def test_host_startswith(self):
-        self.assertEqual(IPAddress.objects.filter(host__startswith="10.0.0.").count(), 5)
-        self.assertEqual(IPAddress.objects.filter(host__startswith="10.0.0.1").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__startswith="10.50.0.").count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__istartswith="10.0.0.").count(), 5)
-        self.assertEqual(IPAddress.objects.filter(host__istartswith="10.0.0.1").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__istartswith="10.50.0.").count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__startswith="10.0.0."),
+            [instance for ip, instance in self.ips.items() if ip.startswith("10.0.0.")],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__startswith="10.0.0.1"),
+            [instance for ip, instance in self.ips.items() if ip.startswith("10.0.0.1")],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__startswith="10.50.0."), [])
 
-        self.assertEqual(IPAddress.objects.filter(host__startswith="2001:db8::").count(), 3)
-        self.assertEqual(IPAddress.objects.filter(host__startswith="2001:db8::1").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__startswith="2001:db8::5").count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__istartswith="2001:db8::").count(), 3)
-        self.assertEqual(IPAddress.objects.filter(host__istartswith="2001:db8::1").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__istartswith="2001:db8::5").count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__istartswith="10.0.0."),
+            [instance for ip, instance in self.ips.items() if ip.startswith("10.0.0.")],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__istartswith="10.0.0.1"),
+            [instance for ip, instance in self.ips.items() if ip.startswith("10.0.0.1")],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__istartswith="10.50.0."), [])
+
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__startswith="2001:db8::"),
+            [instance for ip, instance in self.ips.items() if ip.startswith("2001:db8::")],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__startswith="2001:db8::1"),
+            [instance for ip, instance in self.ips.items() if ip.startswith("2001:db8::1")],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__startswith="2001:db8::5"), [])
+
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__istartswith="2001:db8::"),
+            [instance for ip, instance in self.ips.items() if ip.startswith("2001:db8::")],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__istartswith="2001:db8::1"),
+            [instance for ip, instance in self.ips.items() if ip.startswith("2001:db8::1")],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__istartswith="2001:db8::5"), [])
+
+        # https://github.com/nautobot/nautobot/issues/3480
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.select_related("nat_inside").filter(host__startswith="10.0"),
+            [instance for ip, instance in self.ips.items() if ip.startswith("10.0")],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.select_related("nat_inside").filter(host__istartswith="2001:db8::"),
+            [instance for ip, instance in self.ips.items() if ip.startswith("2001:db8::")],
+        )
 
     @skipIf(
         connection.vendor == "postgresql",
         "Not currently supported on postgresql",
     )
     def test_host_regex(self):
-        self.assertEqual(IPAddress.objects.filter(host__regex=r"10\.(.*)\.1").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__regex=r"10\.(.*)\.4").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__regex=r"10\.(.*)\.50").count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__iregex=r"10\.(.*)\.1").count(), 2)
-        self.assertEqual(IPAddress.objects.filter(host__iregex=r"10\.(.*)\.4").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__iregex=r"10\.(.*)\.50").count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__regex=r"10\.(.*)\.1"),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.(.*)\.1", ip)],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__regex=r"10\.(.*)\.4"),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.(.*)\.4", ip)],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__regex=r"10\.(.*)\.50"), [])
 
-        self.assertEqual(IPAddress.objects.filter(host__regex=r"2001(.*)1").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__regex=r"2001(.*)5").count(), 0)
-        self.assertEqual(IPAddress.objects.filter(host__iregex=r"2001(.*)1").count(), 1)
-        self.assertEqual(IPAddress.objects.filter(host__iregex=r"2001(.*)5").count(), 0)
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__iregex=r"10\.(.*)\.1"),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.(.*)\.1", ip)],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__iregex=r"10\.(.*)\.4"),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.(.*)\.4", ip)],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__iregex=r"10\.(.*)\.50"), [])
+
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__regex=r"2001(.*)1"),
+            [instance for ip, instance in self.ips.items() if re.match(r"2001(.*)1", ip)],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__regex=r"2001(.*)5"), [])
+
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.filter(host__iregex=r"2001(.*)1"),
+            [instance for ip, instance in self.ips.items() if re.match(r"2001(.*)1", ip)],
+        )
+        self.assertQuerysetEqual(IPAddress.objects.filter(host__iregex=r"2001(.*)5"), [])
+
+        # https://github.com/nautobot/nautobot/issues/3480
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.select_related("nat_inside").filter(host__regex=r"10\.(.*)\.1"),
+            [instance for ip, instance in self.ips.items() if re.match(r"10\.(.*)\.1", ip)],
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            IPAddress.objects.select_related("nat_inside").filter(host__iregex=r"2001(.*)1"),
+            [instance for ip, instance in self.ips.items() if re.match(r"2001(.*)1", ip)],
+        )
 
 
 class PrefixQuerysetTestCase(TestCase):

--- a/nautobot/utilities/testing/mixins.py
+++ b/nautobot/utilities/testing/mixins.py
@@ -205,7 +205,7 @@ class NautobotTestCaseMixin:
     def assertQuerysetEqualAndNotEmpty(self, qs, values, *args, **kwargs):
         """Wrapper for assertQuerysetEqual with additional logic to assert input queryset and values are not empty"""
 
-        self.assertNotEqual(qs.count(), 0, "Queryset cannot be empty")
+        self.assertNotEqual(len(qs), 0, "Queryset cannot be empty")
         self.assertNotEqual(len(values), 0, "Values cannot be empty")
 
         return self.assertQuerysetEqual(qs, values, *args, **kwargs)

--- a/nautobot/utilities/testing/mixins.py
+++ b/nautobot/utilities/testing/mixins.py
@@ -205,7 +205,7 @@ class NautobotTestCaseMixin:
     def assertQuerysetEqualAndNotEmpty(self, qs, values, *args, **kwargs):
         """Wrapper for assertQuerysetEqual with additional logic to assert input queryset and values are not empty"""
 
-        self.assertNotEqual(len(qs), 0, "Queryset cannot be empty")
+        self.assertNotEqual(qs.count(), 0, "Queryset cannot be empty")
         self.assertNotEqual(len(values), 0, "Values cannot be empty")
 
         return self.assertQuerysetEqual(qs, values, *args, **kwargs)


### PR DESCRIPTION
# Closes: #3480 
# What's Changed

- Add the table alias when looking up the `q_ip` fields on both Postgres and MySQL to avoid a `"Column 'host' in where clause is ambiguous"` error when querying IPAddress objects in a queryset that has already done a `select_related("nat_inside")`
- Extend the test_querysets IPAddress tests to trigger this case in various ways and verify that it is now fixed.
- Also manually tested the UI and API paths described in the original issue to verify the problem is no longer seen.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
