### PR TITLE
Adds log message when a secrets group for a git repository doesn't yi…

### DIFF
--- a/changes/3897.added
+++ b/changes/3897.added
@@ -1,0 +1,1 @@
+Adds log message when a secrets group for a git repository doesn't yield a token.

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -245,7 +245,7 @@ def get_repo_from_url_to_path_and_from_branch(
             pass
         if not token:
             log_message = (
-                "Repository has a secrets group assigned but is missing a token secret of access type 'HTTP'."
+                "Repository has a secrets group assigned but is missing a 'token' secret of access type 'HTTP'."
                 "Falling through to legacy behaviour."
             )
             if job_result:


### PR DESCRIPTION
…eld a token.

# Closes: DNE
# What's Changed

When a git repository with an attached secrets group is synced today, but doesn't yield a token, there is no user feedback. This can make it frustrating to debug this case.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Outline Remaining Work, Constraints from Design
