### PR TITLE
Hopefully address noisy job output about logs

### DIFF
--- a/changes/3933.fixed
+++ b/changes/3933.fixed
@@ -1,0 +1,1 @@
+Fixed noisy output of unit tests.

--- a/nautobot/core/tests/runner.py
+++ b/nautobot/core/tests/runner.py
@@ -4,6 +4,8 @@ from django.core.management import call_command
 from django.conf import settings
 from django.test.runner import DiscoverRunner
 
+from nautobot.core.celery import app, setup_nautobot_job_logging
+
 
 class NautobotTestRunner(DiscoverRunner):
     """
@@ -49,6 +51,9 @@ class NautobotTestRunner(DiscoverRunner):
         super().setup_test_environment(**kwargs)
         # Remove 'testserver' that Django "helpfully" adds automatically to ALLOWED_HOSTS, masking issues like #3065
         settings.ALLOWED_HOSTS.remove("testserver")
+        if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False):
+            # Make sure logs get captured when running Celery tasks, even though we don't have/need a Celery worker
+            setup_nautobot_job_logging(None, None, app.conf)
 
     def setup_databases(self, **kwargs):
         result = super().setup_databases(**kwargs)

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -19,7 +19,6 @@ from django_celery_beat.clockedschedule import clocked
 from prometheus_client import Histogram
 
 from nautobot.core.celery import (
-    add_nautobot_log_handler,
     app,
     NautobotKombuJSONEncoder,
     setup_nautobot_job_logging,


### PR DESCRIPTION
# Closes: #n/a
# What's Changed

Instead of letting `CELERY_TASK_ALWAYS_EAGER` affect the code flow of how we enqueue jobs, just let it affect how we set up logging for jobs. Tested locally with a few sets of tests and it appears to fix the issue.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
