### PR TITLE
Add Markdown custom field type

### DIFF
--- a/changes/4006.added
+++ b/changes/4006.added
@@ -1,0 +1,1 @@
+Added Markdown custom field type.

--- a/nautobot/core/templates/inc/custom_fields/panel_data.html
+++ b/nautobot/core/templates/inc/custom_fields/panel_data.html
@@ -34,6 +34,8 @@
                                     <a href="{{ value }}">{{ value|truncatechars:70 }}</a>
                                 {% elif field.type == 'multi-select' and value %}
                                     {{ value|join:", " }}
+                                {% elif field.type == 'markdown' and value %}
+                                    {{ value|render_markdown }}
                                 {% elif field.type == 'json' and value is not None %}
                                     <p>
                                         <button class="btn btn-xs btn-primary" type="button" data-toggle="collapse"

--- a/nautobot/extras/choices.py
+++ b/nautobot/extras/choices.py
@@ -50,6 +50,7 @@ class CustomFieldTypeChoices(ChoiceSet):
     TYPE_SELECT = "select"
     TYPE_MULTISELECT = "multi-select"
     TYPE_JSON = "json"
+    TYPE_MARKDOWN = "markdown"
 
     CHOICES = (
         (TYPE_TEXT, "Text"),
@@ -60,6 +61,7 @@ class CustomFieldTypeChoices(ChoiceSet):
         (TYPE_SELECT, "Selection"),
         (TYPE_MULTISELECT, "Multiple selection"),
         (TYPE_JSON, "JSON"),
+        (TYPE_MARKDOWN, "Markdown"),
     )
 
     REGEX_TYPES = (

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -31,6 +31,8 @@ from nautobot.utilities.forms import (
     StaticSelect2,
     StaticSelect2Multiple,
     add_blank_choice,
+    CommentField,
+    SmallTextarea,
 )
 from nautobot.utilities.querysets import RestrictedQuerySet
 from nautobot.utilities.templatetags.helpers import render_markdown
@@ -544,6 +546,10 @@ class CustomField(BaseModel, ChangeLoggedModel, NotesMixin):
                         message=mark_safe(f"Values must match this regex: <code>{self.validation_regex}</code>"),
                     )
                 ]
+
+        # Markdown
+        elif self.type == CustomFieldTypeChoices.TYPE_MARKDOWN:
+            field = CommentField(widget=SmallTextarea, label=None)
 
         # JSON
         elif self.type == CustomFieldTypeChoices.TYPE_JSON:

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -22,17 +22,17 @@ from nautobot.extras.utils import FeatureQuery, extras_features
 from nautobot.core.fields import AutoSlugField
 from nautobot.core.models import BaseModel
 from nautobot.utilities.forms import (
+    CommentField,
     CSVChoiceField,
     CSVMultipleChoiceField,
     DatePicker,
     JSONField,
     LaxURLField,
     NullableDateField,
+    SmallTextarea,
     StaticSelect2,
     StaticSelect2Multiple,
     add_blank_choice,
-    CommentField,
-    SmallTextarea,
 )
 from nautobot.utilities.querysets import RestrictedQuerySet
 from nautobot.utilities.templatetags.helpers import render_markdown


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4006 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
- Added new custom field type for Markdown
  - Reused CommentField
  - Reused SmallTextarea widget -> not required for PR
- Apply markdown render to template

# NOTE
- I think still we need to perform `render_markdown()` to test for script injection similar to [custom_fields.py#L588](https://github.com/nautobot/nautobot/blob/452f02852489d60d9620ffa5fd67ab955c2181cd/nautobot/extras/models/customfields.py#L588) since that doesnt sanitize/check the `field.label` data?


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design

# SCREENSHOTS
![image](https://github.com/nautobot/nautobot/assets/114895043/d16b87a4-bf93-4eab-a3c6-6fcc14e7047d)
![image](https://github.com/nautobot/nautobot/assets/114895043/6dc7301a-84fe-4990-bd49-3558fe5dbd9c)
![image](https://github.com/nautobot/nautobot/assets/114895043/4962a314-69f5-481a-a7f2-853c5b8208b8)

