### PR TITLE
Fix #3924, don't let Git hang at password prompt on clone/fetch

### DIFF
--- a/changes/3924.fixed
+++ b/changes/3924.fixed
@@ -1,0 +1,1 @@
+Fixed a potential server hang at startup when a misconfigured GitRepository is present.


### PR DESCRIPTION
# Closes: #3924 
# What's Changed

Add `GIT_TERMINAL_PROMPT=0` environment variable to `clone_from()` and `fetch()` calls.

I don't fully understand why this wasn't an issue on celery-worker `git clone`/`git fetch` calls, only on nautobot-server startup-time `git clone`/`git fetch` calls but I can verify that this works and prevents server startup from hanging:


Before:

```
Performing database migrations...
Operations to perform:
  Apply all migrations: admin, auth, circuits, contenttypes, database, dcim, django_celery_beat, django_rq, example_plugin, extras, ipam, sessions, social_django, taggit, tenancy, users, virtualization
Running migrations:
  No migrations to apply.
<hangs indefinitely>
```

After, with no existing clone server-side:

```
  Apply all migrations: admin, auth, circuits, contenttypes, database, dcim, django_celery_beat, django_rq, example_plugin, extras, ipam, sessions, social_django, taggit, tenancy, users, virtualization
Running migrations:
  No migrations to apply.
13:46:06.664 DEBUG   nautobot.utilities.git git.py                                __init__() :
  Cloning git repository to /opt/nautobot/git/test...
13:46:07.391 ERROR   nautobot.jobs        git.py                   ensure_git_repository() :
  Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v -- https://<elided> /opt/nautobot/git/test
  stderr: 'Cloning into '/opt/nautobot/git/test'...
fatal: could not read Username for 'https://<elided>': terminal prompts disabled
'
Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v -- https://<elided> /opt/nautobot/git/test
  stderr: 'Cloning into '/opt/nautobot/git/test'...
fatal: could not read Username for 'https://<elided>': terminal prompts disabled
'
13:46:07.391 ERROR   nautobot.jobs        jobs.py                  _get_job_source_paths() :
  Error during local clone of Git repository test: Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v -- https://<elided> /opt/nautobot/git/test
  stderr: 'Cloning into '/opt/nautobot/git/test'...
fatal: could not read Username for '<elided>': terminal prompts disabled
'
Error during local clone of Git repository test: Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v -- https://<elided> /opt/nautobot/git/test
  stderr: 'Cloning into '/opt/nautobot/git/test'...
fatal: could not read Username for 'https://<elided>': terminal prompts disabled
'

<startup continues>
```


After, with existing but not yet resynced clone server-side:

```
Performing database migrations...
Operations to perform:
  Apply all migrations: admin, auth, circuits, contenttypes, database, dcim, django_celery_beat, django_rq, example_plugin, extras, ipam, sessions, social_django, taggit, tenancy, users, virtualization
Running migrations:
  No migrations to apply.
13:45:11.549 ERROR   nautobot.jobs        git.py                   ensure_git_repository() :
  Cmd('git') failed due to: exit code(128)
  cmdline: git fetch -v -- origin
  stderr: 'fatal: could not read Username for 'https://<elided>': terminal prompts disabled'
Cmd('git') failed due to: exit code(128)
  cmdline: git fetch -v -- origin
  stderr: 'fatal: could not read Username for 'https://<elided>': terminal prompts disabled'
13:45:11.550 ERROR   nautobot.jobs        jobs.py                  _get_job_source_paths() :
  Error during local clone of Git repository test: Cmd('git') failed due to: exit code(128)
  cmdline: git fetch -v -- origin
  stderr: 'fatal: could not read Username for 'https://<elided>': terminal prompts disabled'
Error during local clone of Git repository test: Cmd('git') failed due to: exit code(128)
  cmdline: git fetch -v -- origin
  stderr: 'fatal: could not read Username for 'https://<elided>': terminal prompts disabled'

<startup continues>
```


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
