### PR TITLE
Attempt to fix #3574 by setting the filter field/widget in core

### DIFF
--- a/nautobot/extras/filters/customfields.py
+++ b/nautobot/extras/filters/customfields.py
@@ -8,7 +8,7 @@ from nautobot.utilities.filters import (
     MultiValueDateFilter,
     MultiValueNumberFilter,
 )
-from nautobot.utilities.forms import NullableDateField
+from nautobot.utilities.forms import NullableDateField, StaticSelect2Multiple
 
 
 EXACT_FILTER_TYPES = (
@@ -75,6 +75,15 @@ class CustomFieldMultiSelectFilter(CustomFieldFilterMixin, MultiValueCharFilter)
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("lookup_expr", "contains")
+        super().__init__(*args, **kwargs)
+
+
+class CustomFieldMultiValueSelectFilter(CustomFieldFilterMixin, django_filters.MultipleChoiceFilter):
+    """This provides functionality for filtering custom fields with select type"""
+
+    def __init__(self, *args, **kwargs):
+        # TODO(jathan): See if I can make this user `kwargs` instead.
+        self.field_class.widget = StaticSelect2Multiple
         super().__init__(*args, **kwargs)
 
 

--- a/nautobot/extras/filters/mixins.py
+++ b/nautobot/extras/filters/mixins.py
@@ -15,6 +15,7 @@ from nautobot.extras.filters.customfields import (
     CustomFieldJSONFilter,
     CustomFieldMultiSelectFilter,
     CustomFieldMultiValueCharFilter,
+    CustomFieldMultiValueSelectFilter,
     CustomFieldMultiValueDateFilter,
     CustomFieldMultiValueNumberFilter,
     CustomFieldNumberFilter,
@@ -49,7 +50,7 @@ class CustomFieldModelFilterSetMixin(django_filters.FilterSet):
             CustomFieldTypeChoices.TYPE_INTEGER: CustomFieldNumberFilter,
             CustomFieldTypeChoices.TYPE_JSON: CustomFieldJSONFilter,
             CustomFieldTypeChoices.TYPE_MULTISELECT: CustomFieldMultiSelectFilter,
-            CustomFieldTypeChoices.TYPE_SELECT: CustomFieldMultiValueCharFilter,
+            CustomFieldTypeChoices.TYPE_SELECT: CustomFieldMultiValueSelectFilter,
         }
 
         custom_fields = CustomField.objects.filter(

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -891,8 +891,11 @@ def get_filterset_parameter_form_field(model, parameter, filterset=None):
     form_field = field.field
 
     # TODO(Culver): We are having to replace some widgets here because multivalue_field_factory that generates these isn't smart enough
-    if isinstance(field, CustomFieldFilterMixin):
-        form_field = field.custom_field.to_filter_form_field()
+    # If we allow CustomFieldFilters to pass through their choices are always [('null', 'None')] and
+    # not populated from the actual choices. If we can get the form field that is emitted by default
+    # to provide the correct choices, this won't be necessary.
+    if isinstance(field, CustomFieldFilterMixin) and field.lookup_expr == "exact":
+        form_field = field.custom_field.to_form_field()
     elif isinstance(field, NumberFilter):
         form_field = forms.IntegerField()
     elif isinstance(field, filters.ModelMultipleChoiceFilter):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #<ISSUE NUMBER GOES HERE>
# What's Changed
This was the experimentation from last Thursday to see if bringing the filter field/widget overload closer to the core code will work. It does.

Not done:
- See if I can pull out `CustomField.to_filter_form_field()` entirely so we don't need to overlay it in various places
- Fix tests

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
