### PR TITLE
Reduce jumping page behavior for table loading

### DIFF
--- a/changes/3906.changed
+++ b/changes/3906.changed
@@ -1,0 +1,3 @@
+Moved LoadingWidget up & to the left of the ButtonGroup in ObjectListTable.
+Modified when SkeletonText appears in ObjectListTable to include on page number changes.
+Removed top: "40%" from LoadingWidget.

--- a/changes/3906.changed
+++ b/changes/3906.changed
@@ -1,3 +1,1 @@
-Moved LoadingWidget up & to the left of the ButtonGroup in ObjectListTable.
-Modified when SkeletonText appears in ObjectListTable to include on page number changes.
-Removed top: "40%" from LoadingWidget.
+Changed visual loading behavior of object list views in new UI.

--- a/nautobot/ui/src/components/LoadingWidget.js
+++ b/nautobot/ui/src/components/LoadingWidget.js
@@ -10,7 +10,6 @@ export function LoadingWidget({ name = "" }) {
                 textAlign: "center",
                 width: "100%",
                 position: "relative",
-                top: "40%",
                 gridColumn: "2 / span 2",
             }}
         >

--- a/nautobot/ui/src/components/ObjectTable/ObjectListTable.js
+++ b/nautobot/ui/src/components/ObjectTable/ObjectListTable.js
@@ -1,4 +1,4 @@
-import { ButtonGroup, SkeletonText } from "@chakra-ui/react";
+import { ButtonGroup, Flex, SkeletonText, Spacer } from "@chakra-ui/react";
 import * as Icon from "react-icons/tb";
 import { useLocation } from "react-router-dom";
 import { useEffect, useRef, useState } from "react";
@@ -133,48 +133,57 @@ export default function ObjectListTable({
     return (
         <Box background="white-0" borderRadius="md" padding="md" ref={topRef}>
             {!include_button ? null : (
-                <Box display="flex" justifyContent="space-between" mb="sm">
+                <Flex align="center" height="60px">
                     <Heading
                         as="h1"
                         size="H1"
                         display="flex"
                         alignItems="center"
                         gap="5px"
-                        pb="sm"
                     >
                         <NtcThumbnailIcon width="25px" height="30px" />{" "}
                         {tableTitle}
                     </Heading>
-                    <ButtonGroup pb="sm" alignItems="center">
-                        <UIButton size="sm" variant="secondary" onClick={toast}>
-                            Filters
-                        </UIButton>
-                        <UIButton
-                            size="sm"
-                            variant="primary"
-                            leftIcon={<MeatballsIcon />}
-                        >
-                            Actions
-                        </UIButton>
-                        <Icon.TbMinusVertical />
-                        <UIButton
-                            to={`${location.pathname}add/`}
-                            size="sm"
-                            leftIcon={<PlusIcon />}
-                            onClick={(e) => {
-                                e.preventDefault();
-                                // Because there is currently no support for Add view in the new UI for production,
-                                // the code below checks if the app is running in production and redirects the user to
-                                // the Add page; after the page is reloaded, nautobot takes care of rendering the legacy UI.
-                                if (process.env.NODE_ENV === "production") {
-                                    document.location.href += "add/";
-                                }
-                            }}
-                        >
-                            Add {tableTitle}
-                        </UIButton>
-                    </ButtonGroup>
-                </Box>
+                    <Spacer />
+                    {!data_fetched ? (
+                        <Box pr="sm">
+                            <LoadingWidget name={tableTitle} />
+                        </Box>
+                    ) : (
+                        () => {}
+                    )}
+                    <Box>
+                        <ButtonGroup alignItems="center">
+                            <UIButton size="sm" variant="secondary" onClick={toast}>
+                                Filters
+                            </UIButton>
+                            <UIButton
+                                size="sm"
+                                variant="primary"
+                                leftIcon={<MeatballsIcon />}
+                            >
+                                Actions
+                            </UIButton>
+                            <Icon.TbMinusVertical />
+                            <UIButton
+                                to={`${location.pathname}add/`}
+                                size="sm"
+                                leftIcon={<PlusIcon />}
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    // Because there is currently no support for Add view in the new UI for production,
+                                    // the code below checks if the app is running in production and redirects the user to
+                                    // the Add page; after the page is reloaded, nautobot takes care of rendering the legacy UI.
+                                    if (process.env.NODE_ENV === "production") {
+                                        document.location.href += "add/";
+                                    }
+                                }}
+                            >
+                                Add {tableTitle}
+                            </UIButton>
+                        </ButtonGroup>
+                    </Box>
+                </Flex>
             )}
 
             <SkeletonText
@@ -183,15 +192,8 @@ export default function ObjectListTable({
                 skeletonHeight="25"
                 spacing="3"
                 mt="3"
-                isLoaded={data_loaded}
+                isLoaded={data_fetched}
             >
-                {!data_fetched && data_loaded ? (
-                    <Box background="white-0" borderRadius="md" padding="md">
-                        <LoadingWidget name={tableTitle} />
-                    </Box>
-                ) : (
-                    () => {}
-                )}
                 <TableRenderer
                     table={table}
                     containerProps={{ overflow: "auto" }}

--- a/nautobot/ui/src/components/ObjectTable/ObjectListTable.js
+++ b/nautobot/ui/src/components/ObjectTable/ObjectListTable.js
@@ -154,7 +154,11 @@ export default function ObjectListTable({
                     )}
                     <Box>
                         <ButtonGroup alignItems="center">
-                            <UIButton size="sm" variant="secondary" onClick={toast}>
+                            <UIButton
+                                size="sm"
+                                variant="secondary"
+                                onClick={toast}
+                            >
                                 Filters
                             </UIButton>
                             <UIButton


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3906 <ISSUE NUMBER GOES HERE>
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
- Moved LoadingWidget up & to the left of the ButtonGroup in ObjectListTable
- Modified when SkeletonText appears in ObjectListTable to include on page number changes (before, the SkeletonText only showed on initial page load and, when changing page numbers, the table kept the current data until new data was ready)
- Removed top: "40%" from LoadingWidget

### New:

![image](https://github.com/nautobot/nautobot/assets/111259311/5cc6c978-5d55-4911-b56f-fca28f90275b)

### Before:

![image](https://github.com/nautobot/nautobot/assets/111259311/4cb4206c-9fa3-4906-b4e1-60adb8ca767b)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example