### PR TITLE
Fix #3980 - add __str__() implementation on Tag model

### DIFF
--- a/changes/3980.fixed
+++ b/changes/3980.fixed
@@ -1,0 +1,1 @@
+Fixed a regression in the display of Tag records in the UI.

--- a/nautobot/extras/models/tags.py
+++ b/nautobot/extras/models/tags.py
@@ -46,6 +46,9 @@ class Tag(BaseModel, ChangeLoggedModel, CustomFieldModel, RelationshipModel, Not
 
     objects = BaseManager.from_queryset(TagQuerySet)()
 
+    def __str__(self):
+        return self.name
+
     class Meta:
         ordering = ["name"]
 


### PR DESCRIPTION
# Closes: #3980

# What's Changed

When #3914 made it so that `Tag` no longer inherited from taggit's `TagBase` model, I didn't notice that that removed the inherited `__str__` method without replacing it with our own implementation. This just adds that missing method.

![image](https://github.com/nautobot/nautobot/assets/5603551/37ccb63c-cf6b-4384-8917-adf912f705dd)

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
