### PR TITLE
Fix broken tab navigation in secrets

### DIFF
--- a/changes/4048.fixed
+++ b/changes/4048.fixed
@@ -1,0 +1,1 @@
+Fixed broken tab navigation in secrets.

--- a/nautobot/extras/templates/extras/secret.html
+++ b/nautobot/extras/templates/extras/secret.html
@@ -45,6 +45,7 @@
 
 {% block javascript %}
 <script>
+    {{ block.super }}
     function checkSecret() {
         $.ajax({
             url: "{% url 'extras-api:secret-check' pk=object.pk %}",


### PR DESCRIPTION
# Closes: #4048
# What's Changed
This add the parent javascript block in the secret template, to restore tab functionnality.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
