### PR TITLE
Fix advance filter error on multiple custom filter

### DIFF
--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -558,14 +558,13 @@ class CustomField(BaseModel, ChangeLoggedModel, NotesMixin):
             choices = [(cfc.value, cfc.value) for cfc in self.choices.all()]
             default_choice = self.choices.filter(value=self.default).first()
 
-            if not required or default_choice is None:
-                choices = add_blank_choice(choices)
-
             # Set the initial value to the first available choice (if any)
             if set_initial and default_choice:
                 initial = default_choice.value
 
             if self.type == CustomFieldTypeChoices.TYPE_SELECT:
+                if not required or default_choice is None:
+                    choices = add_blank_choice(choices)
                 field_class = CSVChoiceField if for_csv_import else forms.ChoiceField
                 field = field_class(
                     choices=choices,

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -1013,9 +1013,11 @@ def convert_querydict_to_factory_formset_acceptable_querydict(request_querydict,
 
 
 def is_single_choice_field(filterset, field_name):
+    from nautobot.extras.filters import CustomFieldMultiSelectFilter  # Avoid circular imports
+
     # Some filter parameters do not accept multiple values, e.g DateTime, Boolean, Int fields and the q field, etc.
     field = get_filterset_field(filterset, field_name)
-    return not isinstance(field, django_filters.MultipleChoiceFilter)
+    return not isinstance(field, (django_filters.MultipleChoiceFilter, CustomFieldMultiSelectFilter))
 
 
 def get_filterable_params_from_filter_params(filter_params, non_filter_params, filterset):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3391 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Error reported was caused by `is_single_choice_field` returning `True` for `CustomFieldMultiSelectFilter` because `CustomFieldMultiSelectFilter` inherits from `django_filters.Filter` and not `django_filters.MultipleChoiceFilter`.

Also fixed an additional bug where the page freeze after selecting a custom multiple field choice.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
