### PR TITLE
Change REST API to use hyperlinks instead of raw PKs for related objects with depth 0

### DIFF
--- a/changes/3679.added
+++ b/changes/3679.added
@@ -1,0 +1,1 @@
+Added optional `api` argument to `BaseModel.get_absolute_url()`.

--- a/changes/3679.changed
+++ b/changes/3679.changed
@@ -1,0 +1,1 @@
+Changed `BaseModelSerializer` to inherit from `HyperlinkedModelSerializer` instead of `ModelSerializer`. This changed the REST API representation of related objects (at depth 0) from UUIDs to API hyperlinks to improve discoverability and usability of the API.

--- a/changes/3679.removed
+++ b/changes/3679.removed
@@ -1,0 +1,1 @@
+Removed explicit `url` field declarations from most REST API serializers as they are now derived automatically.

--- a/nautobot/circuits/api/serializers.py
+++ b/nautobot/circuits/api/serializers.py
@@ -16,7 +16,6 @@ from nautobot.extras.api.mixins import (
 
 
 class ProviderSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="circuits-api:provider-detail")
     circuit_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -30,8 +29,6 @@ class ProviderSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
 
 
 class ProviderNetworkSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="circuits-api:providernetwork-detail")
-
     class Meta:
         model = ProviderNetwork
         fields = "__all__"
@@ -43,7 +40,6 @@ class ProviderNetworkSerializer(NautobotModelSerializer, TaggedModelSerializerMi
 
 
 class CircuitTypeSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="circuits-api:circuittype-detail")
     circuit_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -52,8 +48,6 @@ class CircuitTypeSerializer(NautobotModelSerializer):
 
 
 class CircuitSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="circuits-api:circuit-detail")
-
     class Meta:
         model = Circuit
         fields = "__all__"
@@ -64,8 +58,6 @@ class CircuitTerminationSerializer(
     CableTerminationModelSerializerMixin,
     PathEndpointModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="circuits-api:circuittermination-detail")
-
     class Meta:
         model = CircuitTermination
         fields = "__all__"

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -1,7 +1,6 @@
 import logging
 import uuid
 
-from abc import abstractmethod
 from django.core.exceptions import (
     FieldError,
     MultipleObjectsReturned,

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -107,7 +107,14 @@ class NautobotHyperlinkedRelatedField(WritableSerializerMixin, serializers.Hyper
         DRF defaults to '{model_name}-detail' instead of '{app_label}:{model_name}-detail'.
         """
         if "view_name" not in kwargs or (kwargs["view_name"].endswith("-detail") and ":" not in kwargs["view_name"]):
-            kwargs["view_name"] = get_route_for_model(kwargs["queryset"].model, "detail", api=True)
+            if "queryset" not in kwargs:
+                logger.warning(
+                    '"view_name=%r" is probably incorrect for this related API field; '
+                    'unable to determine the correct "view_name" as "queryset" wasn\'t specified',
+                    kwargs["view_name"],
+                )
+            else:
+                kwargs["view_name"] = get_route_for_model(kwargs["queryset"].model, "detail", api=True)
         super().__init__(*args, **kwargs)
 
 

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -99,11 +99,20 @@ class OptInFieldsMixin:
         return self.__pruned_fields
 
 
-class NautobotPrimaryKeyRelatedField(WritableSerializerMixin, serializers.PrimaryKeyRelatedField):
-    """DRF's built-in PrimaryKeyRelatedField combined with custom to_internal_value() function"""
+class NautobotHyperlinkedRelatedField(WritableSerializerMixin, serializers.HyperlinkedRelatedField):
+    """DRF's built-in HyperlinkedRelatedField combined with custom to_internal_value() function"""
+
+    def __init__(self, *args, **kwargs):
+        """Override DRF's namespace-unaware default view_name logic for HyperlinkedRelatedField.
+
+        DRF defaults to '{model_name}-detail' instead of '{app_label}:{model_name}-detail'.
+        """
+        if "view_name" not in kwargs or (kwargs["view_name"].endswith("-detail") and ":" not in kwargs["view_name"]):
+            kwargs["view_name"] = get_route_for_model(kwargs["queryset"].model, "detail", api=True)
+        super().__init__(*args, **kwargs)
 
 
-class BaseModelSerializer(OptInFieldsMixin, serializers.ModelSerializer):
+class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializer):
     """
     This base serializer implements common fields and logic for all ModelSerializers.
 
@@ -116,13 +125,12 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.ModelSerializer):
     serializer's associated model (e.g. "dcim.device"). This is required as the OpenAPI schema, using the
     PolymorphicProxySerializer class defined below, relies upon this field as a way to identify to the client
     which of several possible serializers are in use for a given attribute.
-    - ensures that `url` field has to be explicitly declared with a valid view_name on each serializer subclass.
     - supports `?depth` query parameter. It is passed in as `nested_depth` to the `build_nested_field()` function to enable the
     dynamic generation of nested serializers.
     """
 
     display = serializers.SerializerMethodField(read_only=True, help_text="Human friendly display value")
-    serializer_related_field = NautobotPrimaryKeyRelatedField
+    serializer_related_field = NautobotHyperlinkedRelatedField
     object_type = ObjectTypeField()
 
     def __init__(self, *args, **kwargs):
@@ -135,11 +143,6 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.ModelSerializer):
             # RestAPI serializer is not affected by this because get_serializer_context() is always called
             # and depth is either passed into the request.query_params, or default to 0.
             self.Meta.depth = self.context.get("depth", 1)
-
-    @property
-    @abstractmethod
-    def url(self):  # to be explicitly declared on each serializer subclass
-        raise NotImplementedError(f"{self.__class__.__name__} must declare a url field with a valid view_name")
 
     @extend_schema_field(serializers.CharField)
     def get_display(self, instance):
@@ -173,7 +176,7 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.ModelSerializer):
         `Meta.fields` which would surely lead to errors of omission; therefore we have chosen the former approach.
 
         Adds "id" and "display" to the start of `fields` for all models; also appends "created" and "last_updated"
-        to the end of `fields` if they are applicable to this model and this is not a Nested serializer.
+        to the end of `fields` if they are applicable to this model.
         """
         fields = list(super().get_field_names(declared_fields, info))  # Meta.fields could be defined as a tuple
         self.extend_field_names(fields, "display", at_start=True)
@@ -217,12 +220,19 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.ModelSerializer):
 
         return super().build_field(field_name, info, model_class, nested_depth)
 
+    def build_relational_field(self, field_name, relation_info):
+        """Override DRF's default relational-field construction to be app-aware."""
+        field_class, field_kwargs = super().build_relational_field(field_name, relation_info)
+        if "view_name" in field_kwargs:
+            field_kwargs["view_name"] = get_route_for_model(relation_info.related_model, "detail", api=True)
+        return field_class, field_kwargs
+
     def build_property_field(self, field_name, model_class):
         """
         Create a property field for model methods and properties.
         """
         if isinstance(getattr(model_class, field_name, None), TagsManager):
-            field_class = NautobotPrimaryKeyRelatedField
+            field_class = NautobotHyperlinkedRelatedField
             field_kwargs = {
                 "queryset": Tag.objects.get_for_model(model_class),
                 "many": True,
@@ -234,6 +244,13 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.ModelSerializer):
 
     def build_nested_field(self, field_name, relation_info, nested_depth):
         return nested_serializer_factory(relation_info, nested_depth)
+
+    def build_url_field(self, field_name, model_class):
+        """Override DRF's default 'url' field construction to be app-aware."""
+        field_class, field_kwargs = super().build_url_field(field_name, model_class)
+        if "view_name" in field_kwargs:
+            field_kwargs["view_name"] = get_route_for_model(model_class, "detail", api=True)
+        return field_class, field_kwargs
 
 
 class TreeModelSerializerMixin(BaseModelSerializer):

--- a/nautobot/core/api/utils.py
+++ b/nautobot/core/api/utils.py
@@ -335,7 +335,7 @@ def return_nested_serializer_data_based_on_depth(serializer, depth, obj, obj_rel
     if obj_related_field.__class__.__name__ == "RelatedManager":
         result = []
         if depth == 0:
-            result = [obj.get_absolute_url(api=True) for obj in obj_related_field.all()]
+            result = [entry.get_absolute_url(api=True) for entry in obj_related_field.all()]
             if serializer.context.get("request"):
                 result = [serializer.context.get("request").build_absolute_uri(url) for url in result]
         else:

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -39,9 +39,9 @@ class BaseModel(models.Model):
         """
         return not self._state.adding
 
-    def get_absolute_url(self):
+    def get_absolute_url(self, api=False):
         """
-        Return the canonical URL for this object.
+        Return the canonical URL for this object in either the UI or the REST API.
         """
 
         # Iterate the pk-like fields and try to get a URL, or return None.
@@ -53,7 +53,7 @@ class BaseModel(models.Model):
                 continue
 
             for action in actions:
-                route = get_route_for_model(self, action)
+                route = get_route_for_model(self, action, api=api)
 
                 try:
                     return reverse(route, kwargs={field: getattr(self, field)})

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -825,12 +825,12 @@ DRF_REACT_TEMPLATE_TYPE_MAP = {
     #
     # enum=choices is the one that works in the UI as a related field but it
     # includes ALL related objects in the schema.
-    # "NautobotPrimaryKeyRelatedField": {"type": "string", "enum": "choices"},
+    # "NautobotHyperlinkedRelatedField": {"type": "string", "enum": "choices"},
     # readOnly=True disables the fields in the UI; not what we want.
-    # "NautobotPrimaryKeyRelatedField": {"type": "string", "readOnly": True},
+    # "NautobotHyperlinkedRelatedField": {"type": "string", "readOnly": True},
     # type=string results in a free text field; also not what we want. For now,
     # however, this will keep things moving so the unit tests pass.
-    "NautobotPrimaryKeyRelatedField": {"type": "string", "format": "uuid"},
+    "NautobotHyperlinkedRelatedField": {"type": "string", "format": "uuid"},
     "PrimaryKeyRelatedField": {"type": "string", "enum": "choices"},
     "RelationshipsDataField": {"type": "object"},
     "SlugField": {"type": "string"},

--- a/nautobot/core/testing/api.py
+++ b/nautobot/core/testing/api.py
@@ -252,7 +252,10 @@ class APIViewTestCases:
                             self.assertTrue(is_uuid(entry))
                     else:
                         if response_data[field] is not None:
-                            self.assertTrue(is_uuid(response_data[field]))
+                            # The response should be a detail API URL, ending in the UUID of the relevant object
+                            # http://nautobot.example.com/api/circuits/providers/<uuid>/
+                            #                                                    ^^^^^^
+                            self.assertTrue(is_uuid(response_data[field].split("/")[-2]))
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
         def test_list_objects_depth_1(self):

--- a/nautobot/core/testing/mixins.py
+++ b/nautobot/core/testing/mixins.py
@@ -9,7 +9,7 @@ from django.db.models import JSONField, ManyToManyField
 from django.forms.models import model_to_dict
 from django.utils.text import slugify
 from netaddr import IPNetwork
-from rest_framework.test import APIClient
+from rest_framework.test import APIClient, APIRequestFactory
 
 from nautobot.core import testing
 from nautobot.core.models import fields as core_fields
@@ -213,6 +213,11 @@ class NautobotTestCaseMixin:
     #
     # Convenience methods
     #
+
+    def absolute_api_url(self, obj):
+        """Get the absolute API URL ("http://nautobot.example.com/api/...") for a given object."""
+        request = APIRequestFactory(SERVER_NAME="nautobot.example.com").get("")
+        return request.build_absolute_uri(obj.get_absolute_url(api=True))
 
     def standardize_json(self, data):
         obj = json.loads(data)

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -401,9 +401,7 @@ class WritableNestedSerializerTest(testing.APITestCase):
 
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertEqual(
-            str(response.data["location"]), f"http://nautobot.example.com{self.location1.get_absolute_url(api=True)}"
-        )
+        self.assertEqual(str(response.data["location"]), self.absolute_api_url(self.location1))
         vlan = ipam_models.VLAN.objects.get(pk=response.data["id"])
         self.assertEqual(vlan.status, self.statuses.first())
         self.assertEqual(vlan.location, self.location1)
@@ -436,9 +434,7 @@ class WritableNestedSerializerTest(testing.APITestCase):
 
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertEqual(
-            str(response.data["location"]), f"http://nautobot.example.com{self.location1.get_absolute_url(api=True)}"
-        )
+        self.assertEqual(str(response.data["location"]), self.absolute_api_url(self.location1))
         vlan = ipam_models.VLAN.objects.get(pk=response.data["id"])
         self.assertEqual(vlan.location, self.location1)
 

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -401,7 +401,9 @@ class WritableNestedSerializerTest(testing.APITestCase):
 
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertEqual(str(response.data["location"]), str(self.location1.pk))
+        self.assertEqual(
+            str(response.data["location"]), f"http://nautobot.example.com{self.location1.get_absolute_url(api=True)}"
+        )
         vlan = ipam_models.VLAN.objects.get(pk=response.data["id"])
         self.assertEqual(vlan.status, self.statuses.first())
         self.assertEqual(vlan.location, self.location1)
@@ -434,7 +436,9 @@ class WritableNestedSerializerTest(testing.APITestCase):
 
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertEqual(str(response.data["location"]), str(self.location1.pk))
+        self.assertEqual(
+            str(response.data["location"]), f"http://nautobot.example.com{self.location1.get_absolute_url(api=True)}"
+        )
         vlan = ipam_models.VLAN.objects.get(pk=response.data["id"])
         self.assertEqual(vlan.location, self.location1)
 

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -167,7 +167,6 @@ class ConnectedEndpointSerializer(PathEndpointModelSerializerMixin):
 
 
 class LocationTypeSerializer(NautobotModelSerializer, TreeModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:locationtype-detail")
     content_types = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("locations").get_query()),
         required=False,
@@ -184,7 +183,6 @@ class LocationSerializer(
     TaggedModelSerializerMixin,
     TreeModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:location-detail")
     time_zone = TimeZoneSerializerField(required=False, allow_null=True)
     circuit_count = serializers.IntegerField(read_only=True)
     device_count = serializers.IntegerField(read_only=True)
@@ -216,7 +214,6 @@ class LocationSerializer(
 
 
 class RackGroupSerializer(NautobotModelSerializer, TreeModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:rackgroup-detail")
     rack_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -244,7 +241,6 @@ class RackSerializer(
     NautobotModelSerializer,
     TaggedModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:rack-detail")
     type = ChoiceField(choices=RackTypeChoices, allow_blank=True, required=False)
     width = ChoiceField(choices=RackWidthChoices, required=False)
     outer_unit = ChoiceField(choices=RackDimensionUnitChoices, allow_blank=True, required=False)
@@ -282,8 +278,6 @@ class RackUnitSerializer(serializers.Serializer):
 
 
 class RackReservationSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:rackreservation-detail")
-
     class Meta:
         model = RackReservation
         fields = "__all__"
@@ -316,7 +310,6 @@ class RackElevationDetailFilterSerializer(serializers.Serializer):
 
 
 class ManufacturerSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:manufacturer-detail")
     device_type_count = serializers.IntegerField(read_only=True)
     inventory_item_count = serializers.IntegerField(read_only=True)
     platform_count = serializers.IntegerField(read_only=True)
@@ -327,7 +320,6 @@ class ManufacturerSerializer(NautobotModelSerializer):
 
 
 class DeviceTypeSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:devicetype-detail")
     subdevice_role = ChoiceField(choices=SubdeviceRoleChoices, allow_blank=True, required=False)
     device_count = serializers.IntegerField(read_only=True)
 
@@ -353,7 +345,6 @@ class DeviceTypeSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
 
 
 class ConsolePortTemplateSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:consoleporttemplate-detail")
     type = ChoiceField(choices=ConsolePortTypeChoices, allow_blank=True, required=False)
 
     class Meta:
@@ -362,7 +353,6 @@ class ConsolePortTemplateSerializer(NautobotModelSerializer):
 
 
 class ConsoleServerPortTemplateSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:consoleserverporttemplate-detail")
     type = ChoiceField(choices=ConsolePortTypeChoices, allow_blank=True, required=False)
 
     class Meta:
@@ -371,7 +361,6 @@ class ConsoleServerPortTemplateSerializer(NautobotModelSerializer):
 
 
 class PowerPortTemplateSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:powerporttemplate-detail")
     type = ChoiceField(choices=PowerPortTypeChoices, allow_blank=True, required=False)
 
     class Meta:
@@ -380,7 +369,6 @@ class PowerPortTemplateSerializer(NautobotModelSerializer):
 
 
 class PowerOutletTemplateSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:poweroutlettemplate-detail")
     type = ChoiceField(choices=PowerOutletTypeChoices, allow_blank=True, required=False)
     feed_leg = ChoiceField(choices=PowerOutletFeedLegChoices, allow_blank=True, required=False)
 
@@ -390,7 +378,6 @@ class PowerOutletTemplateSerializer(NautobotModelSerializer):
 
 
 class InterfaceTemplateSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:interfacetemplate-detail")
     type = ChoiceField(choices=InterfaceTypeChoices)
 
     class Meta:
@@ -399,7 +386,6 @@ class InterfaceTemplateSerializer(NautobotModelSerializer):
 
 
 class RearPortTemplateSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:rearporttemplate-detail")
     type = ChoiceField(choices=PortTypeChoices)
 
     class Meta:
@@ -408,7 +394,6 @@ class RearPortTemplateSerializer(NautobotModelSerializer):
 
 
 class FrontPortTemplateSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:frontporttemplate-detail")
     type = ChoiceField(choices=PortTypeChoices)
 
     class Meta:
@@ -417,8 +402,6 @@ class FrontPortTemplateSerializer(NautobotModelSerializer):
 
 
 class DeviceBayTemplateSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:devicebaytemplate-detail")
-
     class Meta:
         model = DeviceBayTemplate
         fields = "__all__"
@@ -430,7 +413,6 @@ class DeviceBayTemplateSerializer(NautobotModelSerializer):
 
 
 class PlatformSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:platform-detail")
     device_count = serializers.IntegerField(read_only=True)
     virtual_machine_count = serializers.IntegerField(read_only=True)
 
@@ -440,15 +422,12 @@ class PlatformSerializer(NautobotModelSerializer):
 
 
 class DeviceBaySerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:devicebay-detail")
-
     class Meta:
         model = DeviceBay
         fields = "__all__"
 
 
 class DeviceSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:device-detail")
     face = ChoiceField(choices=DeviceFaceChoices, allow_blank=True, required=False)
     parent_bay = serializers.SerializerMethodField()
 
@@ -507,7 +486,6 @@ class ConsoleServerPortSerializer(
     CableTerminationModelSerializerMixin,
     PathEndpointModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:consoleserverport-detail")
     type = ChoiceField(choices=ConsolePortTypeChoices, allow_blank=True, required=False)
 
     class Meta:
@@ -521,7 +499,6 @@ class ConsolePortSerializer(
     CableTerminationModelSerializerMixin,
     PathEndpointModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:consoleport-detail")
     type = ChoiceField(choices=ConsolePortTypeChoices, allow_blank=True, required=False)
 
     class Meta:
@@ -535,7 +512,6 @@ class PowerOutletSerializer(
     CableTerminationModelSerializerMixin,
     PathEndpointModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:poweroutlet-detail")
     type = ChoiceField(choices=PowerOutletTypeChoices, allow_blank=True, required=False)
     feed_leg = ChoiceField(choices=PowerOutletFeedLegChoices, allow_blank=True, required=False)
 
@@ -550,7 +526,6 @@ class PowerPortSerializer(
     CableTerminationModelSerializerMixin,
     PathEndpointModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:powerport-detail")
     type = ChoiceField(choices=PowerPortTypeChoices, allow_blank=True, required=False)
 
     class Meta:
@@ -582,7 +557,6 @@ class InterfaceSerializer(
     CableTerminationModelSerializerMixin,
     PathEndpointModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:interface-detail")
     type = ChoiceField(choices=InterfaceTypeChoices)
     mode = ChoiceField(choices=InterfaceModeChoices, allow_blank=True, required=False)
     ip_address_count = serializers.IntegerField(read_only=True)
@@ -609,7 +583,6 @@ class InterfaceSerializer(
 
 
 class RearPortSerializer(NautobotModelSerializer, TaggedModelSerializerMixin, CableTerminationModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:rearport-detail")
     type = ChoiceField(choices=PortTypeChoices)
 
     class Meta:
@@ -618,7 +591,6 @@ class RearPortSerializer(NautobotModelSerializer, TaggedModelSerializerMixin, Ca
 
 
 class FrontPortSerializer(NautobotModelSerializer, TaggedModelSerializerMixin, CableTerminationModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:frontport-detail")
     type = ChoiceField(choices=PortTypeChoices)
 
     class Meta:
@@ -630,7 +602,6 @@ class DeviceRedundancyGroupSerializer(
     NautobotModelSerializer,
     TaggedModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:deviceredundancygroup-detail")
     failover_strategy = ChoiceField(choices=DeviceRedundancyGroupFailoverStrategyChoices)
 
     class Meta:
@@ -644,8 +615,6 @@ class DeviceRedundancyGroupSerializer(
 
 
 class InventoryItemSerializer(NautobotModelSerializer, TaggedModelSerializerMixin, TreeModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:inventoryitem-detail")
-
     class Meta:
         model = InventoryItem
         fields = "__all__"
@@ -675,7 +644,6 @@ class CableSerializer(
     NautobotModelSerializer,
     TaggedModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:cable-detail")
     termination_a_type = ContentTypeField(queryset=ContentType.objects.filter(CABLE_TERMINATION_MODELS))
     termination_b_type = ContentTypeField(queryset=ContentType.objects.filter(CABLE_TERMINATION_MODELS))
     termination_a = serializers.SerializerMethodField(read_only=True)
@@ -723,8 +691,6 @@ class TracedCableSerializer(serializers.ModelSerializer):
     """
     Used only while tracing a cable path.
     """
-
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:cable-detail")
 
     class Meta:
         model = Cable
@@ -822,7 +788,6 @@ class InterfaceConnectionSerializer(ValidatedModelSerializer):
 
 
 class VirtualChassisSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:virtualchassis-detail")
     member_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -836,7 +801,6 @@ class VirtualChassisSerializer(NautobotModelSerializer, TaggedModelSerializerMix
 
 
 class PowerPanelSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:powerpanel-detail")
     power_feed_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -850,7 +814,6 @@ class PowerFeedSerializer(
     CableTerminationModelSerializerMixin,
     PathEndpointModelSerializerMixin,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="dcim-api:powerfeed-detail")
     type = ChoiceField(choices=PowerFeedTypeChoices, default=PowerFeedTypeChoices.TYPE_PRIMARY)
     supply = ChoiceField(choices=PowerFeedSupplyChoices, default=PowerFeedSupplyChoices.SUPPLY_AC)
     phase = ChoiceField(choices=PowerFeedPhaseChoices, default=PowerFeedPhaseChoices.PHASE_SINGLE)

--- a/nautobot/dcim/models/device_component_templates.py
+++ b/nautobot/dcim/models/device_component_templates.py
@@ -75,8 +75,8 @@ class ComponentTemplateModel(BaseModel, ChangeLoggedModel, CustomFieldModel, Rel
 
         return super().to_objectchange(action, related_object=device_type, **kwargs)
 
-    def get_absolute_url(self):
-        return self.device_type.get_absolute_url()
+    def get_absolute_url(self, api=False):
+        return self.device_type.get_absolute_url(api=api)
 
     def instantiate_model(self, model, device, **kwargs):
         """

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -1172,7 +1172,10 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
             self._get_detail_url(Device.objects.get(name="Device 1")), patch_data, format="json", **self.header
         )
         self.assertHttpStatus(response, status.HTTP_200_OK)
-        self.assertEqual(str(response.data["local_config_context_schema"]), str(schema.pk))
+        self.assertEqual(
+            str(response.data["local_config_context_schema"]),
+            f"http://nautobot.example.com{schema.get_absolute_url(api=True)}",
+        )
 
     def test_local_config_context_schema_schema_validation_fails(self):
         """
@@ -2140,9 +2143,10 @@ class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
         virtual_chassis_1 = response.json()["results"][0]
 
         # Make sure the master is set
-        self.assertNotEqual(virtual_chassis_1["master"], None)
+        self.assertIsNotNone(virtual_chassis_1["master"])
 
-        master_device = Device.objects.get(pk=virtual_chassis_1["master"])
+        # The `master` key will be a URL now, but it contains the PK
+        master_device = Device.objects.get(pk=virtual_chassis_1["master"].split("/")[-2])
 
         # Set the virtual_chassis of the master device to null
         url = reverse("dcim-api:device-detail", kwargs={"pk": master_device.id})

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -1172,10 +1172,7 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
             self._get_detail_url(Device.objects.get(name="Device 1")), patch_data, format="json", **self.header
         )
         self.assertHttpStatus(response, status.HTTP_200_OK)
-        self.assertEqual(
-            str(response.data["local_config_context_schema"]),
-            f"http://nautobot.example.com{schema.get_absolute_url(api=True)}",
-        )
+        self.assertEqual(str(response.data["local_config_context_schema"]), self.absolute_api_url(schema))
 
     def test_local_config_context_schema_schema_validation_fails(self):
         """

--- a/nautobot/docs/rest-api/overview.md
+++ b/nautobot/docs/rest-api/overview.md
@@ -14,52 +14,42 @@ Additionally, the `OPTIONS` verb can be used to inspect a particular REST API en
 One of the primary benefits of a REST API is its human-friendliness. Because it utilizes HTTP and JSON, it's very easy to interact with Nautobot data on the command line using common tools. For example, we can request an IP address from Nautobot and output the JSON using `curl` and `jq`. The following command makes an HTTP `GET` request for information about a particular IP address, identified by its primary key, and uses `jq` to present the raw JSON data returned in a more human-friendly format. (Piping the output through `jq` isn't strictly required but makes it much easier to read.)
 
 ```no-highlight
-curl -s http://nautobot/api/ipam/ip-addresses/c557df87-9a63-4555-bfd1-21cea2f6aac3/ | jq '.'
+curl -s http://nautobot/api/ipam/ip-addresses/83445aa3-bbd3-4ab4-86f5-36942ce9df60/ | jq '.'
 ```
 
 ```json
 {
-  "id": 2954,
-  "url": "http://nautobot/api/ipam/ip-addresses/c557df87-9a63-4555-bfd1-21cea2f6aac3/",
+  "id": "83445aa3-bbd3-4ab4-86f5-36942ce9df60",
+  "url": "http://nautobot/api/ipam/ip-addresses/83445aa3-bbd3-4ab4-86f5-36942ce9df60/",
+  "display": "10.0.60.39/32",
+  "custom_fields": {},
+  "notes_url": "http://nautobot/api/ipam/ip-addresses/83445aa3-bbd3-4ab4-86f5-36942ce9df60/notes/",
+  "web_url": "/ipam/ip-addresses/83445aa3-bbd3-4ab4-86f5-36942ce9df60/",
   "family": {
     "value": 4,
     "label": "IPv4"
   },
-  "address": "192.168.0.42/26",
+  "address": "10.0.60.39/32",
+  "nat_outside_list": [
+    "http://nautobot/api/ipam/ip-addresses/a7569104-ed58-4938-ab6f-cb6a9e584f14/"
+  ],
+  "created": "2023-04-25T12:46:09.152507Z",
+  "last_updated": "2023-04-25T12:46:09.163545Z",
+  "host": "10.0.60.39",
+  "broadcast": "10.0.60.39",
+  "prefix_length": 32,
+  "dns_name": "desktop-08.cook.biz",
+  "description": "This is an IP Address",
+  "role": "http://nautobot/api/extras/roles/e7a815b0-2c48-499a-84b8-f20350abe415/",
+  "status": "http://nautobot/api/extras/statuses/b7f6a447-5616-4533-a6d5-a4ece50cd08c/",
   "vrf": null,
-  "tenant": null,
-  "status": {
-    "value": "active",
-    "label": "Active"
-  },
-  "role": null,
-  "assigned_object_type": "dcim.interface",
-  "assigned_object_id": "9fd066d2-135c-4005-b032-e0551cc61cec",
-  "assigned_object": {
-    "id": "9fd066d2-135c-4005-b032-e0551cc61cec",
-    "url": "http://nautobot/api/dcim/interfaces/9fd066d2-135c-4005-b032-e0551cc61cec/",
-    "device": {
-      "id": "6a522ebb-5739-4c5c-922f-ab4a2dc12eb0",
-      "url": "http://nautobot/api/dcim/devices/6a522ebb-5739-4c5c-922f-ab4a2dc12eb0/",
-      "name": "router1",
-      "display": "router1"
-    },
-    "name": "et-0/1/2",
-    "cable": null,
-    "connection_status": null
-  },
+  "tenant": "http://nautobot/api/tenancy/tenants/501fffe7-5302-40ae-b9e4-27d5e3ff2108/",
   "nat_inside": null,
-  "nat_outside_list": null,
-  "dns_name": "",
-  "description": "Example IP address",
-  "tags": [],
-  "custom_fields": {},
-  "created": "2020-08-04T00:00:00Z",
-  "last_updated": "2020-08-04T14:12:39.666885Z"
+  "tags": []
 }
 ```
 
-Each attribute of the IP address is expressed as an attribute of the JSON object. Fields may include their own nested objects, as in the case of the `assigned_object` field above. Every object includes a primary key named `id` which uniquely identifies it in the database.
+Each attribute of the IP address is expressed as an attribute of the JSON object. Related objects are identified by their own URLs that may be accessed to retrieve more details of the related object, as in the case of the `role` and `status` fields above. Every object includes a primary key named `id` which uniquely identifies it in the database.
 
 ## Interactive Documentation
 
@@ -91,7 +81,7 @@ Each model generally has two views associated with it: a list view and a detail 
 Lists of objects can be filtered using a set of query parameters. For example, to find all interfaces belonging to the device with ID 6a522ebb-5739-4c5c-922f-ab4a2dc12eb0:
 
 ```no-highlight
-GET /api/dcim/interfaces/?device_id=6a522ebb-5739-4c5c-922f-ab4a2dc12eb0
+GET /api/dcim/interfaces/?device=6a522ebb-5739-4c5c-922f-ab4a2dc12eb0
 ```
 
 See the [filtering documentation](filtering.md) for more details.
@@ -183,45 +173,34 @@ The constructor for Nautobot's `APISelect`/`APISelectMultiple` UI widgets now in
 
 ## Serialization
 
-The REST API employs two types of serializers to represent model data: base serializers and nested serializers. The base serializer is used to present the complete view of a model. This includes all database table fields which comprise the model, and may include additional metadata. A base serializer includes relationships to parent objects, but **does not** include child objects. For example, the `VLANSerializer` includes a nested representation its parent VLANGroup (if any), but does not include any assigned Prefixes.
-
-```json
-{
-    "id": 1048,
-    "site": {
-        "id": "09c9e21c-e038-44fd-be9a-43aef97bff8f",
-        "url": "http://nautobot/api/dcim/sites/09c9e21c-e038-44fd-be9a-43aef97bff8f/",
-        "name": "Corporate HQ",
-        "slug": "corporate-hq"
-    },
-    "group": {
-        "id": "eccc0964-9fab-43bc-bb77-66b1be08f64b",
-        "url": "http://nautobot/api/ipam/vlan-groups/eccc0964-9fab-43bc-bb77-66b1be08f64b/",
-        "name": "Production",
-        "slug": "production"
-    },
-    "vid": 101,
-    "name": "Users-Floor1",
-    "tenant": null,
-    "status": {
-        "value": "active",
-        "label": "Active"
-    },
-    "role": {
-        "id": "a1fd5e46-a85e-48c3-a2f4-3c2ec2bb2464",
-        "url": "http://nautobot/api/ipam/roles/a1fd5e46-a85e-48c3-a2f4-3c2ec2bb2464/",
-        "name": "User Access",
-        "slug": "user-access"
-    },
-    "description": "",
-    "display": "101 (Users-Floor1)",
-    "custom_fields": {}
-}
-```
+The REST API employs "serializers" to represent model data. The representation produced by a serializer typically includes all relevant database table fields which comprise the model, and may also include additional metadata such as information about other relevant objects in the database. Much like the database model itself, a serializer typically will represent information about "parent" objects (those objects that needed to exist in order to define the current object, such as `DeviceType` and `Location` for a `DeviceSerializer`) but typically will not include information about "child" objects (those objects that depend on the current object in order to be defined, such as `Interface` objects for a `DeviceSerializer`).
 
 ### Related Objects
 
-Related objects (e.g. `ForeignKey` fields) are represented using nested serializers. A nested serializer provides a minimal representation of an object, including only its direct URL and enough information to display the object to a user. When performing write API actions (`POST`, `PUT`, and `PATCH`), related objects may be specified by either UUID (primary key), or by a set of attributes sufficiently unique to return the desired object.
+Related objects (e.g. `ForeignKey` fields) are representable in several different ways. By default, when retrieving an object via the REST API, related objects are represented by URLs, or by a JSON `null` if no such related object exists. These URLs may be accessed in order to retrieve the full details of such related objects if needed/desired. For example, when retrieving an `IPAddress`, you might see:
+
+```json
+{
+    "id": "83445aa3-bbd3-4ab4-86f5-36942ce9df60",
+    "url": "http://localhost:8080/api/ipam/ip-addresses/83445aa3-bbd3-4ab4-86f5-36942ce9df60/",
+    "display": "10.0.60.39/32",
+    "address": "10.0.60.39/32",
+    ...
+    "role": "http://localhost:8080/api/extras/roles/e7a815b0-2c48-499a-84b8-f20350abe415/",
+    "status": "http://localhost:8080/api/extras/statuses/b7f6a447-5616-4533-a6d5-a4ece50cd08c/",
+    "vrf": null,
+    "tenant": "http://localhost:8080/api/tenancy/tenants/501fffe7-5302-40ae-b9e4-27d5e3ff2108/",
+    "nat_inside": null,
+    "tags": []
+}
+```
+
+Here, the `role`, `status`, `vrf`, `tenant`, and `nat_outside` fields represent objects related to this `IPAddress`, and the `tags` field is a list of such objects (no tags in this example).
+
++/- 2.0.0
+    The representation of related objects on retrieval has changed from Nautobot 1.x. The `brief` query parameter has been removed, and distinct "nested" serializers no longer exist. Instead, the `depth` parameter controls whether related objects are represented by URLs or as nested objects. Please see [Depth Query Parameter](#depth-query-parameter) for more details.
+
+When performing write API actions (`POST`, `PUT`, and `PATCH`), related objects may be specified by either UUID (primary key), or by a set of attributes sufficiently unique to return the desired object.
 
 For example, when creating a new device, its rack can be specified by Nautobot ID (PK):
 
@@ -239,7 +218,7 @@ Or by a set of nested attributes which uniquely identify the rack:
 {
     "name": "MyNewDevice",
     "rack": {
-        "site": {
+        "location": {
             "name": "Equinix DC6"
         },
         "name": "R204"
@@ -248,58 +227,48 @@ Or by a set of nested attributes which uniquely identify the rack:
 }
 ```
 
-Note that if the provided parameters do not return exactly one object, a validation error is raised.
-
-+++ 2.0.0
-
-Nested serializers are removed in Nautobot v2.0. By default (when `?depth=0`), all related objects are represented by their primary keys. When depth > 0, the related objects will be replaced by dynamically generated base serializers that represent the complete view of the related objects. Please see [Depth Query Parameter](#depth-query-parameter) for more details.
+Note that if the provided parameters do not match exactly one object, a validation error will be raised.
 
 ### Generic Relations
 
-Some objects within Nautobot have attributes which can reference an object of multiple types, known as _generic relations_. For example, an IP address can be assigned to either a device interface _or_ a virtual machine interface. When making this assignment via the REST API, we must specify two attributes:
+Some objects within Nautobot have attributes which can reference an object of multiple types, known as _generic relations_. For example, a `Cable` can be terminated (connected) to an `Interface`, or a `FrontPort`, or a `RearPort`, etc. For such generic relations, when making this assignment via the REST API, we must specify two attributes, typically a `object_type` and an `object_id`, and by convention in Nautobot's API:
 
-* `assigned_object_type` - The content type of the assigned object, defined as `<app>.<model>`
-* `assigned_object_id` - The assigned object's UUID
+* the `object_type` is the type of assigned object, typically represented as `<app_label>.<model_name>`
+* the `object_id` is the UUID (primary key) of the assigned object.
 
-Together, these values identify a unique object in Nautobot. The assigned object (if any) is represented by the `assigned_object` attribute on the IP address model.
+For example, the two ends of a Cable are identified by `termination_a_type`/`termination_a_id` and `termination_b_type`/`termination_b_id`, and might be specified on creation as something like:
 
 ```no-highlight
 curl -X POST \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
--H "Accept: application/json; version=1.3; indent=4" \
-http://nautobot/api/ipam/ip-addresses/ \
+-H "Accept: application/json; version=2.0; indent=4" \
+http://nautobot/api/dcim/cables/ \
 --data '{
-    "address": "192.0.2.1/24",
-    "assigned_object_type": "dcim.interface",
-    "assigned_object_id": "e824bc29-623f-407e-8aa8-828f4c0b98ee"
+    "termination_a_type": "dcim.interface",
+    "termination_a_id": "96ee6c25-d689-46f4-b552-eb72977c27b8",
+    "termination_b_type": "dcim.frontport",
+    "termination_b_id": "ca54e2cc-d1b5-46e2-bb7d-85b1a9e3c1d0",
+    ...
 }'
 ```
 
+On retrieval, the REST API will include the `object_type` and `object_id` fields, but will also typically for convenience include an `object` field containing the URL or nested details of the object identified by the type/id fields. For the above `Cable` example, the retrieval response might look something like:
+
 ```json
 {
-    "id": "e2f29f8f-002a-4c4a-9d19-24cc7549e715",
-    "url": "http://nautobot/api/ipam/ip-addresses/56296/",
-    "assigned_object_type": "dcim.interface",
-    "assigned_object_id": "e824bc29-623f-407e-8aa8-828f4c0b98ee",
-    "assigned_object": {
-        "id": "e824bc29-623f-407e-8aa8-828f4c0b98ee",
-        "url": "http://nautobot/api/dcim/interfaces/e824bc29-623f-407e-8aa8-828f4c0b98ee/",
-        "device": {
-            "id": "76816a69-db2c-40e6-812d-115c61156e21",
-            "url": "http://nautobot/api/dcim/devices/76816a69-db2c-40e6-812d-115c61156e21/",
-            "name": "device105",
-            "display": "device105"
-        },
-        "name": "ge-0/0/0",
-        "cable": null,
-        "connection_status": null
-    },
+    "id": "549dae0d-3345-4bd1-8626-085e46a36ded",
+    "url": "http://localhost:8080/api/dcim/cables/549dae0d-3345-4bd1-8626-085e46a36ded/",
+    ...
+    "termination_a_type": "dcim.interface",
+    "termination_b_type": "dcim.frontport",
+    "termination_a_id": "96ee6c25-d689-46f4-b552-eb72977c27b8",
+    "termination_b_id": "ca54e2cc-d1b5-46e2-bb7d-85b1a9e3c1d0",
+    "termination_a": "http://localhost:8080/api/dcim/interfaces/96ee6c25-d689-46f4-b552-eb72977c27b8/",
+    "termination_b": "http://localhost:8080/api/dcim/front-ports/ca54e2cc-d1b5-46e2-bb7d-85b1a9e3c1d0/",
     ...
 }
 ```
-
-If we wanted to assign this IP address to a virtual machine interface instead, we would have set `assigned_object_type` to `virtualization.vminterface` and updated the object ID appropriately.
 
 ## Pagination
 
@@ -369,7 +338,7 @@ To query Nautobot for a list of objects, make a `GET` request to the model's _li
 
 ```no-highlight
 curl -s -X GET \
--H "Accept: application/json; version=1.3" \
+-H "Accept: application/json; version=2.0" \
 http://nautobot/api/ipam/ip-addresses/ | jq '.'
 ```
 
@@ -408,7 +377,7 @@ To query Nautobot for a single object, make a `GET` request to the model's _deta
 
 ```no-highlight
 curl -s -X GET \
--H "Accept: application/json; version=1.3" \
+-H "Accept: application/json; version=2.0" \
 http://nautobot/api/ipam/ip-addresses/bd307eca-de34-4bda-9195-d69ca52206d6/ | jq '.'
 ```
 
@@ -435,7 +404,7 @@ This parameter is an positive integer value that can range from 0 to 10. In most
 
 #### Default/?depth=0
 
-`?depth` parameter defaults to 0 and offers a very lightweight view of the API where all object-related fields are represented by only their primary keys:
+`?depth` parameter defaults to 0 and offers a very lightweight view of the API where all object-related fields are represented by only their URLs:
 
 ```no-highlight
 curl -s -X GET \
@@ -475,12 +444,12 @@ http://nautobot/api/dcim/locations/0e19e475-89c9-4cf4-8b5f-a0589f0950cd/ | jq '.
     "contact_phone": "",
     "contact_email": "",
     "comments": "Sort share road candidate.",
-    "status": "28eb334b-4171-4da4-a03a-fa6d0c6a9442",
+    "status": "http://nautobot/api/extras/statuses/28eb334b-4171-4da4-a03a-fa6d0c6a9442/",
     "parent": null,
-    "location_type": "e3d4a9af-c6c1-4582-b483-a13301eb6e28",
-    "tenant": "5b1feadb-fab0-4f81-a53f-5192d83b0216",
+    "location_type": "http://nautobot/api/dcim/location-types/e3d4a9af-c6c1-4582-b483-a13301eb6e28/",
+    "tenant": "http://nautobot/api/tenancy/tenants/5b1feadb-fab0-4f81-a53f-5192d83b0216/",
     "tags": [
-        "a50d4568-27ae-4743-87ac-ffdc22b7f5d2",
+        "http://nautobot/api/extras/tags/a50d4568-27ae-4743-87ac-ffdc22b7f5d2/",
     ]
 }
 ```
@@ -540,15 +509,15 @@ http://nautobot/api/dcim/locations/ce69530e-6a4a-4d3c-9f95-fc326ec39abf/?depth=1
         "contact_phone": "",
         "contact_email": "",
         "comments": "Sort share road candidate.",
-        "status": "28eb334b-4171-4da4-a03a-fa6d0c6a9442",
+        "status": "http://nautobot/api/extras/statuses/28eb334b-4171-4da4-a03a-fa6d0c6a9442/",
         "parent": null,
-        "location_type": "e3d4a9af-c6c1-4582-b483-a13301eb6e28",
-        "tenant": "5b1feadb-fab0-4f81-a53f-5192d83b0216",
+        "location_type": "http://nautobot/api/extras/location-types/e3d4a9af-c6c1-4582-b483-a13301eb6e28/",
+        "tenant": "http://nautobot/api/tenancy/tenants/5b1feadb-fab0-4f81-a53f-5192d83b0216/",
         "tags": [
-            "6e8ce6c9-0a8c-4731-b02a-b2ec19db5c52",
-            "1e986e5d-099d-4742-bfa5-16363abea5fd",
-            "21afbdad-c782-4fc5-9b3b-7b59273bb08c",
-            "0118b994-9943-4295-946b-92b27efe15db"
+            "http://nautobot/api/extras/tags/6e8ce6c9-0a8c-4731-b02a-b2ec19db5c52/",
+            "http://nautobot/api/extras/tags/1e986e5d-099d-4742-bfa5-16363abea5fd/",
+            "http://nautobot/api/extras/tags/21afbdad-c782-4fc5-9b3b-7b59273bb08c/",
+            "http://nautobot/api/extras/tags/0118b994-9943-4295-946b-92b27efe15db/"
         ]
     },
     "location_type": {
@@ -569,7 +538,7 @@ http://nautobot/api/dcim/locations/ce69530e-6a4a-4d3c-9f95-fc326ec39abf/?depth=1
         "slug": "building",
         "description": "Protect growth bill all hair along.",
         "nestable": false,
-        "parent": "e3d4a9af-c6c1-4582-b483-a13301eb6e28"
+        "parent": "http://nautobot/api/dcim/location-types/e3d4a9af-c6c1-4582-b483-a13301eb6e28/"
     },
     "tenant": {
         "id": "d043b6bc-6892-45f9-b460-4b006eb68016",
@@ -665,15 +634,15 @@ http://nautobot/api/dcim/locations/3b71a669-faa4-4f8d-a72a-8c94d121b793/?depth=2
             "contact_phone": "",
             "contact_email": "",
             "comments": "Sort share road candidate.",
-            "status": "28eb334b-4171-4da4-a03a-fa6d0c6a9442",
+            "status": "http://nautobot/api/extras/statuses/28eb334b-4171-4da4-a03a-fa6d0c6a9442/",
             "parent": null,
-            "location_type": "e3d4a9af-c6c1-4582-b483-a13301eb6e28",
-            "tenant": "5b1feadb-fab0-4f81-a53f-5192d83b0216",
+            "location_type": "http://nautobot/api/dcim/location-types/e3d4a9af-c6c1-4582-b483-a13301eb6e28/",
+            "tenant": "http://nautobot/api/tenancy/tenants/5b1feadb-fab0-4f81-a53f-5192d83b0216/",
             "tags": [
-                "6e8ce6c9-0a8c-4731-b02a-b2ec19db5c52",
-                "1e986e5d-099d-4742-bfa5-16363abea5fd",
-                "21afbdad-c782-4fc5-9b3b-7b59273bb08c",
-                "0118b994-9943-4295-946b-92b27efe15db"
+                "http://nautobot/api/extras/tags/6e8ce6c9-0a8c-4731-b02a-b2ec19db5c52/",
+                "http://nautobot/api/extras/tags/1e986e5d-099d-4742-bfa5-16363abea5fd/",
+                "http://nautobot/api/extras/tags/21afbdad-c782-4fc5-9b3b-7b59273bb08c/",
+                "http://nautobot/api/extras/tags/0118b994-9943-4295-946b-92b27efe15db/"
             ]
         },
         "location_type": {
@@ -694,7 +663,7 @@ http://nautobot/api/dcim/locations/3b71a669-faa4-4f8d-a72a-8c94d121b793/?depth=2
             "slug": "building",
             "description": "Protect growth bill all hair along.",
             "nestable": false,
-            "parent": "e3d4a9af-c6c1-4582-b483-a13301eb6e28"
+            "parent": "http://nautobot/api/dcim/location-types/e3d4a9af-c6c1-4582-b483-a13301eb6e28/"
         },
         "tenant": null,
         "tags": []
@@ -719,7 +688,7 @@ http://nautobot/api/dcim/locations/3b71a669-faa4-4f8d-a72a-8c94d121b793/?depth=2
             "slug": "building",
             "description": "Protect growth bill all hair along.",
             "nestable": false,
-            "parent": "e3d4a9af-c6c1-4582-b483-a13301eb6e28"
+            "parent": "http://nautobot/api/dcim/location-types/e3d4a9af-c6c1-4582-b483-a13301eb6e28/"
         }
     },
     ...
@@ -798,9 +767,9 @@ To create a new object, make a `POST` request to the model's _list_ endpoint wit
 curl -s -X POST \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
--H "Accept: application/json; version=1.3" \
+-H "Accept: application/json; version=2.0" \
 http://nautobot/api/ipam/prefixes/ \
---data '{"prefix": "192.0.2.0/24", "site": 8df9e629-4338-438b-8ea9-06114f7be08e}' | jq '.'
+--data '{"prefix": "192.0.2.0/24", "location": 8df9e629-4338-438b-8ea9-06114f7be08e}' | jq '.'
 ```
 
 ```json
@@ -812,24 +781,11 @@ http://nautobot/api/ipam/prefixes/ \
     "label": "IPv4"
   },
   "prefix": "192.0.2.0/24",
-  "site": {
-    "id": "8df9e629-4338-438b-8ea9-06114f7be08e",
-    "url": "http://nautobot/api/dcim/sites/8df9e629-4338-438b-8ea9-06114f7be08e/",
-    "name": "US-East 4",
-    "slug": "us-east-4"
-  },
+  "location": "http://nautobot/api/dcim/locations/8df9e629-4338-438b-8ea9-06114f7be08e/",
   "vrf": null,
   "tenant": null,
   "vlan": null,
-  "status": {
-      "display": "Active",
-      "id": "fc32b83f-2448-4602-9d43-fecc6735e4e5",
-      "url": "http://nautobot/api/extras/statuses/fc32b83f-2448-4602-9d43-fecc6735e4e5/",
-      "name": "Active",
-      "slug": "active",
-      "created": "2019-12-09T16:38:50.363404Z",
-      "last_updated": "2019-12-09T16:38:50.363404Z"
-  },
+  "status": "http://nautobot/api/extras/statuses/fc32b83f-2448-4602-9d43-fecc6735e4e5/",
   "role": null,
   "type": "network",
   "description": "",
@@ -847,7 +803,7 @@ To create multiple instances of a model using a single request, make a `POST` re
 ```no-highlight
 curl -X POST -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
--H "Accept: application/json; version=1.3; indent=4" \
+-H "Accept: application/json; version=2.0; indent=4" \
 http://nautobot/api/dcim/sites/ \
 --data '[
 {"name": "Site 1", "slug": "site-1", "region": {"name": "United States"}},
@@ -887,9 +843,9 @@ To modify an object which has already been created, make a `PATCH` request to th
 curl -s -X PATCH \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
--H "Accept: application/json; version=1.3" \
+-H "Accept: application/json; version=2.0" \
 http://nautobot/api/ipam/prefixes/b484b0ac-12e3-484a-84c0-aa17955eaedc/ \
---data '{"status": "reserved"}' | jq '.'
+--data '{"status": "fc32b83f-2448-4602-9d43-fecc6735e4e5"}' | jq '.'
 ```
 
 ```json
@@ -901,24 +857,11 @@ http://nautobot/api/ipam/prefixes/b484b0ac-12e3-484a-84c0-aa17955eaedc/ \
     "label": "IPv4"
   },
   "prefix": "192.0.2.0/24",
-  "site": {
-    "id": "8df9e629-4338-438b-8ea9-06114f7be08e",
-    "url": "http://nautobot/api/dcim/sites/8df9e629-4338-438b-8ea9-06114f7be08e/",
-    "name": "US-East 4",
-    "slug": "us-east-4"
-  },
+  "site": "http://nautobot/api/dcim/sites/8df9e629-4338-438b-8ea9-06114f7be08e/",
   "vrf": null,
   "tenant": null,
   "vlan": null,
-  "status": {
-      "display": "Reserved",
-      "id": "fc32b83f-2448-4602-9d43-fecc6735e4e5",
-      "url": "http://nautobot/api/extras/statuses/fc32b83f-2448-4602-9d43-fecc6735e4e5/",
-      "name": "Reserved",
-      "slug": "reserved",
-      "created": "2019-12-09T00:00:00Z",
-      "last_updated": "2019-12-09T16:38:50.363404Z"
-  },
+  "status": "http://nautobot/api/extras/statuses/fc32b83f-2448-4602-9d43-fecc6735e4e5/",
   "role": null,
   "type": "network",
   "description": "",
@@ -977,15 +920,15 @@ It is possible to modify the objects associated via Relationship with an object 
 
 ### Updating Multiple Objects
 
-Multiple objects can be updated simultaneously by issuing a `PUT` or `PATCH` request to a model's list endpoint with a list of dictionaries specifying the UUID of each object to be deleted and the attributes to be updated. For example, to update sites with UUIDs 18de055e-3ea9-4cc3-ba78-b7eef6f0d589 and 1a414273-3d68-4586-ba22-6ae0a5702b8f to a status of "active", issue the following request:
+Multiple objects can be updated simultaneously by issuing a `PUT` or `PATCH` request to a model's list endpoint with a list of dictionaries specifying the UUID of each object to be deleted and the attributes to be updated. For example, to update sites with UUIDs 18de055e-3ea9-4cc3-ba78-b7eef6f0d589 and 1a414273-3d68-4586-ba22-6ae0a5702b8f to a status of "Active", issue the following request:
 
 ```no-highlight
 curl -s -X PATCH \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
--H "Accept: application/json; version=1.3" \
+-H "Accept: application/json; version=2.0" \
 http://nautobot/api/dcim/sites/ \
---data '[{"id": "18de055e-3ea9-4cc3-ba78-b7eef6f0d589", "status": "active"}, {"id": "1a414273-3d68-4586-ba22-6ae0a5702b8f", "status": "active"}]'
+--data '[{"id": "18de055e-3ea9-4cc3-ba78-b7eef6f0d589", "status": {"name": "Active"}}, {"id": "1a414273-3d68-4586-ba22-6ae0a5702b8f", "status": {"name": "Active"}}]'
 ```
 
 Note that there is no requirement for the attributes to be identical among objects. For instance, it's possible to update the status of one site along with the name of another in the same request.
@@ -1000,7 +943,7 @@ To delete an object from Nautobot, make a `DELETE` request to the model's _detai
 ```no-highlight
 curl -s -X DELETE \
 -H "Authorization: Token $TOKEN" \
--H "Accept: application/json; version=1.3" \
+-H "Accept: application/json; version=2.0" \
 http://nautobot/api/ipam/prefixes/48df6965-0fcb-4155-b5f8-00fe8b9b01af/
 ```
 
@@ -1017,7 +960,7 @@ Nautobot supports the simultaneous deletion of multiple objects of the same type
 curl -s -X DELETE \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
--H "Accept: application/json; version=1.3" \
+-H "Accept: application/json; version=2.0" \
 http://nautobot/api/dcim/sites/ \
 --data '[{"id": "18de055e-3ea9-4cc3-ba78-b7eef6f0d589"}, {"id": "1a414273-3d68-4586-ba22-6ae0a5702b8f"}, {"id": "c2516019-caf6-41f0-98a6-4276c1a73fa3"}]'
 ```

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -90,7 +90,6 @@ logger = logging.getLogger(__name__)
 
 
 class ComputedFieldSerializer(ValidatedModelSerializer, NotesSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:computedfield-detail")
     content_type = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("custom_fields").get_query()).order_by("app_label", "model"),
     )
@@ -115,7 +114,6 @@ class ComputedFieldSerializer(ValidatedModelSerializer, NotesSerializerMixin):
 
 
 class ConfigContextSerializer(ValidatedModelSerializer, TaggedModelSerializerMixin, NotesSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:configcontext-detail")
     owner_content_type = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("config_context_owners").get_query()),
         required=False,
@@ -156,7 +154,6 @@ class ConfigContextSerializer(ValidatedModelSerializer, TaggedModelSerializerMix
 
 
 class ConfigContextSchemaSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:configcontextschema-detail")
     owner_content_type = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("config_context_owners").get_query()),
         required=False,
@@ -208,7 +205,6 @@ class ContentTypeSerializer(BaseModelSerializer):
 
 
 class CustomFieldSerializer(ValidatedModelSerializer, NotesSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:customfield-detail")
     content_types = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("custom_fields").get_query()),
         many=True,
@@ -223,8 +219,6 @@ class CustomFieldSerializer(ValidatedModelSerializer, NotesSerializerMixin):
 
 
 class CustomFieldChoiceSerializer(ValidatedModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:customfieldchoice-detail")
-
     class Meta:
         model = CustomFieldChoice
         fields = "__all__"
@@ -236,7 +230,6 @@ class CustomFieldChoiceSerializer(ValidatedModelSerializer):
 
 
 class CustomLinkSerializer(ValidatedModelSerializer, NotesSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:customlink-detail")
     content_type = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("custom_links").get_query()).order_by("app_label", "model"),
     )
@@ -252,15 +245,12 @@ class CustomLinkSerializer(ValidatedModelSerializer, NotesSerializerMixin):
 
 
 class DynamicGroupMembershipSerializer(ValidatedModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:dynamicgroupmembership-detail")
-
     class Meta:
         model = DynamicGroupMembership
         fields = "__all__"
 
 
 class DynamicGroupSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:dynamicgroup-detail")
     content_type = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("dynamic_groups").get_query()).order_by("app_label", "model"),
     )
@@ -288,7 +278,6 @@ class DynamicGroupSerializer(NautobotModelSerializer):
 
 # TODO: export-templates don't support custom-fields, is this omission intentional?
 class ExportTemplateSerializer(RelationshipModelSerializerMixin, ValidatedModelSerializer, NotesSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:exporttemplate-detail")
     content_type = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("export_templates").get_query()),
     )
@@ -327,7 +316,6 @@ class ExportTemplateSerializer(RelationshipModelSerializerMixin, ValidatedModelS
 class GitRepositorySerializer(NautobotModelSerializer):
     """Git repositories defined as a data source."""
 
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:gitrepository-detail")
     provided_contents = MultipleChoiceJSONField(
         choices=lambda: get_datasource_content_choices("extras.gitrepository"),
         allow_blank=True,
@@ -352,7 +340,6 @@ class GitRepositorySerializer(NautobotModelSerializer):
 
 
 class GraphQLQuerySerializer(ValidatedModelSerializer, NotesSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:graphqlquery-detail")
     variables = serializers.DictField(required=False, allow_null=True, default={})
 
     class Meta:
@@ -379,7 +366,6 @@ class GraphQLQueryOutputSerializer(serializers.Serializer):
 
 
 class ImageAttachmentSerializer(ValidatedModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:imageattachment-detail")
     content_type = ContentTypeField(queryset=ContentType.objects.all())
 
     class Meta:
@@ -420,8 +406,6 @@ class ImageAttachmentSerializer(ValidatedModelSerializer):
 
 
 class JobSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:job-detail")
-
     class Meta:
         model = Job
         fields = "__all__"
@@ -469,7 +453,6 @@ class JobVariableSerializer(serializers.Serializer):
 
 
 class JobResultSerializer(CustomFieldModelSerializerMixin, BaseModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:jobresult-detail")
     status = ChoiceField(choices=JobResultStatusChoices, read_only=True)
     obj_type = ContentTypeField(read_only=True)
 
@@ -484,7 +467,6 @@ class JobResultSerializer(CustomFieldModelSerializerMixin, BaseModelSerializer):
 
 
 class ScheduledJobSerializer(BaseModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:scheduledjob-detail")
     # start_time = serializers.DateTimeField(format=None, required=False)
 
     class Meta:
@@ -539,7 +521,6 @@ class JobClassDetailSerializer(JobClassSerializer):
 
 
 class JobHookSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:jobhook-detail")
     content_types = ContentTypeField(
         queryset=ChangeLoggedModelsQuery().as_queryset(),
         many=True,
@@ -655,7 +636,6 @@ class JobMultiPartInputSerializer(serializers.Serializer):
 
 
 class JobLogEntrySerializer(BaseModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:joblogentry-detail")
     display = serializers.SerializerMethodField()
 
     class Meta:
@@ -673,7 +653,6 @@ class JobLogEntrySerializer(BaseModelSerializer):
 
 
 class JobButtonSerializer(ValidatedModelSerializer, NotesSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:jobbutton-detail")
     content_types = ContentTypeField(queryset=ContentType.objects.all(), many=True)
 
     class Meta:
@@ -697,7 +676,6 @@ class JobButtonSerializer(ValidatedModelSerializer, NotesSerializerMixin):
 
 
 class NoteSerializer(BaseModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:note-detail")
     assigned_object_type = ContentTypeField(queryset=ContentType.objects.all())
     assigned_object = serializers.SerializerMethodField()
 
@@ -736,7 +714,6 @@ class NoteInputSerializer(serializers.Serializer):
 
 
 class ObjectChangeSerializer(BaseModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:objectchange-detail")
     action = ChoiceField(choices=ObjectChangeActionChoices, read_only=True)
     changed_object_type = ContentTypeField(read_only=True)
     changed_object = serializers.SerializerMethodField(read_only=True)
@@ -773,8 +750,6 @@ class ObjectChangeSerializer(BaseModelSerializer):
 
 
 class RelationshipSerializer(ValidatedModelSerializer, NotesSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:relationship-detail")
-
     source_type = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("relationships").get_query()),
     )
@@ -789,8 +764,6 @@ class RelationshipSerializer(ValidatedModelSerializer, NotesSerializerMixin):
 
 
 class RelationshipAssociationSerializer(ValidatedModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:relationshipassociation-detail")
-
     source_type = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("relationships").get_query()),
     )
@@ -812,7 +785,6 @@ class RelationshipAssociationSerializer(ValidatedModelSerializer):
 class RoleSerializer(NautobotModelSerializer):
     """Serializer for `Role` objects."""
 
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:role-detail")
     content_types = ContentTypeField(
         queryset=RoleModelsQuery().as_queryset(),
         many=True,
@@ -831,8 +803,6 @@ class RoleSerializer(NautobotModelSerializer):
 class SecretSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
     """Serializer for `Secret` objects."""
 
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:secret-detail")
-
     class Meta:
         model = Secret
         fields = "__all__"
@@ -841,8 +811,6 @@ class SecretSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
 class SecretsGroupAssociationSerializer(ValidatedModelSerializer):
     """Serializer for `SecretsGroupAssociation` objects."""
 
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:secretsgroupassociation-detail")
-
     class Meta:
         model = SecretsGroupAssociation
         fields = "__all__"
@@ -850,8 +818,6 @@ class SecretsGroupAssociationSerializer(ValidatedModelSerializer):
 
 class SecretsGroupSerializer(NautobotModelSerializer):
     """Serializer for `SecretsGroup` objects."""
-
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:secretsgroup-detail")
 
     # TODO: it would be **awesome** if we could create/update SecretsGroupAssociations
     # alongside creating/updating the base SecretsGroup, but since this is a ManyToManyField with
@@ -880,7 +846,6 @@ class SecretsGroupSerializer(NautobotModelSerializer):
 class StatusSerializer(NautobotModelSerializer):
     """Serializer for `Status` objects."""
 
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:status-detail")
     content_types = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("statuses").get_query()),
         many=True,
@@ -897,7 +862,6 @@ class StatusSerializer(NautobotModelSerializer):
 
 
 class TagSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:tag-detail")
     tagged_items = serializers.IntegerField(read_only=True)
     content_types = ContentTypeField(
         queryset=TaggableClassesQuery().as_queryset(),
@@ -929,7 +893,6 @@ class TagSerializer(NautobotModelSerializer):
 
 
 class WebhookSerializer(ValidatedModelSerializer, NotesSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="extras-api:webhook-detail")
     content_types = ContentTypeField(
         queryset=ContentType.objects.filter(FeatureQuery("webhooks").get_query()).order_by("app_label", "model"),
         many=True,

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -892,9 +892,9 @@ class DynamicGroupMembership(BaseModel):
         """Return the group count."""
         return self.group.count
 
-    def get_absolute_url(self):
+    def get_absolute_url(self, api=False):
         """Return the group's absolute URL."""
-        return self.group.get_absolute_url()
+        return self.group.get_absolute_url(api=api)
 
     def get_group_members_url(self):
         """Return the group members URL."""

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -731,8 +731,8 @@ class RelationshipAssociation(BaseModel):
 
         return None
 
-    def get_absolute_url(self):
-        return self.relationship.get_absolute_url()
+    def get_absolute_url(self, api=False):
+        return self.relationship.get_absolute_url(api=api)
 
     def get_source(self):
         """Accessor for self.source - returns None if the object cannot be located."""

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -277,9 +277,7 @@ class ConfigContextTest(APIViewTestCases.APIViewTestCase):
         }
         response = self.client.post(self._get_list_url(), data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertEqual(
-            response.data["config_context_schema"], f"http://nautobot.example.com{schema.get_absolute_url(api=True)}"
-        )
+        self.assertEqual(response.data["config_context_schema"], self.absolute_api_url(schema))
 
     def test_schema_validation_fails(self):
         """
@@ -1373,10 +1371,7 @@ class JobTest(
         self.assertIn("scheduled_job", response.data)
         self.assertIn("job_result", response.data)
         self.assertEqual(response.data["scheduled_job"]["id"], str(schedule.pk))
-        self.assertEqual(
-            response.data["scheduled_job"]["url"],
-            "http://nautobot.example.com" + reverse("extras-api:scheduledjob-detail", kwargs={"pk": schedule.pk}),
-        )
+        self.assertEqual(response.data["scheduled_job"]["url"], self.absolute_api_url(schedule))
         self.assertEqual(response.data["scheduled_job"]["name"], schedule.name)
         # Python < 3.11 doesn't understand the datetime string "2023-04-27T18:33:16.017865Z",
         # but it *does* understand the string "2023-04-27T18:33:17.330836+00:00"
@@ -1576,10 +1571,7 @@ class JobTest(
         self.assertIn("scheduled_job", response.data)
         self.assertIn("job_result", response.data)
         self.assertEqual(response.data["scheduled_job"]["id"], str(schedule.pk))
-        self.assertEqual(
-            response.data["scheduled_job"]["url"],
-            "http://nautobot.example.com" + reverse("extras-api:scheduledjob-detail", kwargs={"pk": schedule.pk}),
-        )
+        self.assertEqual(response.data["scheduled_job"]["url"], self.absolute_api_url(schedule))
         self.assertEqual(response.data["scheduled_job"]["name"], schedule.name)
         # Python < 3.11 doesn't understand the datetime string "2023-04-27T18:33:16.017865Z",
         # but it *does* understand the string "2023-04-27T18:33:17.330836+00:00"
@@ -1721,10 +1713,7 @@ class JobTest(
         self.assertIn("scheduled_job", response.data)
         self.assertIn("job_result", response.data)
         self.assertEqual(response.data["scheduled_job"]["id"], str(schedule.pk))
-        self.assertEqual(
-            response.data["scheduled_job"]["url"],
-            "http://nautobot.example.com" + reverse("extras-api:scheduledjob-detail", kwargs={"pk": schedule.pk}),
-        )
+        self.assertEqual(response.data["scheduled_job"]["url"], self.absolute_api_url(schedule))
         self.assertEqual(response.data["scheduled_job"]["name"], schedule.name)
         # Python < 3.11 doesn't understand the datetime string "2023-04-27T18:33:16.017865Z",
         # but it *does* understand the string "2023-04-27T18:33:17.330836+00:00"
@@ -2428,10 +2417,7 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase, RequiredRelationshipTes
             {
                 self.relationships[0].slug: {
                     "id": str(self.relationships[0].pk),
-                    "url": (
-                        "http://nautobot.example.com"
-                        + reverse("extras-api:relationship-detail", kwargs={"pk": self.relationships[0].pk})
-                    ),
+                    "url": self.absolute_api_url(self.relationships[0]),
                     "name": self.relationships[0].name,
                     "type": self.relationships[0].type,
                     "peer": {
@@ -2442,10 +2428,7 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase, RequiredRelationshipTes
                 },
                 self.relationships[1].slug: {
                     "id": str(self.relationships[1].pk),
-                    "url": (
-                        "http://nautobot.example.com"
-                        + reverse("extras-api:relationship-detail", kwargs={"pk": self.relationships[1].pk})
-                    ),
+                    "url": self.absolute_api_url(self.relationships[1]),
                     "name": self.relationships[1].name,
                     "type": self.relationships[1].type,
                     "destination": {
@@ -2461,10 +2444,7 @@ class RelationshipTest(APIViewTestCases.APIViewTestCase, RequiredRelationshipTes
                 },
                 self.relationships[2].slug: {
                     "id": str(self.relationships[2].pk),
-                    "url": (
-                        "http://nautobot.example.com"
-                        + reverse("extras-api:relationship-detail", kwargs={"pk": self.relationships[2].pk})
-                    ),
+                    "url": self.absolute_api_url(self.relationships[2]),
                     "name": self.relationships[2].name,
                     "type": self.relationships[2].type,
                     "destination": {
@@ -2882,13 +2862,7 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
         self.maxDiff = None
         relationship_data = response.data["relationships"][self.relationship.slug]
         self.assertEqual(relationship_data["id"], str(self.relationship.pk))
-        self.assertEqual(
-            relationship_data["url"],
-            (
-                "http://nautobot.example.com"
-                + reverse("extras-api:relationship-detail", kwargs={"pk": self.relationship.pk})
-            ),
-        )
+        self.assertEqual(relationship_data["url"], self.absolute_api_url(self.relationship))
         self.assertEqual(relationship_data["name"], self.relationship.name)
         self.assertEqual(relationship_data["type"], "many-to-many")
         self.assertEqual(relationship_data["destination"]["label"], "devices")
@@ -2897,10 +2871,7 @@ class RelationshipAssociationTest(APIViewTestCases.APIViewTestCase):
         objects = response.data["relationships"][self.relationship.slug]["destination"]["objects"]
         for i, obj in enumerate(objects):
             self.assertEqual(obj["id"], str(self.devices[i].pk))
-            self.assertEqual(
-                obj["url"],
-                ("http://nautobot.example.com" + reverse("dcim-api:device-detail", kwargs={"pk": self.devices[i].pk})),
-            )
+            self.assertEqual(obj["url"], self.absolute_api_url(self.devices[i]))
             self.assertEqual(
                 obj["display"],
                 self.devices[i].display,

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -277,7 +277,9 @@ class ConfigContextTest(APIViewTestCases.APIViewTestCase):
         }
         response = self.client.post(self._get_list_url(), data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["config_context_schema"], schema.pk)
+        self.assertEqual(
+            response.data["config_context_schema"], f"http://nautobot.example.com{schema.get_absolute_url(api=True)}"
+        )
 
     def test_schema_validation_fails(self):
         """

--- a/nautobot/extras/tests/test_tags.py
+++ b/nautobot/extras/tests/test_tags.py
@@ -52,10 +52,7 @@ class TaggedItemTest(APITestCase):
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
         # response with default depth is a list of tag URLs
-        self.assertEqual(
-            sorted(response.data["tags"]),
-            sorted([f"http://nautobot.example.com{t.get_absolute_url(api=True)}" for t in self.tags]),
-        )
+        self.assertEqual(sorted(response.data["tags"]), sorted([self.absolute_api_url(t) for t in self.tags]))
         location = Location.objects.get(pk=response.data["id"])
         self.assertListEqual(sorted([t.name for t in location.tags.all()]), sorted([t.name for t in self.tags]))
 
@@ -77,12 +74,7 @@ class TaggedItemTest(APITestCase):
         # response with default depth is a list of tag URLs
         self.assertListEqual(
             sorted(response.data["tags"]),
-            sorted(
-                [
-                    f"http://nautobot.example.com{t.get_absolute_url(api=True)}"
-                    for t in [self.tags[0], self.tags[1], self.tags[3]]
-                ]
-            ),
+            sorted([self.absolute_api_url(t) for t in [self.tags[0], self.tags[1], self.tags[3]]]),
         )
         location = Location.objects.get(pk=response.data["id"])
         self.assertListEqual(

--- a/nautobot/extras/tests/test_tags.py
+++ b/nautobot/extras/tests/test_tags.py
@@ -51,7 +51,11 @@ class TaggedItemTest(APITestCase):
 
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertListEqual(sorted([str(t) for t in response.data["tags"]]), sorted(data["tags"]))
+        # response with default depth is a list of tag URLs
+        self.assertEqual(
+            sorted(response.data["tags"]),
+            sorted([f"http://nautobot.example.com{t.get_absolute_url(api=True)}" for t in self.tags]),
+        )
         location = Location.objects.get(pk=response.data["id"])
         self.assertListEqual(sorted([t.name for t in location.tags.all()]), sorted([t.name for t in self.tags]))
 
@@ -70,10 +74,15 @@ class TaggedItemTest(APITestCase):
 
         response = self.client.patch(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
-        tag_name_list = Tag.objects.filter(pk__in=response.data["tags"]).values_list("name", flat=True)
+        # response with default depth is a list of tag URLs
         self.assertListEqual(
-            sorted(list(tag_name_list)),
-            sorted([t["name"] for t in data["tags"]]),
+            sorted(response.data["tags"]),
+            sorted(
+                [
+                    f"http://nautobot.example.com{t.get_absolute_url(api=True)}"
+                    for t in [self.tags[0], self.tags[1], self.tags[3]]
+                ]
+            ),
         )
         location = Location.objects.get(pk=response.data["id"])
         self.assertListEqual(

--- a/nautobot/ipam/api/serializers.py
+++ b/nautobot/ipam/api/serializers.py
@@ -225,7 +225,11 @@ class IPAddressSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
             return None
         depth = get_nested_serializer_depth(self)
         data = return_nested_serializer_data_based_on_depth(
-            IPAddressSerializer(nat_outside_list), depth, obj, nat_outside_list, "nat_outside_list"
+            IPAddressSerializer(nat_outside_list, context={"request": self.context.get("request")}),
+            depth,
+            obj,
+            nat_outside_list,
+            "nat_outside_list",
         )
         return data
 

--- a/nautobot/ipam/api/serializers.py
+++ b/nautobot/ipam/api/serializers.py
@@ -31,7 +31,6 @@ from nautobot.ipam.models import (
 
 
 class VRFSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="ipam-api:vrf-detail")
     ipaddress_count = serializers.IntegerField(read_only=True)
     prefix_count = serializers.IntegerField(read_only=True)
 
@@ -46,8 +45,6 @@ class VRFSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
 
 
 class RouteTargetSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="ipam-api:routetarget-detail")
-
     class Meta:
         model = RouteTarget
         fields = "__all__"
@@ -59,7 +56,6 @@ class RouteTargetSerializer(NautobotModelSerializer, TaggedModelSerializerMixin)
 
 
 class RIRSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="ipam-api:rir-detail")
     assigned_prefix_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -73,7 +69,6 @@ class RIRSerializer(NautobotModelSerializer):
 
 
 class VLANGroupSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="ipam-api:vlangroup-detail")
     vlan_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -97,7 +92,6 @@ class VLANGroupSerializer(NautobotModelSerializer):
 
 
 class VLANSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="ipam-api:vlan-detail")
     prefix_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -124,7 +118,6 @@ class VLANSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
 
 
 class PrefixSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="ipam-api:prefix-detail")
     family = ChoiceField(choices=IPAddressFamilyChoices, read_only=True)
     prefix = IPFieldSerializer()
     type = ChoiceField(choices=PrefixTypeChoices, default=PrefixTypeChoices.TYPE_NETWORK)
@@ -212,7 +205,6 @@ class AvailablePrefixSerializer(serializers.Serializer):
 
 
 class IPAddressSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="ipam-api:ipaddress-detail")
     family = ChoiceField(choices=IPAddressFamilyChoices, read_only=True)
     address = IPFieldSerializer()
     nat_outside_list = serializers.SerializerMethodField(read_only=True)
@@ -266,7 +258,6 @@ class AvailableIPSerializer(serializers.Serializer):
 
 
 class ServiceSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="ipam-api:service-detail")
     # TODO #3024 make a backlog item to rip out the choice field.
     protocol = ChoiceField(choices=ServiceProtocolChoices, required=False)
     ports = serializers.ListField(

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -184,7 +184,9 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
             response = self.client.post(url, data, format="json", **self.header)
             self.assertHttpStatus(response, status.HTTP_201_CREATED)
             self.assertEqual(response.data["prefix"], str(prefixes_to_be_created[i]))
-            self.assertEqual(str(response.data["vrf"]), str(prefix.vrf.pk))
+            self.assertEqual(
+                str(response.data["vrf"]), f"http://nautobot.example.com{prefix.vrf.get_absolute_url(api=True)}"
+            )
             self.assertEqual(response.data["description"], data["description"])
 
         # Try to create one more prefix
@@ -277,7 +279,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
             }
             response = self.client.post(url, data, format="json", **self.header)
             self.assertHttpStatus(response, status.HTTP_201_CREATED)
-            self.assertEqual(str(response.data["vrf"]), str(vrf.pk))
+            self.assertEqual(str(response.data["vrf"]), f"http://nautobot.example.com{vrf.get_absolute_url(api=True)}")
             self.assertEqual(response.data["description"], data["description"])
 
         # Try to create one more IP

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -184,9 +184,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
             response = self.client.post(url, data, format="json", **self.header)
             self.assertHttpStatus(response, status.HTTP_201_CREATED)
             self.assertEqual(response.data["prefix"], str(prefixes_to_be_created[i]))
-            self.assertEqual(
-                str(response.data["vrf"]), f"http://nautobot.example.com{prefix.vrf.get_absolute_url(api=True)}"
-            )
+            self.assertEqual(str(response.data["vrf"]), self.absolute_api_url(prefix.vrf))
             self.assertEqual(response.data["description"], data["description"])
 
         # Try to create one more prefix
@@ -279,7 +277,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
             }
             response = self.client.post(url, data, format="json", **self.header)
             self.assertHttpStatus(response, status.HTTP_201_CREATED)
-            self.assertEqual(str(response.data["vrf"]), f"http://nautobot.example.com{vrf.get_absolute_url(api=True)}")
+            self.assertEqual(str(response.data["vrf"]), self.absolute_api_url(vrf))
             self.assertEqual(response.data["description"], data["description"])
 
         # Try to create one more IP

--- a/nautobot/tenancy/api/serializers.py
+++ b/nautobot/tenancy/api/serializers.py
@@ -10,7 +10,6 @@ from nautobot.tenancy.models import Tenant, TenantGroup
 
 
 class TenantGroupSerializer(NautobotModelSerializer, TreeModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="tenancy-api:tenantgroup-detail")
     tenant_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -19,7 +18,6 @@ class TenantGroupSerializer(NautobotModelSerializer, TreeModelSerializerMixin):
 
 
 class TenantSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="tenancy-api:tenant-detail")
     circuit_count = serializers.IntegerField(read_only=True)
     device_count = serializers.IntegerField(read_only=True)
     ipaddress_count = serializers.IntegerField(read_only=True)

--- a/nautobot/users/api/serializers.py
+++ b/nautobot/users/api/serializers.py
@@ -12,8 +12,6 @@ from nautobot.users.models import ObjectPermission, Token
 
 
 class UserSerializer(ValidatedModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="users-api:user-detail")
-
     class Meta:
         model = get_user_model()
         exclude = ["user_permissions"]
@@ -41,7 +39,6 @@ class GroupSerializer(ValidatedModelSerializer):
 
 
 class TokenSerializer(ValidatedModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="users-api:token-detail")
     key = serializers.CharField(min_length=40, max_length=40, allow_blank=True, required=False)
 
     class Meta:
@@ -57,7 +54,6 @@ class TokenSerializer(ValidatedModelSerializer):
 
 
 class ObjectPermissionSerializer(ValidatedModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="users-api:objectpermission-detail")
     object_types = ContentTypeField(queryset=ContentType.objects.all(), many=True)
 
     class Meta:

--- a/nautobot/virtualization/api/serializers.py
+++ b/nautobot/virtualization/api/serializers.py
@@ -24,7 +24,6 @@ from nautobot.virtualization.models import (
 
 
 class ClusterTypeSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="virtualization-api:clustertype-detail")
     cluster_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -33,7 +32,6 @@ class ClusterTypeSerializer(NautobotModelSerializer):
 
 
 class ClusterGroupSerializer(NautobotModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name="virtualization-api:clustergroup-detail")
     cluster_count = serializers.IntegerField(read_only=True)
 
     class Meta:
@@ -42,7 +40,6 @@ class ClusterGroupSerializer(NautobotModelSerializer):
 
 
 class ClusterSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="virtualization-api:cluster-detail")
     device_count = serializers.IntegerField(read_only=True)
     virtualmachine_count = serializers.IntegerField(read_only=True)
 
@@ -57,8 +54,6 @@ class ClusterSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
 
 
 class VirtualMachineSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="virtualization-api:virtualmachine-detail")
-
     class Meta:
         model = VirtualMachine
         fields = "__all__"
@@ -87,7 +82,6 @@ class VirtualMachineWithConfigContextSerializer(VirtualMachineSerializer):
 class VMInterfaceSerializer(
     InterfaceCommonSerializer,
 ):
-    url = serializers.HyperlinkedIdentityField(view_name="virtualization-api:vminterface-detail")
     mode = ChoiceField(choices=InterfaceModeChoices, allow_blank=True, required=False)
 
     class Meta:

--- a/nautobot/virtualization/tests/test_api.py
+++ b/nautobot/virtualization/tests/test_api.py
@@ -241,10 +241,7 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
             **self.header,
         )
         self.assertHttpStatus(response, status.HTTP_200_OK)
-        self.assertEqual(
-            str(response.data["local_config_context_schema"]),
-            f"http://nautobot.example.com{schema.get_absolute_url(api=True)}",
-        )
+        self.assertEqual(str(response.data["local_config_context_schema"]), self.absolute_api_url(schema))
 
     def test_local_config_context_schema_schema_validation_fails(self):
         """

--- a/nautobot/virtualization/tests/test_api.py
+++ b/nautobot/virtualization/tests/test_api.py
@@ -241,7 +241,10 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
             **self.header,
         )
         self.assertHttpStatus(response, status.HTTP_200_OK)
-        self.assertEqual(str(response.data["local_config_context_schema"]), str(schema.pk))
+        self.assertEqual(
+            str(response.data["local_config_context_schema"]),
+            f"http://nautobot.example.com{schema.get_absolute_url(api=True)}",
+        )
 
     def test_local_config_context_schema_schema_validation_fails(self):
         """


### PR DESCRIPTION
# Related to #3691 
# What's Changed

Change the base REST API serializer inheritance from `ModelSerializer` to `HyperlinkedModelSerializer`. This changes our rendering of related objects at depth 0 from raw PK UUIDs (which don't provide enough useful information, such as the content-type of the related object) to API URLs (which intrinsically show the type of the related object, and are also walkable by API clients to easily retrieve details of specific related objects if desired. Note that on the "write" side of the API, it's still possible to describe related objects by raw PK or by nested serializer data - this change only impacts the "read" side of the API.

This wasn't quite a drop-in replacement because for whatever reason, DRF's HyperlinkedModelSerializer, HyperlinkedRelatedField, and HyperlinkedIdentityField classes are **not** aware of URL namespacing, and so they default to trying to automatic reverse urls like `<modelname>-detail` instead of what we need of `<applabel>-api:<modelname>-detail`. I've overridden what I believe to be all of the places where this was being used incorrectly.

This lets us remove the explicit `url` field from most of our serializers as a bonus, because it's now provided automatically by the serializer now that we have correct logic in place for finding the URL for a given object instance.

![image](https://user-images.githubusercontent.com/5603551/235785551-34ae1821-c8cb-4203-bd36-667a153b7fbc.png)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
