### PR TITLE
Fix `related_name` performance for Git Repo Jobs

### DIFF
--- a/changes/3704.fixed
+++ b/changes/3704.fixed
@@ -1,0 +1,1 @@
+Fixed GitRepository fetching on Home Page when getting repo-based Job's name.

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -673,7 +673,7 @@ class JobResult(BaseModel, CustomFieldModel):
         if self.job_model:
             # No need to call related_object(), getting the Job class name if we already have a job_model
             return self.job_model.name
-        elif not self.job_model and self.obj_type == get_job_content_type():
+        elif self.obj_type == get_job_content_type():
             # Related object is an extras.Job subclass but the Job Model has been deleted
             # Calling self.related_object will call ensure_git_repository() but will ultimately return None
             return self.name

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -666,9 +666,12 @@ class JobResult(BaseModel, CustomFieldModel):
     @property
     def related_name(self):
         """
-        Similar to self.name, but if there's an appropriate `related_object`, use its name instead.
-
-        Since this calls related_object, the same potential performance concerns exist. Use with caution.
+        A human-friendlier "name" for the Job Result.
+        
+        This is commonly the name for extras.Job based jobs, but if the definition of the Job
+        or in cases of Git Repositories or other Related Objects there is no Job name definition available.
+        
+        Properly handle those cases.
         """
         if self.job_model:
             # No need to call related_object(), getting the Job class name if we already have a job_model

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -667,10 +667,10 @@ class JobResult(BaseModel, CustomFieldModel):
     def related_name(self):
         """
         A human-friendlier "name" for the Job Result.
-        
+
         This is commonly the name for extras.Job based jobs, but if the definition of the Job
         or in cases of Git Repositories or other Related Objects there is no Job name definition available.
-        
+
         Properly handle those cases.
         """
         if self.job_model:

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -670,6 +670,15 @@ class JobResult(BaseModel, CustomFieldModel):
 
         Since this calls related_object, the same potential performance concerns exist. Use with caution.
         """
+        if self.job_model:
+            # No need to call related_object(), getting the Job class name if we already have a job_model
+            return self.job_model.name
+        elif not self.job_model and self.obj_type == get_job_content_type():
+            # Related object is an extras.Job subclass but the Job Model has been deleted
+            # Calling self.related_object will call ensure_git_repository() but will ultimately return None
+            return self.name
+
+        # At this point related_object is likely a GitRepository
         related_object = self.related_object
         if not related_object:
             return self.name


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3704
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Calling `related_name` on Job Results of GitRepository-based Jobs ultimately called `ensure_git_repository`. Scenarios needed to be addressed:

- If the `Job` is installed, we almost certainly have a `JobModel` for it, and therefore just grab the name from there
- If the `Job` has been removed (`GitRepository` removed for example) we should still have a hidden `JobModel` for it, so grab the name from there
- If the `Job` has been removed and so has the `JobModel` the `get_jobs` code shouldn't be doing a sync so we probably won't get it if we call `ensure_git_repository` anyway, in fact, it returns `None` and we fall back to `self.name`. Just do that without needing to call `ensure_git_repository`.

The side benefit of this change is that in scenario two above, we don't return the less-friendly class path when we have the JobModel anyway:

<img width="505" alt="Screenshot 2023-05-04 at 23 28 40" src="https://user-images.githubusercontent.com/31187/236374434-7ea97d89-8c88-41fc-b3a4-4a82d07e53fe.png">

instead of

<img width="504" alt="Screenshot 2023-05-04 at 23 28 14" src="https://user-images.githubusercontent.com/31187/236374457-8dd8050f-ffaf-43f6-adbc-224b1ad1b95a.png">


**Demo Before**


https://user-images.githubusercontent.com/31187/236374548-56a2b47e-92f0-4452-9d9d-347451eb6b9c.mov


**Demo After**


https://user-images.githubusercontent.com/31187/236374569-d4b024eb-7f75-4250-bc75-24da7619246a.mov




# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [NA] Documentation Updates (when adding/changing features)
- [NA] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
