### PR TITLE
Natural key definition fixes and fix IPAddress.natural_key_field_names

### DIFF
--- a/changes/3898.changed
+++ b/changes/3898.changed
@@ -1,0 +1,1 @@
+Changed the `IPAddress` natural key definition (`IPAddress.natural_key_field_names`) to `[parent__namespace, host]`.

--- a/changes/3898.fixed
+++ b/changes/3898.fixed
@@ -1,0 +1,1 @@
+Fixed several errors that could occur when defining a model's `natural_key_field_names` to include related object lookups.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -972,8 +972,7 @@ class IPAddress(PrimaryModel):
             self.mask_length = address.prefixlen
             self.ip_version = address.version
 
-    # TODO: The current IPAddress model has no appropriate natural key available yet.
-    natural_key_field_names = ["id"]
+    natural_key_field_names = ["parent__namespace", "host"]
 
     def clean(self):
         super().clean()


### PR DESCRIPTION
# Closes: #3898 
# What's Changed

- Add logic in `natural_key_field_lookups()` generic method to handle `natural_key_field_names` definitions that include traversal of related fields (e.g. `natural_key_field_names = ["parent__namespace__name", "host"]`)
- Remove logic in `get_by_natural_key()` generic method that was unnecessarily enforcing that related objects could *only* be referenced by their natural key and never by other fields.
- Add logic in `get_by_natural_key()` to handle the usage error of `get_by_natural_key(obj.natural_key())` (it's supposed to be `get_by_natural_key(*obj.natural_key())`) with a helpful warning message.
- Change `IPAddress.natural_key_field_names` to `["parent__namespace", "host"]` (which is implicitly equivalent to `["parent__namespace__name", "host"]` since the natural key for a Namespace is just its `name`).

```python
>>> IPAddress.objects.first().natural_key()
['Global', '8.8.8.8']
>>> IPAddress.natural_key_args_to_kwargs(['Global', '8.8.8.8'])
{'parent__namespace__name': 'Global', 'host': '8.8.8.8'}
>>> IPAddress.objects.get_by_natural_key(*IPAddress.objects.first().natural_key())
<IPAddress: 8.8.8.8/32>
>>> Prefix.objects.get_by_natural_key(Prefix.objects.first().natural_key())
19:08:38.121 WARNING nautobot.core.models.managers managers.py                 get_by_natural_key() :
  Prefix.objects.get_by_natural_key() was called with a single list as its args, instead of a list of individual args. Did you forget a '*' in your call?
<Prefix: 0.0.0.0/0>
>>> Prefix.objects.get_by_natural_key(*Prefix.objects.first().natural_key())
<Prefix: 0.0.0.0/0>
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
