### PR TITLE
Fix 'unsupported operand type' exception (#3789)

### DIFF
--- a/changes/3789.fixed
+++ b/changes/3789.fixed
@@ -1,0 +1,1 @@
+Fixed Exception `unsupported operand type(s) for -: 'list' and 'list'` for MultiObjectVar with missing UUID.

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -429,9 +429,10 @@ class BaseJob:
                 queryset = var.field_attrs["queryset"].filter(pk__in=value)
                 if queryset.count() < len(value):
                     # Not all objects found
-                    not_found_pk_list = value - list(queryset.values_list("pk", flat=True))
+                    found_pks = set(queryset.values_list("pk", flat=True))
+                    not_found_pks = set(value).difference(found_pks)
                     raise queryset.model.DoesNotExist(
-                        f"Failed to find requested objects for var {field_name}: [{', '.join(not_found_pk_list)}]"
+                        f"Failed to find requested objects for var {field_name}: [{', '.join(not_found_pks)}]"
                     )
                 return_data[field_name] = var.field_attrs["queryset"].filter(pk__in=value)
 


### PR DESCRIPTION
# Closes: #3789
# What's Changed
The 'unsupported operand type' exception is raised due to an attempt to subtract one list from another list.  
The proposed change coerces the lists to sets, and takes the difference.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
