### PR TITLE
Don't reset interface status on empty PATCH request, add test coverage

### DIFF
--- a/changes/3533.fixed
+++ b/changes/3533.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where sending a PATCH to `/api/dcim/interfaces/(uuid)/` might reset the interface's status to `Active`.

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -1048,8 +1048,8 @@ class InterfaceSerializerVersion12(
 
     def validate(self, data):
 
-        # set interface status to active if status not provided
-        if not data.get("status"):
+        # set interface status to active on create (only!) if status was not provided
+        if self.instance is None and not data.get("status"):
             # status is currently required in the Interface model but not required in api_version < 1.3 serializers
             # which raises an error when validating except status is explicitly set here
             query = Status.objects.get_for_model(Interface)


### PR DESCRIPTION
# Closes: #3533 
# What's Changed

- Add logic so that the REST API only sets an interface's `status` to `Active` on initial create, not on update.
- Enhance `APIViewTestCases.UpdateObjectViewTestCase.test_update_object` so that it checks that:
   1. Sending an empty PATCH request results in success but no change to the serialized API object.
       - This test does need to work around #3321 for now.
   2. Sending a non-empty PATCH request updates the expected fields but leaves all others unchanged.
- Fix an issue with the test data in `nautobot.dcim.tests.test_api.PowerFeedTestCase` that the above uncovered - we were creating PowerFeed objects without specifying a `status`, so the no-op PATCH was rightly failing due to the objects failing validation.
- Change up the test data in `nautobot.dcim.tests.test_api.InterfaceTest` so that it will actually detect #3533 (previously it was using status `Active` everywhere, so the issue of other statuses getting *reverted* to `Active` would not be detected).

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
