### PR TITLE
RelationshipsDataField OpenAPI/Swagger Fix

### DIFF
--- a/changes/3506.fixed
+++ b/changes/3506.fixed
@@ -1,0 +1,1 @@
+Unnested the OpenAPI/Swagger definition to not have additionalProperties at the top of the RelationshipsDataField schema field override.

--- a/nautobot/extras/api/relationships.py
+++ b/nautobot/extras/api/relationships.py
@@ -41,18 +41,15 @@ side_data_schema = {
     {
         # Dictionary, keyed by relationship slug
         "type": "object",
-        "additionalProperties": {
-            "type": "object",
-            "required": ["id", "url", "name", "type"],
-            "properties": {
-                "id": {"type": "string", "format": "uuid", "readOnly": True},
-                "url": {"type": "string", "format": "uri", "readOnly": True},
-                "name": {"type": "string", "readOnly": True},
-                "type": {"type": "string", "readOnly": True, "example": "one-to-many"},
-                "source": {"type": "object", "properties": side_data_schema},
-                "destination": {"type": "object", "properties": side_data_schema},
-                "peer": {"type": "object", "properties": side_data_schema},
-            },
+        "required": ["id", "url", "name", "type"],
+        "properties": {
+            "id": {"type": "string", "format": "uuid", "readOnly": True},
+            "url": {"type": "string", "format": "uri", "readOnly": True},
+            "name": {"type": "string", "readOnly": True},
+            "type": {"type": "string", "readOnly": True, "example": "one-to-many"},
+            "source": {"type": "object", "properties": side_data_schema},
+            "destination": {"type": "object", "properties": side_data_schema},
+            "peer": {"type": "object", "properties": side_data_schema},
         },
     }
 )

--- a/nautobot/utilities/tests/test_api.py
+++ b/nautobot/utilities/tests/test_api.py
@@ -144,3 +144,15 @@ class APIDocsTestCase(TestCase):
         url = reverse("schema")
         response = self.client.get(url, **headers)
         self.assertEqual(response.status_code, 200)
+
+    def test_openapi_schema_relationships(self):
+        headers = {
+            "HTTP_ACCEPT": "application/vnd.oai.openapi",
+        }
+        url = reverse("schema")
+        response = self.client.get(url, **headers)
+        resp_data = response.json()
+        self.assertNotIn(
+            "additionalProperties",
+            resp_data["components"]["schemas"]["BulkWritableAggregateRequest"]["properties"]["relationships"],
+        )

--- a/nautobot/utilities/tests/test_api.py
+++ b/nautobot/utilities/tests/test_api.py
@@ -146,10 +146,8 @@ class APIDocsTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_openapi_schema_relationships(self):
-        headers = {
-            "HTTP_ACCEPT": "application/vnd.oai.openapi",
-        }
         url = reverse("schema")
+        headers = {"HTTP_ACCEPT": "application/json"}
         response = self.client.get(url, **headers)
         resp_data = response.json()
         self.assertNotIn(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3506 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Unnested the OpenAPI/Swagger definition to not have **additionalProperties** at the top of the RelationshipsDataField schema field override.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
