### PR TITLE
Add `disabled` to `template_args` when rendering grouped job buttons.

### DIFF
--- a/changes/3660.fixed
+++ b/changes/3660.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where grouped job buttons would always be disabled due to a template rendering issue.

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -144,6 +144,7 @@ def job_buttons(context, obj):
                 "object": obj,
                 "job": jb.job,
                 "hidden_inputs": hidden_inputs,
+                "disabled": "" if context["user"].has_perms(("extras.run_jobbutton", "extras.run_job")) else "disabled",
             }
             try:
                 text_rendered = render_jinja2(jb.text, button_context)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3660 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Add `disabled` to the `template_args` used to render button HTML. When a grouped job button requires confirmation, the `CONFIRM_BUTTON` template must be rendered which requires the `disabled` argument.

