### PR TITLE
Add default filename for CSV export from the UI

### DIFF
--- a/changes/3782.fixed
+++ b/changes/3782.fixed
@@ -1,0 +1,1 @@
+Fixed filename for CSV exports.

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -268,6 +268,13 @@ class ModelViewSetMixin:
             self.logger.warning(msg)
             return self.finalize_response(request, Response({"detail": msg}, status=409), *args, **kwargs)
 
+    def finalize_response(self, request, response, *args, **kwargs):
+        # In the case of certain errors, we might not even get to the point of setting request.accepted_media_type
+        if hasattr(request, "accepted_media_type") and "text/csv" in request.accepted_media_type:
+            filename = f"{settings.BRANDING_PREPENDED_FILENAME}{self.queryset.model.__name__.lower()}_data.csv"
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return super().finalize_response(request, response, *args, **kwargs)
+
     @action(detail=True, url_path="detail-view-config")
     def detail_view_config(self, request, pk):
         """

--- a/nautobot/core/templates/buttons/export.html
+++ b/nautobot/core/templates/buttons/export.html
@@ -6,16 +6,31 @@
         </button>
         <ul class="dropdown-menu dropdown-menu-right">
             {% if export_url %}
-                <li><a href="{{ export_url }}?{% if url_params %}{{ url_params.urlencode }}&{% endif %}format=csv">Default format</a></li>
+                <li>
+                    <a href="{{ export_url }}?{% if url_params %}{{ url_params.urlencode }}&{% endif %}format=csv"
+                       download="{{ default_filename }}"
+                    >
+                        Default format
+                    </a>
+                </li>
             {% endif %}
             <li class="divider"></li>
             {% for et in export_templates %}
-                <li><a href="?{% if url_params %}{{ url_params.urlencode }}&{% endif %}export={{ et.name }}"{% if et.description %} title="{{ et.description }}"{% endif %}>{{ et.name }}</a></li>
+                <li>
+                    <a href="?{% if url_params %}{{ url_params.urlencode }}&{% endif %}export={{ et.name }}"
+                       {% if et.description %} title="{{ et.description }}"{% endif %}
+                    >
+                        {{ et.name }}
+                    </a>
+                </li>
             {% endfor %}
         </ul>
     </div>
 {% elif export_url %}
-<a href="{{ export_url }}?{% if url_params %}{{ url_params.urlencode }}&{% endif %}format=csv" class="btn btn-success">
+    <a href="{{ export_url }}?{% if url_params %}{{ url_params.urlencode }}&{% endif %}format=csv"
+       class="btn btn-success"
+       download="{{ default_filename }}"
+    >
         <span class="mdi mdi-database-export" aria-hidden="true"></span> Export
     </a>
 {% endif %}

--- a/nautobot/core/templates/buttons/export.html
+++ b/nautobot/core/templates/buttons/export.html
@@ -7,9 +7,7 @@
         <ul class="dropdown-menu dropdown-menu-right">
             {% if export_url %}
                 <li>
-                    <a href="{{ export_url }}?{% if url_params %}{{ url_params.urlencode }}&{% endif %}format=csv"
-                       download="{{ default_filename }}"
-                    >
+                    <a href="{{ export_url }}?{% if url_params %}{{ url_params.urlencode }}&{% endif %}format=csv">
                         Default format
                     </a>
                 </li>
@@ -29,7 +27,6 @@
 {% elif export_url %}
     <a href="{{ export_url }}?{% if url_params %}{{ url_params.urlencode }}&{% endif %}format=csv"
        class="btn btn-success"
-       download="{{ default_filename }}"
     >
         <span class="mdi mdi-database-export" aria-hidden="true"></span> Export
     </a>

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -1,4 +1,5 @@
 from django import template
+from django.conf import settings
 from django.urls import NoReverseMatch, reverse
 
 from nautobot.core.views import utils as views_utils
@@ -117,12 +118,15 @@ def export_button(context, content_type=None):
             export_url = reverse(lookup.get_route_for_model(content_type.model_class(), "list", api=True))
         except NoReverseMatch:
             export_url = None
+        default_filename = f"{settings.BRANDING_PREPENDED_FILENAME}{content_type.model}_data.csv"
     else:
         export_templates = []
         export_url = None
+        default_filename = ""
 
     return {
         "export_url": export_url,
+        "default_filename": default_filename,
         "url_params": context["request"].GET,
         "export_templates": export_templates,
     }

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -1,5 +1,4 @@
 from django import template
-from django.conf import settings
 from django.urls import NoReverseMatch, reverse
 
 from nautobot.core.views import utils as views_utils
@@ -118,15 +117,12 @@ def export_button(context, content_type=None):
             export_url = reverse(lookup.get_route_for_model(content_type.model_class(), "list", api=True))
         except NoReverseMatch:
             export_url = None
-        default_filename = f"{settings.BRANDING_PREPENDED_FILENAME}{content_type.model}_data.csv"
     else:
         export_templates = []
         export_url = None
-        default_filename = ""
 
     return {
         "export_url": export_url,
-        "default_filename": default_filename,
         "url_params": context["request"].GET,
         "export_templates": export_templates,
     }

--- a/nautobot/core/testing/api.py
+++ b/nautobot/core/testing/api.py
@@ -510,6 +510,10 @@ class APIViewTestCases:
             )
             self.assertHttpStatus(response_1, status.HTTP_200_OK)
             self.assertEqual(response_1.get("Content-Type"), "text/csv; charset=UTF-8")
+            self.assertEqual(
+                response_1.get("Content-Disposition"),
+                f'attachment; filename="nautobot_{self.model.__name__.lower()}_data.csv"',
+            )
 
             # Try same request specifying CSV format via the ACCEPT header
             response_2 = self.client.get(
@@ -517,6 +521,10 @@ class APIViewTestCases:
             )
             self.assertHttpStatus(response_2, status.HTTP_200_OK)
             self.assertEqual(response_2.get("Content-Type"), "text/csv; charset=UTF-8")
+            self.assertEqual(
+                response_2.get("Content-Disposition"),
+                f'attachment; filename="nautobot_{self.model.__name__.lower()}_data.csv"',
+            )
 
             self.maxDiff = None
             # This check is more useful than it might seem. Any related object that wasn't CSV-converted correctly
@@ -639,6 +647,10 @@ class APIViewTestCases:
 
             response = self.client.get(self._get_detail_url(instance) + "?format=csv", **self.header)
             self.assertHttpStatus(response, status.HTTP_200_OK)
+            self.assertEqual(
+                response.get("Content-Disposition"),
+                f'attachment; filename="nautobot_{self.model.__name__.lower()}_data.csv"',
+            )
             csv_data = response.content.decode(response.charset)
 
             serializer_class = get_serializer_for_model(self.model)


### PR DESCRIPTION
# Closes: #3782 
# What's Changed

Add a `download=""` declaration to the CSV export link, so that when downloading a CSV file from the UI, you get a filename like `nautobot_location_data.csv` instead of something random like `EjU0iJSk.csv`.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
