### PR TITLE
Fixed confusing unit test failure message

### DIFF
--- a/changes/3534.added
+++ b/changes/3534.added
@@ -1,0 +1,1 @@
+Added optional args and kwargs to `BaseModel.validated_save()` that pass through to the model's `save` method.

--- a/changes/3534.fixed
+++ b/changes/3534.fixed
@@ -1,0 +1,2 @@
+Fixed confusing unit test failure message when trying to run a non-existent test.
+Fixed unit tests sometimes clearing out the default database.

--- a/nautobot/core/factory.py
+++ b/nautobot/core/factory.py
@@ -14,8 +14,9 @@ class BaseModelFactory(DjangoModelFactory):
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         """Override default DjangoModelFactory behavior to call validated_save() instead of just save()."""
+        using = kwargs.pop("using", cls._meta.database)
         obj = model_class(*args, **kwargs)
-        obj.validated_save()
+        obj.validated_save(using=using)
         return obj
 
 

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -37,7 +37,7 @@ class BaseModel(models.Model):
     class Meta:
         abstract = True
 
-    def validated_save(self):
+    def validated_save(self, *args, **kwargs):
         """
         Perform model validation during instance save.
 
@@ -45,8 +45,8 @@ class BaseModel(models.Model):
         which in effect enforces model validation prior to saving the instance, without having
         to manually make these calls seperately. This is a slight departure from Django norms,
         but is intended to offer an optional, simplified interface for performing this common
-        workflow. The indended use is for user defined Jobs and scripts run via the `nbshell`
+        workflow. The intended use is for user defined Jobs and scripts run via the `nbshell`
         command.
         """
         self.full_clean()
-        self.save()
+        self.save(*args, **kwargs)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3534
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Fixed unit tests sometimes clearing out the default database.
- Fixed confusing unit test failure message when trying to run a non-existent test:

```sh
$ time inv unittest -s -k -l nautobot.tests
Running docker-compose command "ps --services --filter status=running"
Running docker-compose command "run --rm --entrypoint 'coverage run --module nautobot.core.cli test nautobot.tests --config=nautobot/core/tests/nautobot_config.py 
--cache-test-fixtures --keepdb --buffer' nautobot"
PYTHON_VER=3.8 \
docker-compose \
    --project-name "nautobot" \
    --project-directory "/home/gary/github/nautobot/development" \
    -f "/home/gary/github/nautobot/development/docker-compose.yml" \
    -f "/home/gary/github/nautobot/development/docker-compose.postgres.yml" \
    -f "/home/gary/github/nautobot/development/docker-compose.dev.yml" \
    -f "/home/gary/github/nautobot/development/docker-compose.override.yml" run \
    --rm \
    --entrypoint 'coverage run \
    --module nautobot.core.cli test nautobot.tests \
    --config=nautobot/core/tests/nautobot_config.py \
    --cache-test-fixtures \
    --keepdb \
    --buffer' nautobot
[+] Building 0.0s (0/0)                                                                                                                                               
[+] Creating 3/0
 ✔ Container nautobot-selenium-1  Running                                                                                                                        0.0s 
 ✔ Container nautobot-db-1        Running                                                                                                                        0.0s 
 ✔ Container nautobot-redis-1     Running                                                                                                                        0.0s 
[+] Building 0.0s (0/0)                                                                                                                                               
Using NautobotPerformanceTestRunner to run tests ...
System check identified some issues:

WARNINGS:
<Settings "nautobot_config">: (nautobot.core.W005) STORAGE_CONFIG has been set but STORAGE_BACKEND is not defined. STORAGE_CONFIG will be ignored.

System check identified 1 issue (0 silenced).
E
======================================================================
ERROR: tests (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
ModuleNotFoundError: No module named 'nautobot.tests'


----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (errors=1)

real    0m9.023s
user    0m0.515s
sys     0m0.161s
```

- Bonus side effect of being able to run tests that don't require a database, without setting up a database:

```sh
$ time inv unittest -s -k -l nautobot.core.tests.test_celery
Running docker-compose command "ps --services --filter status=running"
Running docker-compose command "run --rm --entrypoint 'coverage run --module nautobot.core.cli test nautobot.core.tests.test_celery 
--config=nautobot/core/tests/nautobot_config.py --cache-test-fixtures --keepdb --buffer' nautobot"
PYTHON_VER=3.8 \
docker-compose \
    --project-name "nautobot" \
    --project-directory "/home/gary/github/nautobot/development" \
    -f "/home/gary/github/nautobot/development/docker-compose.yml" \
    -f "/home/gary/github/nautobot/development/docker-compose.postgres.yml" \
    -f "/home/gary/github/nautobot/development/docker-compose.dev.yml" \
    -f "/home/gary/github/nautobot/development/docker-compose.override.yml" run \
    --rm \
    --entrypoint 'coverage run \
    --module nautobot.core.cli test nautobot.core.tests.test_celery \
    --config=nautobot/core/tests/nautobot_config.py \
    --cache-test-fixtures \
    --keepdb \
    --buffer' nautobot
[+] Building 0.0s (0/0)                                                                                                                                               
[+] Creating 3/0
 ✔ Container nautobot-db-1        Running                                                                                                                        0.0s 
 ✔ Container nautobot-redis-1     Running                                                                                                                        0.0s 
 ✔ Container nautobot-selenium-1  Running                                                                                                                        0.0s 
[+] Building 0.0s (0/0)                                                                                                                                               
Using NautobotPerformanceTestRunner to run tests ...
System check identified some issues:

WARNINGS:
<Settings "nautobot_config">: (nautobot.core.W005) STORAGE_CONFIG has been set but STORAGE_BACKEND is not defined. STORAGE_CONFIG will be ignored.

System check identified 1 issue (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK

real    0m9.520s
user    0m0.593s
sys     0m0.165s
```



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
