### PR TITLE
Allow Create and Update methods to have their own form class in NautobotUIViewSet.

### DIFF
--- a/changes/4161.added
+++ b/changes/4161.added
@@ -1,0 +1,1 @@
+- Allow Create and Update methods to have their own form class in NautobotUIViewSet.

--- a/examples/example_plugin/example_plugin/forms.py
+++ b/examples/example_plugin/example_plugin/forms.py
@@ -49,7 +49,7 @@ class ExampleModelBulkEditForm(BootstrapMixin, BulkEditForm):
         nullable_fields = []
 
 
-class AnotherExampleCreateModelForm(NautobotModelForm):
+class AnotherExampleModelCreateForm(NautobotModelForm):
     """Create only form for `AnotherExampleModel` objects."""
 
     class Meta:
@@ -57,7 +57,7 @@ class AnotherExampleCreateModelForm(NautobotModelForm):
         fields = ["name", "number"]
 
 
-class AnotherExampleUpdateModelForm(NautobotModelForm):
+class AnotherExampleModelUpdateForm(NautobotModelForm):
     """Update only form for `AnotherExampleModel` objects."""
 
     class Meta:

--- a/examples/example_plugin/example_plugin/forms.py
+++ b/examples/example_plugin/example_plugin/forms.py
@@ -49,12 +49,20 @@ class ExampleModelBulkEditForm(BootstrapMixin, BulkEditForm):
         nullable_fields = []
 
 
-class AnotherExampleModelForm(NautobotModelForm):
-    """Generic create/update form for `AnotherExampleModel` objects."""
+class AnotherExampleCreateModelForm(NautobotModelForm):
+    """Create only form for `AnotherExampleModel` objects."""
 
     class Meta:
         model = AnotherExampleModel
         fields = ["name", "number"]
+
+
+class AnotherExampleUpdateModelForm(NautobotModelForm):
+    """Update only form for `AnotherExampleModel` objects."""
+
+    class Meta:
+        model = AnotherExampleModel
+        fields = ["number", "name"]
 
 
 class AnotherExampleModelFilterForm(BootstrapMixin, forms.Form):

--- a/examples/example_plugin/example_plugin/views.py
+++ b/examples/example_plugin/example_plugin/views.py
@@ -95,8 +95,8 @@ class AnotherExampleModelUIViewSet(
     bulk_update_form_class = forms.AnotherExampleModelBulkEditForm
     filterset_class = filters.AnotherExampleModelFilterSet
     filterset_form_class = forms.AnotherExampleModelFilterForm
-    create_form_class = forms.AnotherExampleCreateModelForm
-    update_form_class = forms.AnotherExampleUpdateModelForm
+    create_form_class = forms.AnotherExampleModelCreateForm
+    update_form_class = forms.AnotherExampleModelUpdateForm
     lookup_field = "pk"
     queryset = AnotherExampleModel.objects.all()
     serializer_class = serializers.AnotherExampleModelSerializer

--- a/examples/example_plugin/example_plugin/views.py
+++ b/examples/example_plugin/example_plugin/views.py
@@ -95,7 +95,8 @@ class AnotherExampleModelUIViewSet(
     bulk_update_form_class = forms.AnotherExampleModelBulkEditForm
     filterset_class = filters.AnotherExampleModelFilterSet
     filterset_form_class = forms.AnotherExampleModelFilterForm
-    form_class = forms.AnotherExampleModelForm
+    create_form_class = forms.AnotherExampleCreateModelForm
+    update_form_class = forms.AnotherExampleUpdateModelForm
     lookup_field = "pk"
     queryset = AnotherExampleModel.objects.all()
     serializer_class = serializers.AnotherExampleModelSerializer

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -76,6 +76,8 @@ class NautobotViewSetMixin(GenericViewSet, AccessMixin, GetReturnURLMixin, FormV
     filterset_class = None
     filterset_form_class = None
     form_class = None
+    create_form_class = None
+    update_form_class = None
     parser_classes = [FormParser, MultiPartParser]
     queryset = None
     # serializer_class has to be specified to eliminate the need to override retrieve() in the RetrieveModelMixin for now.
@@ -383,7 +385,10 @@ class NautobotViewSetMixin(GenericViewSet, AccessMixin, GetReturnURLMixin, FormV
         """
 
         if self.action in ["create", "update"]:
-            form_class = getattr(self, "form_class", None)
+            if getattr(self, f"{self.action}_form_class"):
+                form_class = getattr(self, f"{self.action}_form_class")
+            else:
+                form_class = getattr(self, "form_class", None)
         elif self.action == "bulk_create":
 
             class BulkCreateForm(BootstrapMixin, Form):

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -983,6 +983,8 @@ class YourAppModelUIViewSet(NautobotUIViewSet):
     filterset_class = filters.YourAppModelFilterSet
     filterset_form_class = forms.YourAppModelFilterForm
     form_class = forms.YourAppModelForm
+    create_form_class = forms.YourAppCreateModelForm
+    update_form_class = forms.YourAppUpdateModelForm
     queryset = models.YourAppModel.objects.all()
     serializer_class = serializers.YourAppModelSerializer
     table_class = tables.YourAppModelTable

--- a/nautobot/docs/plugins/development.md
+++ b/nautobot/docs/plugins/development.md
@@ -983,8 +983,8 @@ class YourAppModelUIViewSet(NautobotUIViewSet):
     filterset_class = filters.YourAppModelFilterSet
     filterset_form_class = forms.YourAppModelFilterForm
     form_class = forms.YourAppModelForm
-    create_form_class = forms.YourAppCreateModelForm
-    update_form_class = forms.YourAppUpdateModelForm
+    create_form_class = forms.YourAppModelCreateForm
+    update_form_class = forms.YourAppModelUpdateForm
     queryset = models.YourAppModel.objects.all()
     serializer_class = serializers.YourAppModelSerializer
     table_class = tables.YourAppModelTable


### PR DESCRIPTION

# Closes: 4153
# What's Changed

Allow Create and Update methods to have their own form class in NautobotUIViewSet.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Unit, Integration Tests
    - Does not seem to be any tests for this
- [x] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
    - Not clear if `get_form_for_model` or something else is expecting there to be a `form_class`
