### PR TITLE
fixed default sanitizer patterns

### DIFF
--- a/changes/tbd.fixed
+++ b/changes/tbd.fixed
@@ -1,0 +1,1 @@
+Fixed default sanitizer patterns to account for strings beginning with `i` or `is`.

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -115,7 +115,7 @@ SOCIAL_AUTH_BACKEND_PREFIX = "social_core.backends"
 SANITIZER_PATTERNS = [
     # General removal of username-like and password-like tokens
     (re.compile(r"(https?://)?\S+\s*@", re.IGNORECASE), r"\1{replacement}@"),
-    (re.compile(r"(username|password|passwd|pwd)(\s*i?s?\s*:?\s*)?\S+", re.IGNORECASE), r"\1\2{replacement}"),
+    (re.compile(r"(username|password|passwd|pwd)((?:\s+is.?|:)?\s+)\S+", re.IGNORECASE), r"\1\2{replacement}"),
 ]
 
 # Storage

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -465,7 +465,7 @@ SECRET_KEY = os.getenv("NAUTOBOT_SECRET_KEY", "{{ secret_key }}")
 # SANITIZER_PATTERNS = [
 #     # General removal of username-like and password-like tokens
 #     (re.compile(r"(https?://)?\S+\s*@", re.IGNORECASE), r"\1{replacement}@"),
-#     (re.compile(r"(username|password|passwd|pwd)(\s*i?s?\s*:?\s*)?\S+", re.IGNORECASE), r"\1\2{replacement}"),
+#     (re.compile(r"(username|password|passwd|pwd)((?:\s+is.?|:)?\s+)\S+", re.IGNORECASE), r"\1\2{replacement}"),
 # ]
 
 # Configure SSO, for more information see docs/configuration/authentication/sso.md

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -782,7 +782,7 @@ Default:
 ```python
 [
     (re.compile(r"(https?://)?\S+\s*@", re.IGNORECASE), r"\1{replacement}@"),
-    (re.compile(r"(username|password|passwd|pwd)(\s*i?s?\s*:?\s*)?\S+", re.IGNORECASE), r"\1\2{replacement}"),
+    (re.compile(r"(username|password|passwd|pwd)((?:\s+is.?|:)?\s+)\S+", re.IGNORECASE), r"\1\2{replacement}"),
 ]
 ```
 

--- a/nautobot/utilities/tests/test_logging.py
+++ b/nautobot/utilities/tests/test_logging.py
@@ -3,7 +3,6 @@ from nautobot.utilities.testing import TestCase
 
 
 class LoggingUtilitiesTest(TestCase):
-
     DIRTY_CLEAN = (
         # should match first default pattern
         ("http://user:password@localhost", "http://(redacted)@localhost"),
@@ -18,6 +17,10 @@ class LoggingUtilitiesTest(TestCase):
             "I use username FOO and password BAR to log in as https://FOO:BAR@example.com",
             "I use username (redacted) and password (redacted) to log in as https://(redacted)@example.com",
         ),
+        ("Password is1234", "Password (redacted)"),
+        ("Password: is1234", "Password: (redacted)"),
+        ("Password is: is1234", "Password is: (redacted)"),
+        ("Password is is1234", "Password is (redacted)"),
     )
 
     def test_sanitize_default_coverage(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


Now accounts for strings that begin with `i` or `is`:

- `Password is1234` becomes `Password (redacted)`
- `Password: is1234` becomes `Password: (redacted)`
- `Password is: is1234` becomes `Password is: (redacted)`
- `Password is is1234` becomes `Password is (redacted)`

The previous regex was including the `i` or `is` so  `Password is1234` would be displayed as `Password is(redacted)`

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
