### PR TITLE
Fixed a bug preventing Job buttons from supporting the `FORCE_SCRIPT_NAME` setting.

### DIFF
--- a/changes/3891.fixed
+++ b/changes/3891.fixed
@@ -1,0 +1,1 @@
+Fixed a bug preventing Job buttons from supporting the `FORCE_SCRIPT_NAME` setting.

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -33,7 +33,7 @@ NO_CONFIRM_BUTTON = """
 """
 
 NO_CONFIRM_FORM = """
-<form id="form_id_{button_id}" action="/extras/job-button/{button_id}/run/" method="post" class="form">
+<form id="form_id_{button_id}" action="{% url 'extras:jobbutton_run' pk=button_id %}" method="post" class="form">
   {hidden_inputs}
 </form>
 """
@@ -52,7 +52,7 @@ CONFIRM_MODAL = """
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <h4 class="modal-title" id="confirm_modal_label_{button_id}">Confirmation</h4>
       </div>
-      <form id="form_id_{button_id}" action="/extras/job-button/{button_id}/run/" method="post" class="form">
+      <form id="form_id_{button_id}" action="{% url 'extras:jobbutton_run' pk=button_id %}" method="post" class="form">
         <div class="modal-body">
           {hidden_inputs}
           Run Job <strong>'{job}'</strong> with object <strong>'{object}'</strong>?


### PR DESCRIPTION



<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3891 
# What's Changed

- Hard-coded URLs for Job Button run have been replaced with URL patterns.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
