### PR TITLE
Add validation of GitRepository.slug against Python modules

### DIFF
--- a/changes/3859.fixed
+++ b/changes/3859.fixed
@@ -1,0 +1,1 @@
+Added logic to protect against defining a `GitRepository.slug` that would conflict with existing Python modules.

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -82,6 +82,10 @@ class GitRepository(PrimaryModel):
     def clean(self):
         super().clean()
 
+        # Autogenerate slug now, rather than in pre_save(), if not set already, as we need to check it below.
+        if self.slug == "":
+            self._meta.get_field("slug").create_slug(self, add=(not self.present_in_database))
+
         if self.present_in_database and self.slug != self.__initial_slug:
             raise ValidationError(
                 f"Slug cannot be changed once set. Current slug is {self.__initial_slug}, "

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -99,7 +99,7 @@ class GitRepository(PrimaryModel):
             # import the earlier-found Python module in its place, which would be undesirable.
             if find_spec(self.slug) is not None:
                 raise ValidationError(
-                    f'Please choose a different slug, as "{self.slug}" is an existing Python package or module.'
+                    f'Please choose a different slug, as "{self.slug}" is an installed Python package or module.'
                 )
 
     def get_latest_sync(self):


### PR DESCRIPTION
# Closes: #3859 
# What's Changed

- Add a check on creating a new GitRepository to make sure its `slug` won't be shadowed by an existing/available Python module.
- Add test coverage
- Change the base class of a couple of other tests in the same file to broaden their test coverage.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
