### PR TITLE
Improve Role migrations

### DIFF
--- a/changes/3518.fixed
+++ b/changes/3518.fixed
@@ -1,0 +1,1 @@
+Fixed an error seen when running the `extras.0061_collect_roles_from_related_apps_roles` migration.

--- a/nautobot/dcim/migrations/0025_device_and_rack_roles_data_migrations.py
+++ b/nautobot/dcim/migrations/0025_device_and_rack_roles_data_migrations.py
@@ -5,26 +5,30 @@ from nautobot.extras.utils import migrate_role_data
 
 
 def migrate_data_from_legacy_role_to_new_role(apps, schema):
-    """Copy record from role to temp_role"""
-
-    role_model = apps.get_model("extras", "Role")
+    """Copy data from legacy_role to new_role."""
+    new_role_model = apps.get_model("extras", "Role")
     for model_name in ("Device", "Rack"):
         model = apps.get_model("dcim", model_name)
-        migrate_role_data(model=model, role_model=role_model)
+        legacy_role_model = apps.get_model("dcim", f"{model_name}Role")
+        migrate_role_data(
+            model_to_migrate=model,
+            legacy_role_model=legacy_role_model,
+            new_role_model=new_role_model,
+        )
 
 
 def reverse_role_data_migrate(apps, schema):
     """Reverse changes made to new_role"""
-
-    model_role_map = {"Device": "DeviceRole", "Rack": "RackRole"}
-    for model_name, role_name in model_role_map.items():
+    legacy_role_model = apps.get_model("extras", "Role")
+    for model_name in ("Device", "Rack"):
         model = apps.get_model("dcim", model_name)
-        role_model = apps.get_model("dcim", role_name)
+        new_role_model = apps.get_model("dcim", f"{model_name}Role")
         migrate_role_data(
-            model=model,
-            role_model=role_model,
-            legacy_role="new_role",
-            new_role="legacy_role",
+            model_to_migrate=model,
+            legacy_role_field_name="new_role",
+            legacy_role_model=legacy_role_model,
+            new_role_field_name="legacy_role",
+            new_role_model=new_role_model,
         )
 
 

--- a/nautobot/dcim/migrations/0025_device_and_rack_roles_data_migrations.py
+++ b/nautobot/dcim/migrations/0025_device_and_rack_roles_data_migrations.py
@@ -5,30 +5,32 @@ from nautobot.extras.utils import migrate_role_data
 
 
 def migrate_data_from_legacy_role_to_new_role(apps, schema):
-    """Copy data from legacy_role to new_role."""
-    new_role_model = apps.get_model("extras", "Role")
+    """Transfer data from legacy_role to new_role."""
+    to_role_model = apps.get_model("extras", "Role")
     for model_name in ("Device", "Rack"):
         model = apps.get_model("dcim", model_name)
-        legacy_role_model = apps.get_model("dcim", f"{model_name}Role")
+        from_role_model = apps.get_model("dcim", f"{model_name}Role")
         migrate_role_data(
             model_to_migrate=model,
-            legacy_role_model=legacy_role_model,
-            new_role_model=new_role_model,
+            from_role_field_name="legacy_role",
+            from_role_model=from_role_model,
+            to_role_field_name="new_role",
+            to_role_model=to_role_model,
         )
 
 
 def reverse_role_data_migrate(apps, schema):
-    """Reverse changes made to new_role"""
-    legacy_role_model = apps.get_model("extras", "Role")
+    """Transfer data from new_role to legacy_role."""
+    from_role_model = apps.get_model("extras", "Role")
     for model_name in ("Device", "Rack"):
         model = apps.get_model("dcim", model_name)
-        new_role_model = apps.get_model("dcim", f"{model_name}Role")
+        to_role_model = apps.get_model("dcim", f"{model_name}Role")
         migrate_role_data(
             model_to_migrate=model,
-            legacy_role_field_name="new_role",
-            legacy_role_model=legacy_role_model,
-            new_role_field_name="legacy_role",
-            new_role_model=new_role_model,
+            from_role_field_name="new_role",
+            from_role_model=from_role_model,
+            to_role_field_name="legacy_role",
+            to_role_model=to_role_model,
         )
 
 

--- a/nautobot/extras/migrations/0060_role_and_alter_status.py
+++ b/nautobot/extras/migrations/0060_role_and_alter_status.py
@@ -37,12 +37,6 @@ class Migration(migrations.Migration):
                     models.JSONField(blank=True, default=dict, encoder=django.core.serializers.json.DjangoJSONEncoder),
                 ),
                 ("name", models.CharField(max_length=100, unique=True)),
-                (
-                    "slug",
-                    nautobot.core.models.fields.AutoSlugField(
-                        blank=True, max_length=100, populate_from="name", unique=True
-                    ),
-                ),
                 ("color", nautobot.core.models.fields.ColorField(default="9e9e9e", max_length=6)),
                 ("description", models.CharField(blank=True, max_length=200)),
                 ("weight", models.PositiveSmallIntegerField(blank=True, null=True)),

--- a/nautobot/extras/migrations/0064_configcontext_data_migrations.py
+++ b/nautobot/extras/migrations/0064_configcontext_data_migrations.py
@@ -4,32 +4,32 @@ from django.db import migrations
 from nautobot.extras.utils import migrate_role_data
 
 
-def migrate_data_from_legacy_role_to_new_role(apps, schema):
-    """Copy data from legacy_roles to new_roles."""
+def migrate_data_from_legacy_roles_to_new_roles(apps, schema):
+    """Migrate ConfigContext data from legacy_roles to new_roles."""
     ConfigContext = apps.get_model("extras", "ConfigContext")
     DeviceRole = apps.get_model("dcim", "DeviceRole")
     Role = apps.get_model("extras", "Role")
     migrate_role_data(
         model_to_migrate=ConfigContext,
-        legacy_role_field_name="legacy_roles",
-        legacy_role_model=DeviceRole,
-        new_role_field_name="new_roles",
-        new_role_model=Role,
+        from_role_field_name="legacy_roles",
+        from_role_model=DeviceRole,
+        to_role_field_name="new_roles",
+        to_role_model=Role,
         is_m2m_field=True,
     )
 
 
 def reverse_role_data_migrate(apps, schema):
-    """Reverse changes made to new_roles."""
+    """Migrate ConfigContext data from new_roles to legacy_roles."""
     ConfigContext = apps.get_model("extras", "ConfigContext")
     DeviceRole = apps.get_model("dcim", "DeviceRole")
     Role = apps.get_model("extras", "Role")
     migrate_role_data(
         model_to_migrate=ConfigContext,
-        legacy_role_field_name="new_roles",
-        legacy_role_model=Role,
-        new_role_field_name="legacy_roles",
-        new_role_model=DeviceRole,
+        from_role_field_name="new_roles",
+        from_role_model=Role,
+        to_role_field_name="legacy_roles",
+        to_role_model=DeviceRole,
         is_m2m_field=True,
     )
 
@@ -40,5 +40,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(migrate_data_from_legacy_role_to_new_role, reverse_role_data_migrate),
+        migrations.RunPython(migrate_data_from_legacy_roles_to_new_roles, reverse_role_data_migrate),
     ]

--- a/nautobot/extras/migrations/0064_configcontext_data_migrations.py
+++ b/nautobot/extras/migrations/0064_configcontext_data_migrations.py
@@ -5,28 +5,31 @@ from nautobot.extras.utils import migrate_role_data
 
 
 def migrate_data_from_legacy_role_to_new_role(apps, schema):
-    """Copy record from role to temp_role"""
-
-    Role = apps.get_model("extras", "Role")
+    """Copy data from legacy_roles to new_roles."""
     ConfigContext = apps.get_model("extras", "ConfigContext")
+    DeviceRole = apps.get_model("dcim", "DeviceRole")
+    Role = apps.get_model("extras", "Role")
     migrate_role_data(
-        model=ConfigContext,
-        role_model=Role,
-        legacy_role="legacy_roles",
-        new_role="new_roles",
+        model_to_migrate=ConfigContext,
+        legacy_role_field_name="legacy_roles",
+        legacy_role_model=DeviceRole,
+        new_role_field_name="new_roles",
+        new_role_model=Role,
         is_m2m_field=True,
     )
 
 
 def reverse_role_data_migrate(apps, schema):
-    """Reverse changes made to new_role"""
+    """Reverse changes made to new_roles."""
     ConfigContext = apps.get_model("extras", "ConfigContext")
     DeviceRole = apps.get_model("dcim", "DeviceRole")
+    Role = apps.get_model("extras", "Role")
     migrate_role_data(
-        model=ConfigContext,
-        role_model=DeviceRole,
-        legacy_role="new_roles",
-        new_role="legacy_roles",
+        model_to_migrate=ConfigContext,
+        legacy_role_field_name="new_roles",
+        legacy_role_model=Role,
+        new_role_field_name="legacy_roles",
+        new_role_model=DeviceRole,
         is_m2m_field=True,
     )
 

--- a/nautobot/extras/migrations/0077_remove_slug.py
+++ b/nautobot/extras/migrations/0077_remove_slug.py
@@ -31,10 +31,6 @@ class Migration(migrations.Migration):
             name="slug",
         ),
         migrations.RemoveField(
-            model_name="role",
-            name="slug",
-        ),
-        migrations.RemoveField(
             model_name="secret",
             name="slug",
         ),

--- a/nautobot/extras/templates/extras/configcontext.html
+++ b/nautobot/extras/templates/extras/configcontext.html
@@ -67,7 +67,7 @@
                             {% if object.roles.all %}
                                 <ul>
                                     {% for role in object.roles.all %}
-                                        <li><a href="{% url 'dcim:device_list' %}?role={{ role.slug }}">{{ role }}</a></li>
+                                        <li><a href="{% url 'dcim:device_list' %}?role={{ role.name }}">{{ role }}</a></li>
                                     {% endfor %}
                                 </ul>
                             {% else %}

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -602,10 +602,12 @@ def get_instances_to_pk_and_new_role(queryset, role_model, role_choiceset, legac
             else:
                 if not isinstance(legacy_role_field, str):
                     legacy_role_field = legacy_role_field.name
+                if legacy_role_field == "":  # Such as an IPAddress with no assigned role
+                    continue
                 try:
                     role_equivalent = role_model.objects.get(Q(name=legacy_role_field) | Q(slug=legacy_role_field))
                 except role_model.DoesNotExist:
-                    logger.error(f"Role with name {legacy_role_field} not found")
+                    logger.error('Role with name/slug "%s" not found', legacy_role_field)
         else:
             # ChoiceSet.CHOICES has to be inverted to obtain the value using its label
             # i.e {"vrf": "VRF"} --> {"VRF": "vrf"}

--- a/nautobot/ipam/migrations/0011_migrate_ipam_role_data.py
+++ b/nautobot/ipam/migrations/0011_migrate_ipam_role_data.py
@@ -6,38 +6,40 @@ from nautobot.ipam.choices import IPAddressRoleChoices
 
 
 def migrate_data_from_legacy_role_to_new_role(apps, schema):
-    """Copy data from legacy_role to new_role."""
-    new_role_model = apps.get_model("extras", "Role")
+    """Migrate VLAN/Prefix/IPAddress data from legacy_role to new_role."""
+    to_role_model = apps.get_model("extras", "Role")
     ipam_role_model = apps.get_model("ipam", "Role")
-    for model_to_migrate, legacy_role_model, legacy_role_choiceset in [
+    for model_to_migrate, from_role_model, from_role_choiceset in [
         (apps.get_model("ipam", "VLAN"), ipam_role_model, None),
         (apps.get_model("ipam", "Prefix"), ipam_role_model, None),
         (apps.get_model("ipam", "IPAddress"), None, IPAddressRoleChoices),
     ]:
         migrate_role_data(
             model_to_migrate=model_to_migrate,
-            legacy_role_model=legacy_role_model,
-            legacy_role_choiceset=legacy_role_choiceset,
-            new_role_model=new_role_model,
+            from_role_field_name="legacy_role",
+            from_role_model=from_role_model,
+            to_role_field_name="new_role",
+            from_role_choiceset=from_role_choiceset,
+            to_role_model=to_role_model,
         )
 
 
 def migrate_data_from_new_role_to_legacy_role(apps, schema):
-    """Copy data from new_role to legacy_role."""
-    new_role_model = apps.get_model("extras", "Role")
+    """Migrate VLAN/Prefix/IPAddress data from new_role to legacy_role."""
+    to_role_model = apps.get_model("extras", "Role")
     ipam_role_model = apps.get_model("ipam", "Role")
-    for model_to_migrate, legacy_role_model, legacy_role_choiceset in [
+    for model_to_migrate, from_role_model, from_role_choiceset in [
         (apps.get_model("ipam", "VLAN"), ipam_role_model, None),
         (apps.get_model("ipam", "Prefix"), ipam_role_model, None),
         (apps.get_model("ipam", "IPAddress"), None, IPAddressRoleChoices),
     ]:
         migrate_role_data(
             model_to_migrate=model_to_migrate,
-            legacy_role_field_name="new_role",
-            legacy_role_model=new_role_model,
-            new_role_field_name="legacy_role",
-            new_role_model=legacy_role_model,
-            new_role_choiceset=legacy_role_choiceset,
+            from_role_field_name="new_role",
+            from_role_model=to_role_model,
+            to_role_field_name="legacy_role",
+            to_role_model=from_role_model,
+            to_role_choiceset=from_role_choiceset,
         )
 
 

--- a/nautobot/virtualization/migrations/0013_migrate_virtualmachine_role_data.py
+++ b/nautobot/virtualization/migrations/0013_migrate_virtualmachine_role_data.py
@@ -5,28 +5,30 @@ from nautobot.extras.utils import migrate_role_data
 
 
 def migrate_data_from_legacy_role_to_new_role(apps, schema):
-    """Copy record from legacy_role to new_role."""
+    """Migrate DeviceRole data from legacy_role to new_role."""
     model = apps.get_model("virtualization", "VirtualMachine")
-    legacy_role_model = apps.get_model("dcim", "DeviceRole")
-    new_role_model = apps.get_model("extras", "Role")
+    from_role_model = apps.get_model("dcim", "DeviceRole")
+    to_role_model = apps.get_model("extras", "Role")
     migrate_role_data(
         model_to_migrate=model,
-        legacy_role_model=legacy_role_model,
-        new_role_model=new_role_model,
+        from_role_field_name="legacy_role",
+        from_role_model=from_role_model,
+        to_role_field_name="new_role",
+        to_role_model=to_role_model,
     )
 
 
 def reverse_role_data_migrate(apps, schema):
-    """Reverse changes made to new_role"""
+    """Migrate DeviceRole data from new_role to legacy_role."""
     model = apps.get_model("virtualization", "VirtualMachine")
-    legacy_role_model = apps.get_model("extras", "Role")
-    new_role_model = apps.get_model("dcim", "DeviceRole")
+    from_role_model = apps.get_model("extras", "Role")
+    to_role_model = apps.get_model("dcim", "DeviceRole")
     migrate_role_data(
         model_to_migrate=model,
-        legacy_role_field_name="new_role",
-        legacy_role_model=legacy_role_model,
-        new_role_field_name="legacy_role",
-        new_role_model=new_role_model,
+        from_role_field_name="new_role",
+        from_role_model=from_role_model,
+        to_role_field_name="legacy_role",
+        to_role_model=to_role_model,
     )
 
 

--- a/nautobot/virtualization/migrations/0013_migrate_virtualmachine_role_data.py
+++ b/nautobot/virtualization/migrations/0013_migrate_virtualmachine_role_data.py
@@ -5,23 +5,28 @@ from nautobot.extras.utils import migrate_role_data
 
 
 def migrate_data_from_legacy_role_to_new_role(apps, schema):
-    """Copy record from role to temp_role"""
-
+    """Copy record from legacy_role to new_role."""
     model = apps.get_model("virtualization", "VirtualMachine")
-    role_model = apps.get_model("extras", "Role")
-    migrate_role_data(model=model, role_model=role_model)
+    legacy_role_model = apps.get_model("dcim", "DeviceRole")
+    new_role_model = apps.get_model("extras", "Role")
+    migrate_role_data(
+        model_to_migrate=model,
+        legacy_role_model=legacy_role_model,
+        new_role_model=new_role_model,
+    )
 
 
 def reverse_role_data_migrate(apps, schema):
     """Reverse changes made to new_role"""
-
     model = apps.get_model("virtualization", "VirtualMachine")
-    device_role_model = apps.get_model("dcim", "DeviceRole")
+    legacy_role_model = apps.get_model("extras", "Role")
+    new_role_model = apps.get_model("dcim", "DeviceRole")
     migrate_role_data(
-        model=model,
-        role_model=device_role_model,
-        legacy_role="new_role",
-        new_role="legacy_role",
+        model_to_migrate=model,
+        legacy_role_field_name="new_role",
+        legacy_role_model=legacy_role_model,
+        new_role_field_name="legacy_role",
+        new_role_model=new_role_model,
     )
 
 


### PR DESCRIPTION
# Closes: #3518 
# What's Changed

- Rewrite a couple of 2.0 `Role` migrations so that we don't unnecessarily create a `Role.slug` field then turn around and delete it in a later migration. (This eliminated a case we otherwise had to handle on the intermediate extras.Role data migrations where we might try to create records with the same name but differing slugs or vice versa)
- Total rewrite of the `migrate_role_data` function in ways that (I hope!) improve clarity as well as (I think!) efficiency of the migration. Probably would be good to test at scale to be sure.
- Rework the `bulk_create_roles` function in extras.0061 migration to correctly use `Role.objects.get_or_create` so that we don't throw an error (#3518) in the case where we have duplicate Roles across several of the source models.
- Fix a bug I noticed in `config_context.html` while manually testing this.

# Manual tests

- With ipam.Role and DeviceRole and RackRole objects with the same names, migrate forward from develop thru extras.0061 migration and verify #3518 isn't encountered any more.
- Migrate forward and backward between dcim.0023 and dcim.0027
- Migrate forward and backward between extras.0061 and extras.0065
- Migrate forward and backward between ipam.0009 and ipam.0013
- Migrate forward and backward between virtualization.0011 and virtualization.0014

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
