### PR TITLE
Filterset field's DOM element in JSON format.

### DIFF
--- a/changes/3582.added
+++ b/changes/3582.added
@@ -1,0 +1,1 @@
+The 'GetFilterSetFieldDOMElementAPIView' now has the option to return the filterset field's DOM element in JSON format.

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -958,17 +958,17 @@ class GetFilterSetFieldDOMElementAPIView(NautobotAPIVersionMixin, APIView):
             model_form_instance = TempForm(auto_id="id_for_%s")
 
         bound_field = form_field.get_bound_field(model_form_instance, field_name)
-        if "as_json" in request.GET:
+        if request.META.get("HTTP_ACCEPT") == "application/json":
             data = {
                 "field_type": form_field.__class__.__name__,
                 "attrs": bound_field.field.widget.attrs,
-                # The choices attr is present in all field types; choices can be ignored in the UI depending on the `field_type`
-                "choices": list(bound_field.field.widget.choices),
                 # `is_required` is redundant here as it's not used in filterset;
                 # Just leaving it here because this would help when building create/edit form for new UI,
                 # This logic(as_json representation) should be extracted into a helper function at that time
                 "is_required": bound_field.field.widget.is_required,
             }
+            if hasattr(bound_field.field.widget, "choices"):
+                data["choices"] = list(bound_field.field.widget.choices)
         else:
-            data = {"dom_element": bound_field.as_widget()}
+            data = bound_field.as_widget()
         return Response(data)

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -44,7 +44,6 @@ from nautobot.core.utils.requests import ensure_content_type_and_field_name_in_q
 from nautobot.extras.registry import registry
 from . import serializers
 
-
 HTTP_ACTIONS = {
     "GET": "view",
     "OPTIONS": None,
@@ -959,4 +958,17 @@ class GetFilterSetFieldDOMElementAPIView(NautobotAPIVersionMixin, APIView):
             model_form_instance = TempForm(auto_id="id_for_%s")
 
         bound_field = form_field.get_bound_field(model_form_instance, field_name)
-        return Response({"dom_element": bound_field.as_widget()})
+        if "as_json" in request.GET:
+            data = {
+                "field_type": form_field.__class__.__name__,
+                "attrs": bound_field.field.widget.attrs,
+                # The choices attr is present in all field types; choices can be ignored in the UI depending on the `field_type`
+                "choices": list(bound_field.field.widget.choices),
+                # `is_required` is redundant here as it's not used in filterset;
+                # Just leaving it here because this would help when building create/edit form for new UI,
+                # This logic(as_json representation) should be extracted into a helper function at that time
+                "is_required": bound_field.field.widget.is_required,
+            }
+        else:
+            data = {"dom_element": bound_field.as_widget()}
+        return Response(data)

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -408,15 +408,13 @@ class GenerateLookupValueDomElementViewTestCase(testing.APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.data,
-            {
-                "dom_element": '<select name="name" class="form-control nautobot-select2-multi-value-char" data-multiple="1" id="id_for_name" multiple>\n</select>'
-            },
+            '<select name="name" class="form-control nautobot-select2-multi-value-char" data-multiple="1" id="id_for_name" multiple>\n</select>',
         )
 
         # Also assert JSON representation
+        self.header["HTTP_ACCEPT"] = "application/json"
         response = self.client.get(f"{url}?content_type=dcim.location&field_name=name&as_json", **self.header)
         self.assertEqual(response.status_code, 200)
-        print(response.data)
         expected_response = {
             "field_type": "MultiValueCharField",
             "attrs": {"class": "form-control nautobot-select2-multi-value-char", "data-multiple": 1},
@@ -432,12 +430,12 @@ class GenerateLookupValueDomElementViewTestCase(testing.APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.data,
-            {
-                "dom_element": '<select name="role" class="form-control nautobot-select2-api" data-multiple="1" '
+            (
+                '<select name="role" class="form-control nautobot-select2-api" data-multiple="1" '
                 'data-query-param-content_types="[&quot;dcim.device&quot;, &quot;virtualization.virtualmachine&quot;]" '
                 'display-field="display" value-field="name" data-depth="0" data-url="/api/extras/roles/" id="id_for_role" '
                 "multiple>\n</select>"
-            },
+            ),
         )
 
         with self.subTest("Assert correct lookup field dom element is generated"):
@@ -446,9 +444,7 @@ class GenerateLookupValueDomElementViewTestCase(testing.APITestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(
                 response.data,
-                {
-                    "dom_element": '<select name="name" class="form-control nautobot-select2-multi-value-char" data-multiple="1" id="id_for_name" multiple>\n</select>'
-                },
+                '<select name="name" class="form-control nautobot-select2-multi-value-char" data-multiple="1" id="id_for_name" multiple>\n</select>',
             )
 
         with self.subTest("Assert TempFilterForm is used if model filterform raises error at initialization"):
@@ -461,9 +457,7 @@ class GenerateLookupValueDomElementViewTestCase(testing.APITestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(
                 response.data,
-                {
-                    "dom_element": '<select name="name" class="form-control nautobot-select2-multi-value-char" data-multiple="1" id="id_for_name" multiple>\n</select>'
-                },
+                '<select name="name" class="form-control nautobot-select2-multi-value-char" data-multiple="1" id="id_for_name" multiple>\n</select>',
             )
 
 

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -403,7 +403,7 @@ class GenerateLookupValueDomElementViewTestCase(testing.APITestCase):
 
     def test_get_lookup_value_dom_element(self):
         url = reverse("core-api:filtersetfield-retrieve-lookupvaluedomelement")
-        response = self.client.get(url + "?content_type=dcim.location&field_name=name", **self.header)
+        response = self.client.get(f"{url}?content_type=dcim.location&field_name=name", **self.header)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -412,6 +412,18 @@ class GenerateLookupValueDomElementViewTestCase(testing.APITestCase):
                 "dom_element": '<select name="name" class="form-control nautobot-select2-multi-value-char" data-multiple="1" id="id_for_name" multiple>\n</select>'
             },
         )
+
+        # Also assert JSON representation
+        response = self.client.get(f"{url}?content_type=dcim.location&field_name=name&as_json", **self.header)
+        self.assertEqual(response.status_code, 200)
+        print(response.data)
+        expected_response = {
+            "field_type": "MultiValueCharField",
+            "attrs": {"class": "form-control nautobot-select2-multi-value-char", "data-multiple": 1},
+            "choices": [],
+            "is_required": False,
+        }
+        self.assertEqual(response.data, expected_response)
 
     def test_get_lookup_value_dom_element_for_configcontext(self):
         url = reverse("core-api:filtersetfield-retrieve-lookupvaluedomelement")

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -542,11 +542,10 @@ function initializeDynamicFilterForm(context){
             $.ajax({
                 url: `/api/ui/core/filterset-fields/lookup-value-dom-element/?field_name=${lookup_type_val}&content_type=${contenttype}`,
                 async: true,
-                contentType: 'application/json',
-                dataType: 'json',
+                headers: {'Accept': '*/*'},
                 type: 'GET',
             }).done(function (response) {
-                newEl = $(response.dom_element)
+                newEl = $(response)
                 newEl.addClass("lookup_value-input")
                 replaceEl(lookup_value_element, newEl)
                 if (newEl.prop("tagName") == "SELECT") {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3582 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

The ability to return the JSON equivalent of a filter field DOM element has been added.

Filtering in the NewUI should be done in the following ways.
1. Get all model fields from the `schema` in the OPTIONS request
2. Get the field types
3. Get the DOM element in JSON representation


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
