### PR TITLE
Fix "Check Secret" button

### DIFF
--- a/changes/4127.fixed
+++ b/changes/4127.fixed
@@ -1,0 +1,1 @@
+Fixed JavaScript error with 'Check Secret' button introduced in the previous patch release.

--- a/nautobot/extras/templates/extras/secret.html
+++ b/nautobot/extras/templates/extras/secret.html
@@ -44,8 +44,8 @@
 
 
 {% block javascript %}
+{{ block.super }}
 <script>
-    {{ block.super }}
     function checkSecret() {
         $.ajax({
             url: "{% url 'extras-api:secret-check' pk=object.pk %}",


### PR DESCRIPTION
# Closes: #4127 
# What's Changed

Move `{{ block.super }}` to the correct position in the template file. Verified that this fixes #4127 and also that tab navigation on the Secret detail page still works (i.e. no regression of #4048).

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
