### PR TITLE
Fix #3525 - add missing dependency

### DIFF
--- a/changes/3525.dependencies
+++ b/changes/3525.dependencies
@@ -1,0 +1,1 @@
+Added explicit dependency on `packaging` that had been inadvertently omitted.

--- a/development/docker-compose.final.yml
+++ b/development/docker-compose.final.yml
@@ -16,5 +16,6 @@ services:
         - "https://localhost:8443/health/"
   celery_worker:
     image: "local/nautobot-final:local-py${PYTHON_VER}"
+    entrypoint: "nautobot-server celery worker -l INFO --events"
   celery_beat:
     image: "local/nautobot-final:local-py${PYTHON_VER}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2342,7 +2342,7 @@ attrs = ">=19.2.0"
 name = "packaging"
 version = "23.0"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -3992,4 +3992,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "526d0268d447a9116d789a094eaf07f83dd4cbbf69ecdd7454313fcbdd2f0b2b"
+content-hash = "673c2b8d154d3cfab49509986f6a10a24d981e0a413868284a25cf508c422b86"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ netaddr = "~0.8.0"
 # Note: netutils is limited in scope, dependencies, and observes semver, as such
 #       we permit a looser (^) version constraint here.
 netutils = "^1.4.1"
+# Handling of version numbers
+packaging = "~23.0"
 # Image processing library
 Pillow = "~9.5.0"
 # Custom prometheus metrics


### PR DESCRIPTION
# Closes: #3525
# What's Changed

- Add explicit dependency on `packaging`; we previously coasted by on this being a downstream dependency of our other dependencies but this went away as a result of #3304 and other dependency cleanup.
- Fix docker-compose.final.yml to ensure that celery-worker container doesn't use (dev-only) `watchmedo` command.

Tested manually to confirm that rebuilt final image now starts up successfully.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
