### PR TITLE
Update assertInstanceEqual to fix JSON comparison of 'data_schema' keys.

### DIFF
--- a/changes/3116.fixed
+++ b/changes/3116.fixed
@@ -1,0 +1,1 @@
+Fixed JSON comparison of `data_scheme` keys in `assertInstanceEqual` tests.

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -284,7 +284,7 @@ class ConfigContextSchemaTestCase(
         cls.form_data = {
             "name": "Schema X",
             "slug": "schema-x",
-            "data_schema": '{"type": "object","properties": {"baz": {"type": "string"}}}',
+            "data_schema": '{"type": "object","properties": {"baz": {"type": "string"}}}',  # Intentionally misformatted (missing space) to ensure proper formatting on output
         }
 
         cls.bulk_edit_data = {

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -284,7 +284,7 @@ class ConfigContextSchemaTestCase(
         cls.form_data = {
             "name": "Schema X",
             "slug": "schema-x",
-            "data_schema": '{"type": "object", "properties": {"baz": {"type": "string"}}}',
+            "data_schema": '{"type": "object","properties": {"baz": {"type": "string"}}}',
         }
 
         cls.bulk_edit_data = {

--- a/nautobot/utilities/testing/mixins.py
+++ b/nautobot/utilities/testing/mixins.py
@@ -187,6 +187,9 @@ class NautobotTestCaseMixin:
             if isinstance(v, list):
                 # Sort lists of values. This includes items like tags, or other M2M fields
                 new_model_dict[k] = sorted(v)
+            elif k == "data_schema" and isinstance(v, str):
+                # Standardize the data_schema JSON, since the column is JSON and MySQL/dolt do not guarantee order
+                new_model_dict[k] = self.standardize_json(v)
             else:
                 new_model_dict[k] = v
 
@@ -197,6 +200,9 @@ class NautobotTestCaseMixin:
                 if isinstance(v, list):
                     # Sort lists of values. This includes items like tags, or other M2M fields
                     relevant_data[k] = sorted(v)
+                elif k == "data_schema" and isinstance(v, str):
+                    # Standardize the data_schema JSON, since the column is JSON and MySQL/dolt do not guarantee order
+                    relevant_data[k] = self.standardize_json(v)
                 else:
                     relevant_data[k] = v
 
@@ -213,6 +219,11 @@ class NautobotTestCaseMixin:
     #
     # Convenience methods
     #
+
+    def standardize_json(self, jsonText):
+        obj = json.loads(jsonText)
+        newJsonText = json.dumps(obj, sort_keys=True)
+        return newJsonText
 
     @classmethod
     def create_tags(cls, *names):

--- a/nautobot/utilities/testing/mixins.py
+++ b/nautobot/utilities/testing/mixins.py
@@ -220,10 +220,9 @@ class NautobotTestCaseMixin:
     # Convenience methods
     #
 
-    def standardize_json(self, jsonText):
-        obj = json.loads(jsonText)
-        newJsonText = json.dumps(obj, sort_keys=True)
-        return newJsonText
+    def standardize_json(self, data):
+        obj = json.loads(data)
+        return json.dumps(obj, sort_keys=True)
 
     @classmethod
     def create_tags(cls, *names):


### PR DESCRIPTION
This fixes the issue where assertInstanceEqual test code was relying on JSON columns to have the same formatting as the incoming data, which is typically not the case.

# Closes: #3116
# What's Changed
Update assertInstanceEqual to fix JSON comparison of 'data_schema' keys.
This fixes the issue where assertInstanceEqual test code was relying on JSON columns to have the same formatting as the incoming data, which is typically not the case.
This only impacts test code.
