### PR TITLE
Fixed postgres database healthcheck error message in dev environment

### DIFF
--- a/changes/3422.fixed
+++ b/changes/3422.fixed
@@ -1,0 +1,1 @@
+Fixed postgres database healthcheck error message in development environment.

--- a/development/docker-compose.postgres.yml
+++ b/development/docker-compose.postgres.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - pgdata_nautobot:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -d $$POSTGRES_DB -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 5s
       retries: 50


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3422
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
## Before

```
nautobot-nautobot-1       |   Nautobot initialized!
nautobot-db-1             | 2023-06-30 22:12:01.154 UTC [87] FATAL:  role "root" does not exist
nautobot-nautobot-1       | 22:12:01.936 INFO    django.server :
nautobot-nautobot-1       |   "GET /health/ HTTP/1.1" 200 11818
nautobot-db-1             | 2023-06-30 22:12:06.281 UTC [96] FATAL:  role "root" does not exist
nautobot-nautobot-1       | 22:12:07.125 INFO    django.server :
nautobot-nautobot-1       |   "GET /health/ HTTP/1.1" 200 11816
nautobot-db-1             | 2023-06-30 22:12:11.392 UTC [105] FATAL:  role "root" does not exist
```

## After

```
nautobot-nautobot-1       |   Nautobot initialized!
nautobot-nautobot-1       | 22:13:04.807 INFO    django.server :
nautobot-nautobot-1       |   "GET /health/ HTTP/1.1" 200 11818
nautobot-nautobot-1       | 22:13:09.975 INFO    django.server :
nautobot-nautobot-1       |   "GET /health/ HTTP/1.1" 200 11816
nautobot-nautobot-1       | 22:13:15.118 INFO    django.server :
nautobot-nautobot-1       |   "GET /health/ HTTP/1.1" 200 11816
nautobot-nautobot-1       | 22:13:20.265 INFO    django.server :
nautobot-nautobot-1       |   "GET /health/ HTTP/1.1" 200 11816
nautobot-nautobot-1       | 22:13:25.436 INFO    django.server :
nautobot-nautobot-1       |   "GET /health/ HTTP/1.1" 200 11816
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
