### PR TITLE
Fix breadcrumb rendering in new UI

### DIFF
--- a/changes/3998.fixed
+++ b/changes/3998.fixed
@@ -1,0 +1,1 @@
+Fixed rendering of breadcrumbs in the 2.0 UI.

--- a/nautobot/ui/src/views/generic/GenericView.js
+++ b/nautobot/ui/src/views/generic/GenericView.js
@@ -85,7 +85,7 @@ export default function GenericView({
     gridBackground = "",
 }) {
     const { pathname } = useLocation();
-    const { menu, isSuccess } = useGetUIMenuQuery();
+    const { data: menu, isSuccess } = useGetUIMenuQuery();
 
     const breadcrumbs = useMemo(
         () =>
@@ -100,8 +100,8 @@ export default function GenericView({
                     ];
                 }
                 return breadcrumbsRecursive(
-                    findMenuPathRecursive(pathname, menu.data),
-                    menu.data,
+                    findMenuPathRecursive(pathname, menu),
+                    menu,
                     objectData
                 );
             })(),

--- a/nautobot/ui/src/views/generic/GenericView.js
+++ b/nautobot/ui/src/views/generic/GenericView.js
@@ -121,7 +121,7 @@ export default function GenericView({
         >
             <Navbar appState={currentState} />
             <Box flex="1" overflow="auto">
-                <Breadcrumbs paddingX="md">
+                <Breadcrumbs paddingX="md" position="relative" zIndex="5">
                     {breadcrumbs.map((props) => (
                         <Breadcrumb {...props} />
                     ))}


### PR DESCRIPTION
# Closes: #n/a
# What's Changed

Fix incorrect data reference in GenericView code that was causing breadcrumbs never to render correctly and always fall back to just displaying "Home". I think this is an alternative solution to #3957 and more preferable.

Before:

![image](https://github.com/nautobot/nautobot/assets/5603551/e2027d4d-2cbb-4ac2-9a2a-913b54a80acb)

After:

![image](https://github.com/nautobot/nautobot/assets/5603551/bc37da9a-2081-4432-bc46-c075832f6ecd)



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
