### PR TITLE
Update IPAM natural keys

### DIFF
--- a/changes/3973.changed
+++ b/changes/3973.changed
@@ -1,0 +1,4 @@
+Changed natural-key for `Prefix` model to `[namespace, prefix]`.
+Changed natural-key for `Service` model to `[name, virtual_machine, device]`.
+Changed natural-key for `VLANGroup` model to simply `[name]`.
+Changed natural-key for `VLAN` model to `[pk]` for now.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -531,6 +531,8 @@ class Prefix(PrimaryModel):
     def __str__(self):
         return str(self.prefix)
 
+    natural_key_field_names = ["namespace", "prefix"]
+
     def _deconstruct_prefix(self, prefix):
         if prefix:
             if isinstance(prefix, str):
@@ -1223,8 +1225,6 @@ class VLANGroup(OrganizationalModel):
         verbose_name = "VLAN group"
         verbose_name_plural = "VLAN groups"
 
-    natural_key_field_names = ["name", "location"]  # location needs to be last since it's a variadic natural key
-
     def clean(self):
         super().clean()
 
@@ -1306,7 +1306,7 @@ class VLAN(PrimaryModel):
         "description",
     ]
 
-    natural_key_field_names = ["vid", "vlan_group"]
+    natural_key_field_names = ["pk"]
 
     class Meta:
         ordering = (
@@ -1426,7 +1426,7 @@ class Service(PrimaryModel):
     def parent(self):
         return self.device or self.virtual_machine
 
-    natural_key_field_names = ["name", "device", "virtual_machine"]
+    natural_key_field_names = ["name", "virtual_machine", "device"]
 
     def clean(self):
         super().clean()


### PR DESCRIPTION
# Closes: #3973 
# What's Changed

- Changed natural-key for `Prefix` model to `[namespace, prefix]` instead of `[namespace, network, prefix_length]`.
   - This required a few code changes in BaseModel to ensure that the netaddr.Network object is coerced to a string and to handle natural-key components that are a property rather than a field.
   - This required a change in PrefixQuerySet to ensure that `composite_key` lookup deconstructs the composite key before deconstructing the `prefix` parameter
- Changed natural-key for `Service` model to `[name, virtual_machine, device]` rather than `[name, device, virtual_machine]` since `device` natural-key is variable-length.
- Changed natural-key for `VLANGroup` model to simply `[name]` rather than `[name, location]` since `name` is now globally unique.
- Changed natural-key for `VLAN` model to `[pk]` for now because we don't currently have a true uniqueness constraint on `VLAN`.
- Added at least minimal model test cases for these models where they were absent.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
