### PR TITLE
Use plugins `next-2.0` branch for `next` upstream tests

### DIFF
--- a/.github/workflows/plugin_upstream_testing_base.yml
+++ b/.github/workflows/plugin_upstream_testing_base.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
+        with:
+          ref: "${{ matrix.nautobot-version == 'next' && 'next-2.0' || env.GITHUB_REF_NAME || 'develop' }}"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v2"
       - name: "Set up Docker Buildx"

--- a/changes/3502.fixed
+++ b/changes/3502.fixed
@@ -1,0 +1,1 @@
+Updated upstream workflow to support testing apps `next-2.0` branches against `next`.


### PR DESCRIPTION
# Closes: #3501 

## What's Changed

- Use `next-2.0` branch to checkout on plugin upstream testing for `next` tests

## TODO

- [x] Verify the functionality