### PR TITLE
Fix DynamicGroup Serialization Bug

### DIFF
--- a/changes/4178.fixed
+++ b/changes/4178.fixed
@@ -1,0 +1,1 @@
+Fixed JSON serialization of overloaded/non-default FilterForm fields on Dynamic Groups.

--- a/examples/example_plugin/example_plugin/filter_extensions.py
+++ b/examples/example_plugin/example_plugin/filter_extensions.py
@@ -1,6 +1,8 @@
 from django import forms
 
 from nautobot.apps.filters import FilterExtension, MultiValueCharFilter
+from nautobot.tenancy.models import Tenant
+from nautobot.utilities.forms import DynamicModelMultipleChoiceField
 
 
 def suffix_search(queryset, name, value):
@@ -36,4 +38,23 @@ class DeviceFilterExtension(FilterExtension):
     model = "dcim.device"
 
 
-filter_extensions = [TenantFilterExtension, DeviceFilterExtension]
+class PrefixFilterExtension(FilterExtension):
+    """Created to test filter extensions and Dynamic Group support."""
+
+    model = "ipam.prefix"
+
+    filterset_fields = {
+        "example_plugin_prefix_tenant_name": MultiValueCharFilter(field_name="tenant__name", label="Tenant Name"),
+    }
+
+    filterform_fields = {
+        "example_plugin_prefix_tenant_name": DynamicModelMultipleChoiceField(
+            queryset=Tenant.objects.all(),
+            to_field_name="name",
+            required=False,
+            label="Tenant Name",
+        )
+    }
+
+
+filter_extensions = [TenantFilterExtension, DeviceFilterExtension, PrefixFilterExtension]

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -371,7 +371,7 @@ class DynamicGroup(OrganizationalModel):
             field = declared_form.declared_fields.get(field_name, filterset_form.fields[field_name])
             field_value = filterset_form.cleaned_data[field_name]
 
-            if isinstance(field, forms.ModelMultipleChoiceField) or isinstance(field, TagFilterField):
+            if isinstance(field, (forms.ModelMultipleChoiceField, TagFilterField)):
                 field_to_query = field.to_field_name or "pk"
                 new_value = [getattr(item, field_to_query) for item in field_value]
 

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -371,6 +371,10 @@ class DynamicGroup(OrganizationalModel):
             field = declared_form.declared_fields.get(field_name, filterset_form.fields[field_name])
             field_value = filterset_form.cleaned_data[field_name]
 
+            # `tag` on FilterForms is not a ModelMultipleChoiceField, so we need to handle it.
+            # On `FilterSetForm.tag`, it is a ModelMultipleChoiceField.
+            # TODO: This could/should check for both "convenience" FilterForm fields (ex: DynamicModelMultipleChoiceField)
+            # and literal FilterSet fields (ex: MultiValueCharFilter).
             if isinstance(field, (forms.ModelMultipleChoiceField, TagFilterField)):
                 field_to_query = field.to_field_name or "pk"
                 new_value = [getattr(item, field_to_query) for item in field_value]

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -18,6 +18,7 @@ from nautobot.extras.choices import DynamicGroupOperatorChoices
 from nautobot.extras.querysets import DynamicGroupQuerySet, DynamicGroupMembershipQuerySet
 from nautobot.extras.utils import extras_features
 from nautobot.utilities.forms.constants import BOOLEAN_WITH_BLANK_CHOICES
+from nautobot.utilities.forms.fields import TagFilterField
 from nautobot.utilities.forms.widgets import StaticSelect2
 from nautobot.utilities.utils import get_filterset_for_model, get_form_for_model
 
@@ -354,6 +355,9 @@ class DynamicGroup(OrganizationalModel):
         # Use the auto-generated filterset form perform creation of the filter dictionary.
         filterset_form = filterset.form
 
+        # Get the declared form for any overloaded form field definitions.
+        declared_form = get_form_for_model(filterset._meta.model, form_prefix="Filter")
+
         # It's expected that the incoming data has already been cleaned by a form. This `is_valid()`
         # call is primarily to reduce the fields down to be able to work with the `cleaned_data` from the
         # filterset form, but will also catch errors in case a user-created dict is provided instead.
@@ -364,10 +368,10 @@ class DynamicGroup(OrganizationalModel):
         # empty/null value fields.
         new_filter = {}
         for field_name in filter_fields:
-            field = filterset_form.fields[field_name]
+            field = declared_form.declared_fields.get(field_name, filterset_form.fields[field_name])
             field_value = filterset_form.cleaned_data[field_name]
 
-            if isinstance(field, forms.ModelMultipleChoiceField):
+            if isinstance(field, forms.ModelMultipleChoiceField) or isinstance(field, TagFilterField):
                 field_to_query = field.to_field_name or "pk"
                 new_value = [getattr(item, field_to_query) for item in field_value]
 

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -36,6 +36,7 @@ from nautobot.extras.models import (
     Status,
 )
 from nautobot.ipam.models import Prefix
+from nautobot.tenancy.models import Tenant
 from nautobot.utilities.forms.fields import MultiValueCharField
 from nautobot.utilities.forms.widgets import MultiValueCharInput
 from nautobot.utilities.testing import TestCase
@@ -940,6 +941,25 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
         self.assertIn(device, dg.members)
         expected = [str(device)]
         self.assertEqual(sorted(dg.members.values_list("name", flat=True)), expected)
+
+    def test_group_overloaded_filter_form_field(self):
+        """FilterForm fields can overload how they pass in the values."""
+
+        prefix_ct = ContentType.objects.get_for_model(Prefix)
+
+        a_tenant = Tenant.objects.first()
+
+        this_dg = DynamicGroup(
+            name="Prefix Group",
+            slug="prefix-dg",
+            description="A group of prefixes with a specific Tenant name.",
+            filter={},
+            content_type=prefix_ct,
+        )
+        this_dg.validated_save()
+
+        this_dg.set_filter({"example_plugin_prefix_tenant_name": [a_tenant]})
+        this_dg.validated_save()
 
 
 class DynamicGroupMembershipModelTest(DynamicGroupTestBase):

--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -454,6 +454,8 @@ class TagFilterField(forms.MultipleChoiceField):
         # Choices are fetched each time the form is initialized
         super().__init__(label="Tags", choices=get_choices, required=False, *args, **kwargs)
 
+    to_field_name = "slug"
+
 
 class DynamicModelChoiceMixin:
     """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Worked with @lampwins to reproduce this bug.

TLDR: When a Dynamic Group is being saved, there is an edge case where a Filter Form and a _FilterSet_ Form are not identical. A way to reproduce this is with: https://github.com/nautobot/nautobot/tree/u/bryanculver-dg-bug and creating the necessary relationship to filter on it. What happened is the nested filter through the relationship and ultimately is filtering on the `name` of an FK, the FilterSet Form expects inputs to be a list of strings (it's a MultiValueCharFilter after all). But for UX we want to have a selection of names of object instances. We can do this by using the `to_field_name` and processing accordingly. We have logic in Dynamic Groups that does this if the FilterSetForm filed is of the right type. The FilterForm is helping us to this today, but the FilterSetForms need some work to be returning/use the smarter Form field types.

This fix allows to use the FilterForm field first if it's available and falls back if it's not.

Special handling had to be done for Tags because our Tag filter form field isn't a ModelMultipleChoiceField; the FilterSetForm field before was using a ModelMultipleChoiceField.

I'm open to ideas on how to write a test for this which doesn't require a bunch of complex setup like in the branch referenced above.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
