### PR TITLE
Document that approvals are not supported for Job Hooks.

### DIFF
--- a/changes/3440.changed
+++ b/changes/3440.changed
@@ -1,0 +1,1 @@
+Added warning admonitions for Job Hooks and Job Approvals documentation that setting `Meta.approval_required` is ignored on `JobHookReceiver` classes.

--- a/nautobot/docs/additional-features/job-scheduling-and-approvals.md
+++ b/nautobot/docs/additional-features/job-scheduling-and-approvals.md
@@ -43,6 +43,9 @@ For custom interval, a `crontab` parameter must be added.
 
 Jobs that have `approval_required` set to `True` on their `Meta` object require another user to approve a scheduled job.
 
+!!! warning
+    Requiring approval for execution of Job Hooks by setting the `Meta.approval_required` attribute to `True` on your `JobHookReceiver` subclass is not supported. The value of this attribute will be ignored. Support for requiring approval of Job Hooks will be added in a future release.
+
 Scheduled jobs can be approved or denied via the UI and API by any user that has the `extras.approve_job` permission for the job in question, as well as the appropriate `extras.change_scheduledjob` and/or `extras.delete_scheduledjob` permissions.
 
 +/- 1.3.0

--- a/nautobot/docs/models/extras/jobhook.md
+++ b/nautobot/docs/models/extras/jobhook.md
@@ -16,6 +16,9 @@ A Job Hook is a mechanism for automatically starting a [job](../../additional-fe
 
 Job Hooks are only able to initiate a specific type of job called a **Job Hook Receiver**. These are jobs that subclass the `nautobot.extras.jobs.JobHookReceiver` class. Job hook receivers are similar to normal jobs except they are hard coded to accept only an `object_change` [variable](../../additional-features/jobs.md#variables). Job Hook Receivers are hidden from the jobs listing UI by default but otherwise function similarly to other jobs. The `JobHookReceiver` class only implements one method called `receive_job_hook`.
 
+!!! warning
+    Requiring approval for execution of Job Hooks by setting the `Meta.approval_required` attribute to `True` on your `JobHookReceiver` subclass is not supported. The value of this attribute will be ignored. Support for requiring approval of Job Hooks will be added in a future release.
+
 !!! important
     To prevent negatively impacting system performance through an infinite loop, a change that was made by a `JobHookReceiver` job will not trigger another `JobHookReceiver` job to run.
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Related to: #3440 
# What's Changed
- Added warning admonitions for Job Hooks and Job Approvals documentation that setting `Meta.approval_required` is ignored on `JobHookReceiver` classes.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
