### PR TITLE
Changed device component instantiation to be a separate method.

### DIFF
--- a/changes/3680.changed
+++ b/changes/3680.changed
@@ -1,0 +1,1 @@
+Changed device component instantiation to be a separate method.

--- a/nautobot/docs/models/dcim/device.md
+++ b/nautobot/docs/models/dcim/device.md
@@ -18,9 +18,9 @@ For Devices forming a group (Failover, Load-Sharing, Redundacy or similar) refer
 
 ## Developer API
 
-The `Device` Django model class supports a method called `create_components()`. This method is normally called during `Device.save()`, which is called whenever you save create a Device via the GUI or the REST API, but if you are working directly in the ORM and encounter one of the two following scenarios, `Device.save()` is not called:
+The `Device` Django model class supports a method called `create_components()`. This method is normally called during `device_instance.save()`, which is called whenever you save create a Device via the GUI or the REST API, but if you are working directly in the ORM and encounter one of the two following scenarios, `device_instance.save()` is not called:
 
-- Usage of `Device.objects.bulk_create()` to perform a bulk creation of Device objects
-- Usage of `Device.save()` during handling of the `nautobot_database_ready` signal (which uses [historical models](https://docs.djangoproject.com/en/3.2/topics/migrations/#historical-models))
+- Usage of `device_instance.objects.bulk_create()` to perform a bulk creation of Device objects
+- Usage of `device_instance.save()` during handling of the `nautobot_database_ready` signal (which uses [historical models](https://docs.djangoproject.com/en/3.2/topics/migrations/#historical-models))
 
-In these cases you will have to manually run `Device.create_components()` in order to instantiate the [device type's](devicetype.md) component templates (interfaces, power ports, etc.).
+In these cases you will have to manually run `device_instance.create_components()` in order to instantiate the [device type's](devicetype.md) component templates (interfaces, power ports, etc.).

--- a/nautobot/docs/models/dcim/device.md
+++ b/nautobot/docs/models/dcim/device.md
@@ -18,9 +18,9 @@ For Devices forming a group (Failover, Load-Sharing, Redundacy or similar) refer
 
 ## Developer API
 
-The `Device` Django ORM class supports a method called `create_components`. This method is normally called during `Device.save`, which is called whenever you save create a device via the GUI or the REST API, but if you are working directly in the ORM and encounter one of the two following scenarios, `Device.save` is not used:
+The `Device` Django model class supports a method called `create_components()`. This method is normally called during `Device.save()`, which is called whenever you save create a Device via the GUI or the REST API, but if you are working directly in the ORM and encounter one of the two following scenarios, `Device.save()` is not called:
 
-- Usage of `Device.bulk_create`
-- Usage of `Device.save` during handling of the `nautobot_database_ready` signal (uses [historical models](https://docs.djangoproject.com/en/3.2/topics/migrations/#historical-models))
+- Usage of `Device.objects.bulk_create()` to perform a bulk creation of Device objects
+- Usage of `Device.save()` during handling of the `nautobot_database_ready` signal (which uses [historical models](https://docs.djangoproject.com/en/3.2/topics/migrations/#historical-models))
 
-In these cases you will have to 'manually' re-run `Device.create_components` in order to instantiate the [device type's](devicetype.md) component templates (interfaces, power ports, etc.).
+In these cases you will have to manually run `Device.create_components()` in order to instantiate the [device type's](devicetype.md) component templates (interfaces, power ports, etc.).

--- a/nautobot/docs/models/dcim/device.md
+++ b/nautobot/docs/models/dcim/device.md
@@ -15,3 +15,12 @@ Device names must be unique within a site, unless the device has been assigned t
 When a device has one or more interfaces with IP addresses assigned, a primary IP for the device can be designated, for both IPv4 and IPv6.
 
 For Devices forming a group (Failover, Load-Sharing, Redundacy or similar) refer to [Device Redundancy Groups](deviceredundancygroup.md) model documentation.
+
+## Developer API
+
+The `Device` Django ORM class supports a method called `create_components`. This method is normally called during `Device.save`, which is called whenever you save create a device via the GUI or the REST API, but if you are working directly in the ORM and encounter one of the two following scenarios, `Device.save` is not used:
+
+- Usage of `Device.bulk_create`
+- Usage of `Device.save` during handling of the `nautobot_database_ready` signal (uses [historical models](https://docs.djangoproject.com/en/3.2/topics/migrations/#historical-models))
+
+In these cases you will have to 'manually' re-run `Device.create_components` in order to instantiate the [device type's](devicetype.md) component templates (interfaces, power ports, etc.).


### PR DESCRIPTION

# Closes: #DNE
# What's Changed

`Device.save` now calls `Device.create_components` to create its components. The advantage lies in the fact that now that method can be used to populate the components when the `save` method is not available, such as with `bulk_create`.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
