### PR TITLE
Fix device name copy button adding an extra space/return

### DIFF
--- a/changes/3948.fixed
+++ b/changes/3948.fixed
@@ -1,0 +1,1 @@
+Fixed device name copy button adding an extra space/return

--- a/changes/3948.fixed
+++ b/changes/3948.fixed
@@ -1,1 +1,1 @@
-Fixed device name copy button adding an extra space/return
+Fixed device name copy button adding an extra space/return.

--- a/nautobot/dcim/templates/dcim/device/base.html
+++ b/nautobot/dcim/templates/dcim/device/base.html
@@ -53,8 +53,8 @@
 
 {% block masthead %}
     <span class="hover_copy">
-        <h1 id="devicename">
-            {% block title %}{{ object }}{% endblock title %}
+        <h1>
+            <span id="devicename">{% block title %}{{ object }}{% endblock title %}</span>
             <button class="btn btn-xs btn-default hover_copy_button" data-clipboard-target="#devicename">
                 <span class="mdi mdi-content-copy"></span>
             </button>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: 

# What's Changed
This fixes the device name copy button that adds an extra space (chrome) or return (firefox) to the copied text, by enclosing the device name in a span that now use the `devicename` id (instead of the h1)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
