### PR TITLE
Added `nautobot-server audit_dynamic_groups` management command for evaluating breaking filter changes to existing `DynamicGroup` instances.

### DIFF
--- a/changes/3287.added
+++ b/changes/3287.added
@@ -1,0 +1,1 @@
+Added `nautobot-server audit_dynamic_groups` management command for evaluating breaking filter changes to existing DynamicGroup instances.

--- a/changes/3287.changed
+++ b/changes/3287.changed
@@ -1,0 +1,1 @@
+Changed the `ip_version` filters in `PrefixFilterSet` and `IPAddressFilterSet` to `django_filters.NumberFilter`.

--- a/nautobot/core/management/commands/audit_dynamic_groups.py
+++ b/nautobot/core/management/commands/audit_dynamic_groups.py
@@ -1,0 +1,33 @@
+from django.core.management.base import BaseCommand
+
+from nautobot.core.utils.lookup import get_filterset_for_model
+
+
+class Command(BaseCommand):
+    help = "Audit all existing DynamicGroup instances in the database and output invalid filter data"
+
+    def handle(self, *args, **options):
+        from nautobot.extras.models import DynamicGroup
+
+        print("\n>>> Auditing existing DynamicGroup data for invalid filters ...\n")
+
+        dynamic_groups = DynamicGroup.objects.all().order_by("name")
+        is_valid = True
+        for dynamic_group in dynamic_groups:
+            dynamic_group_model = dynamic_group.content_type.model_class()
+            dynamic_group_model_filter = get_filterset_for_model(dynamic_group_model)
+            valid_filterset_fields = dynamic_group_model_filter().filters
+            filter_data = dynamic_group.filter
+            for filter in filter_data.keys():
+                if filter not in valid_filterset_fields:
+                    print(
+                        f"    DynamicGroup instance with name `{dynamic_group.name}` and content type `{dynamic_group.content_type}` has an invalid filter `{filter}`"
+                    )
+                    is_valid = False
+        if is_valid:
+            print("\n>>> All DynamicGroup filters are validated successfully!")
+        else:
+            print(
+                "\n>>> Please fix the broken filters stated above according to the documentations at available"
+                "'<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes'"
+            )

--- a/nautobot/core/management/commands/audit_dynamic_groups.py
+++ b/nautobot/core/management/commands/audit_dynamic_groups.py
@@ -29,5 +29,5 @@ class Command(BaseCommand):
         else:
             print(
                 "\n>>> Please fix the broken filters stated above according to the documentations at available"
-                "'<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes'"
+                "'<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes'\n"
             )

--- a/nautobot/core/management/commands/audit_dynamic_groups.py
+++ b/nautobot/core/management/commands/audit_dynamic_groups.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         from nautobot.extras.models import DynamicGroup
 
-        print("\n>>> Auditing existing DynamicGroup data for invalid filters ...\n")
+        self.stdout.write("\n>>> Auditing existing DynamicGroup data for invalid filters ...\n")
 
         dynamic_groups = DynamicGroup.objects.all().order_by("name")
         is_valid = True
@@ -20,14 +20,14 @@ class Command(BaseCommand):
             filter_data = dynamic_group.filter
             for filter_field in filter_data.keys():
                 if filter_field not in valid_filterset_fields:
-                    print(
+                    self.stdout.write(
                         f"    DynamicGroup instance with name `{dynamic_group.name}` and content type `{dynamic_group.content_type}` has an invalid filter `{filter_field}`"
                     )
                     is_valid = False
         if is_valid:
-            print("\n>>> All DynamicGroup filters are validated successfully!")
+            self.stdout.write("\n>>> All DynamicGroup filters are validated successfully!")
         else:
-            print(
-                "\n>>> Please fix the broken filters stated above according to the documentations at available"
-                "'<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes'\n"
+            self.stdout.write(
+                "\n>>> Please fix the broken filters stated above according to the documentations available at:\n"
+                "<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes\n"
             )

--- a/nautobot/core/management/commands/audit_dynamic_groups.py
+++ b/nautobot/core/management/commands/audit_dynamic_groups.py
@@ -18,10 +18,10 @@ class Command(BaseCommand):
             dynamic_group_model_filter = get_filterset_for_model(dynamic_group_model)
             valid_filterset_fields = dynamic_group_model_filter().filters
             filter_data = dynamic_group.filter
-            for filter in filter_data.keys():
-                if filter not in valid_filterset_fields:
+            for filter_field in filter_data.keys():
+                if filter_field not in valid_filterset_fields:
                     print(
-                        f"    DynamicGroup instance with name `{dynamic_group.name}` and content type `{dynamic_group.content_type}` has an invalid filter `{filter}`"
+                        f"    DynamicGroup instance with name `{dynamic_group.name}` and content type `{dynamic_group.content_type}` has an invalid filter `{filter_field}`"
                     )
                     is_valid = False
         if is_valid:

--- a/nautobot/core/management/commands/audit_dynamic_groups.py
+++ b/nautobot/core/management/commands/audit_dynamic_groups.py
@@ -28,6 +28,6 @@ class Command(BaseCommand):
             self.stdout.write("\n>>> All DynamicGroup filters are validated successfully!")
         else:
             self.stdout.write(
-                "\n>>> Please fix the broken filters stated above according to the documentations available at:\n"
+                "\n>>> Please fix the broken filters stated above according to the documentation available at:\n"
                 "<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes\n"
             )

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -1368,7 +1368,7 @@ query {
                 IPAddress.objects.filter(host="10.0.1.1").count(),
             ),
             (
-                'ip_version: "4"',
+                "ip_version: 4",
                 IPAddress.objects.filter(ip_version=4).count(),
             ),
             (

--- a/nautobot/docs/administration/nautobot-server.md
+++ b/nautobot/docs/administration/nautobot-server.md
@@ -28,6 +28,48 @@ nautobot-server migrate --help
 
 ## Available Commands
 
+### `audit_dynamic_groups`
+
+`nautobot-server audit_dynamic_groups`
+
+After upgrading your Nautobot instance from v1.x to v2.x, breaking changes made to model filter fields will, in some cases, invalidate existing `DynamicGroup` instances' filter data. `nautobot-server audit_dynamic_groups` is a helper command to assist you in cleaning up `DynamicGroup` filter data by spotting invalid filters and outputting them to the command line interface.
+
+```no-highlight
+nautobot-server audit_dynamic_groups
+```
+
+Example output:
+
+If you have invalid filters in your `DynamicGroup` instances, the following output should be expected:
+
+```no-highlight
+>>> Auditing existing DynamicGroup data for invalid filters ...
+
+    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `site`
+    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `length`
+    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `region`
+    DynamicGroup instance with name `Test DP 1` and content type `ipam | IP address` has an invalid filter `site`
+    DynamicGroup instance with name `Test DP 1` and content type `ipam | IP address` has an invalid filter `length`
+    DynamicGroup instance with name `Test DP 2` and content type `dcim | device` has an invalid filter `site`
+    DynamicGroup instance with name `Test DP 2` and content type `dcim | device` has an invalid filter `region`
+    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `site`
+    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `length`
+    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `region`
+    DynamicGroup instance with name `Test DP 4` and content type `example_plugin | another example model` has an invalid filter `site`
+
+>>> Please fix the broken filters stated above according to the documentation available at:
+<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes
+```
+
+If your filter data is valid, you should see a success message at the end of the output:
+
+```no-highlight
+>>> Auditing existing DynamicGroup data for invalid filters ...
+
+
+>>> All DynamicGroup filters are validated successfully!
+```
+
 ### `celery`
 
 `nautobot-server celery`

--- a/nautobot/docs/installation/upgrading-from-nautobot-v1.md
+++ b/nautobot/docs/installation/upgrading-from-nautobot-v1.md
@@ -179,6 +179,41 @@ Please see the [documentation on the `?depth` query parameter](../rest-api/overv
 
 ## UI, GraphQL, and REST API Filter Changes
 
+### Post Migration Helper Command `audit_dynamic_groups`
+
+These sweeping changes made to model filter fields will, in some cases, invalidate existing `DynamicGroup` instances' filter data. `nautobot-server audit_dynmaic_groups` is a helper command to assist users in cleaning up `DynamicGroup` filter data by spotting invalid filters and outputting them to the command line interface. You should run this command after your Nautobot instances is upgraded to v2.x.
+
+If you have invalid filters in your `DynamicGroup` instances, the following output should be expected:
+
+no-highlight
+```
+>>> Auditing existing DynamicGroup data for invalid filters ...
+
+    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `site`
+    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `length`
+    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `region`
+    DynamicGroup instance with name `Test DP 1` and content type `ipam | IP address` has an invalid filter `site`
+    DynamicGroup instance with name `Test DP 1` and content type `ipam | IP address` has an invalid filter `length`
+    DynamicGroup instance with name `Test DP 2` and content type `dcim | device` has an invalid filter `site`
+    DynamicGroup instance with name `Test DP 2` and content type `dcim | device` has an invalid filter `region`
+    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `site`
+    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `length`
+    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `region`
+    DynamicGroup instance with name `Test DP 4` and content type `example_plugin | another example model` has an invalid filter `site`
+
+>>> Please fix the broken filters stated above according to the documentations at available'<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes'
+```
+
+If your filter data is valid, you should see a success message at the end of the output:
+
+no-highlight
+```
+>>> Auditing existing DynamicGroup data for invalid filters ...
+
+
+>>> All DynamicGroup filters are validated successfully!
+```
+
 ### Removed Changelog URL from View Context
 
 `changelog_url` is no longer provided in the `ObjectView` context. To get a model instance's changelog URL, you can retrieve it from the instance itself if it supports it: `model_instance.get_changelog_url()`.

--- a/nautobot/docs/installation/upgrading-from-nautobot-v1.md
+++ b/nautobot/docs/installation/upgrading-from-nautobot-v1.md
@@ -179,38 +179,8 @@ Please see the [documentation on the `?depth` query parameter](../rest-api/overv
 
 ## UI, GraphQL, and REST API Filter Changes
 
-### Post Migration Helper Command `audit_dynamic_groups`
-
-These sweeping changes made to model filter fields will, in some cases, invalidate existing `DynamicGroup` instances' filter data. `nautobot-server audit_dynmaic_groups` is a helper command to assist users in cleaning up `DynamicGroup` filter data by spotting invalid filters and outputting them to the command line interface. You should run this command after your Nautobot instances is upgraded to v2.x.
-
-If you have invalid filters in your `DynamicGroup` instances, the following output should be expected:
-
-```no-highlight
->>> Auditing existing DynamicGroup data for invalid filters ...
-
-    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `site`
-    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `length`
-    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `region`
-    DynamicGroup instance with name `Test DP 1` and content type `ipam | IP address` has an invalid filter `site`
-    DynamicGroup instance with name `Test DP 1` and content type `ipam | IP address` has an invalid filter `length`
-    DynamicGroup instance with name `Test DP 2` and content type `dcim | device` has an invalid filter `site`
-    DynamicGroup instance with name `Test DP 2` and content type `dcim | device` has an invalid filter `region`
-    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `site`
-    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `length`
-    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `region`
-    DynamicGroup instance with name `Test DP 4` and content type `example_plugin | another example model` has an invalid filter `site`
-
->>> Please fix the broken filters stated above according to the documentations at available'<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes'
-```
-
-If your filter data is valid, you should see a success message at the end of the output:
-
-```no-highlight
->>> Auditing existing DynamicGroup data for invalid filters ...
-
-
->>> All DynamicGroup filters are validated successfully!
-```
+!!! note
+    These sweeping changes made to model filter fields will, in some cases, invalidate existing `DynamicGroup` instances' filter data. Please utilize [`nautobot-server audit_dynamic_groups`](../administration/nautobot-server.md/#audit_dynamic_groups) helper command when you are cleaning up `DynamicGroup` filter data. You should run this command after your Nautobot instance is upgraded to v2.x successfully.
 
 ### Removed Changelog URL from View Context
 

--- a/nautobot/docs/installation/upgrading-from-nautobot-v1.md
+++ b/nautobot/docs/installation/upgrading-from-nautobot-v1.md
@@ -185,8 +185,7 @@ These sweeping changes made to model filter fields will, in some cases, invalida
 
 If you have invalid filters in your `DynamicGroup` instances, the following output should be expected:
 
-no-highlight
-```
+```no-highlight
 >>> Auditing existing DynamicGroup data for invalid filters ...
 
     DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `site`
@@ -206,8 +205,7 @@ no-highlight
 
 If your filter data is valid, you should see a success message at the end of the output:
 
-no-highlight
-```
+```no-highlight
 >>> Auditing existing DynamicGroup data for invalid filters ...
 
 

--- a/nautobot/docs/installation/upgrading-from-nautobot-v1.md
+++ b/nautobot/docs/installation/upgrading-from-nautobot-v1.md
@@ -175,12 +175,12 @@ These endpoints `/ipam/roles/`, `/dcim/rack-roles/` and `/dcim/device-roles/` ar
 ### API Query Parameters Changes
 
 Nautobot 2.0 removes the `?brief` query parameter and adds support for the `?depth` query parameter. As a result, the ability to specify `brief_mode` in `DynamicModelChoiceField`, `DynamicModelMultipleChoiceField`, and `MultiMatchModelMultipleChoiceField` has also been removed. For every occurrence of the aforementioned fields where you have `brief_mode` set to `True/False` (e.g. `brief_mode=True`), please remove the statement, leaving other occurrences of the fields where you do not have `brief_mode` specified as they are.
-Please see the [documentation on the `?depth` query parameter](../rest-api/overview.md/#depth-query-parameter) for more information.
+Please see the [documentation on the `?depth` query parameter](../rest-api/overview.md#depth-query-parameter) for more information.
 
 ## UI, GraphQL, and REST API Filter Changes
 
 !!! note
-    These sweeping changes made to model filter fields will, in some cases, invalidate existing `DynamicGroup` instances' filter data. Please utilize [`nautobot-server audit_dynamic_groups`](../administration/nautobot-server.md/#audit_dynamic_groups) helper command when you are cleaning up `DynamicGroup` filter data. You should run this command after your Nautobot instance is upgraded to v2.x successfully.
+    These sweeping changes made to model filter fields will, in some cases, invalidate existing `DynamicGroup` instances' filter data. Please utilize the [`nautobot-server audit_dynamic_groups`](../administration/nautobot-server.md#audit_dynamic_groups) helper command when you are cleaning up `DynamicGroup` filter data. You should run this command after your Nautobot instance is upgraded to v2.x successfully.
 
 ### Removed Changelog URL from View Context
 

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -237,10 +237,11 @@ class PrefixFilterSet(
         to_field_name="name",
         label="Namespace (name or ID)",
     )
+    ip_version = django_filters.NumberFilter()
 
     class Meta:
         model = Prefix
-        fields = ["date_allocated", "id", "ip_version", "prefix", "tags", "type"]
+        fields = ["date_allocated", "id", "prefix", "tags", "type"]
 
     def filter_prefix(self, queryset, name, value):
         value = value.strip()
@@ -389,10 +390,11 @@ class IPAddressFilterSet(
         method="_has_interface_assignments",
         label="Has Interface Assignments",
     )
+    ip_version = django_filters.NumberFilter()
 
     class Meta:
         model = IPAddress
-        fields = ["id", "ip_version", "dns_name", "type", "tags", "mask_length"]
+        fields = ["id", "dns_name", "type", "tags", "mask_length"]
 
     def generate_query__has_interface_assignments(self, value):
         """Helper method used by DynamicGroups and by _assigned_to_interface method."""

--- a/nautobot/ipam/tests/test_filters.py
+++ b/nautobot/ipam/tests/test_filters.py
@@ -184,13 +184,13 @@ class PrefixTestCase(FilterTestCases.FilterTestCase, FilterTestCases.TenancyFilt
             self.assertEqual(self.filterset(params, self.queryset).qs.count(), count)
 
     def test_ip_version(self):
-        params = {"ip_version": ["6"]}
+        params = {"ip_version": "6"}
         ipv6_prefixes = self.queryset.filter(ip_version=6)
         self.assertQuerysetEqualAndNotEmpty(self.filterset(params, self.queryset).qs, ipv6_prefixes)
-        params = {"ip_version": ["4"]}
+        params = {"ip_version": "4"}
         ipv4_prefixes = self.queryset.filter(ip_version=4)
         self.assertQuerysetEqualAndNotEmpty(self.filterset(params, self.queryset).qs, ipv4_prefixes)
-        params = {"ip_version": [""]}
+        params = {"ip_version": ""}
         all_prefixes = self.queryset.all()
         self.assertQuerysetEqualAndNotEmpty(self.filterset(params, self.queryset).qs, all_prefixes)
 
@@ -569,15 +569,15 @@ class IPAddressTestCase(FilterTestCases.FilterTestCase, FilterTestCases.TenancyF
             self.assertQuerysetEqualAndNotEmpty(self.filterset(params, self.queryset).qs, self.queryset.all())
 
     def test_ip_version(self):
-        params = {"ip_version": ["6"]}
+        params = {"ip_version": "6"}
         self.assertQuerysetEqualAndNotEmpty(
             self.filterset(params, self.queryset).qs, self.queryset.filter(ip_version=6)
         )
-        params = {"ip_version": ["4"]}
+        params = {"ip_version": "4"}
         self.assertQuerysetEqualAndNotEmpty(
             self.filterset(params, self.queryset).qs, self.queryset.filter(ip_version=4)
         )
-        params = {"ip_version": [""]}
+        params = {"ip_version": ""}
         self.assertQuerysetEqualAndNotEmpty(self.filterset(params, self.queryset).qs, self.queryset.all())
 
     def test_dns_name(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3287 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Command output with invalid filters:
```
>>> Auditing existing DynamicGroup data for invalid filters ...

    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `site`
    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `length`
    DynamicGroup instance with name `Test DP` and content type `dcim | rack` has an invalid filter `region`
    DynamicGroup instance with name `Test DP 1` and content type `ipam | IP address` has an invalid filter `site`
    DynamicGroup instance with name `Test DP 1` and content type `ipam | IP address` has an invalid filter `length`
    DynamicGroup instance with name `Test DP 1` and content type `ipam | IP address` has an invalid filter `region`
    DynamicGroup instance with name `Test DP 2` and content type `dcim | device` has an invalid filter `site`
    DynamicGroup instance with name `Test DP 2` and content type `dcim | device` has an invalid filter `length`
    DynamicGroup instance with name `Test DP 2` and content type `dcim | device` has an invalid filter `region`
    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `site`
    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `length`
    DynamicGroup instance with name `Test DP 3` and content type `dcim | device redundancy group` has an invalid filter `region`
    DynamicGroup instance with name `Test DP 4` and content type `example_plugin | another example model` has an invalid filter `site`
    DynamicGroup instance with name `Test DP 4` and content type `example_plugin | another example model` has an invalid filter `length`
    DynamicGroup instance with name `Test DP 4` and content type `example_plugin | another example model` has an invalid filter `region`
    DynamicGroup instance with name `Test DP 5` and content type `ipam | IP address` has an invalid filter `site`
    DynamicGroup instance with name `Test DP 5` and content type `ipam | IP address` has an invalid filter `length`
    DynamicGroup instance with name `Test DP 5` and content type `ipam | IP address` has an invalid filter `region`
    DynamicGroup instance with name `Test DP 6` and content type `ipam | prefix` has an invalid filter `site`
    DynamicGroup instance with name `Test DP 6` and content type `ipam | prefix` has an invalid filter `length`
    DynamicGroup instance with name `Test DP 6` and content type `ipam | prefix` has an invalid filter `region`
    DynamicGroup instance with name `Test DP 7` and content type `virtualization | cluster` has an invalid filter `site`
    DynamicGroup instance with name `Test DP 7` and content type `virtualization | cluster` has an invalid filter `length`
    DynamicGroup instance with name `Test DP 7` and content type `virtualization | cluster` has an invalid filter `region`
    DynamicGroup instance with name `Test DP 8` and content type `virtualization | virtual machine` has an invalid filter `site`
    DynamicGroup instance with name `Test DP 8` and content type `virtualization | virtual machine` has an invalid filter `length`
    DynamicGroup instance with name `Test DP 8` and content type `virtualization | virtual machine` has an invalid filter `region`

>>> Please fix the broken filters stated above according to the documentations at available'<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes'
```

Command output with valid filter data:
```
>>> Auditing existing DynamicGroup data for invalid filters ...


>>> All DynamicGroup filters are validated successfully!
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
