### PR TITLE
added missing "status" to interfaces in serializers.py

### DIFF
--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -1026,6 +1026,7 @@ class InterfaceSerializerVersion12(
             "name",
             "label",
             "type",
+            "status",
             "enabled",
             "parent_interface",
             "bridge",


### PR DESCRIPTION
Bugfixing: missing "status" in dcim.interfaces API


# Closes: #3517
# What's Changed

added "status" field to dcim.interfaces serializer 

# TODO

- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
