### PR TITLE
Only strip domain.tld part from lldp_device

### DIFF
--- a/changes/3968.changed
+++ b/changes/3968.changed
@@ -1,0 +1,1 @@
+Changed lldp_device parser to only strip domain and tld parts from neighbor_host allowing a device subdomain to be correctly matched.

--- a/nautobot/dcim/templates/dcim/device/lldp_neighbors.html
+++ b/nautobot/dcim/templates/dcim/device/lldp_neighbors.html
@@ -74,7 +74,7 @@ $(document).ready(function() {
                 // Clean up hostnames/interfaces learned via LLDP
                 var neighbor_host = neighbor['remote_system_name'] || ""; // sanitize hostname if it's null to avoid breaking the split func
                 var neighbor_port = neighbor['remote_port'] || ""; // sanitize port if it's null to avoid breaking the split func
-                var lldp_device = neighbor_host.split(".")[0];  // Strip off any trailing domain name
+                var lldp_device = neighbor_host.split(".").slice(0, -2).join(".");  // Strip off any trailing domain name, leaving any sub-domain part intact
                 var lldp_interface = neighbor_port.split(".")[0];   // Strip off any trailing subinterface ID
 
                 // Add LLDP neighbors to table


### PR DESCRIPTION
Any device hostname returned by LLDP that contains a subdomain will appear in the LLDP Neighbors tab as a mismatch.  This is due to `lldp_device` being parsed with an assumption that the hostname will never contain a subdomain part and only ever contain a domain name part.

IEEE 802.1AB does not specify exactly what the System Name TLV should contain, nor does it specify one way or the other whether the how the domain name should be treated.

This PR does not account for cases where a second level domain is used, so that would still be a corner case which would get mis-handled.  On the other hand, it is being completely stripped previously currently, so in either case, if a device hostname with a second level domain name also contained a subdomain, it would report incorrectly in the `LLDP Neighbors` tab.

An alternative approach could be to not strip anything, and leave it up to the LLDP implementation and/or knobs on the device itself to correctly format the TLV and leave Nautobot out of that decision process.

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #<ISSUE NUMBER GOES HERE>
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
