### PR TITLE
Apply Custom Validators without the need of a DB lookup for ContentType

### DIFF
--- a/changes/3633.changed
+++ b/changes/3633.changed
@@ -1,0 +1,1 @@
+Changed Custom Validator applicator to not require DB query.

--- a/nautobot/extras/plugins/validators.py
+++ b/nautobot/extras/plugins/validators.py
@@ -40,7 +40,7 @@ def wrap_model_clean_methods():
     """
     Helper function that wraps plugin model validator registered clean methods for all applicable models
     """
-    for app_label, models in FeatureQuery("custom_validators").get_dict():
+    for app_label, models in FeatureQuery("custom_validators").as_dict():
         for model in models:
             model_class = apps.get_model(app_label=app_label, model_name=model)
             model_class.clean = custom_validator_clean(model_class.clean)

--- a/nautobot/extras/plugins/validators.py
+++ b/nautobot/extras/plugins/validators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from django.contrib.contenttypes.models import ContentType
+from django.apps import apps
 
 from nautobot.extras.plugins import CustomValidator
 from nautobot.extras.registry import registry
@@ -40,6 +40,7 @@ def wrap_model_clean_methods():
     """
     Helper function that wraps plugin model validator registered clean methods for all applicable models
     """
-    for model in ContentType.objects.filter(FeatureQuery("custom_validators").get_query()):
-        model_class = model.model_class()
-        model_class.clean = custom_validator_clean(model_class.clean)
+    for app_label, models in FeatureQuery("custom_validators").get_dict():
+        for model in models:
+            model_class = apps.get_model(app_label=app_label, model_name=model)
+            model_class.clean = custom_validator_clean(model_class.clean)

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -123,12 +123,12 @@ class FeatureQuery:
         Given an extras feature, return a Q object for content type lookup
         """
         query = Q()
-        for app_label, models in self.get_dict():
+        for app_label, models in self.as_dict():
             query |= Q(app_label=app_label, model__in=models)
 
         return query
 
-    def get_dict(self):
+    def as_dict(self):
         """
         Given an extras feature, return a dict of app_label: [models] for content type lookup
         """

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -123,10 +123,16 @@ class FeatureQuery:
         Given an extras feature, return a Q object for content type lookup
         """
         query = Q()
-        for app_label, models in registry["model_features"][self.feature].items():
+        for app_label, models in self.get_dict():
             query |= Q(app_label=app_label, model__in=models)
 
         return query
+
+    def get_dict(self):
+        """
+        Given an extras feature, return a dict of app_label: [models] for content type lookup
+        """
+        return registry["model_features"][self.feature].items()
 
     def get_choices(self):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
Observing the need for this: https://github.com/nautobot/nautobot/pull/3614/files#diff-cca2a364f59877c49898f8d14d311f7567adfb80b5aec6fa51748be4f79ef9b5R44-R46

This might be one of the weird DB calls we see on startup pre-fork in Celery 🤷 


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
