### PR TITLE
[WIP] Patch webhook and jobhook triggered multiple times for single change

### DIFF
--- a/changes/3015.fixed
+++ b/changes/3015.fixed
@@ -1,0 +1,1 @@
+Fixed issue of multipe jobhooks and webhooks being triggered by a single change.

--- a/nautobot/core/middleware.py
+++ b/nautobot/core/middleware.py
@@ -88,7 +88,7 @@ class ObjectChangeMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        from nautobot.extras.jobs import enqueue_job_hooks # avoid circular import
+        from nautobot.extras.jobs import enqueue_job_hooks  # avoid circular import
         from nautobot.extras.models import ObjectChange
 
         # Determine the resolved path of the request that initiated the change

--- a/nautobot/core/middleware.py
+++ b/nautobot/core/middleware.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.conf import settings
 from django.contrib.auth.middleware import RemoteUserMiddleware as RemoteUserMiddleware_
 from django.db import ProgrammingError
@@ -86,6 +88,9 @@ class ObjectChangeMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        from nautobot.extras.jobs import enqueue_job_hooks # avoid circular import
+        from nautobot.extras.models import ObjectChange
+
         # Determine the resolved path of the request that initiated the change
         try:
             change_context_detail = resolve(request.path).view_name
@@ -93,11 +98,14 @@ class ObjectChangeMiddleware:
             change_context_detail = ""
 
         # Pass request rather than user here because at this point in the request handling logic, request.user may not have been set yet
-        change_context = WebChangeContext(request=request, context_detail=change_context_detail)
+        request_id = uuid.uuid4()
+        change_context = WebChangeContext(request=request, context_detail=change_context_detail, change_id=request_id)
 
         # Process the request with change logging enabled
         with change_logging(change_context):
             response = self.get_response(request)
+            for oc in ObjectChange.objects.filter(request_id=request_id):
+                enqueue_job_hooks(oc)
 
         return response
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1348,12 +1348,12 @@ def enqueue_job_hooks(object_change):
         return
 
     # Determine whether this type of object supports job hooks
-    model_type = object_change.changed_object._meta.model
-    if model_type not in ChangeLoggedModelsQuery().list_subclasses():
+    model_type = object_change.changed_object_type
+    if model_type not in ChangeLoggedModelsQuery().as_queryset():
         return
 
     # Retrieve any applicable job hooks
-    content_type = ContentType.objects.get_for_model(object_change.changed_object)
+    content_type = object_change.changed_object_type
     action_flag = {
         ObjectChangeActionChoices.ACTION_CREATE: "type_create",
         ObjectChangeActionChoices.ACTION_UPDATE: "type_update",

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -14,7 +14,6 @@ from db_file_storage.form_widgets import DBClearableFileInput
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.validators import RegexValidator
 from django.db import IntegrityError, transaction

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -55,7 +55,6 @@ def _handle_changed_object(sender, instance, raw=False, **kwargs):
     """
     Fires when an object is created or updated.
     """
-    from .jobs import enqueue_job_hooks  # avoid circular import
 
     if raw:
         return

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -104,10 +104,6 @@ def _handle_changed_object(sender, instance, raw=False, **kwargs):
         # restore field cache
         instance._state.fields_cache = original_cache
 
-        # Enqueue job hooks
-        if objectchange is not None:
-            enqueue_job_hooks(objectchange)
-
     # Enqueue webhooks
     enqueue_webhooks(instance, change_context_state.get().get_user(), change_context_state.get().change_id, action)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3015
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

This change patches the multiple firings of a jobhook/webhook that occurs when there is a singular change in Nautobot
- Moves enqueue_job_hooks call from ./extras/signals.py to ./core/middleware.py

# Screenshots
![image](https://github.com/nautobot/nautobot/assets/114895043/4f99ea7e-505f-442d-b684-5989fef87195)
![image](https://github.com/nautobot/nautobot/assets/114895043/b0a5e3b5-69b6-4ea7-8548-13840fa0c5af)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
