### PR TITLE
[Docs] Adds notes for an object's custom fields for jinja templates

### DIFF
--- a/changes/3695.added
+++ b/changes/3695.added
@@ -1,0 +1,1 @@
+Added note to documentation about using `{{ obj.cf }}` to access custom fields in jinja templates.

--- a/nautobot/docs/models/extras/computedfield.md
+++ b/nautobot/docs/models/extras/computedfield.md
@@ -41,6 +41,9 @@ Computed field templates can utilize the context of the object the field is bein
 {{ obj.site.name }}
 ```
 
+!!! note
+    To access custom fields of an object within a template, use the `cf` attribute. For example, `{{ obj.cf.color }}` will return the value (if any) for a custom field named `color` on `obj`.
+
 ## Computed Field Template Filters
 
 Computed field templates can also utilize built-in Jinja2 filters or custom ones that have been registered via plugins. These filters can be used by providing the name of the filter function. As an example:

--- a/nautobot/docs/models/extras/customlink.md
+++ b/nautobot/docs/models/extras/customlink.md
@@ -51,6 +51,9 @@ As another example, if you wanted to show only devices belonging to a certain ma
 
 The link will only appear when viewing a device with a manufacturer name of "Cisco."
 
+!!! note
+    To access custom fields of an object within a template, use the `cf` attribute. For example, `{{ obj.cf.color }}` will return the value (if any) for a custom field named `color` on `obj`.
+
 ## Link Groups
 
 Group names can be specified to organize links into groups. Links with the same group name will render as a dropdown menu beneath a single button bearing the name of the group.

--- a/nautobot/docs/models/extras/exporttemplate.md
+++ b/nautobot/docs/models/extras/exporttemplate.md
@@ -16,7 +16,8 @@ Height: {{ rack.u_height }}U
 {% endfor %}
 ```
 
-To access custom fields of an object within a template, use the `cf` attribute. For example, `{{ obj.cf.color }}` will return the value (if any) for a custom field named `color` on `obj`.
+!!! note
+    To access custom fields of an object within a template, use the `cf` attribute. For example, `{{ obj.cf.color }}` will return the value (if any) for a custom field named `color` on `obj`.
 
 A MIME type and file extension can optionally be defined for each export template. The default MIME type is `text/plain`.
 

--- a/nautobot/docs/models/extras/jobbutton.md
+++ b/nautobot/docs/models/extras/jobbutton.md
@@ -73,6 +73,9 @@ The button will only appear if they have the permission to run jobs.
 
 ![Job Buttons on Site object](../../media/models/site_jobbuttons.png "Job Buttons on Site object")
 
+!!! note
+    To access custom fields of an object within a template, use the `cf` attribute. For example, `{{ obj.cf.color }}` will return the value (if any) for a custom field named `color` on `obj`.
+
 ## Job Button Receivers
 
 Job Buttons are only able to initiate a specific type of job called a **Job Button Receiver**. These are jobs that subclass the `nautobot.extras.jobs.JobButtonReceiver` class. Job Button Receivers are similar to normal jobs except they are hard coded to accept only `object_pk` and `object_model_name` [variables](../../additional-features/jobs.md#variables). Job Button Receivers are hidden from the jobs listing UI by default but otherwise function similarly to other jobs. The `JobButtonReceiver` class only implements one method called `receive_job_button`.

--- a/nautobot/docs/models/extras/secret.md
+++ b/nautobot/docs/models/extras/secret.md
@@ -29,3 +29,6 @@ In some cases you may have a collection of closely related secrets values that a
 
 - A "Device Password" secret could use the *Text File* provider and specify the file `path` as `"/opt/nautobot/device_passwords/{{ obj.site.slug }}/{{ obj.name }}.txt"`, so that a device `csr1` at site `nyc` would be able to retrieve its password value from `/opt/nautobot/device_passwords/nyc/csr1.txt`.
 - A "Git Token" secret could use the *Environment Variable* provider and specify the `variable` name as `"GIT_TOKEN_{{ obj.slug | replace('-', '_') | upper }}"`, so that a Git repository `golden-config` would be able to retrieve its token value from `$GIT_TOKEN_GOLDEN_CONFIG`.
+
+!!! note
+    To access custom fields of an object within a template, use the `cf` attribute. For example, `{{ obj.cf.color }}` will return the value (if any) for a custom field named `color` on `obj`.


### PR DESCRIPTION
# Closes: #3695 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Just adding a note to use `obj.cf.foo` to access an object's custom fields to help steer users away from trying to use `obj._custom_field_data.foo` as the latter does not work due to the [Jinja2 SandboxEnvironment](https://jinja.palletsprojects.com/en/3.0.x/sandbox/).

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
