### PR TITLE
Fixes to Prefix views and functionality

### DIFF
--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -324,7 +324,7 @@ class PrefixForm(LocatableModelFormMixin, NautobotModelForm, TenancyForm, Prefix
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.instance is not None:
-            self.initial["vrfs"] = self.instance.vrfs.all().values_list("id", flat=True)
+            self.initial["vrfs"] = self.instance.vrfs.values_list("id", flat=True)
 
     def save(self, *args, **kwargs):
         instance = super().save(*args, **kwargs)

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -271,16 +271,6 @@ class RIRFilterForm(NautobotFilterForm):
 
 
 class PrefixForm(LocatableModelFormMixin, NautobotModelForm, TenancyForm, PrefixFieldMixin):
-    """
-    vrf = DynamicModelChoiceField(
-        empty_label="Global",
-        null_option="Global",
-        queryset=VRF.objects.all(),
-        required=False,
-        label="VRF",
-    )
-    """
-
     vlan_group = DynamicModelChoiceField(
         queryset=VLANGroup.objects.all(),
         required=False,
@@ -300,13 +290,21 @@ class PrefixForm(LocatableModelFormMixin, NautobotModelForm, TenancyForm, Prefix
     )
     rir = DynamicModelChoiceField(queryset=RIR.objects.all(), required=False, label="RIR")
     namespace = DynamicModelChoiceField(queryset=Namespace.objects.all())
+    vrfs = DynamicModelMultipleChoiceField(
+        queryset=VRF.objects.all(),
+        required=False,
+        label="VRFs",
+        query_params={
+            "namespace": "$namespace",
+        },
+    )
 
     class Meta:
         model = Prefix
         fields = [
             "prefix",
             "namespace",
-            # "vrf",
+            "vrfs",
             "location",
             "vlan",
             "status",
@@ -322,6 +320,16 @@ class PrefixForm(LocatableModelFormMixin, NautobotModelForm, TenancyForm, Prefix
         widgets = {
             "date_allocated": DateTimePicker(),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance is not None:
+            self.initial["vrfs"] = self.instance.vrfs.all().values_list("id", flat=True)
+
+    def save(self, *args, **kwargs):
+        instance = super().save(*args, **kwargs)
+        instance.vrfs.set(self.cleaned_data["vrfs"])
+        return instance
 
 
 class PrefixCSVForm(

--- a/nautobot/ipam/migrations/0027_ipam__namespaces.py
+++ b/nautobot/ipam/migrations/0027_ipam__namespaces.py
@@ -18,9 +18,17 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.AddField(
+            model_name="prefix",
+            name="ip_version",
+            field=models.IntegerField(db_index=True, editable=False, null=True),
+        ),
         migrations.AlterModelOptions(
             name="prefix",
-            options={"ordering": ("namespace", "network", "prefix_length"), "verbose_name_plural": "prefixes"},
+            options={
+                "ordering": ("namespace", "ip_version", "network", "prefix_length"),
+                "verbose_name_plural": "prefixes",
+            },
         ),
         migrations.AlterModelOptions(
             name="vrf",
@@ -157,7 +165,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name="prefix",
-            unique_together={("namespace", "network", "prefix_length")},
+            unique_together={("namespace", "ip_version", "network", "prefix_length")},
         ),
         migrations.AlterUniqueTogether(
             name="vrf",

--- a/nautobot/ipam/migrations/0027_ipam__namespaces.py
+++ b/nautobot/ipam/migrations/0027_ipam__namespaces.py
@@ -18,31 +18,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name="prefix",
-            name="ip_version",
-            field=models.IntegerField(db_index=True, editable=False, null=True),
-        ),
-        migrations.AlterModelOptions(
-            name="prefix",
-            options={
-                "ordering": ("namespace", "ip_version", "network", "prefix_length"),
-                "verbose_name_plural": "prefixes",
-            },
-        ),
-        migrations.AlterModelOptions(
-            name="vrf",
-            options={"ordering": ("namespace", "name"), "verbose_name": "VRF", "verbose_name_plural": "VRFs"},
-        ),
-        migrations.RemoveField(
-            model_name="ipaddress",
-            name="vrf",
-        ),
-        migrations.AlterField(
-            model_name="vrf",
-            name="rd",
-            field=models.CharField(blank=True, max_length=21, null=True),
-        ),
         migrations.CreateModel(
             name="VRFPrefixAssignment",
             fields=[
@@ -126,12 +101,18 @@ class Migration(migrations.Migration):
             ],
             options={
                 "abstract": False,
+                "ordering": ("name",),
             },
             bases=(
                 models.Model,
                 nautobot.extras.models.mixins.DynamicGroupMixin,
                 nautobot.extras.models.mixins.NotesMixin,
             ),
+        ),
+        migrations.AddField(
+            model_name="prefix",
+            name="ip_version",
+            field=models.IntegerField(db_index=True, editable=False, null=True),
         ),
         migrations.AddField(
             model_name="prefix",
@@ -142,6 +123,17 @@ class Migration(migrations.Migration):
                 related_name="prefixes",
                 to="ipam.namespace",
             ),
+        ),
+        migrations.AlterModelOptions(
+            name="prefix",
+            options={
+                "ordering": ("namespace", "ip_version", "network", "prefix_length"),
+                "verbose_name_plural": "prefixes",
+            },
+        ),
+        migrations.AlterUniqueTogether(
+            name="prefix",
+            unique_together={("namespace", "network", "prefix_length")},
         ),
         migrations.AddField(
             model_name="vrf",
@@ -163,13 +155,22 @@ class Migration(migrations.Migration):
             name="prefixes",
             field=models.ManyToManyField(related_name="vrfs", through="ipam.VRFPrefixAssignment", to="ipam.Prefix"),
         ),
-        migrations.AlterUniqueTogether(
-            name="prefix",
-            unique_together={("namespace", "ip_version", "network", "prefix_length")},
+        migrations.AlterField(
+            model_name="vrf",
+            name="rd",
+            field=models.CharField(blank=True, max_length=21, null=True),
+        ),
+        migrations.AlterModelOptions(
+            name="vrf",
+            options={"ordering": ("namespace", "name"), "verbose_name": "VRF", "verbose_name_plural": "VRFs"},
         ),
         migrations.AlterUniqueTogether(
             name="vrf",
             unique_together={("namespace", "name"), ("namespace", "rd")},
+        ),
+        migrations.RemoveField(
+            model_name="ipaddress",
+            name="vrf",
         ),
         migrations.RemoveField(
             model_name="prefix",

--- a/nautobot/ipam/migrations/0028_ipam__prefix__add_parent.py
+++ b/nautobot/ipam/migrations/0028_ipam__prefix__add_parent.py
@@ -25,8 +25,8 @@ class Migration(migrations.Migration):
         migrations.AlterIndexTogether(
             name="prefix",
             index_together={
-                ("ip_version", "network", "broadcast", "prefix_length"),
-                ("namespace", "ip_version", "network", "broadcast", "prefix_length"),
+                ("network", "broadcast", "prefix_length"),
+                ("namespace", "network", "broadcast", "prefix_length"),
             },
         ),
     ]

--- a/nautobot/ipam/migrations/0028_ipam__prefix__add_parent.py
+++ b/nautobot/ipam/migrations/0028_ipam__prefix__add_parent.py
@@ -13,11 +13,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name="prefix",
-            name="ip_version",
-            field=models.IntegerField(db_index=True, editable=False, null=True),
-        ),
-        migrations.AddField(
-            model_name="prefix",
             name="parent",
             field=models.ForeignKey(
                 blank=True,
@@ -30,8 +25,8 @@ class Migration(migrations.Migration):
         migrations.AlterIndexTogether(
             name="prefix",
             index_together={
-                ("network", "broadcast", "prefix_length"),
-                ("namespace", "network", "broadcast", "prefix_length"),
+                ("ip_version", "network", "broadcast", "prefix_length"),
+                ("namespace", "ip_version", "network", "broadcast", "prefix_length"),
             },
         ),
     ]

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -506,14 +506,15 @@ class Prefix(PrimaryModel, StatusModel, RoleModelMixin):
     class Meta:
         ordering = (
             "namespace",
+            "ip_version",
             "network",
             "prefix_length",
         )
         index_together = [
-            ["network", "broadcast", "prefix_length"],
-            ["namespace", "network", "broadcast", "prefix_length"],
+            ["ip_version", "network", "broadcast", "prefix_length"],
+            ["namespace", "ip_version", "network", "broadcast", "prefix_length"],
         ]
-        unique_together = ["namespace", "network", "prefix_length"]
+        unique_together = ["namespace", "ip_version", "network", "prefix_length"]
         verbose_name_plural = "prefixes"
 
     def validate_unique(self, exclude=None):

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -278,15 +278,14 @@ class VRFDeviceAssignmentTable(BaseTable):
 class VRFPrefixAssignmentTable(BaseTable):
     """Table for displaying VRF Prefix Assignments."""
 
-    vrf = tables.LinkColumn(verbose_name="VRF")
-    prefix = tables.LinkColumn()
-    name = tables.Column(accessor="vrf.name")
+    vrf = tables.Column(verbose_name="VRF", linkify=lambda record: record.vrf.get_absolute_url(), accessor="vrf.name")
+    prefix = tables.Column(linkify=True)
     rd = tables.Column(accessor="vrf.rd", verbose_name="RD")
     tenant = TenantColumn(accessor="vrf.tenant")
 
     class Meta(BaseTable.Meta):
         model = VRFPrefixAssignment
-        fields = ("vrf", "prefix", "name", "rd", "tenant")
+        fields = ("vrf", "prefix", "rd", "tenant")
 
 
 #
@@ -356,6 +355,7 @@ class PrefixTable(StatusTableMixin, RoleTableMixin, BaseTable):
     # vrf = tables.TemplateColumn(template_code=VRF_LINK, verbose_name="VRF")
     tenant = TenantColumn()
     location = tables.Column(linkify=True)
+    namespace = tables.Column(linkify=True)
     vlan = tables.Column(linkify=True, verbose_name="VLAN")
     rir = tables.Column(linkify=True)
     children = tables.Column(accessor="descendants_count")
@@ -363,6 +363,7 @@ class PrefixTable(StatusTableMixin, RoleTableMixin, BaseTable):
 
     class Meta(BaseTable.Meta):
         model = Prefix
+        orderable = False
         fields = (
             "pk",
             "prefix",
@@ -405,13 +406,13 @@ class PrefixDetailTable(PrefixTable):
     class Meta(PrefixTable.Meta):
         fields = (
             "pk",
+            "namespace",
             "prefix",
             "type",
             "status",
             "children",
             # "vrf",
             "utilization",
-            "namespace",
             "tenant",
             "location",
             "vlan",
@@ -421,13 +422,13 @@ class PrefixDetailTable(PrefixTable):
         )
         default_columns = (
             "pk",
+            "namespace",
             "prefix",
             "type",
             "status",
             "children",
             # "vrf",
             "utilization",
-            "namespace",
             "tenant",
             "location",
             "vlan",

--- a/nautobot/ipam/templates/ipam/prefix.html
+++ b/nautobot/ipam/templates/ipam/prefix.html
@@ -1,11 +1,11 @@
 {% extends 'generic/object_detail.html' %}
 {% load helpers %}
 
-{% block extra_breadcrumbs %}
-                {% if object.vrf %}
-                    <li>{{ object.vrf|hyperlinked_object }}</li>
-                {% endif %}
-{% endblock extra_breadcrumbs %}
+{% block breadcrumbs %}
+    <li><a href="{% url 'ipam:namespace_list' %}">Namespaces</a></li>
+    <li>{{ object.namespace | hyperlinked_object }}</li>
+    {{ block.super }}
+{% endblock breadcrumbs %}
 
 {% block masthead %}
 <h1>
@@ -59,16 +59,6 @@
                         <td>Type</td>
                         <td>
                             {{ object.get_type_display }}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>VRF</td>
-                        <td>
-                            {% if object.vrf %}
-                                {{ object.vrf|hyperlinked_object }} ({{ object.vrf.rd }})
-                            {% else %}
-                                <span>Global</span>
-                            {% endif %}
                         </td>
                     </tr>
                     <tr>

--- a/nautobot/ipam/templates/ipam/prefix.html
+++ b/nautobot/ipam/templates/ipam/prefix.html
@@ -4,7 +4,9 @@
 {% block breadcrumbs %}
     <li><a href="{% url 'ipam:namespace_list' %}">Namespaces</a></li>
     <li>{{ object.namespace | hyperlinked_object }}</li>
-    {{ block.super }}
+    <li><a href="{% url list_url %}?namespace={{ object.namespace.pk }}">{{ verbose_name_plural|bettertitle }}</a></li>
+    {% block extra_breadcrumbs %}{% endblock extra_breadcrumbs %}
+    <li>{{ object|hyperlinked_object }}</li>
 {% endblock breadcrumbs %}
 
 {% block masthead %}

--- a/nautobot/ipam/templates/ipam/prefix_edit.html
+++ b/nautobot/ipam/templates/ipam/prefix_edit.html
@@ -9,11 +9,16 @@
             {% render_field form.namespace %}
             {% render_field form.type %}
             {% render_field form.status %}
-            {% render_field form.vrf %}
             {% render_field form.role %}
             {% render_field form.rir %}
             {% render_field form.date_allocated %}
             {% render_field form.description %}
+        </div>
+    </div>
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>VRF Assignment</strong></div>
+        <div class="panel-body">
+            {% render_field form.vrfs %}
         </div>
     </div>
     <div class="panel panel-default">

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -54,11 +54,13 @@ class NamespaceUIViewSet(
         if self.action == "retrieve":
             vrfs = instance.vrfs.restrict(request.user, "view")
             vrf_table = tables.VRFTable(vrfs, orderable=False)
+            vrf_table.columns.hide("namespace")
             context["vrf_table"] = vrf_table
 
             prefixes = instance.prefixes.restrict(request.user, "view")
             prefix_count = prefixes.count()
-            prefix_table = tables.PrefixTable(prefixes, orderable=False)
+            prefix_table = tables.PrefixTable(prefixes)
+            prefix_table.columns.hide("namespace")
             context["prefix_count"] = prefix_count
             context["prefix_table"] = prefix_table
 
@@ -85,7 +87,7 @@ class VRFView(generic.ObjectView):
 
         prefixes = instance.prefixes.restrict(request.user, "view")
         prefix_count = prefixes.count()
-        prefix_table = tables.PrefixTable(prefixes.select_related("namespace"), orderable=False)
+        prefix_table = tables.PrefixTable(prefixes.select_related("namespace"))
 
         # devices = instance.devices.restrict(request.user, "view")
         # device_count = devices.count()
@@ -292,12 +294,12 @@ class PrefixView(generic.ObjectView):
     def get_extra_context(self, request, instance):
         # Parent prefixes table
         parent_prefixes = instance.ancestors().restrict(request.user, "view")
-        parent_prefix_table = tables.PrefixTable(list(parent_prefixes), orderable=False)
+        parent_prefix_table = tables.PrefixTable(list(parent_prefixes))
 
         # TODO(jathan): Make duplicate prefixes go away entirely.
         # Duplicate prefixes table
         duplicate_prefixes = Prefix.objects.none()
-        duplicate_prefix_table = tables.PrefixTable(list(duplicate_prefixes), orderable=False)
+        duplicate_prefix_table = tables.PrefixTable(list(duplicate_prefixes))
 
         vrfs = instance.vrf_assignments.restrict(request.user, "view")
         vrf_table = tables.VRFPrefixAssignmentTable(vrfs, orderable=False)
@@ -458,7 +460,7 @@ class IPAddressView(generic.ObjectView):
             # .filter(vrf=instance.vrf)
             .select_related("location", "status", "role")
         )
-        parent_prefixes_table = tables.PrefixTable(list(parent_prefixes), orderable=False)
+        parent_prefixes_table = tables.PrefixTable(list(parent_prefixes))
         # parent_prefixes_table.exclude = ("vrf",)
 
         # Duplicate IPs table
@@ -733,7 +735,7 @@ class VLANView(generic.ObjectView):
                 "namespace",
             )
         )
-        prefix_table = tables.PrefixTable(list(prefixes), orderable=False)
+        prefix_table = tables.PrefixTable(list(prefixes))
         prefix_table.exclude = ("vlan",)
 
         return {


### PR DESCRIPTION
# Closes: #N/A (progress toward #3429)
# What's Changed

- Add working `VRFs` field to Prefix create/edit form
- Rework Prefix ~`unique_together`, `index_together`, and~`ordering` to include `ip_version` as a factor (without this, at least on MySQL, I was seeing the table view interleave IPv4 and IPv6 prefixes confusingly)
   - [x] ~TODO: are the `unique_together` and `index_together` changes actually correct/appropriate/necessary? The `ordering` definitely is.~ Reverted the unique_together and index_together changes.
   - [x] Ordering of Namespace should probably be by `name` instead of PK.
- In `VRFPrefixAssignmentTable` collapse the `VRF` and `name` columns together as they were redundant.
- In `PrefixTable` linkify the `namespace` column and move it to the left of the table for visibility.
    - Also, mark the entire table as `orderable = False` because sorting a tree model just makes for confusion.
        - This also allows me to remove various cases in `ipam/views.py` where we were explicitly instantiating a `PrefixTable(orderable=False)` before
- In the Prefix detail template, prepend the namespace information to the `breadcrumbs` and remove redundant single-VRF information.
- In the related object tables in the Namespace detail view, hide the redundant `namespace` columns.

![image](https://user-images.githubusercontent.com/5603551/228059796-c5ffdb01-b020-4a17-89f5-0fac157bb23d.png)

![image](https://user-images.githubusercontent.com/5603551/228059835-94b30c90-12c7-46ad-aafd-3c711439b8b2.png)

![image](https://user-images.githubusercontent.com/5603551/228060445-fb3ae64b-03fb-4f22-933e-0639bf03aa76.png)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- n/a Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
