### PR TITLE
Fix #3592: Better duplicate call detection for populate_model_features_registry()

### DIFF
--- a/changes/3592.fixed
+++ b/changes/3592.fixed
@@ -1,0 +1,1 @@
+Fixed heuristic for duplicate calls to `populate_model_features_registry` causing skipped updates.

--- a/examples/example_plugin/example_plugin/models.py
+++ b/examples/example_plugin/example_plugin/models.py
@@ -40,6 +40,7 @@ class ExampleModel(OrganizationalModel):
     "export_templates",
     # "graphql", Not specified here as we have a custom type for this model, see example_plugin.graphql.types
     "webhooks",
+    "relationships",  # Defined here to ensure no clobbering: https://github.com/nautobot/nautobot/issues/3592
 )
 class AnotherExampleModel(OrganizationalModel):
     name = models.CharField(max_length=20)

--- a/nautobot/extras/tests/test_utils.py
+++ b/nautobot/extras/tests/test_utils.py
@@ -49,22 +49,31 @@ class UtilsTestCase(TestCase):
         with self.subTest("Empty queue"):
             self.assertEqual(get_worker_count(queue="nobody"), 0)
 
-    @mock.patch("nautobot.extras.utils.find_models_with_matching_fields")
-    def test_populate_model_features_registry(self, mocked_field_finder):
+    def test_populate_model_features_registry(self):
         original_custom_fields_registry = registry["model_features"]["custom_fields"].copy()
-        mocked_field_finder.return_value = {"test": ["testmodel"]}
+
+        self.assertIn(
+            "circuit", registry["model_features"]["custom_fields"]["circuits"], "Registry should already be populated"
+        )
 
         populate_model_features_registry()
-        self.assertEqual(
+        self.assertDictEqual(
             registry["model_features"]["custom_fields"],
             original_custom_fields_registry,
             "Registry should not be modified if refresh flag not set",
         )
-        mocked_field_finder.assert_not_called()
 
-        populate_model_features_registry(refresh=True)
+        registry["model_features"]["custom_fields"].pop("circuits")
         self.assertNotEqual(
             registry["model_features"]["custom_fields"],
             original_custom_fields_registry,
-            "Registry should be modified if refresh flag is set",
+            "Registry should be successfully modified",
+        )
+
+        # Make sure we return to the original state
+        populate_model_features_registry(refresh=True)
+        self.assertDictEqual(
+            registry["model_features"]["custom_fields"],
+            original_custom_fields_registry,
+            "Registry should be restored to original state",
         )

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -136,11 +136,8 @@ class FeatureQuery:
         # initialization of the application, before `ExtrasConfig.ready` is called.
         # Calling `populate_model_features_registry` in `ExtrasConfig.ready` would lead to an outdated `model_features`
         # `registry` record being used by `FeatureQuery`.
-        # As the `populate_model_features_registry` can be resource-intensive. The check the conditional check is used to
-        # avoid calling the function multiple times and optimize the performance of the application.
-        # TODO(timizuo): Provide a better solution for this; check https://github.com/nautobot/nautobot/pull/3360/files#r1131373797 comment.
-        if not registry["model_features"].get("relationships"):
-            populate_model_features_registry()
+
+        populate_model_features_registry()
         query = Q()
         for app_label, models in registry["model_features"][self.feature].items():
             query |= Q(app_label=app_label, model__in=models)
@@ -223,7 +220,7 @@ def extras_features(*features):
     return wrapper
 
 
-def populate_model_features_registry():
+def populate_model_features_registry(refresh=False):
     """
     Populate the registry model features with new apps.
 
@@ -243,6 +240,9 @@ def populate_model_features_registry():
     - For each dictionary in lookup_confs, calls lookup_by_field() function to look for all models that have fields with the names given in the dictionary.
     - Groups the results by app and updates the registry model features for each app.
     """
+    if registry["model_features"].get("populate_model_features_registry_called", False) and not refresh:
+        return
+
     RelationshipAssociation = apps.get_model(app_label="extras", model_name="relationshipassociation")
 
     lookup_confs = [
@@ -266,6 +266,9 @@ def populate_model_features_registry():
         )
         feature_name = lookup_conf["feature_name"]
         registry["model_features"][feature_name] = registry_items
+
+    if registry["model_features"].get("populate_model_features_registry_called", False):
+        registry["populate_model_features_registry_called"] = True
 
 
 def generate_signature(request_body, secret):

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -240,7 +240,7 @@ def populate_model_features_registry(refresh=False):
     - For each dictionary in lookup_confs, calls lookup_by_field() function to look for all models that have fields with the names given in the dictionary.
     - Groups the results by app and updates the registry model features for each app.
     """
-    if registry["model_features"].get("populate_model_features_registry_called", False) and not refresh:
+    if registry.get("populate_model_features_registry_called", False) and not refresh:
         return
 
     RelationshipAssociation = apps.get_model(app_label="extras", model_name="relationshipassociation")
@@ -267,7 +267,7 @@ def populate_model_features_registry(refresh=False):
         feature_name = lookup_conf["feature_name"]
         registry["model_features"][feature_name] = registry_items
 
-    if registry["model_features"].get("populate_model_features_registry_called", False):
+    if registry.get("populate_model_features_registry_called", False):
         registry["populate_model_features_registry_called"] = True
 
 

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -267,7 +267,7 @@ def populate_model_features_registry(refresh=False):
         feature_name = lookup_conf["feature_name"]
         registry["model_features"][feature_name] = registry_items
 
-    if registry.get("populate_model_features_registry_called", False):
+    if not registry.get("populate_model_features_registry_called", False):
         registry["populate_model_features_registry_called"] = True
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3592
# What's Changed
Uses the registry to know if `populate_model_features_registry` has already been called. Provide a way to refresh it if needed (see: https://github.com/nautobot/nautobot/pull/3360#discussion_r1131373797).


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [NA] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [NA] Documentation Updates (when adding/changing features)
- [X] Example Plugin Updates (when adding/changing features)
- [X] Outline Remaining Work, Constraints from Design
