### PR TITLE
Fix #3726, handle cable_terminations filters

### DIFF
--- a/changes/3726.fixed
+++ b/changes/3726.fixed
@@ -1,0 +1,1 @@
+Fixed a `KeyError` when filtering Cables in the UI by `termination_a_type` or `termination_b_type`.

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -910,6 +910,9 @@ def get_filterset_parameter_form_field(model, parameter, filterset=None):
         # While there are other objects using `ContentTypeMultipleChoiceFilter`, the case where
         # models that have sucha  filter and the `verbose_name_plural` has multiple words is ony one: "dynamic groups".
         plural_name = slugify_dashes_to_underscores(model._meta.verbose_name_plural)
+        # Cable-connectable models use "cable_terminations", not "cables", as the feature name
+        if plural_name == "cables":
+            plural_name == "cable_terminations"
         try:
             form_field = MultipleContentTypeField(choices_as_strings=True, feature=plural_name)
         except KeyError:


### PR DESCRIPTION
# Closes: #3726 
# What's Changed

Mapping of models to feature names is inherently problematic, but as a spot fix, I've corrected the logic to fix "cables" to "cable_terminations" when doing a feature query.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
