### PR TITLE
Fixed missing trailing slash in NautobotUIViewSet urls.

### DIFF
--- a/changes/3109.fixed
+++ b/changes/3109.fixed
@@ -1,0 +1,1 @@
+Fixed missing trailing slash in NautobotUIViewSet urls.

--- a/nautobot/circuits/tests/test_urls.py
+++ b/nautobot/circuits/tests/test_urls.py
@@ -1,17 +1,26 @@
 from django.urls import reverse
 
-from nautobot.circuits.models import Provider
+from nautobot.circuits.models import Circuit, CircuitType, Provider
+from nautobot.extras.models import Status
 from nautobot.utilities.testing import TestCase
 
 
 class URLTestCase(TestCase):
     def test_nautobot_ui_viewset_urls(self):
         """Asset that NautobotUIViewSet views urls includes a trailing slash"""
-        provider = Provider.objects.create(name="Provider 1", slug="provider-1")
-        url = f"/circuits/providers/{provider.slug}"
+        provider = Provider.objects.create(name="Provider")
+        circuit_type = CircuitType.objects.create(name="Circuit Type 1")
+        status = Status.objects.get_for_model(Circuit).first()
+        circuit = Circuit.objects.create(
+            cid="Circuit",
+            provider=provider,
+            type=circuit_type,
+            status=status,
+        )
+        url = f"/circuits/circuits/{circuit.pk}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 301)
         # Assert url is redirected to include a trailing slash
-        self.assertEqual(response.url, f"/circuits/providers/{provider.slug}/")
+        self.assertEqual(response.url, f"/circuits/circuits/{circuit.pk}/")
         # Assert reverse url include a trailing slash
-        self.assertEqual(reverse("circuits:provider", args=[provider.slug]), f"/circuits/providers/{provider.slug}/")
+        self.assertEqual(reverse("circuits:provider", args=[circuit.pk]), f"/circuits/providers/{circuit.pk}/")

--- a/nautobot/circuits/tests/test_urls.py
+++ b/nautobot/circuits/tests/test_urls.py
@@ -1,0 +1,17 @@
+from django.urls import reverse
+
+from nautobot.circuits.models import Provider
+from nautobot.utilities.testing import TestCase
+
+
+class URLTestCase(TestCase):
+    def test_nautobot_ui_viewset_urls(self):
+        """Asset that NautobotUIViewSet views urls includes a trailing slash"""
+        provider = Provider.objects.create(name="Provider 1", slug="provider-1")
+        url = f"/circuits/providers/{provider.slug}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 301)
+        # Assert url is redirected to include a trailing slash
+        self.assertEqual(response.url, f"/circuits/providers/{provider.slug}/")
+        # Assert reverse url include a trailing slash
+        self.assertEqual(reverse("circuits:provider", args=[provider.slug]), f"/circuits/providers/{provider.slug}/")

--- a/nautobot/core/views/routers.py
+++ b/nautobot/core/views/routers.py
@@ -53,7 +53,7 @@ class NautobotUIViewSetRouter(SimpleRouter):
             initkwargs={"suffix": "Bulk Delete"},
         ),
         Route(
-            url=r"^{prefix}/{lookup}$",
+            url=r"^{prefix}/{lookup}/$",
             mapping={"get": "retrieve"},
             name="{basename}",
             detail=True,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3109 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
