### PR TITLE
Fix default descriptions of REST API endpoints in the openapi schema.

### DIFF
--- a/changes/3786.fixed
+++ b/changes/3786.fixed
@@ -1,0 +1,1 @@
+Fixed default descriptions of REST API actions in the OpenAPI schema to be more accurate.


### PR DESCRIPTION
Heavily based on https://github.com/netbox-community/netbox/pull/12218

# Closes: #<ISSUE NUMBER GOES HERE>
# What's Changed

Implement an improved `get_description` method in Nautobot's schema generation to handle the many, many cases where our API viewsets don't provide bespoke docstrings.

Before:

![image](https://github.com/nautobot/nautobot/assets/5603551/01cb5e7d-320f-4828-8428-7de938486445)

![image](https://github.com/nautobot/nautobot/assets/5603551/1ec661df-0bc3-49d5-90c3-82f256d93127)

![image](https://github.com/nautobot/nautobot/assets/5603551/1e4eb37c-25f1-4e9c-b49d-2185873bccdf)


After:

![image](https://github.com/nautobot/nautobot/assets/5603551/956973d3-912d-4341-9a62-3ba9f0f8cca5)

![image](https://github.com/nautobot/nautobot/assets/5603551/8330ed07-1686-4446-8405-14f801d4775e)

![image](https://github.com/nautobot/nautobot/assets/5603551/d53b53e2-5270-46c3-9178-1d020ed9e695)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
