### PR TITLE
Fix 2374 - update guidance on use of dumpdata/loaddata/trace_paths

### DIFF
--- a/changes/2374.fixed
+++ b/changes/2374.fixed
@@ -1,0 +1,2 @@
+Removed problematic guidance to use `--natural-primary` flag when running `nautobot-server dumpdata`.
+Added guidance to run `nautobot-server trace_paths` after `nautobot-server loaddata`.

--- a/changes/2374.fixed
+++ b/changes/2374.fixed
@@ -1,2 +1,4 @@
-Removed problematic guidance to use `--natural-primary` flag when running `nautobot-server dumpdata`.
-Added guidance to run `nautobot-server trace_paths` after `nautobot-server loaddata`.
+Revised documentation for recommended parameters to use when running `nautobot-server dumpdata`.
+Revised documentation around preparing to run `nautobot-server loaddata`.
+Added documentation to run `nautobot-server trace_paths` after `nautobot-server loaddata`.
+Fixed a signal handler that could cause `nautobot-server loaddata` to abort if certain data is present.

--- a/nautobot/dcim/signals.py
+++ b/nautobot/dcim/signals.py
@@ -6,6 +6,7 @@ from django.db.models.signals import m2m_changed, post_save, pre_delete
 from django.db import transaction
 from django.dispatch import receiver
 
+from nautobot.core.signals import disable_for_loaddata
 from .models import (
     Cable,
     CablePath,
@@ -286,6 +287,7 @@ def nullify_connected_endpoints(instance, **kwargs):
 
 
 @receiver(m2m_changed, sender=Interface.tagged_vlans.through)
+@disable_for_loaddata
 def prevent_adding_tagged_vlans_with_incorrect_mode_or_site(sender, instance, action, **kwargs):
     if action != "pre_add":
         return

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -472,7 +472,7 @@ Markdown rendering is supported for log messages.
     As a security measure, the `message` passed to any of these methods will be passed through the `nautobot.utilities.logging.sanitize()` function in an attempt to strip out information such as usernames/passwords that should not be saved to the logs. This is of course best-effort only, and Job authors should take pains to ensure that such information is not passed to the logging APIs in the first place. The set of redaction rules used by the `sanitize()` function can be configured as [settings.SANITIZER_PATTERNS](../configuration/optional-settings.md#sanitizer_patterns).
 
 !!! note
-    Using `self.log_failure()`, in addition to recording a log message, will flag the overall job as failed, but it will **not** stop the execution of the job, nor will it result in an automatic rollback of any database changes made by the job. To end a job early, you can use a Python `raise` or `return` as appropriate. Raising any exception (e.g. `ValueError` for malformed input values) will ensure that any database changes are rolled back as part of the process of ending the job. `AbortTransaction` from Nautobot, which was recommended in past versions of the docs, should explicitly _not_ be used, as it is only intended for use by Nautobot's internal job handling.
+    Using `self.log_failure()`, in addition to recording a log message, will flag the overall job as failed, but it will **not** stop the execution of the job, nor will it result in an automatic rollback of any database changes made by the job. To end a job early, you can use a Python `raise` or `return` as appropriate. Raising any exception (e.g. `ValueError` for malformed input values) will ensure that any database changes are rolled back as part of the process of ending the job. `AbortTransaction` from Nautobot, which was recommended in past versions of the docs, should explicitly *not* be used, as it is only intended for use by Nautobot's internal job handling.
 
 ### Accessing Request Data
 
@@ -514,12 +514,12 @@ An administrator or user with `extras.change_job` permission can edit the Job to
 * Navigate to Jobs > Jobs menu
 * Select a job that has been installed
 * Select **Edit** button
-* In the second section titled _Job_, select the **Enabled** checkbox
+* In the second section titled *Job*, select the **Enabled** checkbox
 * Select **Update** button at the bottom
 
 #### Enabling Job Hooks
 
- Job hooks are enabled in a similar fashion, but by using the _default_ filters when navigating to the Jobs page the Job Hooks will not be visible. To enable job hooks:
+ Job hooks are enabled in a similar fashion, but by using the *default* filters when navigating to the Jobs page the Job Hooks will not be visible. To enable job hooks:
 
 * Navigate to Jobs > Jobs menu
 * Select the **Filter** button to bring up the Filter Jobs context
@@ -527,7 +527,7 @@ An administrator or user with `extras.change_job` permission can edit the Job to
 * Select **Apply** button
 * Select a job that has been installed
 * Select **Edit** button
-* In the second section titled _Job_, select the **Enabled** checkbox
+* In the second section titled *Job*, select the **Enabled** checkbox
 * Select **Update** button at the bottom
 
 ### Overriding Metadata

--- a/nautobot/docs/administration/nautobot-server.md
+++ b/nautobot/docs/administration/nautobot-server.md
@@ -151,12 +151,14 @@ nautobot=> \q
     - `extras.job` should now be included in the dump (removed `--exclude extras.job` from the example usage)
     - `django_rq` should now be excluded from the dump (added `--exclude django_rq` to the example usage)
 
++/- 1.5.22
+    - We do not recommend at this time using `--natural-primary` as this can result in inconsistent or incorrect data for data models that use GenericForeignKeys, such as `Cable`, `Note`, `ObjectChange`, and `Tag`.
+
 ```no-highlight
 nautobot-server dumpdata \
   --natural-foreign \
-  --natural-primary \
-  --exclude contenttypes \
   --exclude auth.permission \
+  --exclude contenttypes \
   --exclude django_rq \
   --format json \
   --indent 2 \
@@ -165,7 +167,7 @@ nautobot-server dumpdata \
 
 Use this command to generate a JSON dump of the database contents.
 
-One example of using this command would be to [`export data from PostgreSQL`](../installation/migrating-from-postgresql.md#export-data-from-postgresql).
+One example of using this command would be to [export data from PostgreSQL](../installation/migrating-from-postgresql.md#export-data-from-postgresql) and then [import the data dump into MySQL](../installation/migrating-from-postgresql.md#import-the-database-dump-into-mysql).
 
 ### `fix_custom_fields`
 
@@ -306,8 +308,9 @@ There are a number of other options not covered here.
 
 To import the data that was exported with `nautobot-server dumpdata ...` see the following documentation:
 
-- [`Remove the auto-populated Status records from the database`](../installation/migrating-from-postgresql.md#remove-the-auto-populated-status-records-from-the-mysql-database)
-- [`Import the database dump`](../installation/migrating-from-postgresql.md#import-the-database-dump-into-mysql)
+- [Remove auto-populated records from the database](../installation/migrating-from-postgresql.md#remove-auto-populated-records-from-the-mysql-database)
+- [Import the database dump](../installation/migrating-from-postgresql.md#import-the-database-dump-into-mysql)
+- [Rebuild cached cable path traces](../installation/migrating-from-postgresql.md#rebuild-cached-cable-path-traces)
 
 ### `migrate`
 

--- a/nautobot/docs/administration/nautobot-server.md
+++ b/nautobot/docs/administration/nautobot-server.md
@@ -151,18 +151,19 @@ nautobot=> \q
     - `extras.job` should now be included in the dump (removed `--exclude extras.job` from the example usage)
     - `django_rq` should now be excluded from the dump (added `--exclude django_rq` to the example usage)
 
-+/- 1.5.22
++/- 1.5.23
     - We do not recommend at this time using `--natural-primary` as this can result in inconsistent or incorrect data for data models that use GenericForeignKeys, such as `Cable`, `Note`, `ObjectChange`, and `Tag`.
+    - We also do not recommend at this time using `--natural-foreign` as it can potentially result in errors if any data models incorrectly implement their `natural_key()` and/or `get_by_natural_key()` API methods.
+    - `contenttypes` must not be excluded from the dump (it could be excluded previously due to the use of `--natural-foreign`).
 
 ```no-highlight
 nautobot-server dumpdata \
-  --natural-foreign \
   --exclude auth.permission \
-  --exclude contenttypes \
   --exclude django_rq \
   --format json \
   --indent 2 \
-  --traceback  > nautobot_dump.json
+  --traceback \
+  > nautobot_dump.json
 ```
 
 Use this command to generate a JSON dump of the database contents.

--- a/nautobot/docs/installation/migrating-from-postgresql.md
+++ b/nautobot/docs/installation/migrating-from-postgresql.md
@@ -8,9 +8,7 @@ In your existing installation of Nautobot with PostgreSQL, run the following com
 
 ```no-highlight
 nautobot-server dumpdata \
-    --natural-foreign \
     --exclude auth.permission \
-    --exclude contenttypes \
     --exclude django_rq \
     --format json \
     --indent 2 \
@@ -18,8 +16,10 @@ nautobot-server dumpdata \
     > nautobot_dump.json
 ```
 
-+/- 1.5.22
++/- 1.5.23
     - We do not recommend at this time using `--natural-primary` as this can result in inconsistent or incorrect data for data models that use GenericForeignKeys, such as `Cable`, `Note`, `ObjectChange`, and `Tag`.
+    - We also do not recommend at this time using `--natural-foreign` as it can potentially result in errors if any data models incorrectly implement their `natural_key()` and/or `get_by_natural_key()` API methods.
+    - `contenttypes` must not be excluded from the dump (it could be excluded previously due to the use of `--natural-foreign`).
 
 This will result in a file named `nautobot_dump.json`.
 
@@ -54,21 +54,44 @@ nautobot-server migrate
 
 ## Remove auto-populated records from the MySQL database
 
-A side effect of the `nautobot-server migrate` command is that it will populate the `Status` table with a number of predefined records. This is normally useful for getting started quickly with Nautobot, but since we're going to be importing data from our other database, these records will likely conflict with the records to be imported. Therefore we need to remove them, using the `nautobot-server nbshell` command in our MySQL instance of Nautobot (`(nautobot-mysql) $` shell prompt):
+A side effect of the `nautobot-server migrate` command is that it will populate the `ContentType`, `Job`, and `Status` tables with a number of predefined records. Depending on what Nautobot App(s) you have installed, the app(s) may also have auto-created database records of their own, such as `CustomField` or `Tag` records, in response to `nautobot-server migrate`. This is normally useful for getting started quickly with Nautobot, but since we're going to be importing data from our other database, these records will likely conflict with the records to be imported. Therefore we need to remove them, using the `nautobot-server nbshell` command in our MySQL instance of Nautobot (`(nautobot-mysql) $` shell prompt):
 
 ```no-highlight
 nautobot-server nbshell
 ```
 
+Enter the following Python commands into the shell:
+
+```python
+from django.apps import apps
+for model in apps.get_models():
+    if model._meta.managed and model.objects.exists():
+        print(f"Deleting objects of {model}")
+        print(model.objects.all().delete())
+```
+
 Example output:
 
 ```no-highlight
-### Nautobot interactive shell (32cec46b2b7e)
-### Python 3.9.7 | Django 3.1.13 | Nautobot 1.1.3
+### Nautobot interactive shell (1f2ecc58cf6b)
+### Python 3.7.13 | Django 3.2.19 | Nautobot 1.5.22b1
 ### lsmodels() will show available models. Use help(<model>) for more info.
->>> Status.objects.all().delete()
-(67, {'extras.Status_content_types': 48, 'extras.Status': 19})
->>>
+>>> from django.apps import apps
+>>> for model in apps.get_models():
+...     if model._meta.managed and model.objects.exists():
+...         print(f"Deleting objects of {model}")
+...         print(model.objects.all().delete())
+...
+Deleting objects of <class 'django.contrib.auth.models.Permission'>
+(465, {'auth.Permission': 465})
+Deleting objects of <class 'django.contrib.contenttypes.models.ContentType'>
+(186, {'extras.CustomField_content_types': 1, 'extras.Status_content_types': 68, 'contenttypes.ContentType': 117})
+Deleting objects of <class 'nautobot.extras.models.customfields.CustomField'>
+(1, {'extras.CustomField': 1})
+Deleting objects of <class 'nautobot.extras.models.statuses.Status'>
+(20, {'extras.Status': 20})
+Deleting objects of <class 'nautobot.extras.models.jobs.Job'>
+(6, {'extras.Job': 6})
 ```
 
 Press Control-D to exit the `nbshell` when you are finished.


### PR DESCRIPTION
# Closes: #2374 
# What's Changed

- Removed problematic guidance to use `--natural-primary` flag when running `nautobot-server dumpdata`. (see #3666)
- Added guidance to run `nautobot-server trace_paths` after `nautobot-server loaddata`. (fixes #2374).

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
