### PR TITLE
Explicitly allow null mac_address in GraphQL

### DIFF
--- a/changes/3902.fixed
+++ b/changes/3902.fixed
@@ -1,0 +1,1 @@
+Fixed a GraphQL error when querying Interface `mac_address` when unset/null/empty values are present.

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -113,6 +113,10 @@ class InterfaceType(gql_optimizer.OptimizedDjangoObjectType, CableTerminationMix
         filterset_class = InterfaceFilterSet
         exclude = ["_name"]
 
+    # At the DB level, mac_address is null=False, but empty strings are represented as null in the ORM and REST API,
+    # so for consistency, we'll keep that same representation in GraphQL.
+    mac_address = graphene.String(required=False)
+
     # Field Definitions
     cable_peer_circuit_termination = graphene.Field("nautobot.circuits.graphql.types.CircuitTerminationType")
     cable_peer_front_port = graphene.Field("nautobot.dcim.graphql.types.FrontPortType")

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -1523,6 +1523,7 @@ class InterfaceTest(Mixins.BasePortTestMixin):
                 "bridge": cls.interfaces[3].pk,
                 "tagged_vlans": [cls.vlans[0].pk, cls.vlans[1].pk],
                 "untagged_vlan": cls.vlans[2].pk,
+                "mac_address": None,
             },
             {
                 "device": cls.devices[0].pk,

--- a/nautobot/dcim/tests/test_graphql.py
+++ b/nautobot/dcim/tests/test_graphql.py
@@ -3,7 +3,8 @@ from django.test import override_settings
 
 from nautobot.core.graphql import execute_query
 from nautobot.core.testing import create_test_user, TestCase
-from nautobot.dcim.models import Device, DeviceType, Location, LocationType, Manufacturer
+from nautobot.dcim.choices import InterfaceTypeChoices
+from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer
 from nautobot.extras.models import DynamicGroup, Role, Status
 
 
@@ -22,13 +23,36 @@ class GraphQLTestCase(TestCase):
             name="Device",
             status=device_status,
         )
+        interface_status = Status.objects.get_for_model(Interface).first()
+        self.interfaces = (
+            Interface(
+                device=self.device,
+                name="eth0",
+                status=interface_status,
+                type=InterfaceTypeChoices.TYPE_VIRTUAL,
+                mac_address="11:22:33:44:55:66",
+            ),
+            Interface(
+                device=self.device,
+                name="eth1",
+                status=interface_status,
+                type=InterfaceTypeChoices.TYPE_VIRTUAL,
+                mac_address=None,
+            ),
+        )
+        for interface in self.interfaces:
+            interface.validated_save()
         self.dynamic_group = DynamicGroup.objects.create(
             name="Dynamic_Group", content_type=ContentType.objects.get_for_model(Device)
         )
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_execute_query(self):
-        query = "query {devices {name dynamic_groups {name}}}"
+        query = "query {devices {name interfaces {name mac_address} dynamic_groups {name}}}"
         resp = execute_query(query, user=self.user).to_dict()
         self.assertFalse(resp["data"].get("error"))
+        self.assertEqual(
+            resp["data"]["devices"][0]["interfaces"][0]["mac_address"], str(self.interfaces[0].mac_address)
+        )
+        self.assertIsNone(resp["data"]["devices"][0]["interfaces"][1]["mac_address"])
         self.assertEqual(resp["data"]["devices"][0]["dynamic_groups"][0]["name"], self.dynamic_group.name)

--- a/nautobot/virtualization/graphql/types.py
+++ b/nautobot/virtualization/graphql/types.py
@@ -39,3 +39,7 @@ class VMInterfaceType(gql_optimizer.OptimizedDjangoObjectType):
         model = VMInterface
         filterset_class = VMInterfaceFilterSet
         exclude = ["_name"]
+
+    # At the DB level, mac_address is null=False, but empty strings are represented as null in the ORM and REST API,
+    # so for consistency, we'll keep that same representation in GraphQL.
+    mac_address = graphene.String(required=False)


### PR DESCRIPTION
# Closes: #3902 
# What's Changed

Collateral damage from #3046. The `mac_address` field on Interface and VMInterface is not nullable at the DB level (since it's a CharField, and not `unique=True`, unset MAC addresses are represented as `""`, not `null`) but unset values are represented as null in the ORM and the REST API. The GraphQL representation was complaining about this mismatch between the DB representation and the ORM/REST representation when rendering `None` values to GraphQL `null`. The fix is to explicitly declare these fields in the GraphQL object type as `graphene.String(required=False)` which allows for null values.

Also added testing in both the REST API and the GraphQL tests to confirm that null values are handled correctly.

![image](https://github.com/nautobot/nautobot/assets/5603551/7d0eb33a-d341-450a-8851-387df2c0ce24)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
