### PR TITLE
Revised all IPAM model tests to support Namespaces

### DIFF
--- a/changes/3687.fixed
+++ b/changes/3687.fixed
@@ -1,0 +1,1 @@
+Fixed a bug in `Prefix.reparent_ips()` that was too greedy in reparenting IP addresses when child prexies were deeply nested (such as /31)

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -643,7 +643,10 @@ class Prefix(PrimaryModel, StatusModel, RoleModelMixin):
     def reparent_ips(self):
         """Determine the list of child IPAddresses and set the parent to self."""
         query = IPAddress.objects.select_for_update().filter(
+            ip_version=self.ip_version,
             parent_id=self.parent_id,
+            host__gte=self.network,
+            host__lte=self.broadcast,
         )
 
         return query.update(parent=self)

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -453,7 +453,7 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             Prefix(prefix="10.0.32.0/20", status=self.status, namespace=self.namespace),
             Prefix(prefix="10.0.128.0/18", status=self.status, namespace=self.namespace),
         ]
-        [p.save() for p in prefixes]
+        [p.save() for p in prefixes]  # pylint: disable=expression-not-assigned
         missing_prefixes = netaddr.IPSet(
             [
                 "10.0.16.0/20",
@@ -469,15 +469,15 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
     def test_get_available_ips(self):
         parent_prefix = Prefix.objects.create(prefix="10.0.0.0/28", status=self.status, namespace=self.namespace)
         ip_list = [
-            IPAddress(address="10.0.0.1/32", status=self.status, namespace=self.namespace),
-            IPAddress(address="10.0.0.3/32", status=self.status, namespace=self.namespace),
-            IPAddress(address="10.0.0.5/32", status=self.status, namespace=self.namespace),
-            IPAddress(address="10.0.0.7/32", status=self.status, namespace=self.namespace),
-            IPAddress(address="10.0.0.9/32", status=self.status, namespace=self.namespace),
-            IPAddress(address="10.0.0.11/32", status=self.status, namespace=self.namespace),
-            IPAddress(address="10.0.0.13/32", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.1/26", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.3/26", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.5/26", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.7/26", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.9/26", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.11/26", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.13/26", status=self.status, namespace=self.namespace),
         ]
-        [i.save() for i in ip_list]
+        [i.save() for i in ip_list]  # pylint: disable=expression-not-assigned
         missing_ips = netaddr.IPSet(
             [
                 "10.0.0.2/32",
@@ -499,7 +499,7 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             Prefix(prefix="10.0.1.0/24", status=self.status, namespace=self.namespace),
             Prefix(prefix="10.0.2.0/24", status=self.status, namespace=self.namespace),
         ]
-        [p.save() for p in prefixes]
+        [p.save() for p in prefixes]  # pylint: disable=expression-not-assigned
         self.assertEqual(prefixes[0].get_first_available_prefix(), netaddr.IPNetwork("10.0.3.0/24"))
 
         Prefix.objects.create(prefix="10.0.3.0/24", status=self.status, namespace=self.namespace)
@@ -512,7 +512,7 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             IPAddress(address="10.0.0.2/24", status=self.status, namespace=self.namespace),
             IPAddress(address="10.0.0.3/24", status=self.status, namespace=self.namespace),
         ]
-        [i.save() for i in ip_list]
+        [i.save() for i in ip_list]  # pylint: disable=expression-not-assigned
         self.assertEqual(parent_prefix.get_first_available_ip(), "10.0.0.4/24")
 
         IPAddress.objects.create(address="10.0.0.4/24", status=self.status, namespace=self.namespace)
@@ -527,7 +527,7 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             Prefix(prefix="10.0.0.0/26", status=self.status, namespace=self.namespace),
             Prefix(prefix="10.0.0.128/26", status=self.status, namespace=self.namespace),
         ]
-        [p.save() for p in prefixes]
+        [p.save() for p in prefixes]  # pylint: disable=expression-not-assigned
         self.assertEqual(prefix.get_utilization(), (128, 256))
 
         # IPv4 Non-container Prefix /24
@@ -541,7 +541,7 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             IPAddress(address="10.0.0.0/32", status=self.status, namespace=self.namespace),
             IPAddress(address="10.0.0.255/32", status=self.status, namespace=self.namespace),
         ]
-        [i.save() for i in ip_list]
+        [i.save() for i in ip_list]  # pylint: disable=expression-not-assigned
 
         # The parent prefix has no children because of the two child /26 prefixes.
         self.assertEqual(prefix.get_utilization(), (0, 254))
@@ -564,7 +564,7 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             IPAddress(address="10.0.1.0/32", status=self.status, namespace=self.namespace),
             IPAddress(address="10.0.1.1/32", status=self.status, namespace=self.namespace),
         ]
-        [i.save() for i in ip_list]
+        [i.save() for i in ip_list]  # pylint: disable=expression-not-assigned
         self.assertEqual(prefix.get_utilization(), (2, 2))
 
         # IPv6 Non-container Prefix, network and broadcast addresses count toward utilization
@@ -573,7 +573,7 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             IPAddress(address="aaaa::0/128", status=self.status, namespace=self.namespace),
             IPAddress(address="aaaa::f/128", status=self.status, namespace=self.namespace),
         ]
-        [i.save() for i in ip_list]
+        [i.save() for i in ip_list]  # pylint: disable=expression-not-assigned
         self.assertEqual(prefix.get_utilization(), (2, 16))
 
         # Large Prefix
@@ -588,7 +588,7 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             Prefix(prefix="22.32.0.0/12", status=self.status, namespace=self.namespace),
             Prefix(prefix="22.48.0.0/12", status=self.status, namespace=self.namespace),
         ]
-        [p.save() for p in prefixes]
+        [p.save() for p in prefixes]  # pylint: disable=expression-not-assigned
         self.assertEqual(large_prefix.get_utilization(), (4194304, 16777216))
 
         # 50% utilization
@@ -611,7 +611,7 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             Prefix(prefix="ab20::/12", status=self.status, namespace=self.namespace),
             Prefix(prefix="ab30::/12", status=self.status, namespace=self.namespace),
         ]
-        [p.save() for p in prefixes]
+        [p.save() for p in prefixes]  # pylint: disable=expression-not-assigned
         self.assertEqual(large_prefix_v6.get_utilization(), (2**118, 2**120))
 
         # 50% utilization

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -1,9 +1,10 @@
-from unittest import skipIf, expectedFailure, skip
+import random
+from unittest import skipIf
 
 import netaddr
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.db import connection
+from django.db import connection, IntegrityError
 from django.test import TestCase
 
 from nautobot.core.testing.models import ModelTestCases
@@ -11,16 +12,21 @@ from nautobot.dcim import choices as dcim_choices
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType
 from nautobot.extras.models import Role, Status
 from nautobot.ipam.choices import IPAddressStatusChoices, PrefixTypeChoices
-from nautobot.ipam.models import IPAddress, IPAddressToInterface, Namespace, Prefix, VLAN, VLANGroup, VRF
+from nautobot.ipam.models import IPAddress, IPAddressToInterface, Namespace, Prefix, VLAN, VLANGroup
 from nautobot.virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
 
 
-@skip
+# TODO(jathan): Add VRF model tests.
+
+
 class IPAddressToInterfaceTest(TestCase):
     """Tests for `nautobot.ipam.models.IPAddressToInterface`."""
 
     @classmethod
     def setUpTestData(cls):
+        cls.namespace = Namespace.objects.first()
+        cls.status = Status.objects.get(name="Active")
+        cls.prefix = Prefix.objects.create(prefix="192.0.2.0/24", status=cls.status, namespace=cls.namespace)
         cls.test_device = Device.objects.create(
             name="device1",
             role=Role.objects.get_for_model(Device).first(),
@@ -71,7 +77,7 @@ class IPAddressToInterfaceTest(TestCase):
         ip_to_interface_2 = IPAddressToInterface.objects.get(interface=self.test_int2, ip_address=dev_ip_addr)
         self.assertIsNotNone(ip_to_interface_1)
         self.assertIsNotNone(ip_to_interface_2)
-        if dev_ip_addr.family == 4:
+        if dev_ip_addr.ip_version == 4:
             self.test_device.primary_ip4 = dev_ip_addr
         else:
             self.test_device.primary_ip6 = dev_ip_addr
@@ -80,7 +86,7 @@ class IPAddressToInterfaceTest(TestCase):
         # Since the second Interface still contains that IPAddress
         self.test_int1.remove_ip_addresses(dev_ip_addr)
         self.test_device.refresh_from_db()
-        if dev_ip_addr.family == 4:
+        if dev_ip_addr.ip_version == 4:
             self.assertEqual(self.test_device.primary_ip4, dev_ip_addr)
         else:
             self.assertEqual(self.test_device.primary_ip6, dev_ip_addr)
@@ -88,7 +94,7 @@ class IPAddressToInterfaceTest(TestCase):
         # that contains the primary ip
         self.test_int2.remove_ip_addresses(dev_ip_addr)
         self.test_device.refresh_from_db()
-        if dev_ip_addr.family == 4:
+        if dev_ip_addr.ip_version == 4:
             self.assertEqual(self.test_device.primary_ip4, None)
         else:
             self.assertEqual(self.test_device.primary_ip6, None)
@@ -104,7 +110,7 @@ class IPAddressToInterfaceTest(TestCase):
         ip_to_vminterface_2 = IPAddressToInterface.objects.get(vm_interface=self.test_vmint2, ip_address=vm_ip_addr)
         self.assertIsNotNone(ip_to_vminterface_1)
         self.assertIsNotNone(ip_to_vminterface_2)
-        if vm_ip_addr.family == 4:
+        if vm_ip_addr.ip_version == 4:
             self.test_vm.primary_ip4 = vm_ip_addr
         else:
             self.test_vm.primary_ip6 = vm_ip_addr
@@ -113,7 +119,7 @@ class IPAddressToInterfaceTest(TestCase):
         # Since the second Interface still contains that IPAddress
         self.test_vmint1.remove_ip_addresses(vm_ip_addr)
         self.test_vm.refresh_from_db()
-        if vm_ip_addr.family == 4:
+        if vm_ip_addr.ip_version == 4:
             self.assertEqual(self.test_vm.primary_ip4, vm_ip_addr)
         else:
             self.assertEqual(self.test_vm.primary_ip6, vm_ip_addr)
@@ -121,13 +127,13 @@ class IPAddressToInterfaceTest(TestCase):
         # that contains the primary ip
         self.test_vmint2.remove_ip_addresses(vm_ip_addr)
         self.test_vm.refresh_from_db()
-        if vm_ip_addr.family == 4:
+        if vm_ip_addr.ip_version == 4:
             self.assertEqual(self.test_vm.primary_ip4, None)
         else:
             self.assertEqual(self.test_vm.primary_ip6, None)
 
     def test_ip_address_to_interface_uniqueness_constraint(self):
-        ip_addr = IPAddress.objects.create(address="192.0.2.1/24")
+        ip_addr = IPAddress.objects.create(address="192.0.2.1/24", status=self.status, namespace=self.namespace)
         IPAddressToInterface.objects.create(interface=self.test_int1, ip_address=ip_addr)
         with self.assertRaises(ValidationError):
             IPAddressToInterface.objects.create(
@@ -138,7 +144,7 @@ class IPAddressToInterfaceTest(TestCase):
             IPAddressToInterface.objects.create(vm_interface=self.test_vmint1, ip_address=ip_addr)
 
     def test_pre_save_signal_invoked_on_ip_address_to_interface_manual_creation(self):
-        ip_addr = IPAddress.objects.create(address="192.0.2.1/24")
+        ip_addr = IPAddress.objects.create(address="192.0.2.1/24", status=self.status, namespace=self.namespace)
         with self.assertRaises(ValidationError) as cm:
             IPAddressToInterface.objects.create(
                 vm_interface=self.test_vmint1, interface=self.test_int1, ip_address=ip_addr
@@ -158,7 +164,9 @@ class TestVarbinaryIPField(TestCase):
         super().setUp()
 
         # Field is a VarbinaryIPField we'll use to test.
-        self.prefix = Prefix.objects.create(prefix="10.0.0.0/24")
+        self.namespace = Namespace.objects.first()
+        self.status = Status.objects.get(name="Active")
+        self.prefix = Prefix.objects.create(prefix="10.0.0.0/24", status=self.status, namespace=self.namespace)
         self.field = self.prefix._meta.get_field("network")
         self.network = self.prefix.network
         self.network_packed = bytes(self.prefix.prefix.network)
@@ -251,7 +259,6 @@ class TestVarbinaryIPField(TestCase):
         self.assertEqual(prepped, manual)
 
 
-@skip
 class TestPrefix(ModelTestCases.BaseModelTestCase):
     model = Prefix
 
@@ -259,20 +266,22 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
         super().setUp()
         # With advent of `Prefix.parent`, Prefixes can't just be bulk deleted without clearing their
         # `parent` first in an `update()` query which doesn't call `save()` or `fire `(pre|post)_save` signals.
+        IPAddress.objects.update(parent=None)
+        IPAddress.objects.all().delete()
         Prefix.objects.update(parent=None)
         Prefix.objects.all().delete()
-        IPAddress.objects.all().delete()
+        self.namespace = Namespace.objects.first()
         self.statuses = Status.objects.get_for_model(Prefix)
         self.status = self.statuses.first()
-        self.root = Prefix.objects.create(prefix="101.102.0.0/24", status=self.status)
-        self.parent = Prefix.objects.create(prefix="101.102.0.0/25", status=self.status)
-        self.child1 = Prefix.objects.create(prefix="101.102.0.0/26", status=self.status)
-        self.child2 = Prefix.objects.create(prefix="101.102.0.64/26", status=self.status)
+        self.root = Prefix.objects.create(prefix="101.102.0.0/24", status=self.status, namespace=self.namespace)
+        self.parent = Prefix.objects.create(prefix="101.102.0.0/25", status=self.status, namespace=self.namespace)
+        self.child1 = Prefix.objects.create(prefix="101.102.0.0/26", status=self.status, namespace=self.namespace)
+        self.child2 = Prefix.objects.create(prefix="101.102.0.64/26", status=self.status, namespace=self.namespace)
 
     def test_prefix_validation(self):
         location_type = LocationType.objects.get(name="Room")
         location = Location.objects.filter(location_type=location_type).first()
-        prefix = Prefix(prefix=netaddr.IPNetwork("192.0.2.0/24"), location=location)
+        prefix = Prefix(prefix="192.0.2.0/24", location=location)
         prefix.status = self.statuses[0]
         with self.assertRaises(ValidationError) as cm:
             prefix.validated_save()
@@ -328,11 +337,10 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
         # siblings()
         self.assertEqual(list(self.child1.siblings()), [self.child2])
         self.assertEqual(list(self.child1.siblings(include_self=True)), [self.child1, self.child2])
-        parent2 = Prefix.objects.create(prefix="101.102.0.128/25", status=self.status)
+        parent2 = Prefix.objects.create(prefix="101.102.0.128/25", status=self.status, namespace=self.namespace)
         self.assertEqual(list(self.parent.siblings()), [parent2])
         self.assertEqual(list(self.parent.siblings(include_self=True)), [self.parent, parent2])
 
-    # TODO(jathan): When Namespaces are implemented, these tests must be extended to assert it.
     def test_reparenting(self):
         """Test that reparenting algorithm works in its most basic form."""
         # tree hierarchy
@@ -351,7 +359,7 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
         self.assertEqual(self.child2.parent, self.root)
         self.assertEqual(list(self.child1.ancestors()), [self.root])
 
-        # Add /25 back in as a partn and assert that child1/child2 now have it as their parent, and
+        # Add /25 back in as a parent and assert that child1/child2 now have it as their parent, and
         # /24 is its parent.
         self.parent.save()  # This creates another Prefix using the same instance.
         self.child1.refresh_from_db()
@@ -360,14 +368,51 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
         self.assertEqual(self.child2.parent, self.parent)
         self.assertEqual(list(self.child1.ancestors()), [self.root, self.parent])
 
+        # Now let's create some duplicates in another Namespace and perform the same tests.
+
+        namespace = random.choice(Namespace.objects.exclude(name="Global"))
+        root = Prefix.objects.create(prefix="101.102.0.0/24", status=self.status, namespace=namespace)
+        parent = Prefix.objects.create(prefix="101.102.0.0/25", status=self.status, namespace=namespace)
+        child1 = Prefix.objects.create(prefix="101.102.0.0/26", status=self.status, namespace=namespace)
+        child2 = Prefix.objects.create(prefix="101.102.0.64/26", status=self.status, namespace=namespace)
+
+        # tree hierarchy
+        self.assertIsNone(root.parent)
+        self.assertEqual(parent.parent, root)
+        self.assertEqual(child1.parent, parent)
+
+        # Delete the parent (/25); child1/child2 now have root (/24) as their parent.
+        num_deleted, _ = parent.delete()
+        self.assertEqual(num_deleted, 1)
+
+        self.assertEqual(list(root.children.all()), [child1, child2])
+        child1.refresh_from_db()
+        child2.refresh_from_db()
+        self.assertEqual(child1.parent, root)
+        self.assertEqual(child2.parent, root)
+        self.assertEqual(list(child1.ancestors()), [root])
+
+        # Add /25 back in as a parent and assert that child1/child2 now have it as their parent, and
+        # /24 is its parent.
+        parent.save()  # This creates another Prefix using the same instance.
+        child1.refresh_from_db()
+        child2.refresh_from_db()
+        self.assertEqual(child1.parent, parent)
+        self.assertEqual(child2.parent, parent)
+        self.assertEqual(list(child1.ancestors()), [root, parent])
+
     def test_descendants(self):
-        vrfs = VRF.objects.all()[:3]
         prefixes = (
-            Prefix.objects.create(prefix=netaddr.IPNetwork("10.0.0.0/16"), type=PrefixTypeChoices.TYPE_CONTAINER),
-            Prefix.objects.create(prefix=netaddr.IPNetwork("10.0.0.0/24"), vrf=None),
-            Prefix.objects.create(prefix=netaddr.IPNetwork("10.0.1.0/24"), vrf=vrfs[0]),
-            Prefix.objects.create(prefix=netaddr.IPNetwork("10.0.2.0/24"), vrf=vrfs[1]),
-            Prefix.objects.create(prefix=netaddr.IPNetwork("10.0.3.0/24"), vrf=vrfs[2]),
+            Prefix.objects.create(
+                prefix="10.0.0.0/16",
+                type=PrefixTypeChoices.TYPE_CONTAINER,
+                status=self.status,
+                namespace=self.namespace,
+            ),
+            Prefix.objects.create(prefix="10.0.0.0/24", status=self.status, namespace=self.namespace),
+            Prefix.objects.create(prefix="10.0.1.0/24", status=self.status, namespace=self.namespace),
+            Prefix.objects.create(prefix="10.0.2.0/24", status=self.status, namespace=self.namespace),
+            Prefix.objects.create(prefix="10.0.3.0/24", status=self.status, namespace=self.namespace),
         )
         prefix_pks = {p.pk for p in prefixes[1:]}
         child_prefix_pks = {p.pk for p in prefixes[0].descendants()}
@@ -375,67 +420,46 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
         # Global container should return all children
         self.assertSetEqual(child_prefix_pks, prefix_pks)
 
-        # TODO(jathan): VRF is no longer considered for uniqueness/parenting algorithm, so this
-        # check is no longer valid so we'll filter it by VRF for now to keep the test working.
-        prefixes[0].vrf = vrfs[0]
-        prefixes[0].save()
-        child_prefix_pks = {p.pk for p in prefixes[0].descendants().filter(vrf=vrfs[0])}
-
-        # VRF container is limited to its own VRF
-        self.assertSetEqual(child_prefix_pks, {prefixes[2].pk})
-
     def test_child_ip_addresses(self):
-        vrfs = VRF.objects.all()[:3]
-        namespace = Namespace.objects.first()
         parent_prefix = Prefix.objects.create(
-            prefix=netaddr.IPNetwork("10.0.0.0/16"), namespace=namespace, type=PrefixTypeChoices.TYPE_CONTAINER
+            prefix="10.0.0.0/16", status=self.status, namespace=self.namespace, type=PrefixTypeChoices.TYPE_CONTAINER
         )
         ips = (
-            IPAddress.objects.create(address=netaddr.IPNetwork("10.0.0.1/24"), namespace=namespace, vrf=None),
-            IPAddress.objects.create(address=netaddr.IPNetwork("10.0.1.1/24"), namespace=namespace, vrf=vrfs[0]),
-            IPAddress.objects.create(address=netaddr.IPNetwork("10.0.2.1/24"), namespace=namespace, vrf=vrfs[1]),
-            IPAddress.objects.create(address=netaddr.IPNetwork("10.0.3.1/24"), namespace=namespace, vrf=vrfs[2]),
+            IPAddress.objects.create(address="10.0.0.1/24", status=self.status, namespace=self.namespace),
+            IPAddress.objects.create(address="10.0.1.1/24", status=self.status, namespace=self.namespace),
+            IPAddress.objects.create(address="10.0.2.1/24", status=self.status, namespace=self.namespace),
+            IPAddress.objects.create(address="10.0.3.1/24", status=self.status, namespace=self.namespace),
         )
         child_ip_pks = {p.pk for p in parent_prefix.ip_addresses.all()}
 
         # Global container should return all children
         self.assertSetEqual(child_ip_pks, {ips[0].pk, ips[1].pk, ips[2].pk, ips[3].pk})
 
-        parent_prefix.vrf = vrfs[0]
-        parent_prefix.save()
-        child_ip_pks = {p.pk for p in parent_prefix.ip_addresses.all()}
-
-        # VRF container is limited to its own VRF
-        self.assertSetEqual(child_ip_pks, {ips[1].pk})
-
         # Make sure /31 is handled correctly
         parent_prefix_31 = Prefix.objects.create(
-            prefix=netaddr.IPNetwork("10.0.4.0/31"), namespace=namespace, type=PrefixTypeChoices.TYPE_CONTAINER
+            prefix="10.0.4.0/31", status=self.status, namespace=self.namespace, type=PrefixTypeChoices.TYPE_CONTAINER
         )
         ips_31 = (
-            IPAddress.objects.create(address=netaddr.IPNetwork("10.0.4.0/31"), namespace=namespace, vrf=None),
-            IPAddress.objects.create(address=netaddr.IPNetwork("10.0.4.1/31"), namespace=namespace, vrf=None),
+            IPAddress.objects.create(address="10.0.4.0/31", status=self.status, namespace=self.namespace),
+            IPAddress.objects.create(address="10.0.4.1/31", status=self.status, namespace=self.namespace),
         )
-
         child_ip_pks = {p.pk for p in parent_prefix_31.ip_addresses.all()}
         self.assertSetEqual(child_ip_pks, {ips_31[0].pk, ips_31[1].pk})
 
     def test_get_available_prefixes(self):
-        namespace = Namespace.objects.first()
-        prefixes = Prefix.objects.bulk_create(
-            (
-                Prefix(prefix=netaddr.IPNetwork("10.0.0.0/16"), namespace=namespace),  # Parent prefix
-                Prefix(prefix=netaddr.IPNetwork("10.0.0.0/20"), namespace=namespace),
-                Prefix(prefix=netaddr.IPNetwork("10.0.32.0/20"), namespace=namespace),
-                Prefix(prefix=netaddr.IPNetwork("10.0.128.0/18"), namespace=namespace),
-            )
-        )
+        prefixes = [
+            Prefix(prefix="10.0.0.0/16", status=self.status, namespace=self.namespace),  # Parent prefix
+            Prefix(prefix="10.0.0.0/20", status=self.status, namespace=self.namespace),
+            Prefix(prefix="10.0.32.0/20", status=self.status, namespace=self.namespace),
+            Prefix(prefix="10.0.128.0/18", status=self.status, namespace=self.namespace),
+        ]
+        [p.save() for p in prefixes]
         missing_prefixes = netaddr.IPSet(
             [
-                netaddr.IPNetwork("10.0.16.0/20"),
-                netaddr.IPNetwork("10.0.48.0/20"),
-                netaddr.IPNetwork("10.0.64.0/18"),
-                netaddr.IPNetwork("10.0.192.0/18"),
+                "10.0.16.0/20",
+                "10.0.48.0/20",
+                "10.0.64.0/18",
+                "10.0.192.0/18",
             ]
         )
         available_prefixes = prefixes[0].get_available_prefixes()
@@ -443,19 +467,17 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
         self.assertEqual(available_prefixes, missing_prefixes)
 
     def test_get_available_ips(self):
-        namespace = Namespace.objects.first()
-        parent_prefix = Prefix.objects.create(prefix=netaddr.IPNetwork("10.0.0.0/28"))
-        IPAddress.objects.bulk_create(
-            (
-                IPAddress(address=netaddr.IPNetwork("10.0.0.1/26"), namespace=namespace),
-                IPAddress(address=netaddr.IPNetwork("10.0.0.3/26"), namespace=namespace),
-                IPAddress(address=netaddr.IPNetwork("10.0.0.5/26"), namespace=namespace),
-                IPAddress(address=netaddr.IPNetwork("10.0.0.7/26"), namespace=namespace),
-                IPAddress(address=netaddr.IPNetwork("10.0.0.9/26"), namespace=namespace),
-                IPAddress(address=netaddr.IPNetwork("10.0.0.11/26"), namespace=namespace),
-                IPAddress(address=netaddr.IPNetwork("10.0.0.13/26"), namespace=namespace),
-            )
-        )
+        parent_prefix = Prefix.objects.create(prefix="10.0.0.0/28", status=self.status, namespace=self.namespace)
+        ip_list = [
+            IPAddress(address="10.0.0.1/32", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.3/32", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.5/32", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.7/32", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.9/32", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.11/32", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.13/32", status=self.status, namespace=self.namespace),
+        ]
+        [i.save() for i in ip_list]
         missing_ips = netaddr.IPSet(
             [
                 "10.0.0.2/32",
@@ -468,124 +490,136 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             ]
         )
         available_ips = parent_prefix.get_available_ips()
-
         self.assertEqual(available_ips, missing_ips)
 
     def test_get_first_available_prefix(self):
-        namespace = Namespace.objects.first()
-        prefixes = Prefix.objects.bulk_create(
-            (
-                Prefix(prefix=netaddr.IPNetwork("10.0.0.0/16"), namespace=namespace),  # Parent prefix
-                Prefix(prefix=netaddr.IPNetwork("10.0.0.0/24"), namespace=namespace),
-                Prefix(prefix=netaddr.IPNetwork("10.0.1.0/24"), namespace=namespace),
-                Prefix(prefix=netaddr.IPNetwork("10.0.2.0/24"), namespace=namespace),
-            )
-        )
+        prefixes = [
+            Prefix(prefix="10.0.0.0/16", status=self.status, namespace=self.namespace),  # Parent prefix
+            Prefix(prefix="10.0.0.0/24", status=self.status, namespace=self.namespace),
+            Prefix(prefix="10.0.1.0/24", status=self.status, namespace=self.namespace),
+            Prefix(prefix="10.0.2.0/24", status=self.status, namespace=self.namespace),
+        ]
+        [p.save() for p in prefixes]
         self.assertEqual(prefixes[0].get_first_available_prefix(), netaddr.IPNetwork("10.0.3.0/24"))
 
-        Prefix.objects.create(prefix=netaddr.IPNetwork("10.0.3.0/24"))
+        Prefix.objects.create(prefix="10.0.3.0/24", status=self.status, namespace=self.namespace)
         self.assertEqual(prefixes[0].get_first_available_prefix(), netaddr.IPNetwork("10.0.4.0/22"))
 
     def test_get_first_available_ip(self):
-        namespace = Namespace.objects.first()
-        parent_prefix = Prefix.objects.create(prefix=netaddr.IPNetwork("10.0.0.0/24"), namespace=namespace)
-        IPAddress.objects.bulk_create(
-            (
-                IPAddress(address=netaddr.IPNetwork("10.0.0.1/24"), namespace=namespace),
-                IPAddress(address=netaddr.IPNetwork("10.0.0.2/24"), namespace=namespace),
-                IPAddress(address=netaddr.IPNetwork("10.0.0.3/24"), namespace=namespace),
-            )
-        )
+        parent_prefix = Prefix.objects.create(prefix="10.0.0.0/24", status=self.status, namespace=self.namespace)
+        ip_list = [
+            IPAddress(address="10.0.0.1/24", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.2/24", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.3/24", status=self.status, namespace=self.namespace),
+        ]
+        [i.save() for i in ip_list]
         self.assertEqual(parent_prefix.get_first_available_ip(), "10.0.0.4/24")
 
-        IPAddress.objects.create(address=netaddr.IPNetwork("10.0.0.4/24"), namespace=namespace)
+        IPAddress.objects.create(address="10.0.0.4/24", status=self.status, namespace=self.namespace)
         self.assertEqual(parent_prefix.get_first_available_ip(), "10.0.0.5/24")
 
     def test_get_utilization(self):
         # Container Prefix
-        prefix = Prefix.objects.create(prefix=netaddr.IPNetwork("10.0.0.0/24"), type=PrefixTypeChoices.TYPE_CONTAINER)
-        Prefix.objects.bulk_create(
-            (
-                Prefix(prefix=netaddr.IPNetwork("10.0.0.0/26")),
-                Prefix(prefix=netaddr.IPNetwork("10.0.0.128/26")),
-            )
+        prefix = Prefix.objects.create(
+            prefix="10.0.0.0/24", type=PrefixTypeChoices.TYPE_CONTAINER, status=self.status, namespace=self.namespace
         )
+        prefixes = [
+            Prefix(prefix="10.0.0.0/26", status=self.status, namespace=self.namespace),
+            Prefix(prefix="10.0.0.128/26", status=self.status, namespace=self.namespace),
+        ]
+        [p.save() for p in prefixes]
         self.assertEqual(prefix.get_utilization(), (128, 256))
 
         # IPv4 Non-container Prefix /24
         prefix.type = PrefixTypeChoices.TYPE_NETWORK
-        prefix.save()
-        IPAddress.objects.bulk_create(
-            # Create 32 IPAddresses within the Prefix
-            [IPAddress(address=netaddr.IPNetwork(f"10.0.0.{i}/24")) for i in range(1, 33)]
-        )
+        # Create 32 IPAddresses within the Prefix
+        ip_list = [
+            IPAddress(address=f"10.0.0.{i}/24", status=self.status, namespace=self.namespace) for i in range(1, 33)
+        ]
         # Create IPAddress objects for network and broadcast addresses
-        IPAddress.objects.bulk_create(
-            (IPAddress(address=netaddr.IPNetwork("10.0.0.0/32")), IPAddress(address=netaddr.IPNetwork("10.0.0.255/32")))
-        )
-        self.assertEqual(prefix.get_utilization(), (32, 254))
+        ip_list += [
+            IPAddress(address="10.0.0.0/32", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.0.255/32", status=self.status, namespace=self.namespace),
+        ]
+        [i.save() for i in ip_list]
+
+        # The parent prefix has no children because of the two child /26 prefixes.
+        self.assertEqual(prefix.get_utilization(), (0, 254))
+
+        # The first child will have 32 IPs
+        slash26 = prefix.descendants().first()
+        self.assertEqual(slash26.get_utilization(), (32, 62))
 
         # Change prefix to a pool, network and broadcast address will count toward numerator and denominator in utilization
         prefix.type = PrefixTypeChoices.TYPE_POOL
-        prefix.save()
-        self.assertEqual(prefix.get_utilization(), (34, 256))
+        slash26.type = PrefixTypeChoices.TYPE_POOL
+        # Parent prefix only has one child IP (10.0.0.255)
+        self.assertEqual(prefix.get_utilization(), (1, 256))
+        # The slash26 will have 33.
+        self.assertEqual(slash26.get_utilization(), (33, 64))
 
         # IPv4 Non-container Prefix /31, network and broadcast addresses count toward utilization
-        prefix = Prefix.objects.create(prefix="10.0.1.0/31")
-        IPAddress.objects.bulk_create(
-            (IPAddress(address=netaddr.IPNetwork("10.0.1.0/32")), IPAddress(address=netaddr.IPNetwork("10.0.1.1/32")))
-        )
+        prefix = Prefix.objects.create(prefix="10.0.1.0/31", status=self.status, namespace=self.namespace)
+        ip_list = [
+            IPAddress(address="10.0.1.0/32", status=self.status, namespace=self.namespace),
+            IPAddress(address="10.0.1.1/32", status=self.status, namespace=self.namespace),
+        ]
+        [i.save() for i in ip_list]
         self.assertEqual(prefix.get_utilization(), (2, 2))
 
         # IPv6 Non-container Prefix, network and broadcast addresses count toward utilization
-        prefix = Prefix.objects.create(prefix="aaaa::/124")
-        IPAddress.objects.bulk_create(
-            (IPAddress(address=netaddr.IPNetwork("aaaa::0/128")), IPAddress(address=netaddr.IPNetwork("aaaa::f/128")))
-        )
+        prefix = Prefix.objects.create(prefix="aaaa::/124", status=self.status, namespace=self.namespace)
+        ip_list = [
+            IPAddress(address="aaaa::0/128", status=self.status, namespace=self.namespace),
+            IPAddress(address="aaaa::f/128", status=self.status, namespace=self.namespace),
+        ]
+        [i.save() for i in ip_list]
         self.assertEqual(prefix.get_utilization(), (2, 16))
 
         # Large Prefix
-        large_prefix = Prefix.objects.create(prefix="22.0.0.0/8", type=PrefixTypeChoices.TYPE_CONTAINER)
+        large_prefix = Prefix.objects.create(
+            prefix="22.0.0.0/8", type=PrefixTypeChoices.TYPE_CONTAINER, status=self.status, namespace=self.namespace
+        )
 
         # 25% utilization
-        Prefix.objects.bulk_create(
-            (
-                Prefix(prefix=netaddr.IPNetwork("22.0.0.0/12")),
-                Prefix(prefix=netaddr.IPNetwork("22.16.0.0/12")),
-                Prefix(prefix=netaddr.IPNetwork("22.32.0.0/12")),
-                Prefix(prefix=netaddr.IPNetwork("22.48.0.0/12")),
-            )
-        )
+        prefixes = [
+            Prefix(prefix="22.0.0.0/12", status=self.status, namespace=self.namespace),
+            Prefix(prefix="22.16.0.0/12", status=self.status, namespace=self.namespace),
+            Prefix(prefix="22.32.0.0/12", status=self.status, namespace=self.namespace),
+            Prefix(prefix="22.48.0.0/12", status=self.status, namespace=self.namespace),
+        ]
+        [p.save() for p in prefixes]
         self.assertEqual(large_prefix.get_utilization(), (4194304, 16777216))
 
         # 50% utilization
-        Prefix.objects.bulk_create((Prefix(prefix=netaddr.IPNetwork("22.64.0.0/10")),))
+        Prefix.objects.create(prefix="22.64.0.0/10", status=self.status, namespace=self.namespace)
         self.assertEqual(large_prefix.get_utilization(), (8388608, 16777216))
 
         # 100% utilization
-        Prefix.objects.bulk_create((Prefix(prefix=netaddr.IPNetwork("22.128.0.0/9")),))
+        Prefix.objects.create(prefix="22.128.0.0/9", status=self.status, namespace=self.namespace)
         self.assertEqual(large_prefix.get_utilization(), (16777216, 16777216))
 
         # IPv6 Large Prefix
-        large_prefix_v6 = Prefix.objects.create(prefix="ab00::/8", type=PrefixTypeChoices.TYPE_CONTAINER)
+        large_prefix_v6 = Prefix.objects.create(
+            prefix="ab00::/8", type=PrefixTypeChoices.TYPE_CONTAINER, status=self.status, namespace=self.namespace
+        )
 
         # 25% utilization
-        Prefix.objects.bulk_create(
-            (
-                Prefix(prefix=netaddr.IPNetwork("ab00::/12")),
-                Prefix(prefix=netaddr.IPNetwork("ab10::/12")),
-                Prefix(prefix=netaddr.IPNetwork("ab20::/12")),
-                Prefix(prefix=netaddr.IPNetwork("ab30::/12")),
-            )
-        )
+        prefixes = [
+            Prefix(prefix="ab00::/12", status=self.status, namespace=self.namespace),
+            Prefix(prefix="ab10::/12", status=self.status, namespace=self.namespace),
+            Prefix(prefix="ab20::/12", status=self.status, namespace=self.namespace),
+            Prefix(prefix="ab30::/12", status=self.status, namespace=self.namespace),
+        ]
+        [p.save() for p in prefixes]
         self.assertEqual(large_prefix_v6.get_utilization(), (2**118, 2**120))
 
         # 50% utilization
-        Prefix.objects.bulk_create((Prefix(prefix=netaddr.IPNetwork("ab40::/10")),))
+        Prefix.objects.create(prefix="ab40::/10", status=self.status, namespace=self.namespace)
         self.assertEqual(large_prefix_v6.get_utilization(), (2**119, 2**120))
 
         # 100% utilization
-        Prefix.objects.bulk_create((Prefix(prefix=netaddr.IPNetwork("ab80::/9")),))
+        Prefix.objects.create(prefix="ab80::/9", status=self.status, namespace=self.namespace)
         self.assertEqual(large_prefix_v6.get_utilization(), (2**120, 2**120))
 
     #
@@ -593,71 +627,59 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
     #
 
     def test_duplicate_global_unique(self):
-        """This should raise a ValidationError."""
-        Prefix.objects.create(prefix=netaddr.IPNetwork("192.0.2.0/24"))
-        duplicate_prefix = Prefix(prefix=netaddr.IPNetwork("192.0.2.0/24"))
+        """Test that duplicate Prefixes in the same Namespace raises an error."""
+        Prefix.objects.create(prefix="192.0.2.0/24", status=self.status, namespace=self.namespace)
+        duplicate_prefix = Prefix(prefix="192.0.2.0/24", status=self.status, namespace=self.namespace)
+        # self.assertRaises(IntegrityError, duplicate_prefix.full_clean)
         self.assertRaises(ValidationError, duplicate_prefix.full_clean)
 
 
 class TestIPAddress(ModelTestCases.BaseModelTestCase):
     model = IPAddress
 
-    @expectedFailure
-    def test_get_duplicates(self):
-        ips = (
-            IPAddress.objects.create(address=netaddr.IPNetwork("192.0.2.1/24")),
-            IPAddress.objects.create(address=netaddr.IPNetwork("192.0.2.1/24")),
-            IPAddress.objects.create(address=netaddr.IPNetwork("192.0.2.1/24")),
-        )
-        duplicate_ip_pks = [p.pk for p in ips[0].get_duplicates()]
-
-        self.assertSetEqual(set(duplicate_ip_pks), {ips[1].pk, ips[2].pk})
+    def setUp(self):
+        super().setUp()
+        self.namespace = Namespace.objects.first()
+        self.status = Status.objects.get(name="Active")
+        self.prefix = Prefix.objects.create(prefix="192.0.2.0/24", status=self.status, namespace=self.namespace)
 
     #
     # Uniqueness enforcement tests
     #
 
-    @expectedFailure
     def test_duplicate_global_unique(self):
-        namespace = Namespace.objects.first()
-        Prefix.objects.create(prefix="192.0.2.0/24", namespace=namespace)
-        IPAddress.objects.create(address=netaddr.IPNetwork("192.0.2.1/24"), namespace=namespace)
-        duplicate_ip = IPAddress(address=netaddr.IPNetwork("192.0.2.1/24"), namespace=namespace)
-        self.assertRaises(ValidationError, duplicate_ip.clean)
+        """Test that duplicate IPs in the same Namespace raises an error."""
+        IPAddress.objects.create(address="192.0.2.1/24", status=self.status, namespace=self.namespace)
+        with self.assertRaises(IntegrityError):
+            IPAddress.objects.create(address="192.0.2.1/24", status=self.status, namespace=self.namespace)
 
-    @expectedFailure
-    def test_duplicate_nonunique_role(self):
-        roles = Role.objects.get_for_model(IPAddress)
-        IPAddress.objects.create(
-            address=netaddr.IPNetwork("192.0.2.1/24"),
-            role=roles[0],
-        )
-        IPAddress.objects.create(
-            address=netaddr.IPNetwork("192.0.2.1/24"),
-            role=roles[1],
-        )
-
-    @expectedFailure
     def test_multiple_nat_outside_list(self):
         """
         Test suite to test supporing nat_outside_list.
         """
-        nat_inside = IPAddress.objects.create(address=netaddr.IPNetwork("192.168.0.1/24"))
-        nat_outside1 = IPAddress.objects.create(address=netaddr.IPNetwork("192.0.2.1/24"), nat_inside=nat_inside)
-        nat_outside2 = IPAddress.objects.create(address=netaddr.IPNetwork("192.0.2.2/24"), nat_inside=nat_inside)
-        nat_outside3 = IPAddress.objects.create(address=netaddr.IPNetwork("192.0.2.3/24"), nat_inside=nat_inside)
+        Prefix.objects.create(prefix="192.168.0.0/24", status=self.status, namespace=self.namespace)
+        nat_inside = IPAddress.objects.create(address="192.168.0.1/24", status=self.status, namespace=self.namespace)
+        nat_outside1 = IPAddress.objects.create(
+            address="192.0.2.1/24", nat_inside=nat_inside, status=self.status, namespace=self.namespace
+        )
+        nat_outside2 = IPAddress.objects.create(
+            address="192.0.2.2/24", nat_inside=nat_inside, status=self.status, namespace=self.namespace
+        )
+        nat_outside3 = IPAddress.objects.create(
+            address="192.0.2.3/24", nat_inside=nat_inside, status=self.status, namespace=self.namespace
+        )
         nat_inside.refresh_from_db()
         self.assertEqual(nat_inside.nat_outside_list.count(), 3)
         self.assertEqual(nat_inside.nat_outside_list.all()[0], nat_outside1)
         self.assertEqual(nat_inside.nat_outside_list.all()[1], nat_outside2)
         self.assertEqual(nat_inside.nat_outside_list.all()[2], nat_outside3)
 
-    @expectedFailure
     def test_create_ip_address_without_slaac_status(self):
         slaac_status_name = IPAddressStatusChoices.as_dict()[IPAddressStatusChoices.STATUS_SLAAC]
         IPAddress.objects.filter(status__name=slaac_status_name).delete()
         Status.objects.get(name=slaac_status_name).delete()
-        IPAddress.objects.create(address="1.1.1.1/32")
+        Prefix.objects.create(prefix="1.1.1.0/24", status=self.status, namespace=self.namespace)
+        IPAddress.objects.create(address="1.1.1.1/32", status=self.status, namespace=self.namespace)
         self.assertTrue(IPAddress.objects.filter(address="1.1.1.1/32").exists())
 
     def test_get_closest_parent(self):


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3687 
# What's Changed
- Un-skipped `InterfaceToIPAddress` and `Prefix` tests
- Got rid of all `expectedFailure` and `skip` decorations for test cases.
- Also made sure that every object created that requires it has a proper `status` field and `namespace`
- Revised assertions for `Prefix.get_utilization()` testing because of proper parenting now to child prefixes if they exist.
- Fixed a bug in `Prefix.reparent_ips()` that was too greedy in reparenting IP addresses when child prefixes were deeply nested (such as a /31)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Implement tests for `VRF`
- [ ] Implement tests for `VRFDeviceAssignment`
- [ ] Implement tests for `VRFPrefixAssigntment`
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
