### PR TITLE
Remove deprecated distutils dependency

### DIFF
--- a/changes/3882.fixed
+++ b/changes/3882.fixed
@@ -1,0 +1,1 @@
+Remove deprecated distutils dependency.

--- a/changes/3882.fixed
+++ b/changes/3882.fixed
@@ -1,1 +1,1 @@
-Remove deprecated distutils dependency.
+Removed deprecated distutils dependency.

--- a/nautobot/core/settings_funcs.py
+++ b/nautobot/core/settings_funcs.py
@@ -57,7 +57,14 @@ def is_truthy(arg):
     """
     if isinstance(arg, bool):
         return arg
-    return bool(strtobool(str(arg)))
+
+    val = str(arg).lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 def parse_redis_connection(redis_database):

--- a/nautobot/core/settings_funcs.py
+++ b/nautobot/core/settings_funcs.py
@@ -63,7 +63,7 @@ def is_truthy(arg):
     elif val in ("n", "no", "f", "false", "off", "0"):
         return False
     else:
-        raise ValueError("invalid truth value %r" % (val,))
+        raise ValueError(f"Invalid truthy value: `{arg}`")
 
 
 def parse_redis_connection(redis_database):

--- a/nautobot/core/settings_funcs.py
+++ b/nautobot/core/settings_funcs.py
@@ -1,7 +1,6 @@
 """Helper functions to detect settings after app initialization (AKA 'dynamic settings')."""
 
 from django.conf import settings
-from distutils.util import strtobool
 from functools import lru_cache
 import os
 

--- a/nautobot/core/settings_funcs.py
+++ b/nautobot/core/settings_funcs.py
@@ -59,9 +59,9 @@ def is_truthy(arg):
         return arg
 
     val = str(arg).lower()
-    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+    if val in ("y", "yes", "t", "true", "on", "1"):
         return True
-    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+    elif val in ("n", "no", "f", "false", "off", "0"):
         return False
     else:
         raise ValueError("invalid truth value %r" % (val,))

--- a/tasks.py
+++ b/tasks.py
@@ -52,7 +52,7 @@ def is_truthy(arg):
     elif val in ("n", "no", "f", "false", "off", "0"):
         return False
     else:
-        raise ValueError("invalid truth value %r" % (val,))
+        raise ValueError(f"Invalid truthy value: `{arg}`")
 
 
 # Use pyinvoke configuration for default values, see http://docs.pyinvoke.org/en/stable/concepts/configuration.html

--- a/tasks.py
+++ b/tasks.py
@@ -12,7 +12,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from distutils.util import strtobool
 import os
 import re
 
@@ -33,18 +32,27 @@ except ModuleNotFoundError:
 
 
 def is_truthy(arg):
-    """Convert "truthy" strings into Booleans.
+    """
+    Convert "truthy" strings into Booleans.
 
     Examples:
         >>> is_truthy('yes')
         True
+
     Args:
         arg (str): Truthy string (True values are y, yes, t, true, on and 1; false values are n, no,
         f, false, off and 0. Raises ValueError if val is anything else.
     """
     if isinstance(arg, bool):
         return arg
-    return bool(strtobool(arg))
+
+    val = str(arg).lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 # Use pyinvoke configuration for default values, see http://docs.pyinvoke.org/en/stable/concepts/configuration.html

--- a/tasks.py
+++ b/tasks.py
@@ -47,9 +47,9 @@ def is_truthy(arg):
         return arg
 
     val = str(arg).lower()
-    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+    if val in ("y", "yes", "t", "true", "on", "1"):
         return True
-    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+    elif val in ("n", "no", "f", "false", "off", "0"):
         return False
     else:
         raise ValueError("invalid truth value %r" % (val,))


### PR DESCRIPTION
# Closes: #3882 

`distutils` was used only in `is_truthy` implementation.

# What's Changed

Refactored `is_truthy` to use the same logic as deprecated `distutils.strtobool`.