### PR TITLE
[WIP/Prototype] Forking Unittests by App

### DIFF
--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -272,6 +272,9 @@ DATABASES = {
         "PORT": os.getenv("NAUTOBOT_DB_PORT", ""),
         "CONN_MAX_AGE": int(os.getenv("NAUTOBOT_DB_TIMEOUT", "300")),
         "ENGINE": os.getenv("NAUTOBOT_DB_ENGINE", "django.db.backends.postgresql"),
+        "TEST": {
+            "NAME": os.getenv("NAUTOBOT_DB_TEST_NAME", "test_nautobot"),
+        },
     }
 }
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
Hacky attempt at speeding up unittests. Output is garbage but locally it let me run unittests in under 9 minutes on my Macbook Air. I'm sure there are many improvements here (for example pool size should be equal to core count).

Leaving this here to maybe pick up later.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
