### PR TITLE
Fixed a bug that prevents  `__init__()` function of `bulk_create_form_class` being overridden in `NauotbotUIViewSet`.

### DIFF
--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -249,7 +249,7 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
                 context.update(
                     {
                         "active_tab": view.bulk_create_active_tab if view.bulk_create_active_tab else "csv-data",
-                        "fields": view.bulk_create_form_class(model).fields if view.bulk_create_form_class else None,
+                        "fields": view.bulk_create_form_class().fields if view.bulk_create_form_class else None,
                     }
                 )
             elif view.action in ["changelog", "notes"]:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3809 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
The issue was happening because I passed in `model` as a function parameter to the `bulk_create_form_class` while initializing it in the renderer. So `data.get()` essentially is doing `model.get()`, hence the error described in the issue. So removing the unnecessary `model` parameter makes it work as expected.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
