### PR TITLE
Fix a couple of migration-impacting bugs.

### DIFF
--- a/nautobot/dcim/migrations/0030_migrate_region_and_site_data_to_locations.py
+++ b/nautobot/dcim/migrations/0030_migrate_region_and_site_data_to_locations.py
@@ -194,7 +194,9 @@ def reassign_site_model_instances_to_locations(apps, site_lt):
     site_lt.content_types.set(ContentType.objects.filter(FeatureQuery("locations").get_query()))
 
     # Circuits App
-    cts = CircuitTermination.objects.filter(location__isnull=True).select_related("site__migrated_location")
+    cts = CircuitTermination.objects.filter(location__isnull=True, site__isnull=False).select_related(
+        "site__migrated_location"
+    )
     for ct in cts:
         ct.location = ct.site.migrated_location
     CircuitTermination.objects.bulk_update(cts, ["location"], 1000)


### PR DESCRIPTION
# Closes: #<ISSUE NUMBER GOES HERE>
# What's Changed

In working on automated testing for #3900, I uncovered a couple of migration bugs. This PR is to fix those bugs immediately; the actual test automation for #3900 will be a later PR as I'm still refining it.

- dcim.0030 migration would error out if any CircuitTerminations were terminated to a ProviderNetwork instead of a Site.
- ipam.0031 migration:
    - erroneously flagged any interface with multiple IPs in the same VRF as having mismatched VRFs, due to a missing `distinct=True` parameter
    - wouldn't catch the case where an interface has a mix of non-VRF IPs and IPs in a single VRF


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- (future) Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
