### PR TITLE
Fixed a 500 error when filtering by `content_type` in Dynamic Groups list view.

### DIFF
--- a/changes/3612.fixed
+++ b/changes/3612.fixed
@@ -1,0 +1,1 @@
+Fixed a 500 error when filtering by `content_type` in Dynamic Groups list view.

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -525,6 +525,17 @@ class DynamicGroupTestCase(
         instance.refresh_from_db()
         self.assertEqual(instance.filter, {"serial": data["filter-serial"]})
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_filter_by_content_type(self):
+        """
+        Test that filtering by `content_type` in the UI succeeds.
+
+        This is a regression test for https://github.com/nautobot/nautobot/issues/3612
+        """
+        path = self._get_url("list")
+        response = self.client.get(path + "?content_type=dcim.device")
+        self.assertHttpStatus(response, 200)
+
 
 class ExportTemplateTestCase(
     ViewTestCases.CreateObjectViewTestCase,

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -916,7 +916,7 @@ def get_filterset_parameter_form_field(model, parameter, filterset=None):
             # `MultipleContentTypeField` employs `registry["model features"][feature]`, which may
             # result in an error if `feature` is not found in the `registry["model features"]` dict.
             # In this case use queryset
-            queryset_map = {"tags": TaggableClassesQuery, "job hooks": ChangeLoggedModelsQuery}
+            queryset_map = {"tags": TaggableClassesQuery, "job_hooks": ChangeLoggedModelsQuery}
             form_field = MultipleContentTypeField(
                 choices_as_strings=True, queryset=queryset_map[plural_name]().as_queryset()
             )

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -907,7 +907,9 @@ def get_filterset_parameter_form_field(model, parameter, filterset=None):
 
         form_field = DynamicModelMultipleChoiceField(**form_attr)
     elif isinstance(field, ContentTypeMultipleChoiceFilter):
-        plural_name = model._meta.verbose_name_plural
+        # While there are other objects using `ContentTypeMultipleChoiceFilter`, the case where
+        # models that have sucha  filter and the `verbose_name_plural` has multiple words is ony one: "dynamic groups".
+        plural_name = slugify_dashes_to_underscores(model._meta.verbose_name_plural)
         try:
             form_field = MultipleContentTypeField(choices_as_strings=True, feature=plural_name)
         except KeyError:


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3612 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
