### PR TITLE
Disable config context/dynamic groups annotation

### DIFF
--- a/nautobot/extras/querysets.py
+++ b/nautobot/extras/querysets.py
@@ -94,6 +94,9 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
         """
         from nautobot.extras.models import ConfigContext
 
+        if settings.CONFIG_CONTEXT_DYNAMIC_GROUPS_ENABLED:
+            return self
+
         return self.annotate(
             config_context_data=Subquery(
                 ConfigContext.objects.filter(self._get_config_context_filters())


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3432
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
This change will disable the config context annotation on device queries in order to allow config contexts to be mapped by dynamic group.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
