### PR TITLE
Harden Job class API a bit and gracefully handle errors when registering Jobs to the DB

### DIFF
--- a/changes/4005.fixed
+++ b/changes/4005.fixed
@@ -1,0 +1,3 @@
+Added logic to catch and report errors when registering a Job to the database.
+Added logic to Job class `@classproperty` methods to enforce correct data types.
+Fixed incorrect documentation about how to register Jobs from an app.

--- a/nautobot/core/celery/__init__.py
+++ b/nautobot/core/celery/__init__.py
@@ -217,5 +217,6 @@ nautobot_task = shared_task
 def register_jobs(*jobs):
     """Helper method to register jobs with Celery"""
     for job in jobs:
+        # TODO: should we only register a job if it corresponds to a Job database record?
         logger.debug("Registering job %s.%s", job.__module__, job.__name__)
         app.register_task(job)

--- a/nautobot/docs/additional-features/jobs.md
+++ b/nautobot/docs/additional-features/jobs.md
@@ -35,7 +35,7 @@ In any case, each module holds one or more Jobs (Python classes), each of which 
 For example, we can create a module named `devices.py` to hold all of our jobs which pertain to devices in Nautobot. Within that module, we might define several jobs. Each job is defined as a Python class inheriting from `extras.jobs.Job`, which provides the base functionality needed to accept user input and log activity.
 
 +/- 2.0.0
-    All job classes must now be registered with `nautobot.core.celery.register_jobs` on module import. For plugins providing jobs, the module containing the jobs must be imported by the plugin's `__init__.py` and the `register_jobs` method called at import time. The `register_jobs` method accepts one or more job classes as arguments.
+    All job classes must now be registered with `nautobot.core.celery.register_jobs` on module import. For plugins providing jobs, the `register_jobs` method must called from the plugin's `jobs.py` file/submodule at import time. The `register_jobs` method accepts one or more job classes as arguments.
 
 !!! warning
     Make sure you are *not* inheriting `extras.jobs.models.Job` instead, otherwise Django will think you want to define a new database model.

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -564,6 +564,7 @@ By default, for each app, Nautobot looks for an iterable named `jobs` within a `
 
 ```python
 # jobs.py
+from nautobot.core.celery import register_jobs
 from nautobot.extras.jobs import Job
 
 
@@ -580,7 +581,11 @@ class DeviceIPsReport(Job):
 
 
 jobs = [CreateDevices, DeviceConnectionsReport, DeviceIPsReport]
+register_jobs(*jobs)
 ```
+
++/- 2.0.0
+    Because Jobs are now proper Celery tasks, you now must call `register_jobs()` from within your `jobs.py` file when it is imported; any jobs not included in this call will not be available for Celery to schedule and execute.
 
 ### Implementing Custom Validators
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -422,14 +422,22 @@ class BaseJob(Task):
         return getattr(module, "name", module.__name__)
 
     @final
+    @classmethod
+    def _get_meta_attr_and_assert_type(cls, attr_name, default, expected_type):
+        result = getattr(cls.Meta, attr_name, default)
+        if not isinstance(result, expected_type):
+            raise TypeError(f"Meta.{attr_name} should be {expected_type}, not {type(result)}")
+        return result
+
+    @final
     @classproperty
     def name(cls) -> str:  # pylint: disable=no-self-argument
-        return getattr(cls.Meta, "name", cls.__name__)
+        return cls._get_meta_attr_and_assert_type("name", cls.__name__, expected_type=str)
 
     @final
     @classproperty
     def description(cls) -> str:  # pylint: disable=no-self-argument
-        return dedent(getattr(cls.Meta, "description", "")).strip()
+        return dedent(cls._get_meta_attr_and_assert_type("description", "", expected_type=str)).strip()
 
     @final
     @classproperty
@@ -441,42 +449,42 @@ class BaseJob(Task):
     @final
     @classproperty
     def dryrun_default(cls) -> bool:  # pylint: disable=no-self-argument
-        return bool(getattr(cls.Meta, "dryrun_default", False))
+        return cls._get_meta_attr_and_assert_type("dryrun_default", False, expected_type=bool)
 
     @final
     @classproperty
     def hidden(cls) -> bool:  # pylint: disable=no-self-argument
-        return bool(getattr(cls.Meta, "hidden", False))
+        return cls._get_meta_attr_and_assert_type("hidden", False, expected_type=bool)
 
     @final
     @classproperty
     def field_order(cls):  # pylint: disable=no-self-argument
-        return getattr(cls.Meta, "field_order", None)
+        return cls._get_meta_attr_and_assert_type("field_order", None, expected_type=(list, tuple))
 
     @final
     @classproperty
     def read_only(cls) -> bool:  # pylint: disable=no-self-argument
-        return bool(getattr(cls.Meta, "read_only", False))
+        return cls._get_meta_attr_and_assert_type("read_only", False, expected_type=bool)
 
     @final
     @classproperty
     def approval_required(cls) -> bool:  # pylint: disable=no-self-argument
-        return bool(getattr(cls.Meta, "approval_required", False))
+        return cls._get_meta_attr_and_assert_type("approval_required", False, expected_type=bool)
 
     @final
     @classproperty
     def soft_time_limit(cls) -> int:  # pylint: disable=no-self-argument
-        return int(getattr(cls.Meta, "soft_time_limit", 0))
+        return cls._get_meta_attr_and_assert_type("soft_time_limit", 0, expected_type=int)
 
     @final
     @classproperty
     def time_limit(cls) -> int:  # pylint: disable=no-self-argument
-        return int(getattr(cls.Meta, "time_limit", 0))
+        return cls._get_meta_attr_and_assert_type("time_limit", 0, expected_type=int)
 
     @final
     @classproperty
     def has_sensitive_variables(cls) -> bool:  # pylint: disable=no-self-argument
-        return bool(getattr(cls.Meta, "has_sensitive_variables", True))
+        return cls._get_meta_attr_and_assert_type("has_sensitive_variables", True, expected_type=bool)
 
     @final
     @classproperty
@@ -486,7 +494,7 @@ class BaseJob(Task):
     @final
     @classproperty
     def task_queues(cls) -> list:  # pylint: disable=no-self-argument
-        return list(getattr(cls.Meta, "task_queues", []))
+        return cls._get_meta_attr_and_assert_type("task_queues", [], expected_type=(list, tuple))
 
     @final
     @classproperty

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -459,7 +459,7 @@ class BaseJob(Task):
     @final
     @classproperty
     def field_order(cls):  # pylint: disable=no-self-argument
-        return cls._get_meta_attr_and_assert_type("field_order", None, expected_type=(list, tuple))
+        return cls._get_meta_attr_and_assert_type("field_order", [], expected_type=(list, tuple))
 
     @final
     @classproperty

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -7,6 +7,7 @@ import logging
 import os
 import tempfile
 from textwrap import dedent
+from typing import final
 import warnings
 
 from billiard.einfo import ExceptionInfo
@@ -377,10 +378,12 @@ class BaseJob(Task):
         state = states.SUCCESS if ret.info is None else ret.info.state
         return EagerResult(task_id, retval, state, traceback=tb)
 
+    @final
     @classproperty
     def file_path(cls):  # pylint: disable=no-self-argument
         return inspect.getfile(cls)
 
+    @final
     @classproperty
     def class_path(cls):  # pylint: disable=no-self-argument
         """
@@ -394,6 +397,7 @@ class BaseJob(Task):
         """
         return f"{cls.__module__}.{cls.__name__}"
 
+    @final
     @classproperty
     def class_path_dotted(cls):  # pylint: disable=no-self-argument
         """
@@ -403,6 +407,7 @@ class BaseJob(Task):
         """
         return cls.class_path
 
+    @final
     @classproperty
     def class_path_js_escaped(cls):  # pylint: disable=no-self-argument
         """
@@ -410,65 +415,80 @@ class BaseJob(Task):
         """
         return cls.class_path.replace(".", r"\.")
 
+    @final
     @classproperty
     def grouping(cls):  # pylint: disable=no-self-argument
         module = inspect.getmodule(cls)
         return getattr(module, "name", module.__name__)
 
+    @final
     @classproperty
     def name(cls):  # pylint: disable=no-self-argument
         return getattr(cls.Meta, "name", cls.__name__)
 
+    @final
     @classproperty
     def description(cls):  # pylint: disable=no-self-argument
         return dedent(getattr(cls.Meta, "description", "")).strip()
 
+    @final
     @classproperty
     def description_first_line(cls):  # pylint: disable=no-self-argument
         if cls.description:  # pylint: disable=using-constant-test
             return cls.description.splitlines()[0]
         return ""
 
+    @final
     @classproperty
-    def dryrun_default(cls):  # pylint: disable=no-self-argument
-        return getattr(cls.Meta, "dryrun_default", False)
+    def dryrun_default(cls) -> bool:  # pylint: disable=no-self-argument
+        return bool(getattr(cls.Meta, "dryrun_default", False))
 
+    @final
     @classproperty
-    def hidden(cls):  # pylint: disable=no-self-argument
-        return getattr(cls.Meta, "hidden", False)
+    def hidden(cls) -> bool:  # pylint: disable=no-self-argument
+        return bool(getattr(cls.Meta, "hidden", False))
 
+    @final
     @classproperty
     def field_order(cls):  # pylint: disable=no-self-argument
         return getattr(cls.Meta, "field_order", None)
 
+    @final
     @classproperty
-    def read_only(cls):  # pylint: disable=no-self-argument
-        return getattr(cls.Meta, "read_only", False)
+    def read_only(cls) -> bool:  # pylint: disable=no-self-argument
+        return bool(getattr(cls.Meta, "read_only", False))
 
+    @final
     @classproperty
-    def approval_required(cls):  # pylint: disable=no-self-argument
-        return getattr(cls.Meta, "approval_required", False)
+    def approval_required(cls) -> bool:  # pylint: disable=no-self-argument
+        return bool(getattr(cls.Meta, "approval_required", False))
 
+    @final
     @classproperty
-    def soft_time_limit(cls):  # pylint: disable=no-self-argument
-        return getattr(cls.Meta, "soft_time_limit", 0)
+    def soft_time_limit(cls) -> int:  # pylint: disable=no-self-argument
+        return int(getattr(cls.Meta, "soft_time_limit", 0))
 
+    @final
     @classproperty
-    def time_limit(cls):  # pylint: disable=no-self-argument
-        return getattr(cls.Meta, "time_limit", 0)
+    def time_limit(cls) -> int:  # pylint: disable=no-self-argument
+        return int(getattr(cls.Meta, "time_limit", 0))
 
+    @final
     @classproperty
-    def has_sensitive_variables(cls):  # pylint: disable=no-self-argument
-        return getattr(cls.Meta, "has_sensitive_variables", True)
+    def has_sensitive_variables(cls) -> bool:  # pylint: disable=no-self-argument
+        return bool(getattr(cls.Meta, "has_sensitive_variables", True))
 
+    @final
     @classproperty
-    def supports_dryrun(cls):  # pylint: disable=no-self-argument
+    def supports_dryrun(cls) -> bool:  # pylint: disable=no-self-argument
         return isinstance(getattr(cls, "dryrun", None), DryRunVar)
 
+    @final
     @classproperty
-    def task_queues(cls):  # pylint: disable=no-self-argument
-        return getattr(cls.Meta, "task_queues", [])
+    def task_queues(cls) -> tuple:  # pylint: disable=no-self-argument
+        return tuple(getattr(cls.Meta, "task_queues", []))
 
+    @final
     @classproperty
     def properties_dict(cls):  # pylint: disable=no-self-argument
         """
@@ -488,6 +508,7 @@ class BaseJob(Task):
             "task_queues": cls.task_queues,
         }
 
+    @final
     @classproperty
     def registered_name(cls):  # pylint: disable=no-self-argument
         return f"{cls.__module__}.{cls.__name__}"

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -380,12 +380,12 @@ class BaseJob(Task):
 
     @final
     @classproperty
-    def file_path(cls):  # pylint: disable=no-self-argument
+    def file_path(cls) -> str:  # pylint: disable=no-self-argument
         return inspect.getfile(cls)
 
     @final
     @classproperty
-    def class_path(cls):  # pylint: disable=no-self-argument
+    def class_path(cls) -> str:  # pylint: disable=no-self-argument
         """
         Unique identifier of a specific Job class, in the form <module_name>.<ClassName>.
 
@@ -399,7 +399,7 @@ class BaseJob(Task):
 
     @final
     @classproperty
-    def class_path_dotted(cls):  # pylint: disable=no-self-argument
+    def class_path_dotted(cls) -> str:  # pylint: disable=no-self-argument
         """
         Dotted class_path, suitable for use in things like Python logger names.
 
@@ -409,7 +409,7 @@ class BaseJob(Task):
 
     @final
     @classproperty
-    def class_path_js_escaped(cls):  # pylint: disable=no-self-argument
+    def class_path_js_escaped(cls) -> str:  # pylint: disable=no-self-argument
         """
         Escape various characters so that the class_path can be used as a jQuery selector.
         """
@@ -417,23 +417,23 @@ class BaseJob(Task):
 
     @final
     @classproperty
-    def grouping(cls):  # pylint: disable=no-self-argument
+    def grouping(cls) -> str:  # pylint: disable=no-self-argument
         module = inspect.getmodule(cls)
         return getattr(module, "name", module.__name__)
 
     @final
     @classproperty
-    def name(cls):  # pylint: disable=no-self-argument
+    def name(cls) -> str:  # pylint: disable=no-self-argument
         return getattr(cls.Meta, "name", cls.__name__)
 
     @final
     @classproperty
-    def description(cls):  # pylint: disable=no-self-argument
+    def description(cls) -> str:  # pylint: disable=no-self-argument
         return dedent(getattr(cls.Meta, "description", "")).strip()
 
     @final
     @classproperty
-    def description_first_line(cls):  # pylint: disable=no-self-argument
+    def description_first_line(cls) -> str:  # pylint: disable=no-self-argument
         if cls.description:  # pylint: disable=using-constant-test
             return cls.description.splitlines()[0]
         return ""
@@ -485,12 +485,12 @@ class BaseJob(Task):
 
     @final
     @classproperty
-    def task_queues(cls) -> tuple:  # pylint: disable=no-self-argument
-        return tuple(getattr(cls.Meta, "task_queues", []))
+    def task_queues(cls) -> list:  # pylint: disable=no-self-argument
+        return list(getattr(cls.Meta, "task_queues", []))
 
     @final
     @classproperty
-    def properties_dict(cls):  # pylint: disable=no-self-argument
+    def properties_dict(cls) -> dict:  # pylint: disable=no-self-argument
         """
         Return all relevant classproperties as a dict.
 
@@ -510,7 +510,7 @@ class BaseJob(Task):
 
     @final
     @classproperty
-    def registered_name(cls):  # pylint: disable=no-self-argument
+    def registered_name(cls) -> str:  # pylint: disable=no-self-argument
         return f"{cls.__module__}.{cls.__name__}"
 
     @classmethod

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -9,6 +9,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.validators import ValidationError
+from django.db import transaction
 from django.db.models import Q
 from django.template.loader import get_template, TemplateDoesNotExist
 from django.utils.deconstruct import deconstructible
@@ -409,42 +410,53 @@ def refresh_job_model_from_job_class(job_model_class, job_class):
             job_name,
         )
 
-    job_model, created = job_model_class.objects.get_or_create(
-        module_name=job_class.__module__[:JOB_MAX_NAME_LENGTH],
-        job_class_name=job_class.__name__[:JOB_MAX_NAME_LENGTH],
-        defaults={
-            "grouping": job_class.grouping[:JOB_MAX_GROUPING_LENGTH],
-            "name": job_name,
-            "is_job_hook_receiver": issubclass(job_class, JobHookReceiver),
-            "is_job_button_receiver": issubclass(job_class, JobButtonReceiver),
-            "read_only": job_class.read_only,
-            "supports_dryrun": job_class.supports_dryrun,
-            "installed": True,
-            "enabled": False,
-        },
-    )
+    try:
+        with transaction.atomic():
+            job_model, created = job_model_class.objects.get_or_create(
+                module_name=job_class.__module__[:JOB_MAX_NAME_LENGTH],
+                job_class_name=job_class.__name__[:JOB_MAX_NAME_LENGTH],
+                defaults={
+                    "grouping": job_class.grouping[:JOB_MAX_GROUPING_LENGTH],
+                    "name": job_name,
+                    "is_job_hook_receiver": issubclass(job_class, JobHookReceiver),
+                    "is_job_button_receiver": issubclass(job_class, JobButtonReceiver),
+                    "read_only": job_class.read_only,
+                    "supports_dryrun": job_class.supports_dryrun,
+                    "installed": True,
+                    "enabled": False,
+                },
+            )
 
-    if job_name != default_job_name:
-        job_model.name_override = True
+            if job_name != default_job_name:
+                job_model.name_override = True
 
-    if created and job_model.module_name.startswith("nautobot."):
-        # System jobs should be enabled by default when first created
-        job_model.enabled = True
+            if created and job_model.module_name.startswith("nautobot."):
+                # System jobs should be enabled by default when first created
+                job_model.enabled = True
 
-    for field_name in JOB_OVERRIDABLE_FIELDS:
-        # Was this field directly inherited from the job before, or was it overridden in the database?
-        if not getattr(job_model, f"{field_name}_override", False):
-            # It was inherited and not overridden
-            setattr(job_model, field_name, getattr(job_class, field_name))
+            for field_name in JOB_OVERRIDABLE_FIELDS:
+                # Was this field directly inherited from the job before, or was it overridden in the database?
+                if not getattr(job_model, f"{field_name}_override", False):
+                    # It was inherited and not overridden
+                    setattr(job_model, field_name, getattr(job_class, field_name))
 
-    # set supports_dryrun to match the property on the job class
-    job_model.supports_dryrun = job_class.supports_dryrun
+            # set supports_dryrun to match the property on the job class
+            job_model.supports_dryrun = job_class.supports_dryrun
 
-    if not created:
-        # Mark it as installed regardless
-        job_model.installed = True
+            if not created:
+                # Mark it as installed regardless
+                job_model.installed = True
+                # Update the `read_only` and `supports_dryrun` flags in case they've changed in the source
+                job_model.read_only = job_class.read_only
+                job_model.supports_dryrun = job_class.supports_dryrun
 
-    job_model.save()
+            job_model.save()
+
+    except Exception as exc:
+        logger.error(
+            'Exception while trying to create/update a database record for Job class "%s": %s', job_class.__name__, exc
+        )
+        return (None, False)
 
     logger.info(
         '%s Job "%s: %s" from <%s>',

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -440,13 +440,12 @@ def refresh_job_model_from_job_class(job_model_class, job_class):
                     # It was inherited and not overridden
                     setattr(job_model, field_name, getattr(job_class, field_name))
 
-            # set supports_dryrun to match the property on the job class
-            job_model.supports_dryrun = job_class.supports_dryrun
-
             if not created:
                 # Mark it as installed regardless
                 job_model.installed = True
-                # Update the `read_only` and `supports_dryrun` flags in case they've changed in the source
+                # Update the non-overridable flags in case they've changed in the source
+                job_model.is_job_hook_receiver = issubclass(job_class, JobHookReceiver)
+                job_model.is_job_button_receiver = issubclass(job_class, JobButtonReceiver)
                 job_model.read_only = job_class.read_only
                 job_model.supports_dryrun = job_class.supports_dryrun
 


### PR DESCRIPTION
# Closes: #4005
# What's Changed

- Correct an admonition in the jobs documentation that instructed app authors to call `register_jobs()` from `__init__.py`; it should be called from `jobs.py`.
- Added `register_jobs()` call to documentation about developing jobs in an app.
- Added `@final` decorator to Job classproperties (https://peps.python.org/pep-0591/); this doesn't *prevent* subclasses from overriding these methods but at least serves as documentation that doing so is discouraged.
- Add type hints to Job classproperties
- Add type ~coercion~ enforcement to Job classproperties (e.g., force `read_only` property to return a `bool` or else raise a TypeError, rather than potentially return a non-bool value)
- In `refresh_job_model_from_job_class()`, add `transaction.atomic` wrapper around the creation and updating of each Job DB record, and catch and log any errors encountered in doing so, so that a single invalid Job doesn't cause the entire function to abort.


I tested this manually by adding a Job to the example plugin that defines invalid values for some or all of its `Meta` properties, i.e.:

```python
class ExampleBuggyJob(Job):
    class Meta:
        name = "Example job with invalid parameters"
        dryrun_default = "no"
        hidden = ""
        has_sensitive_variables = "who knows?"
        ...

    def run(self):
        pass
```

and verifying that an unhandled `ValidationError` is no longer encountered but instead an appropriate error message is logged and the invalid job is not registered to the database. Probably wouldn't hurt to automate this but I'm not sure the value is there - let me know what you think.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
