### PR TITLE
Fix #2799 - change default REST API versioning behavior to latest.

### DIFF
--- a/changes/2799.changed
+++ b/changes/2799.changed
@@ -1,0 +1,1 @@
+Changed REST API versioning to default to latest instead of earliest when unspecified by the client.

--- a/nautobot/core/api/versioning.py
+++ b/nautobot/core/api/versioning.py
@@ -1,8 +1,9 @@
-from django.conf import settings
+from django.utils.functional import classproperty
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions
 from rest_framework.compat import unicode_http_header
 from rest_framework.utils.mediatypes import _MediaType
+from rest_framework.settings import api_settings
 from rest_framework.versioning import AcceptHeaderVersioning
 
 
@@ -14,15 +15,30 @@ class APIVersionMismatch(exceptions.APIException):
 class NautobotAPIVersioning(AcceptHeaderVersioning):
     """Support both accept-header versioning and query-parameter versioning as options."""
 
-    invalid_version_in_header = _('Invalid version in "Accept" header. Supported versions are %(versions)s') % {
-        "versions": ", ".join(settings.REST_FRAMEWORK["ALLOWED_VERSIONS"])
-    }
-    invalid_version_in_query = _("Invalid version in query parameter. Supported versions are %(versions)s") % {
-        "versions": ", ".join(settings.REST_FRAMEWORK["ALLOWED_VERSIONS"])
-    }
-
     header_version_param = "version"  # staying consistent with pre-1.3 versions of Nautobot
     query_version_param = "api_version"  # to avoid ambiguity with filtersets potentially including a "version" param
+
+    @classproperty  # https://github.com/PyCQA/pylint-django/issues/240
+    def allowed_versions(cls):  # pylint: disable=no-self-argument
+        """
+        List of version strings that are accepted by this class, based on api_settings.ALLOWED_VERSIONS.
+
+        The base `AcceptHeaderVersioning.allowed_versions` is a class property that is set at import time,
+        which means that things like `@override_settings` in tests happen "too late" to change it.
+        By re-implementing it as a property, we bypass that problem.
+        """
+        return api_settings.ALLOWED_VERSIONS
+
+    @classproperty  # https://github.com/PyCQA/pylint-django/issues/240
+    def default_version(cls):  # pylint: disable=no-self-argument
+        """
+        Default version number to use if unspecified by the requester, based on api_settings.DEFAULT_VERSION.
+
+        The base `AcceptHeaderVersioning.default_version` is a class property that is set at import time,
+        which means that things like `@override_settings` in tests happen "too late" to change it.
+        By re-implementing it as a property, we bypass that problem.
+        """
+        return api_settings.DEFAULT_VERSION
 
     def determine_version(self, request, *args, **kwargs):
         """Use either Accept header or query parameter for versioning."""
@@ -40,10 +56,16 @@ class NautobotAPIVersioning(AcceptHeaderVersioning):
             raise APIVersionMismatch()
         if header_version is not None and not self.is_allowed_version(header_version):
             # Behave like AcceptHeaderVersioning
-            raise exceptions.NotAcceptable(self.invalid_version_in_header)
+            raise exceptions.NotAcceptable(
+                f'Invalid version "{header_version}" in "Accept" header. Supported versions are: '
+                + ", ".join(self.allowed_versions)
+            )
         if query_version is not None and not self.is_allowed_version(query_version):
             # Behave like QueryParameterVersioning
-            raise exceptions.NotFound(self.invalid_version_in_query)
+            raise exceptions.NotFound(
+                f'Invalid version "{query_version}" in query parameter. Supported versions are: '
+                + ", ".join(self.allowed_versions)
+            )
         version = header_version or query_version or self.default_version
         # self.default_version is always allowed, no need to re-check is_allowed_version here
         return version

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -13,7 +13,7 @@ from nautobot.core.settings_funcs import is_truthy, parse_redis_connection, Cons
 # Environment setup
 #
 
-# This is used for display in the UI.
+# This is used for display in the UI. There are also VERSION_MAJOR and VERSION_MINOR derived from this later.
 VERSION = __version__
 
 # Hostname of the system. This is displayed in the web UI footers along with the
@@ -169,11 +169,11 @@ STRICT_FILTERING = is_truthy(os.getenv("NAUTOBOT_STRICT_FILTERING", "True"))
 #
 
 REST_FRAMEWORK_VERSION = VERSION.rsplit(".", 1)[0]  # Use major.minor as API version
-current_major, current_minor = REST_FRAMEWORK_VERSION.split(".")
+VERSION_MAJOR, VERSION_MINOR = [int(v) for v in REST_FRAMEWORK_VERSION.split(".")]
 # We support all major.minor API versions from 2.0 to the present latest version.
 # Similar logic exists in tasks.py, please keep them in sync!
-assert current_major == "2", f"REST_FRAMEWORK_ALLOWED_VERSIONS needs to be updated to handle version {current_major}"
-REST_FRAMEWORK_ALLOWED_VERSIONS = [f"{current_major}.{minor}" for minor in range(0, int(current_minor) + 1)]
+assert VERSION_MAJOR == 2, f"REST_FRAMEWORK_ALLOWED_VERSIONS needs to be updated to handle version {VERSION_MAJOR}"
+REST_FRAMEWORK_ALLOWED_VERSIONS = [f"{VERSION_MAJOR}.{minor}" for minor in range(0, VERSION_MINOR + 1)]
 
 REST_FRAMEWORK = {
     "ALLOWED_VERSIONS": REST_FRAMEWORK_ALLOWED_VERSIONS,
@@ -198,9 +198,8 @@ REST_FRAMEWORK = {
         "nautobot.core.api.parsers.NautobotCSVParser",
     ),
     "DEFAULT_SCHEMA_CLASS": "nautobot.core.api.schema.NautobotAutoSchema",
-    # Version to use if the client doesn't request otherwise.
-    # This should only change (if at all) with Nautobot major (breaking) releases.
-    "DEFAULT_VERSION": "2.0",
+    # Version to use if the client doesn't request otherwise. Default to current (i.e. latest)
+    "DEFAULT_VERSION": REST_FRAMEWORK_VERSION,
     "DEFAULT_VERSIONING_CLASS": "nautobot.core.api.versioning.NautobotAPIVersioning",
     "ORDERING_PARAM": "sort",  # This is not meant to be changed by users, but is used internally by the API
     "PAGE_SIZE": None,

--- a/nautobot/core/testing/schema.py
+++ b/nautobot/core/testing/schema.py
@@ -4,6 +4,7 @@ import yaml
 from django.conf import settings
 from django.core.management import call_command
 from django.test import tag
+from rest_framework.settings import api_settings
 
 from nautobot.core.testing import views
 
@@ -18,7 +19,7 @@ class OpenAPISchemaTestCases:
             # We could load the schema from the /api/swagger.yaml endpoint in setUp(self) via self.client,
             # but it's fairly expensive to do so. Better to do so only once per class.
             cls.schemas = {}
-            for api_version in settings.REST_FRAMEWORK_ALLOWED_VERSIONS:
+            for api_version in api_settings.ALLOWED_VERSIONS:
                 out = StringIO()
                 err = StringIO()
                 call_command("spectacular", "--api-version", api_version, stdout=out, stderr=err)

--- a/nautobot/docs/release-notes/version-2.0.md
+++ b/nautobot/docs/release-notes/version-2.0.md
@@ -128,6 +128,10 @@ Check out the [Region and Site Related Data Model Migration Guide](../installati
 
 `nautobot.utilities` no longer exists as a separate Python module or Django app. Its functionality has been collapsed into the `nautobot.core` app. See details at [Python Code Location Changes](../installation/upgrading-from-nautobot-v1.md#python-code-location-changes).
 
+#### REST API Versioning Behavior ([#2799](https://github.com/nautobot/nautobot/issues/2799))
+
+In Nautobot 2.0 and later, the REST API defaults, when the caller doesn't request a specific API version, to using the latest available version of the REST API. This is a change from Nautobot 1.x, where the default behavior was to use the 1.2 version of the REST API even when newer versions were available.
+
 #### Revamped CSV Import and Export ([#2569](https://github.com/nautobot/nautobot/issues/2569), [#3715](https://github.com/nautobot/nautobot/issues/3715))
 
 Exporting objects and lists of objects to CSV format has been totally reimplemented in a new framework for ease of use and maintainability. Instead of accessing `http://nautobot/<app>/<model>/?export` you will now use the URL pattern `http://nautobot/api/<app>/<model>/?format=csv`, as the new CSV renderer is based on the REST API serializer definitions. This results in substantially more comprehensive CSV representations of many models.

--- a/nautobot/docs/rest-api/overview.md
+++ b/nautobot/docs/rest-api/overview.md
@@ -96,17 +96,18 @@ As of Nautobot 1.3, the REST API supports multiple versions. A REST API client m
 
 Generally the former approach is recommended when writing automated API integrations, as it can be set as a general request header alongside the [authentication token](authentication.md) and re-used across a series of REST API interactions, while the latter approach may be more convenient when initially exploring the REST API via the interactive documentation as described above.
 
-### Default Versions and Backward Compatibility
+### Default Versions
 
-By default, a REST API request that does not specify an API version number will default to compatibility with a specified Nautobot version. This default REST API version can be expected to remain constant throughout the lifespan of a given Nautobot major release.
+By default, a REST API request that does not specify an API version number will default to compatibility with the current Nautobot version.
 
-!!! note
++++ 1.3.0
     For Nautobot 1.x, the default API behavior is to be compatible with the REST API of Nautobot version 1.2, in other words, for all Nautobot 1.x versions (beginning with Nautobot 1.2.0), `Accept: application/json` is functionally equivalent to `Accept: application/json; version=1.2`.
 
-    For Nautobot 2.x, the default API version is 2.0.
++/- 2.0.0
+    As of Nautobot 2.0, the default API behavior is changed to use the latest available REST API version. In other words, the default REST API version for Nautobot 2.0.y will be `2.0`, for Nautobot 2.1.y will be `2.1`, etc. This means that REST API clients that do not explicitly request a particular REST API version may encounter potentially [breaking changes](#breaking-changes) in the REST API when Nautobot is upgraded to a new minor or major version.
 
-!!! tip
-    The default REST API version compatibility may change in a subsequent Nautobot major release, so as a best practice, it is recommended that a REST API client _should always_ request the exact Nautobot REST API version that it is compatible with, rather than relying on the default behavior to remain constant.
+!!! important
+    As a best practice, it is recommended that a REST API client _should always_ request the exact Nautobot REST API version that it is compatible with, rather than relying on the default behavior to remain constant.
 
 !!! tip
     Any successful REST API response will include an `API-Version` header showing the API version that is in use for the specific API request being handled.
@@ -127,42 +128,39 @@ Non-breaking (forward- and backward-compatible) REST API changes may be introduc
 Breaking (non-backward-compatible) REST API changes also may be introduced in major or minor Nautobot releases. Examples would include:
 
 * Removal of deprecated fields
-* Addition of new, _required_ fields in POST/PUT/PATCH requests
+* Addition of new, _required_ fields in POST/PUT/PATCH requests or changing an existing field from optional to required
 * Changed field types (for example, changing a single value to a list of values)
 * Redesigned API (for example, listing and accessing Job instances by UUID primary-key instead of by class-path string)
 
 Per Nautobot's [feature-deprecation policy](../development/index.md#deprecation-policy), the previous REST API version(s) will continue to be supported until the next major release. Upon the next major release, previously deprecated API versions will be removed and the newest behavior will become the default. You will no longer be able to request API versions from the previous major version.
 
 !!! important
-    When breaking changes are introduced in a minor release, for compatibility as described above, the default REST API behavior within the remainder of the current major release cycle will continue to be the previous (unchanged) API version. API clients must "opt in" to the new version of the API by explicitly requesting the new API version.
-
-!!! tip
-    This is another reason to always specify the exact `major.minor` Nautobot REST API version when developing a REST API client integration, as it guarantees that the client will be receiving the latest API feature set available in that release rather than possibly defaulting to an older REST API version that is still default but is now deprecated.
+    Again, REST API clients are strongly encouraged to always specify the REST API version they are expecting, as otherwise unexpected breaking changes may be encountered when Nautobot is upgraded to a new major or minor release.
 
 ### Example of API Version Behavior
 
-As an example, let us say that Nautobot 1.3 introduced a new, _non-backwards-compatible_ REST API for the `/api/extras/jobs/` endpoint, and also introduced a new, _backwards-compatible_ set of additional fields on the `/api/dcim/sites/` endpoint. Depending on what API version a REST client interacting with Nautobot 1.3 specified (or didn't specify), it would see the following responses from the server:
+As an example, let us say that Nautobot 2.1 introduced a new, _non-backwards-compatible_ REST API for the `/api/extras/jobs/` endpoint, and also introduced a new, _backwards-compatible_ set of additional fields on the `/api/dcim/locations/` endpoint. Depending on what API version a REST client interacting with Nautobot 2.1 specified (or didn't specify), it would see the following responses from the server:
+
+| API endpoint        | Requested API version | Response                                        |
+| ------------------- | --------------------- | ----------------------------------------------- |
+| `/api/extras/jobs/` | (unspecified)         | Updated 2.1 REST API (not backwards compatible) |
+| `/api/extras/jobs/` | `2.0`                 | Deprecated 2.0-compatible REST API              |
+| `/api/extras/jobs/` | `2.1`                 | New/updated 2.1-compatible REST API             |
+
++/- 2.0.0
+    The [default behavior](#default-versions) when the API version is unspecified is changed from Nautobot 1.x.
+
+| API endpoint            | Requested API version | Response                                     |
+| ----------------------- | --------------------- | -------------------------------------------- |
+| `/api/dcim/locations/`  | (unspecified)         | 2.1-updated, 2.0-compatible REST API         |
+| `/api/dcim/locations/`  | `2.0`                 | 2.1-updated, 2.0-compatible REST API         |
+| `/api/dcim/locations/`  | `2.1`                 | 2.1-updated, 2.0-compatible REST API         |
 
 | API endpoint        | Requested API version | Response                                     |
 | ------------------- | --------------------- | -------------------------------------------- |
-| `/api/extras/jobs/` | (unspecified)         | Deprecated 1.2-compatible REST API           |
-| `/api/extras/jobs/` | `1.2`                 | Deprecated 1.2-compatible REST API           |
-| `/api/extras/jobs/` | `1.3`                 | New/updated 1.3-compatible REST API          |
-
-!!! important
-    Note again that if not specifying an API version, the client _would not_ receive the latest API version when breaking changes are present. Even though the server had Nautobot version 1.3, the default Jobs REST API behavior would be that of Nautobot 1.2. Only by actually requesting API version `1.3` was the client able to access the new Jobs REST API.
-
-| API endpoint        | Requested API version | Response                                     |
-| ------------------- | --------------------- | -------------------------------------------- |
-| `/api/dcim/sites/`  | (unspecified)         | 1.3-updated, 1.2-compatible REST API         |
-| `/api/dcim/sites/`  | `1.2`                 | 1.3-updated, 1.2-compatible REST API         |
-| `/api/dcim/sites/`  | `1.3`                 | 1.3-updated, 1.2-compatible REST API         |
-
-| API endpoint        | Requested API version | Response                                     |
-| ------------------- | --------------------- | -------------------------------------------- |
-| `/api/dcim/racks/`  | (unspecified)         | 1.2-compatible REST API (unchanged)          |
-| `/api/dcim/racks/`  | `1.2`                 | 1.2-compatible REST API (unchanged)          |
-| `/api/dcim/racks/`  | `1.3`                 | 1.3-compatible REST API (unchanged from 1.2) |
+| `/api/dcim/racks/`  | (unspecified)         | 2.1-compatible REST API (unchanged from 2.0) |
+| `/api/dcim/racks/`  | `2.0`                 | 2.1-compatible REST API (unchanged from 2.0) |
+| `/api/dcim/racks/`  | `2.1`                 | 2.1-compatible REST API (unchanged from 2.0) |
 
 ### APISelect with versioning capability
 

--- a/tasks.py
+++ b/tasks.py
@@ -651,9 +651,9 @@ def check_schema(context, api_version=None):
     else:
         nautobot_version = get_nautobot_version()
         # logic equivalent to nautobot.core.settings REST_FRAMEWORK_ALLOWED_VERSIONS - keep them in sync!
-        current_major, current_minor = nautobot_version.split(".")[:2]
-        assert current_major == "2", f"check_schemas version calc must be updated to handle version {current_major}"
-        api_versions = [f"{current_major}.{minor}" for minor in range(0, int(current_minor) + 1)]
+        current_major, current_minor = [int(v) for v in nautobot_version.split(".")[:2]]
+        assert current_major == 2, f"check_schemas version calc must be updated to handle version {current_major}"
+        api_versions = [f"{current_major}.{minor}" for minor in range(0, current_minor + 1)]
 
     for api_vers in api_versions:
         command = f"nautobot-server spectacular --api-version {api_vers} --validate --fail-on-warn --file /dev/null"


### PR DESCRIPTION
# Closes: #2799 
# What's Changed

- Change `settings.REST_FRAMEWORK["DEFAULT_VERSION"]` from a hard-coded "2.0" to instead use `settings.REST_FRAMEWORK_VERSION` (i.e. latest major.minor version)
- Everything else in the diff is cleanup and additional testing:
  - Tweak the wording of the errors raised when a client requests an invalid/unsupported API version to now include the version that was requested
  - Change `NautobotAPIVersioning` `.allowed_versions` and `.default_version` from their inherited base class behavior (set at import time) to classproperties (queried at runtime) to facilitate testing with `@override_settings` without needing to muck around inside the class itself as part of the test.
  - Explicitly expose `settings.VERSION_MAJOR` and `settings.VERSION_MINOR` as settings values
  - Reference DRF settings via its `api_settings` accessor instead of via `settings.REST_FRAMEWORK` where appropriate
  - Extend API versioning tests to test both with the actual `ALLOWED_VERSIONS` (which is just `["2.0"]` in Nautobot 2.0) as well as with an augmented set of versions that include (currently, but dynamically calculated) `"1.99"` and `"2.1"`.
  - Update documentation and release-notes to describe this change in behavior.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
