### PR TITLE
Fix MySQL Out of sort memory error in Job list views (#3787)

### DIFF
--- a/changes/3787.fixed
+++ b/changes/3787.fixed
@@ -1,0 +1,1 @@
+Fixed MySQL `Out of sort memory` error on `JobListView` and `JobResultListView`.

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -341,7 +341,12 @@ class Job(PrimaryModel):
 
     @property
     def latest_result(self):
-        """Return the most recent JobResult object associated with this Job."""
+        """
+        Return the most recent JobResult object associated with this Job.
+        
+        Note that, as a performance optimization for this function's repeated use in
+        JobListview, the returned object only includes its `status` field.
+        """
         if self._latest_result is None:
             self._latest_result = self.results.only("status").first()
         return self._latest_result

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -343,7 +343,7 @@ class Job(PrimaryModel):
     def latest_result(self):
         """
         Return the most recent JobResult object associated with this Job.
-        
+
         Note that, as a performance optimization for this function's repeated use in
         JobListview, the returned object only includes its `status` field.
         """

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -342,7 +342,7 @@ class Job(PrimaryModel):
     @property
     def latest_result(self):
         if self._latest_result is None:
-            self._latest_result = self.results.first()
+            self._latest_result = self.results.only("status").first()
         return self._latest_result
 
     @property

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -341,6 +341,7 @@ class Job(PrimaryModel):
 
     @property
     def latest_result(self):
+        """Return the most recent JobResult object associated with this Job."""
         if self._latest_result is None:
             self._latest_result = self.results.only("status").first()
         return self._latest_result

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1503,7 +1503,7 @@ class JobResultDeleteView(generic.ObjectDeleteView):
 
 
 class JobResultBulkDeleteView(generic.BulkDeleteView):
-    queryset = JobResult.objects.all()
+    queryset = JobResult.objects.defer("data").all()
     table = tables.JobResultTable
 
 

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1491,7 +1491,7 @@ class JobResultListView(generic.ObjectListView):
     List JobResults
     """
 
-    queryset = JobResult.objects.select_related("job_model", "obj_type", "user").prefetch_related("logs")
+    queryset = JobResult.objects.defer("data").select_related("job_model", "obj_type", "user").prefetch_related("logs")
     filterset = filters.JobResultFilterSet
     filterset_form = forms.JobResultFilterForm
     table = tables.JobResultTable


### PR DESCRIPTION
# Closes: #3787
# What's Changed
For the `JobResultListView` the `defer("data")` has been added to the queryset. This avoids the sort memory issue and speeds up the page load.

For  the `JobListView` the issue is with the `Last Status` column in the table.  This column uses the `latest_result` accessor, which is a property on the `Job` model. This property returns the complete object, when it only requires the `status` field.  This property is not used elsewhere in the Nautobot code, aside from the tests.


# TODO
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
