### PR TITLE
Fix Advance Filtering on interface list page 

### DIFF
--- a/changes/3573.fixed
+++ b/changes/3573.fixed
@@ -1,0 +1,1 @@
+Fixed advanced filtering on interface UI list page not working.

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -766,5 +766,5 @@ class GetFilterSetFieldDOMElementAPIView(NautobotAPIVersionMixin, APIView):
         TempForm = type("TempForm", (forms.Form,), {field_name: form_field})
         temp_form = TempForm()
         bound_field = temp_form[field_name]
-        field_dom_representation = bound_field.as_widget()
+        field_dom_representation = bound_field.as_widget(attrs={"id": f"id_for_{field_name}"})
         return Response({"dom_element": field_dom_representation})

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -41,6 +41,7 @@ from nautobot.utilities.utils import (
     get_filterset_parameter_form_field,
     FilterSetFieldNotFound,
     ensure_content_type_and_field_name_inquery_params,
+    get_form_for_model,
 )
 from . import serializers
 
@@ -761,10 +762,22 @@ class GetFilterSetFieldDOMElementAPIView(NautobotAPIVersionMixin, APIView):
         except FilterSetFieldNotFound:
             return Response("field_name not found", 404)
 
-        # Create a temporary form and get a BoundField for the specified field
-        # This is necessary to generate the HTML representation using as_widget()
-        TempForm = type("TempForm", (forms.Form,), {field_name: form_field})
-        temp_form = TempForm()
-        bound_field = temp_form[field_name]
-        field_dom_representation = bound_field.as_widget(attrs={"id": f"id_for_{field_name}"})
-        return Response({"dom_element": field_dom_representation})
+        try:
+            model_form = get_form_for_model(model)
+            model_form_instance = model_form(auto_id="id_for_%s")
+        except Exception as err:
+            # Cant determine the exceptions to handle because any exception could be raised,
+            # e.g InterfaceForm would raise a ObjectDoesNotExist Error since no device was provided
+            # While other forms might raise other errors, also if model_form is None a TypeError would be raised.
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                f"Exception: {err}",
+            )
+
+            # Create a temporary form and get a BoundField for the specified field
+            # This is necessary to generate the HTML representation using as_widget()
+            TempForm = type("TempForm", (forms.Form,), {field_name: form_field})
+            model_form_instance = TempForm(auto_id="id_for_%s")
+
+        bound_field = model_form_instance[field_name]
+        return Response({"dom_element": bound_field.as_widget()})

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -773,5 +773,11 @@ class GetFilterSetFieldDOMElementAPIView(NautobotAPIVersionMixin, APIView):
         except FilterSetFieldNotFound:
             return Response("field_name not found", 404)
 
+        print(" \n\n\n=====>",)
+        print(model_form)
+        print(form_field)
+        print(" \n\n\n=====>")
+
+
         field_dom_representation = form_field.get_bound_field(model_form(auto_id="id_for_%s"), field_name).as_widget()
         return Response({"dom_element": field_dom_representation})

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -779,5 +779,5 @@ class GetFilterSetFieldDOMElementAPIView(NautobotAPIVersionMixin, APIView):
             TempForm = type("TempForm", (forms.Form,), {field_name: form_field})
             model_form_instance = TempForm(auto_id="id_for_%s")
 
-        bound_field = model_form_instance[field_name]
+        bound_field = form_field.get_bound_field(model_form_instance, field_name)
         return Response({"dom_element": bound_field.as_widget()})

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -39,7 +39,6 @@ from nautobot.utilities.api import get_serializer_for_model
 from nautobot.utilities.utils import (
     get_all_lookup_expr_for_field,
     get_filterset_parameter_form_field,
-    get_form_for_model,
     FilterSetFieldNotFound,
     ensure_content_type_and_field_name_inquery_params,
 )

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -770,9 +770,7 @@ class GetFilterSetFieldDOMElementAPIView(NautobotAPIVersionMixin, APIView):
             # e.g InterfaceForm would raise a ObjectDoesNotExist Error since no device was provided
             # While other forms might raise other errors, also if model_form is None a TypeError would be raised.
             logger = logging.getLogger(__name__)
-            logger.warning(
-                f"Exception: {err}",
-            )
+            logger.debug(f"Handled expected exception when generating filter field: {err}")
 
             # Create a temporary form and get a BoundField for the specified field
             # This is necessary to generate the HTML representation using as_widget()

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -281,12 +281,28 @@ class GenerateLookupValueDomElementViewTestCase(APITestCase):
 
     def test_get_lookup_value_dom_element(self):
         url = reverse("core-api:filtersetfield-retrieve-lookupvaluedomelement")
-        response = self.client.get(url + "?content_type=dcim.site&field_name=name", **self.header)
+        with self.subTest("Assert correct lookup field dom element is generated"):
+            response = self.client.get(url + "?content_type=dcim.site&field_name=name", **self.header)
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.data,
-            {
-                "dom_element": '<select name="name" class="form-control nautobot-select2-multi-value-char" data-multiple="1" id="id_for_name" multiple>\n</select>'
-            },
-        )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.data,
+                {
+                    "dom_element": '<select name="name" class="form-control nautobot-select2-multi-value-char" data-multiple="1" id="id_for_name" multiple>\n</select>'
+                },
+            )
+
+        with self.subTest("Assert TempFilterForm is used if model filterform raises error at initialization"):
+            # The generation of a lookup field DOM representation is dependent on the ModelForm of the field;;
+            # if an error occurs when initializing the ModelForm, it should fall back to creating a temp ModelForm.
+            # Because the InterfaceModelForm requires a device to initialize, this is a perfect example to test that
+            # the Temp ModelForm is used.
+            response = self.client.get(url + "?content_type=dcim.interface&field_name=name", **self.header)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.data,
+                {
+                    "dom_element": '<select name="name" class="form-control nautobot-select2-multi-value-char" data-multiple="1" id="id_for_name" multiple>\n</select>'
+                },
+            )

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -282,7 +282,7 @@ class GenerateLookupValueDomElementViewTestCase(APITestCase):
     def test_get_lookup_value_dom_element(self):
         url = reverse("core-api:filtersetfield-retrieve-lookupvaluedomelement")
         with self.subTest("Assert correct lookup field dom element is generated"):
-            response = self.client.get(url + "?content_type=dcim.site&field_name=name", **self.header)
+            response = self.client.get(url + "?content_type=dcim.location&field_name=name", **self.header)
 
             self.assertEqual(response.status_code, 200)
             self.assertEqual(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3390 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
The error on the interface page was cause by https://github.com/nautobot/nautobot/issues/3390#issuecomment-1500798022
> The DynamicFilterForm is attempting to asking what the rendered element should be for the given model and filter field. It's throwing an exception: `nautobot.dcim.models.device_components.Interface.device.RelatedObjectDoesNotExist: Interface has no device.` This is because since there is no form attached it has no way of getting what the widget should be and in some cases that filter doesn't have any widget available. It uses the model form but this has dependencies in the Interface case on a Device being associated since we don't have a "Create Interface" view that doesn't require Device already passed in.

In this change, I opted to dynamically create a Django form instead of using a predefined form. This approach has no real impact on the outcome of the HTML DOM representation. Therefore, creating the form dynamically yields the same result as the predefined form while avoiding the complexities associated with predefined forms.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
