### PR TITLE
make sure that response serializers is rendered as depth=0 when reques.method is not GET

### DIFF
--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -194,6 +194,11 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.ModelSerializer):
         """
         Return a two tuple of (cls, kwargs) to build a serializer field with.
         """
+        request = self.context.get("request")
+        # Make sure that PATCH/POST/PUT method response serializers are consistent
+        # with depth of 0
+        if request is not None and request.method != "GET":
+            nested_depth = 0
         # For tags field, DRF does not recognize the relationship between tags and the model itself (?)
         # so instead of calling build_nested_field() it will call build_property_field() which
         # makes the field impervious to the `?depth` parameter.

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -225,10 +225,11 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.ModelSerializer):
         """
         Create a property field for model methods and properties.
         """
-        if field_name == "tags":
+        if isinstance(getattr(model_class, field_name, None), (_NautobotTaggableManager, _TaggableManager)):
             field_class = NautobotPrimaryKeyRelatedField
             field_kwargs = {
                 "queryset": Tag.objects.get_for_model(model_class),
+                "many": True,
                 "required": False,
             }
 

--- a/nautobot/core/testing/api.py
+++ b/nautobot/core/testing/api.py
@@ -557,7 +557,7 @@ class APIViewTestCases:
             obj_perm.actions = ["view"]
             obj_perm.save()
             # Get initial serialized object representation
-            get_response = self.client.get(url, {"depth": 1}, **self.header)
+            get_response = self.client.get(url, **self.header)
             self.assertHttpStatus(get_response, status.HTTP_200_OK)
             initial_serialized_object = get_response.json()
             strip_serialized_object(initial_serialized_object)

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -401,7 +401,7 @@ class WritableNestedSerializerTest(testing.APITestCase):
 
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["location"]["id"], str(self.location1.pk))
+        self.assertEqual(str(response.data["location"]), str(self.location1.pk))
         vlan = ipam_models.VLAN.objects.get(pk=response.data["id"])
         self.assertEqual(vlan.status, self.statuses.first())
         self.assertEqual(vlan.location, self.location1)
@@ -434,7 +434,7 @@ class WritableNestedSerializerTest(testing.APITestCase):
 
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["location"]["id"], str(self.location1.pk))
+        self.assertEqual(str(response.data["location"]), str(self.location1.pk))
         vlan = ipam_models.VLAN.objects.get(pk=response.data["id"])
         self.assertEqual(vlan.location, self.location1)
 

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -1172,7 +1172,7 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
             self._get_detail_url(Device.objects.get(name="Device 1")), patch_data, format="json", **self.header
         )
         self.assertHttpStatus(response, status.HTTP_200_OK)
-        self.assertEqual(str(response.data["local_config_context_schema"]["id"]), str(schema.pk))
+        self.assertEqual(str(response.data["local_config_context_schema"]), str(schema.pk))
 
     def test_local_config_context_schema_schema_validation_fails(self):
         """

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 import uuid
 import tempfile
-from unittest import mock, skip
+from unittest import mock
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -759,10 +759,6 @@ class DynamicGroupMembershipTest(DynamicGroupTestMixin, APIViewTestCases.APIView
                 "weight": 30,
             },
         ]
-
-    @skip("TODO: This is returning a depth aware PATCH which is not supposed to happen.")
-    def test_update_object(self):
-        pass
 
 
 class ExportTemplateTest(APIViewTestCases.APIViewTestCase):

--- a/nautobot/extras/tests/test_tags.py
+++ b/nautobot/extras/tests/test_tags.py
@@ -80,7 +80,7 @@ class TaggedItemTest(APITestCase):
         self.assertHttpStatus(response, status.HTTP_200_OK)
         tag_name_list = Tag.objects.filter(pk__in=response.data["tags"]).values_list("name", flat=True)
         self.assertListEqual(
-            sorted([name for name in tag_name_list]),
+            sorted(list(tag_name_list)),
             sorted([t["name"] for t in data["tags"]]),
         )
         location = Location.objects.get(pk=response.data["id"])

--- a/nautobot/extras/tests/test_tags.py
+++ b/nautobot/extras/tests/test_tags.py
@@ -59,7 +59,7 @@ class TaggedItemTest(APITestCase):
 
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertListEqual(sorted([t["id"] for t in response.data["tags"]]), sorted(data["tags"]))
+        self.assertListEqual(sorted([str(t) for t in response.data["tags"]]), sorted(data["tags"]))
         location = Location.objects.get(pk=response.data["id"])
         self.assertListEqual(sorted([t.name for t in location.tags.all()]), sorted([t.name for t in self.tags]))
 
@@ -78,8 +78,9 @@ class TaggedItemTest(APITestCase):
 
         response = self.client.patch(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
+        tag_name_list = Tag.objects.filter(pk__in=response.data["tags"]).values_list("name", flat=True)
         self.assertListEqual(
-            sorted([t["name"] for t in response.data["tags"]]),
+            sorted([name for name in tag_name_list]),
             sorted([t["name"] for t in data["tags"]]),
         )
         location = Location.objects.get(pk=response.data["id"])

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -184,7 +184,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
             response = self.client.post(url, data, format="json", **self.header)
             self.assertHttpStatus(response, status.HTTP_201_CREATED)
             self.assertEqual(response.data["prefix"], str(prefixes_to_be_created[i]))
-            self.assertEqual(response.data["vrf"]["id"], str(prefix.vrf.pk))
+            self.assertEqual(str(response.data["vrf"]), str(prefix.vrf.pk))
             self.assertEqual(response.data["description"], data["description"])
 
         # Try to create one more prefix
@@ -277,7 +277,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
             }
             response = self.client.post(url, data, format="json", **self.header)
             self.assertHttpStatus(response, status.HTTP_201_CREATED)
-            self.assertEqual(response.data["vrf"]["id"], str(vrf.pk))
+            self.assertEqual(str(response.data["vrf"]), str(vrf.pk))
             self.assertEqual(response.data["description"], data["description"])
 
         # Try to create one more IP

--- a/nautobot/virtualization/tests/test_api.py
+++ b/nautobot/virtualization/tests/test_api.py
@@ -241,7 +241,7 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
             **self.header,
         )
         self.assertHttpStatus(response, status.HTTP_200_OK)
-        self.assertEqual(str(response.data["local_config_context_schema"]["id"]), str(schema.pk))
+        self.assertEqual(str(response.data["local_config_context_schema"]), str(schema.pk))
 
     def test_local_config_context_schema_schema_validation_fails(self):
         """


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #<ISSUE NUMBER GOES HERE>
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
