### PR TITLE
Natural key definitions for Token and various extras models

### DIFF
--- a/changes/3974.fixed
+++ b/changes/3974.fixed
@@ -1,1 +1,1 @@
-Corrected the natural-key definitions for `ComputedField`, `CustomField`, `FileAttachment`, `ImageAttachment`, `ObjectChange`, `Relationship`, `RelationshipAssociation, and `Token` models.
+Corrected the natural-key definitions for `ComputedField`, `CustomField`, `FileAttachment`, `ImageAttachment`, `ObjectChange`, `Relationship`, `RelationshipAssociation`, and `Token` models.

--- a/changes/3974.fixed
+++ b/changes/3974.fixed
@@ -1,0 +1,1 @@
+Corrected the natural-key definitions for `ComputedField`, `CustomField`, `FileAttachment`, `ImageAttachment`, `ObjectChange`, `Relationship`, `RelationshipAssociation, and `Token` models.

--- a/changes/4131.fixed
+++ b/changes/4131.fixed
@@ -1,0 +1,3 @@
+Fixed inability to filter most models with `.exclude(composite_key="...")`.
+Fixed inability to call `Prefix.objects.exclude(prefix="...")`.
+Fixed inability to call `IPAddress.objects.exclude(address="...")`.

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -7,9 +7,18 @@ from django.utils.encoding import is_protected_type
 from django.utils.functional import classproperty
 
 from nautobot.core.models.managers import BaseManager
-from nautobot.core.models.querysets import RestrictedQuerySet
-from nautobot.core.models.utils import construct_composite_key
+from nautobot.core.models.querysets import CompositeKeyQuerySetMixin, RestrictedQuerySet
+from nautobot.core.models.utils import construct_composite_key, deconstruct_composite_key
 from nautobot.core.utils.lookup import get_route_for_model
+
+__all__ = (
+    "BaseManager",
+    "BaseModel",
+    "CompositeKeyQuerySetMixin",
+    "RestrictedQuerySet",
+    "construct_composite_key",
+    "deconstruct_composite_key",
+)
 
 
 class BaseModel(models.Model):

--- a/nautobot/core/models/querysets.py
+++ b/nautobot/core/models/querysets.py
@@ -3,6 +3,7 @@ from django.db.models.functions import Coalesce
 
 from nautobot.core.models.utils import deconstruct_composite_key
 from nautobot.core.utils import permissions
+from nautobot.core.utils.data import merge_dicts_without_collision
 
 
 def count_related(model, field):
@@ -18,20 +19,75 @@ def count_related(model, field):
 
 class CompositeKeyQuerySetMixin:
     """
-    Mixin to extend a base queryset class with support for filtering by `composite_key=...`.
+    Mixin to extend a base queryset class with support for filtering by `composite_key=...` as a virtual parameter.
+
+    Example:
+
+        >>> Location.objects.last().composite_key
+        'Durham;AMER'
+
+    Note that `Location.composite_key` is a `@property`, *not* a database field, and so would not normally be usable in
+    a `QuerySet` query, but because `RestrictedQuerySet` inherits from this mixin, the following "just works":
+
+        >>> Location.objects.get(composite_key="Durham;AMER")
+        <Location: Durham>
+
+    This is a shorthand for what would otherwise be a multi-step process:
+
+        >>> from nautobot.core.models.utils import deconstruct_composite_key
+        >>> deconstruct_composite_key("Durham;AMER")
+        ['Durham', 'AMER']
+        >>> Location.natural_key_args_to_kwargs(['Durham', 'AMER'])
+        {'name': 'Durham', 'parent__name': 'AMER'}
+        >>> Location.objects.get(name="Durham", parent__name="AMER")
+        <Location: Durham>
+
+    This works for QuerySet `filter()` and `exclude()` as well:
+
+        >>> Location.objects.filter(composite_key='Durham;AMER')
+        <LocationQuerySet [<Location: Durham>]>
+        >>> Location.objects.exclude(composite_key='Durham;AMER')
+        <LocationQuerySet [<Location: AMER>]>
+
+    `composite_key` can also be used in combination with other query parameters:
+
+        >>> Location.objects.filter(composite_key='Durham;AMER', status__name='Planned')
+        <LocationQuerySet []>
+
+    It will raise a ValueError if the deconstructed composite key collides with another query parameter:
+
+        >>> Location.objects.filter(composite_key='Durham;AMER', name='Raleigh')
+        ValueError: Conflicting values for key "name": ('Durham', 'Raleigh')
+
+    See also `BaseModel.composite_key` and `utils.construct_composite_key()`/`utils.deconstruct_composite_key()`.
     """
 
-    def filter(self, *args, **kwargs):
+    def split_composite_key_into_kwargs(self, composite_key=None, **kwargs):
         """
-        This is an enhanced version of natural-key slug support from django-natural-keys.
+        Helper method abstracting a common need from filter() and exclude().
+
+        Subclasses may need to call this directly if they also have special processing of other filter/exclude params.
+        """
+        if composite_key and isinstance(composite_key, str):
+            natural_key_values = deconstruct_composite_key(composite_key)
+            return merge_dicts_without_collision(self.model.natural_key_args_to_kwargs(natural_key_values), kwargs)
+        return kwargs
+
+    def filter(self, *args, composite_key=None, **kwargs):
+        """
+        Explicitly handle `filter(composite_key="...")` by decomposing the composite-key into natural key parameters.
+
         Counterpart to BaseModel.composite_key property.
         """
-        composite_key = kwargs.pop("composite_key", None)
-        if composite_key and isinstance(composite_key, str):
-            values = deconstruct_composite_key(composite_key)
-            kwargs.update(self.model.natural_key_args_to_kwargs(values))
+        return super().filter(*args, **self.split_composite_key_into_kwargs(composite_key, **kwargs))
 
-        return super().filter(*args, **kwargs)
+    def exclude(self, *args, composite_key=None, **kwargs):
+        """
+        Explicitly handle `exclude(composite_key="...")` by decomposing the composite-key into natural key parameters.
+
+        Counterpart to BaseModel.composite_key property.
+        """
+        return super().exclude(*args, **self.split_composite_key_into_kwargs(composite_key, **kwargs))
 
 
 class RestrictedQuerySet(CompositeKeyQuerySetMixin, QuerySet):

--- a/nautobot/core/templatetags/helpers.py
+++ b/nautobot/core/templatetags/helpers.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import re
 
 from django import template
@@ -22,6 +23,9 @@ HTML_FALSE = '<span class="text-danger"><i class="mdi mdi-close-thick" title="No
 HTML_NONE = '<span class="text-muted">&mdash;</span>'
 
 register = template.Library()
+
+
+logger = logging.getLogger(__name__)
 
 
 #
@@ -402,6 +406,7 @@ def get_docs_url(model):
     # Check to see if documentation exists in any of the static paths.
     if find(path):
         return static(path)
+    logger.debug("No documentation found for %s (expected to find it at %s)", model, path)
     return None
 
 

--- a/nautobot/core/testing/models.py
+++ b/nautobot/core/testing/models.py
@@ -26,7 +26,16 @@ class ModelTestCases:
             if not hasattr(instance, "composite_key"):
                 self.skipTest("No composite_key on this model.")
             self.assertIsNotNone(instance.composite_key)
+            # get()
             self.assertEqual(self.model.objects.get(composite_key=instance.composite_key), instance)
+            # filter()
+            match = self.model.objects.filter(composite_key=instance.composite_key)
+            self.assertEqual(1, len(match))
+            self.assertEqual(match[0], instance)
+            # exclude()
+            match = self.model.objects.exclude(composite_key=instance.composite_key)
+            self.assertEqual(self.model.objects.count() - 1, match.count())
+            self.assertNotIn(instance, match)
 
         def test_get_docs_url(self):
             """Check that `get_docs_url()` returns a valid static file path for this model."""

--- a/nautobot/core/tests/test_utils.py
+++ b/nautobot/core/tests/test_utils.py
@@ -678,3 +678,20 @@ class IsFooTest(TestCase):
             self.assertFalse(data_utils.is_uuid(None))
             self.assertFalse(data_utils.is_uuid(1))
             self.assertFalse(data_utils.is_uuid("abc123"))
+
+
+class MergeDictsWithoutCollisionTest(TestCase):
+    """Test the merge_dicts_without_collision() data utility function."""
+
+    def test_no_collisions(self):
+        self.assertEqual({"a": 1, "b": 2}, data_utils.merge_dicts_without_collision({"a": 1}, {"b": 2}))
+
+    def test_collision_but_same_value(self):
+        self.assertEqual(
+            {"a": 1, "b": 2, "c": 3}, data_utils.merge_dicts_without_collision({"a": 1, "c": 3}, {"b": 2, "c": 3})
+        )
+
+    def test_collision_differing_values(self):
+        with self.assertRaises(ValueError) as err:
+            data_utils.merge_dicts_without_collision({"a": 1}, {"a": 2})
+        self.assertEqual(str(err.exception), 'Conflicting values for key "a": (1, 2)')

--- a/nautobot/core/utils/data.py
+++ b/nautobot/core/utils/data.py
@@ -83,6 +83,17 @@ def is_url(value):
         return False
 
 
+def merge_dicts_without_collision(d1, d2):
+    """
+    Merge two dicts into a new dict, but raise a ValueError if any key exists with differing values across both dicts.
+    """
+    intersection = d1.keys() & d2.keys()
+    for k in intersection:
+        if d1[k] != d2[k]:
+            raise ValueError(f'Conflicting values for key "{k}": ({d1[k]!r}, {d2[k]!r})')
+    return {**d1, **d2}
+
+
 def render_jinja2(template_code, context):
     """
     Render a Jinja2 template with the provided context. Return the rendered content.

--- a/nautobot/extras/models/change_logging.py
+++ b/nautobot/extras/models/change_logging.py
@@ -109,6 +109,7 @@ class ObjectChange(BaseModel):
     object_data_v2 = models.JSONField(encoder=NautobotKombuJSONEncoder, editable=False, null=True, blank=True)
 
     documentation_static_path = "docs/user-guide/platform-functionality/change-logging.html"
+    natural_key_field_names = ["pk"]
 
     class Meta:
         ordering = ["-time"]

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -88,6 +88,7 @@ class ComputedField(BaseModel, ChangeLoggedModel, NotesMixin):
     objects = ComputedFieldManager()
 
     clone_fields = ["content_type", "description", "template", "fallback_value", "weight"]
+    natural_key_field_names = ["key"]
 
     class Meta:
         ordering = ["weight", "key"]
@@ -395,6 +396,7 @@ class CustomField(BaseModel, ChangeLoggedModel, NotesMixin):
         "validation_maximum",
         "validation_regex",
     ]
+    natural_key_field_names = ["key"]
 
     class Meta:
         ordering = ["weight", "label"]

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -445,6 +445,8 @@ class FileAttachment(BaseModel):
     filename = models.CharField(max_length=255)
     mimetype = models.CharField(max_length=255)
 
+    natural_key_field_names = ["pk"]
+
     def __str__(self):
         return self.filename
 
@@ -578,6 +580,8 @@ class ImageAttachment(BaseModel):
     image_width = models.PositiveSmallIntegerField()
     name = models.CharField(max_length=50, blank=True, db_index=True)
     created = models.DateTimeField(auto_now_add=True)
+
+    natural_key_field_names = ["pk"]
 
     class Meta:
         ordering = ("name",)  # name may be non-unique

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -432,6 +432,7 @@ class Relationship(BaseModel, ChangeLoggedModel, NotesMixin):
         'It will appear in the "Advanced" tab instead.',
     )
 
+    natural_key_field_names = ["key"]
     objects = RelationshipManager()
 
     class Meta:
@@ -698,6 +699,7 @@ class RelationshipAssociation(BaseModel):
     destination = GenericForeignKey(ct_field="destination_type", fk_field="destination_id")
 
     documentation_static_path = "docs/user-guide/platform-functionality/relationship.html"
+    natural_key_field_names = ["relationship", "source_id", "destination_id"]
 
     class Meta:
         unique_together = (

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -24,7 +24,12 @@ from nautobot.users.models import ObjectPermission
 from nautobot.virtualization.models import VirtualMachine
 
 
-class CustomFieldTest(TestCase):  # TODO: change to BaseModelTestCase once we have some baseline custom-field records
+# TODO: this needs to be both a BaseModelTestCase (as it tests the model class) and a (views) TestCase,
+#       (due to the test_multi_select_field_value_after_bulk_update() test).
+#       At some point we should probably split this into separate classes.
+class CustomFieldTest(ModelTestCases.BaseModelTestCase, TestCase):
+    model = CustomField
+
     def setUp(self):
         super().setUp()
         location_status = Status.objects.get_for_model(Location).first()

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -742,6 +742,14 @@ class FileProxyTest(ModelTestCases.BaseModelTestCase):
         self.assertEqual(FileProxy.objects.count(), 0)
         self.assertEqual(FileAttachment.objects.count(), 0)
 
+    def test_natural_key_symmetry(self):
+        """Test FileAttachment as well as FileProxy."""
+        super().test_natural_key_symmetry()
+        instance = FileAttachment.objects.first()
+        self.assertIsNotNone(instance)
+        self.assertIsNotNone(instance.natural_key())
+        self.assertEqual(FileAttachment.objects.get_by_natural_key(*instance.natural_key()), instance)
+
 
 class GitRepositoryTest(ModelTestCases.BaseModelTestCase):
     """

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -1054,7 +1054,9 @@ class RelationshipTableTest(RelationshipBaseTest, TestCase):
                 self.assertIn(value, rendered_value)
 
 
-class RequiredRelationshipTestMixin(TestCase):
+class RequiredRelationshipTestMixin:
+    """Common test mixin for both view and API tests dealing with required relationships."""
+
     def send_data(self, model_class, data, interact_with, action="add", url_kwargs=None):
         # Helper to post data to a URL
 
@@ -1143,6 +1145,7 @@ class RequiredRelationshipTestMixin(TestCase):
             required_on="source",
         )
         relationship_o2o.validated_save()
+        vlan_group = VLANGroup.objects.first()
 
         tests_params = [
             # Required many-to-many:
@@ -1151,7 +1154,7 @@ class RequiredRelationshipTestMixin(TestCase):
                     "vid": "1",
                     "name": "New VLAN",
                     "status": str(Status.objects.get_for_model(VLAN).first().pk),
-                    "vlan_group": str(self.vlan_group.pk),
+                    "vlan_group": str(vlan_group.pk),
                 },
                 "relationship": relationship_m2m,
                 "required_objects_generator": [

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -1,6 +1,5 @@
 import logging
 import uuid
-from unittest import skip
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
@@ -14,6 +13,7 @@ from nautobot.core.forms import (
 )
 from nautobot.core.tables import RelationshipColumn
 from nautobot.core.testing import TestCase
+from nautobot.core.testing.models import ModelTestCases
 from nautobot.core.utils.lookup import get_route_for_model
 from nautobot.dcim.models import Device, Platform, Rack, Location, LocationType
 from nautobot.dcim.tables import LocationTable
@@ -24,14 +24,14 @@ from nautobot.extras.choices import RelationshipRequiredSideChoices, Relationshi
 from nautobot.extras.models import Relationship, RelationshipAssociation, Status
 
 
-class RelationshipBaseTest(TestCase):
+class RelationshipBaseTest:
     @classmethod
     def setUpTestData(cls):
         cls.location_ct = ContentType.objects.get_for_model(Location)
         cls.rack_ct = ContentType.objects.get_for_model(Rack)
         cls.vlan_ct = ContentType.objects.get_for_model(VLAN)
 
-        cls.locations = Location.objects.all()[:5]
+        cls.locations = Location.objects.get_for_model(Rack).get_for_model(VLAN)[:5]
 
         cls.rack_status = Status.objects.get_for_model(Rack).first()
         cls.racks = [
@@ -41,16 +41,16 @@ class RelationshipBaseTest(TestCase):
         ]
 
         cls.vlan_status = Status.objects.get_for_model(VLAN).first()
-        vlan_groups = (VLANGroupFactory.create(location=cls.locations[idx]) for idx in range(3))
+        cls.vlan_group = VLANGroup.objects.create(name="Relationship Test VLANGroup")
         cls.vlans = [
             VLAN.objects.create(
-                name="VLAN A", vid=100, location=cls.locations[0], status=cls.vlan_status, vlan_group=vlan_groups[0]
+                name="VLAN A", vid=100, location=cls.locations[0], status=cls.vlan_status, vlan_group=cls.vlan_group
             ),
             VLAN.objects.create(
-                name="VLAN B", vid=100, location=cls.locations[1], status=cls.vlan_status, vlan_group=vlan_groups[0]
+                name="VLAN B", vid=101, location=cls.locations[1], status=cls.vlan_status, vlan_group=cls.vlan_group
             ),
             VLAN.objects.create(
-                name="VLAN C", vid=100, location=cls.locations[2], status=cls.vlan_status, vlan_group=vlan_groups[0]
+                name="VLAN C", vid=102, location=cls.locations[2], status=cls.vlan_status, vlan_group=cls.vlan_group
             ),
         ]
 
@@ -157,8 +157,9 @@ class RelationshipBaseTest(TestCase):
         ]
 
 
-@skip
-class RelationshipTest(RelationshipBaseTest):  # TODO: BaseModelTestCase mixin?
+class RelationshipTest(RelationshipBaseTest, ModelTestCases.BaseModelTestCase):
+    model = Relationship
+
     def test_clean_filter_not_dict(self):
         m2m = Relationship(
             label="Another VLAN to Rack",
@@ -429,8 +430,9 @@ class RelationshipTest(RelationshipBaseTest):  # TODO: BaseModelTestCase mixin?
         )
 
 
-@skip
-class RelationshipAssociationTest(RelationshipBaseTest):
+class RelationshipAssociationTest(RelationshipBaseTest, ModelTestCases.BaseModelTestCase):
+    model = RelationshipAssociation
+
     def setUp(self):
         super().setUp()
 
@@ -901,8 +903,7 @@ class RelationshipAssociationTest(RelationshipBaseTest):
         self.assertEqual(1, RelationshipAssociation.objects.filter(destination_dcim_location=self.locations[0]).count())
 
 
-@skip
-class RelationshipTableTest(RelationshipBaseTest):
+class RelationshipTableTest(RelationshipBaseTest, TestCase):
     """
     Test inclusion of relationships in object table views.
     """
@@ -1143,7 +1144,6 @@ class RequiredRelationshipTestMixin(TestCase):
             required_on="source",
         )
         relationship_o2o.validated_save()
-        vlan_group = VLANGroup.objects.first()
 
         tests_params = [
             # Required many-to-many:
@@ -1152,7 +1152,7 @@ class RequiredRelationshipTestMixin(TestCase):
                     "vid": "1",
                     "name": "New VLAN",
                     "status": str(Status.objects.get_for_model(VLAN).first().pk),
-                    "vlan_group": str(vlan_group.pk),
+                    "vlan_group": str(self.vlan_group.pk),
                 },
                 "relationship": relationship_m2m,
                 "required_objects_generator": [

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -18,7 +18,6 @@ from nautobot.core.utils.lookup import get_route_for_model
 from nautobot.dcim.models import Device, Platform, Rack, Location, LocationType
 from nautobot.dcim.tables import LocationTable
 from nautobot.dcim.tests.test_views import create_test_device
-from nautobot.ipam.factory import VLANGroupFactory
 from nautobot.ipam.models import VLAN, VLANGroup
 from nautobot.extras.choices import RelationshipRequiredSideChoices, RelationshipSideChoices, RelationshipTypeChoices
 from nautobot.extras.models import Relationship, RelationshipAssociation, Status

--- a/nautobot/ipam/tests/test_querysets.py
+++ b/nautobot/ipam/tests/test_querysets.py
@@ -91,6 +91,8 @@ class IPAddressQuerySet(TestCase):
     def test_filter_by_address(self):
         address = self.queryset.net_in(["10.0.0.1/24"])[0]
         self.assertEqual(self.queryset.filter(address="10.0.0.1/24")[0], address)
+        self.assertEqual(self.queryset.count() - 1, self.queryset.exclude(address="10.0.0.1/24").count())
+        self.assertNotIn(address, self.queryset.exclude(address="10.0.0.1/24"))
 
     def test__is_ambiguous_network_string(self):
         self.assertTrue(self.queryset._is_ambiguous_network_string("10"))
@@ -544,6 +546,8 @@ class PrefixQuerysetTestCase(TestCase):
     def test_filter_by_prefix(self):
         prefix = self.queryset.net_equals(netaddr.IPNetwork("192.168.0.0/16"))[0]
         self.assertEqual(self.queryset.filter(prefix="192.168.0.0/16")[0], prefix)
+        self.assertEqual(self.queryset.count() - 1, self.queryset.exclude(prefix="192.168.0.0/16").count())
+        self.assertNotIn(prefix, self.queryset.exclude(prefix="192.168.0.0/16"))
 
     def test_string_search(self):
         search_terms = {

--- a/nautobot/users/tests/test_models.py
+++ b/nautobot/users/tests/test_models.py
@@ -1,12 +1,35 @@
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+
+from nautobot.core.testing.models import ModelTestCases
+from nautobot.users.models import ObjectPermission, Token
 
 
 # Use the proper swappable User model
 User = get_user_model()
 
 
-class UserConfigTest(TestCase):
+class ObjectPermissionTest(ModelTestCases.BaseModelTestCase):
+    model = ObjectPermission
+
+    def setUp(self):
+        ObjectPermission.objects.create(name="Test Permission", actions=["view", "add", "change", "delete"])
+
+
+class TokenTest(ModelTestCases.BaseModelTestCase):
+    model = Token
+
+    def setUp(self):
+        user = User.objects.create_user(username="testuser")
+        self.token = Token.objects.create(user=user)
+
+    def test_natural_key_does_not_expose_token_key(self):
+        self.assertNotEqual(self.token.key, "")
+        self.assertNotIn(self.token.key, self.token.natural_key())
+
+
+class UserConfigTest(ModelTestCases.BaseModelTestCase):
+    model = User
+
     def setUp(self):
         user = User.objects.create_user(username="testuser")
         user.config_data = {


### PR DESCRIPTION
# Closes: #3974 
# What's Changed

- Corrected the natural-key definitions for `ComputedField`, `CustomField`, `FileAttachment`, `ImageAttachment`, `ObjectChange`, `Relationship`, `RelationshipAssociation`, and `Token` models.
- Re-enabled some Relationship/RelationshipAssociation tests that had been disabled during the IPAM Namespaces work.
- Fixed the problem that while we could do `model.objects.get(composite_key=...)` and `model.objects.filter(composite_key=...)`, we didn't have code in place for `model.objects.exclude(composite_key=...)`.
- Similarly, fixed lack of support for `Prefix.objects.exclude(prefix=...)` and `IPAddress.objects.exclude(address=...)`.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
