### PR TITLE
Add the ability to actually download SVG from Rack

### DIFF
--- a/changes/3987.fixed
+++ b/changes/3987.fixed
@@ -1,0 +1,1 @@
+Fixed issue where download SVG download did not actually download.

--- a/nautobot/dcim/templates/dcim/inc/rack_elevation.html
+++ b/nautobot/dcim/templates/dcim/inc/rack_elevation.html
@@ -2,7 +2,7 @@
     <object data="{% url 'dcim-api:rack-elevation' pk=object.pk %}?face={{face}}&render=svg" class="rack_elevation"></object>
 </div>
 <div class="text-center text-small">
-    <a href="{% url 'dcim-api:rack-elevation' pk=object.pk %}?face={{face}}&render=svg" class="rack_elevation_save_svg_link">
+    <a href="{% url 'dcim-api:rack-elevation' pk=object.pk %}?face={{face}}&render=svg" class="rack_elevation_save_svg_link" download="rack_{{ face }}_{{ object }}.svg">
         <i class="mdi mdi-content-save-outline"></i> Save SVG
     </a>
 </div>


### PR DESCRIPTION

# Closes: DNE
# What's Changed

Add the ability to actually download SVG from Rack

<img width="1065" alt="image" src="https://github.com/nautobot/nautobot/assets/9260483/3870daba-3108-4ebd-abdf-8f7671acd5c9">

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
