### PR TITLE
Revert 'temporary' workaround code from views/generic, add appropriate IPAM-specific form fixes in its place

### DIFF
--- a/changes/4115.fixed
+++ b/changes/4115.fixed
@@ -1,0 +1,1 @@
+Fixed missing data validation in `IPAddressForm` and `PrefixForm`.

--- a/changes/4115.removed
+++ b/changes/4115.removed
@@ -1,0 +1,1 @@
+Removed temporary code from `ObjectEditView` that was working around some IPAddress/Prefix form validation gaps.

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -438,58 +438,10 @@ class ObjectEditView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
                 else:
                     return redirect(self.get_return_url(request, obj))
 
-            # TODO(jathan): This is a temporary workaround for legacy generic views in support of
-            # PrefixEditView/PrefixForm where `unique_together` constraint raises an IntegrityError
-            # because `network` & `prefix_length` are excluded from the form and are therefore not
-            # passed to `full_clean()`. This results in `form.is_valid()` always returning `True`,
-            # and any exceptions end up getting bubbled up when `form.save()` is called. Therefore
-            # the error(s) have to be handled here.
-            #
-            # The problem is that the error from `IntegrityError` is hideous, and looks like this:
-            #
-            # IntegrityError: duplicate key value violates unique constraint "ipam_prefix_namespace_id_network_prefix_length_b2dd8b57_uniq"
-            # DETAIL:  Key (namespace_id, network, prefix_length)=(e0b0aa8d-d24d-4312-a2e5-f185c41281e6, \x0a000000, 8) already exists.
-            #
-            # So, there is a `pre_save` signal handler to forcibly call `Prefix.full_clean` without
-            # field exclusions which results in a `ValidationError` that looks pretty, like so:
-            #
-            # ValidationError: {'__all__': ['Prefix with this Namespace, Network and Prefix length already exists.']}
-            #
-            # No extra work shall be spent on this as the form validation is being replaced with
-            # JSON schema forms in the v2 UI and all of this should go away because validation will
-            # be performed by serializers instead. When `serializer.is_valid()` is called, it
-            # actually returns `False` and properly shows the errors:
-            #
-            # >>> serializer.is_valid()
-            # False
-            #
-            # >>> serializer.errors
-            # {'__all__': [ErrorDetail(string='Prefix with this Namespace, Network and Prefix length already exists.', code='unique_together')]}
-            except ValidationError as err:
-                logger.exception(err)
-                for field, errors in err.message_dict.items():
-                    if field == "__all__":
-                        field = None
-                    for error in errors:
-                        form.add_error(field, error)
-            # This is necessary due to the uniqueness constraint from the database for `ipam.Prefix`
-            # bubbling up. Just a quick fix for the time being without debugging too hard, to know
-            # that this at least surfaces the (ugly) error in the UI.
-            except IntegrityError as err:
-                logger.exception(err)
-                models = ", ".join(o.replace("_", " ").title() for o in obj._meta.unique_together[0])
-                model_name = obj._meta.verbose_name.title()
-                msg = f"{model_name} with this {models} already exists."
-                form.add_error(None, msg)
-            except ObjectDoesNotExist as err:
-                if self.queryset.model._meta.model_name == "ipaddress":
-                    msg = str(err) + "! Does it exist?"
-                    field = "address"
-                else:
-                    msg = "Object save failed due to object-level permissions violation"
-                    field = None
+            except ObjectDoesNotExist:
+                msg = "Object save failed due to object-level permissions violation"
                 logger.debug(msg)
-                form.add_error(field, msg)
+                form.add_error(None, msg)
 
         else:
             logger.debug("Form validation failed")

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -472,6 +472,17 @@ class IPAddressForm(NautobotModelForm, TenancyForm, ReturnURLForm, AddressFieldM
             "tags",
         ]
 
+    def _get_validation_exclusions(self):
+        """
+        By default Django excludes "host" and "parent" from model validation because they are not form fields.
+
+        This is wrong since we need those fields to be included in the validate_unique() calculation!
+        """
+        exclude = super()._get_validation_exclusions()
+        exclude.remove("host")
+        exclude.remove("parent")
+        return exclude
+
     def clean_namespace(self):
         """
         Explicitly set the Namespace on the instance so it will be used on save.
@@ -488,7 +499,7 @@ class IPAddressForm(NautobotModelForm, TenancyForm, ReturnURLForm, AddressFieldM
         # If user input was bad, might not even *have* an identifiable host
         if self.instance.host and self.instance._namespace:
             try:
-                (
+                self.instance.parent = (
                     Prefix.objects.filter(namespace=self.instance._namespace)
                     # 3.0 TODO: disallow IPAddress from parenting to a TYPE_POOL prefix, instead pick TYPE_NETWORK
                     # .exclude(type=PrefixTypeChoices.TYPE_POOL)

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django import forms
 
 from nautobot.core.forms import (
@@ -273,6 +274,17 @@ class PrefixForm(LocatableModelFormMixin, NautobotModelForm, TenancyForm, Prefix
             "date_allocated": DateTimePicker(),
         }
 
+    def _get_validation_exclusions(self):
+        """
+        By default Django excludes "network"/"prefix_length" from model validation because they are not form fields.
+
+        This is wrong since we need those fields to be included in the validate_unique() calculation!
+        """
+        exclude = super()._get_validation_exclusions()
+        exclude.remove("network")
+        exclude.remove("prefix_length")
+        return exclude
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.instance is not None:
@@ -470,6 +482,20 @@ class IPAddressForm(NautobotModelForm, TenancyForm, ReturnURLForm, AddressFieldM
         """
         namespace = self.cleaned_data.pop("namespace")
         setattr(self.instance, "_namespace", namespace)
+
+    def clean(self):
+        super().clean()
+        # If user input was bad, might not even *have* an identifiable host
+        if self.instance.host and self.instance._namespace:
+            try:
+                (
+                    Prefix.objects.filter(namespace=self.instance._namespace)
+                    # 3.0 TODO: disallow IPAddress from parenting to a TYPE_POOL prefix, instead pick TYPE_NETWORK
+                    # .exclude(type=PrefixTypeChoices.TYPE_POOL)
+                    .get_closest_parent(self.instance.host, include_self=True)
+                )
+            except Prefix.DoesNotExist:
+                raise ValidationError({"namespace": "No suitable parent Prefix exists in this Namespace"})
 
     def __init__(self, *args, **kwargs):
         # Initialize helper selectors

--- a/nautobot/ipam/tests/test_views.py
+++ b/nautobot/ipam/tests/test_views.py
@@ -423,7 +423,7 @@ class IPAddressTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         }
         response = self.client.post(**request)
         self.assertEqual(200, response.status_code)
-        self.assertIn(f"Could not determine parent Prefix for {instance}! Does it exist?", str(response.content))
+        self.assertIn("No suitable parent Prefix exists in this Namespace", str(response.content))
         # Create an exact copy of the parent prefix but in a different namespace. See if the re-parenting is successful
         new_parent = Prefix.objects.create(
             prefix=instance.parent.prefix,


### PR DESCRIPTION
# Closes: #n/a
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

#3378 added some code in the generic view handler to add special-case handling for IntegrityError, ValidationError, and DoesNotExist exceptions raised during `form.save()` as a workaround for a few cases where form validation was not catching certain error cases with the revised IPAddress and Prefix models. Specifically, the cases I'm aware of were:

- creation of a duplicate Prefix wasn't being caught until instance save(), at which point an IntegrityError would be raised due to violation of uniqueness constraints
- similarly, creation of a duplicate IPAddress wouldn't be caught until it raised an IntegrityError on save()
- creation of an IPAddress into a Namespace that lacked an appropriate Prefix wouldn't be caught until save(), at which point it would raise a Prefix.DoesNotExist exception (which would be reported by the existing view code as a permissions failure, as those are normally the case in which a user would hit a DoesNotExist otherwise)

This PR removes that generic view code, as it was inelegant and more importantly could result in false messages in the UI (see for example https://github.com/nautobot/nautobot/pull/4090#discussion_r1261539461). Instead I've added code to the appropriate IPAM forms to enable appropriate clean-time validation of these models.

Proof is in the screenshots:

![image](https://github.com/nautobot/nautobot/assets/5603551/3843f2d6-c49a-4535-8891-1e6c25ed7d78)

![image](https://github.com/nautobot/nautobot/assets/5603551/695c69c2-76e3-4611-83dd-b5c51849c7b9)

![image](https://github.com/nautobot/nautobot/assets/5603551/a58024ae-c906-4aac-a9af-fdb311c3860a)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
