### PR TITLE
Add support for PKs in CSV import and composite-keys in JSON REST API

### DIFF
--- a/changes/3976.added
+++ b/changes/3976.added
@@ -1,0 +1,2 @@
+Added support for related-object specification by PK (UUID) in CSV imports as an alternative to composite-keys.
+Added support for related-object specification by composite-key in JSON REST API data.

--- a/changes/3976.changed
+++ b/changes/3976.changed
@@ -1,0 +1,1 @@
+Moved `NautobotHyperlinkedRelatedField` from `nautobot.core.api.serializers` to `nautobot.core.api.fields`.

--- a/changes/3976.fixed
+++ b/changes/3976.fixed
@@ -1,0 +1,1 @@
+Fixed an error when creating `VRF` or `Prefix` records via the REST API without specifying a `namespace` value.

--- a/nautobot/core/api/__init__.py
+++ b/nautobot/core/api/__init__.py
@@ -1,6 +1,7 @@
 from .fields import (
     ChoiceField,
     ContentTypeField,
+    NautobotHyperlinkedRelatedField,
     SerializedPKRelatedField,
     TimeZoneSerializerField,
 )
@@ -23,6 +24,7 @@ __all__ = (
     "ChoiceField",
     "ContentTypeField",
     "CustomFieldModelSerializerMixin",
+    "NautobotHyperlinkedRelatedField",
     "NautobotModelSerializer",
     "NotesSerializerMixin",
     "RelationshipModelSerializerMixin",

--- a/nautobot/core/api/parsers.py
+++ b/nautobot/core/api/parsers.py
@@ -9,8 +9,6 @@ from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import BaseParser
 
-from nautobot.core.models.utils import deconstruct_composite_key
-
 
 logger = logging.getLogger(__name__)
 

--- a/nautobot/core/api/parsers.py
+++ b/nautobot/core/api/parsers.py
@@ -95,15 +95,13 @@ class NautobotCSVParser(BaseParser):
             if isinstance(serializer_field, serializers.ManyRelatedField):
                 # A list of related objects, represented as a list of composite-keys
                 if value:
-                    related_model = serializer_field.child_relation.get_queryset().model
-                    value = [self.get_composite_key_dict(comp_key, related_model) for comp_key in value.split(",")]
+                    value = value.split(",")
                 else:
                     value = []
             elif isinstance(serializer_field, serializers.RelatedField):
                 # A single related object, represented by its composite-key
                 if value:
-                    related_model = serializer_field.get_queryset().model
-                    value = self.get_composite_key_dict(value, related_model)
+                    pass
                 else:
                     value = None
             elif isinstance(serializer_field, (serializers.ListField, serializers.MultipleChoiceField)):
@@ -134,21 +132,3 @@ class NautobotCSVParser(BaseParser):
             data[key] = value
 
         return data
-
-    def get_composite_key_dict(self, composite_key, model):
-        """
-        Get the data dictionary corresponding to the given composite key list or string for the given model.
-        """
-        if not composite_key:
-            return None
-        if model._meta.label_lower == "contenttypes.contenttype":
-            # Our ContentTypeField just uses the "app_label.model" string to look up ContentTypes, rather than the
-            # actual ([app_label, model]) natural key for ContentType.
-            return composite_key
-        if model._meta.label_lower == "auth.group":
-            # auth.Group is a base Django model and so doesn't implement our natural_key_args_to_kwargs() method.
-            return {"name": deconstruct_composite_key(composite_key)}
-        if hasattr(model, "natural_key_args_to_kwargs"):
-            return model.natural_key_args_to_kwargs(deconstruct_composite_key(composite_key))
-        logger.error("%s doesn't implement natural_key_args_to_kwargs()", model.__name__)
-        return {"pk": composite_key}

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -7,7 +7,7 @@ from django.core.exceptions import (
     ObjectDoesNotExist,
     ValidationError as DjangoValidationError,
 )
-from django.db.models import AutoField, ManyToManyField, Model
+from django.db.models import AutoField, ManyToManyField
 from django.db.models.fields.related_descriptors import ManyToManyDescriptor
 from django.urls import NoReverseMatch
 from drf_spectacular.types import OpenApiTypes
@@ -19,15 +19,14 @@ from rest_framework.reverse import reverse
 from rest_framework.serializers import SerializerMethodField
 from rest_framework.utils.model_meta import RelationInfo, _get_to_field
 
-from nautobot.core.api.fields import ObjectTypeField
-from nautobot.core.api.mixins import WritableSerializerMixin
+from nautobot.core.api.fields import NautobotHyperlinkedRelatedField, ObjectTypeField
 from nautobot.core.api.utils import (
     dict_to_filter_params,
     nested_serializer_factory,
 )
+from nautobot.core.models.constants import COMPOSITE_KEY_SEPARATOR
 from nautobot.core.models.managers import TagsManager
-from nautobot.core.models.utils import construct_composite_key, deconstruct_composite_key
-from nautobot.core.utils.data import is_url, is_uuid
+from nautobot.core.models.utils import construct_composite_key
 from nautobot.core.utils.lookup import get_route_for_model
 from nautobot.core.utils.requests import normalize_querydict
 from nautobot.extras.api.relationships import RelationshipsDataField
@@ -101,95 +100,6 @@ class OptInFieldsMixin:
         return self.__pruned_fields
 
 
-@extend_schema_field(
-    {
-        "type": "object",
-        "properties": {
-            "id": {
-                "oneOf": [
-                    {"type": "string", "format": "uuid"},
-                    {"type": "integer"},
-                ]
-            },
-            "object_type": {"type": "string", "pattern": "^[a-z][a-z0-9_]+\\.[a-z][a-z0-9_]+$"},
-            "url": {
-                "type": "string",
-                "format": "uri",
-            },
-        },
-    }
-)
-class NautobotHyperlinkedRelatedField(WritableSerializerMixin, serializers.HyperlinkedRelatedField):
-    """DRF's built-in HyperlinkedRelatedField combined with custom to_internal_value() function"""
-
-    def __init__(self, *args, **kwargs):
-        """Override DRF's namespace-unaware default view_name logic for HyperlinkedRelatedField.
-
-        DRF defaults to '{model_name}-detail' instead of '{app_label}:{model_name}-detail'.
-        """
-        if "view_name" not in kwargs or (kwargs["view_name"].endswith("-detail") and ":" not in kwargs["view_name"]):
-            if "queryset" not in kwargs:
-                logger.warning(
-                    '"view_name=%r" is probably incorrect for this related API field; '
-                    'unable to determine the correct "view_name" as "queryset" wasn\'t specified',
-                    kwargs["view_name"],
-                )
-            else:
-                kwargs["view_name"] = get_route_for_model(kwargs["queryset"].model, "detail", api=True)
-        super().__init__(*args, **kwargs)
-
-    @property
-    def _related_model(self):
-        """The model class that this field is referencing to."""
-        if self.queryset is not None:
-            return self.queryset.model
-        # Foreign key where the destination is referenced by string rather than by Python class
-        if getattr(self.parent.Meta.model, self.source, False):
-            return getattr(self.parent.Meta.model, self.source).field.model
-
-        logger.warning(
-            "Unable to determine model for related field %r; "
-            "ensure that either the field defines a 'queryset' or the Meta defines the related 'model'.",
-            self.field_name,
-        )
-        return None
-
-    def to_internal_value(self, data):
-        """Convert potentially nested representation to a model instance."""
-        if isinstance(data, dict):
-            if "url" in data:
-                return super().to_internal_value(data["url"])
-            elif "id" in data:
-                return super().to_internal_value(data["id"])
-        if isinstance(data, str) and not is_uuid(data) and not is_url(data):
-            # Maybe it's a composite-key?
-            related_model = self._related_model
-            if related_model is not None and hasattr(related_model, "natural_key_args_to_kwargs"):
-                try:
-                    data = related_model.natural_key_args_to_kwargs(deconstruct_composite_key(data))
-                except ValueError as err:
-                    # Not a correctly constructed composite key?
-                    raise ValidationError(f"Related object not found using provided composite-key: {data}") from err
-            elif related_model is not None and related_model.label_lower == "auth.group":
-                # auth.Group is a base Django model and so doesn't implement our natural_key_args_to_kwargs() method
-                data = {"name": deconstruct_composite_key(data)}
-        return super().to_internal_value(data)
-
-    def to_representation(self, value):
-        """Convert URL representation to a brief nested representation."""
-        url = super().to_representation(value)
-
-        # nested serializer provides an instance
-        if isinstance(value, Model):
-            model = type(value)
-        else:
-            model = self._related_model
-
-        if model is None:
-            return {"id": value.pk, "object_type": "unknown.unknown", "url": url}
-        return {"id": value.pk, "object_type": model._meta.label_lower, "url": url}
-
-
 class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializer):
     """
     This base serializer implements common fields and logic for all ModelSerializers.
@@ -231,7 +141,12 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializ
         """
         return getattr(instance, "display", str(instance))
 
-    @extend_schema_field(serializers.CharField)
+    @extend_schema_field(
+        {
+            "type": "string",
+            "example": COMPOSITE_KEY_SEPARATOR.join(["attribute1", "attribute2"]),
+        }
+    )
     def get_composite_key(self, instance):
         try:
             return getattr(instance, "composite_key", construct_composite_key(instance.natural_key()))

--- a/nautobot/core/templates/generic/object_bulk_create.html
+++ b/nautobot/core/templates/generic/object_bulk_create.html
@@ -128,7 +128,7 @@
                     objects.
                 </p>
                 <p class="small text-muted">
-                    <i class="mdi mdi-information-outline"></i> Related objects must be referenced by their composite keys. You can find this information in the "Advanced" tab of any object's detail view.
+                    <i class="mdi mdi-information-outline"></i> Related objects may be referenced by their UUID and/or by their composite key. You can find this information in the "Advanced" tab of any object's detail view.
                 </p>
             {% endif %}
         </div>

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -494,8 +494,8 @@ class NautobotCSVParserTest(TestCase):
                     "vid": "22",  # parser could be enhanced to turn this to an int, but the serializer can handle it
                     "name": "hello",
                     "description": "It, I say, is a living!",
-                    "status": {"name": status.name},
-                    "tags": [{"name": tags.first().name}, {"name": tags.last().name}],
+                    "status": status.name,  # will be understood as a composite-key by the serializer
+                    "tags": [tags.first().name, tags.last().name],  # understood as a list of composite-keys
                     "tenant": None,
                 },
             ],

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -19,13 +19,13 @@ from nautobot.core import testing
 from nautobot.core.api.parsers import NautobotCSVParser
 from nautobot.core.api.renderers import NautobotCSVRenderer
 from nautobot.core.api.versioning import NautobotAPIVersioning
+from nautobot.core.models.constants import COMPOSITE_KEY_SEPARATOR
 from nautobot.dcim import models as dcim_models
 from nautobot.dcim.api import serializers as dcim_serializers
 from nautobot.extras import choices
 from nautobot.extras import models as extras_models
 from nautobot.ipam import models as ipam_models
 from nautobot.ipam.api import serializers as ipam_serializers
-from nautobot.ipam.factory import VLANGroupFactory
 
 
 class AppTest(testing.APITestCase):
@@ -585,9 +585,9 @@ class WritableNestedSerializerTest(testing.APITestCase):
             parent=self.location1,
             status=self.statuses[0],
         )
-        self.vlan_group1 = VLANGroupFactory.create(location=self.location1)
-        self.vlan_group2 = VLANGroupFactory.create(location=self.location2)
-        self.vlan_group3 = VLANGroupFactory.create(location=self.location3)
+        self.vlan_group1 = ipam_models.VLANGroup.objects.create(name="Test VLANGroup 1", location=self.location1)
+        self.vlan_group2 = ipam_models.VLANGroup.objects.create(name="Test VLANGroup 2", location=self.location2)
+        self.vlan_group3 = ipam_models.VLANGroup.objects.create(name="Test VLANGroup 3", location=self.location3)
 
     def test_related_by_pk(self):
         data = {
@@ -677,6 +677,42 @@ class WritableNestedSerializerTest(testing.APITestCase):
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(ipam_models.VLAN.objects.filter(name="Test VLAN 100").count(), 0)
         self.assertTrue(response.data["location"][0].startswith("Multiple objects match"))
+
+    def test_related_by_composite_key(self):
+        data = {
+            "vid": 100,
+            "name": "Test VLAN 100",
+            "status": self.statuses.first().composite_key,
+            "location": self.location1.composite_key,
+            "vlan_group": self.vlan_group1.composite_key,
+        }
+        url = reverse("ipam-api:vlan-list")
+        self.add_permissions("ipam.add_vlan")
+
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(str(response.data["location"]["url"]), self.absolute_api_url(self.location1))
+        vlan = ipam_models.VLAN.objects.get(pk=response.data["id"])
+        self.assertEqual(vlan.location, self.location1)
+
+    def test_related_by_composite_key_no_match(self):
+        data = {
+            "vid": 100,
+            "name": "Test VLAN 100",
+            "status": self.statuses.first().composite_key + COMPOSITE_KEY_SEPARATOR + "xyz",
+            "location": self.location1.composite_key + COMPOSITE_KEY_SEPARATOR + "hello" + COMPOSITE_KEY_SEPARATOR,
+            "vlan_group": self.vlan_group1.composite_key[1:-1],
+        }
+        url = reverse("ipam-api:vlan-list")
+        self.add_permissions("ipam.add_vlan")
+
+        with testing.disable_warnings("django.request"):
+            response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(ipam_models.VLAN.objects.filter(name="Test VLAN 100").count(), 0)
+        self.assertTrue(response.data["status"][0].startswith("Related object not found"))
+        self.assertTrue(response.data["location"][0].startswith("Related object not found"))
+        self.assertTrue(response.data["vlan_group"][0].startswith("Related object not found"))
 
     def test_related_by_invalid(self):
         data = {

--- a/nautobot/core/views/utils.py
+++ b/nautobot/core/views/utils.py
@@ -143,12 +143,14 @@ def get_csv_form_fields_from_serializer_class(serializer_class):
             if isinstance(field.child_relation, ContentTypeField):
                 field_info["format"] = mark_safe('<code>"app_label.model,app_label.model"</code>')
             else:
-                field_info["format"] = mark_safe('<code>"composite_key,composite_key"</code>')
+                field_info["format"] = mark_safe(
+                    '<code>"composite_key,composite_key"</code> or <code>"UUID,UUID"</code>'
+                )
         elif isinstance(field, serializers.RelatedField):
             if isinstance(field, ContentTypeField):
                 field_info["format"] = mark_safe("<code>app_label.model</code>")
             else:
-                field_info["format"] = mark_safe("<code>composite_key</code>")
+                field_info["format"] = mark_safe("<code>composite_key</code> or <code>UUID</code>")
         elif isinstance(field, (serializers.ListField, serializers.MultipleChoiceField)):
             field_info["format"] = mark_safe('<code>"value,value"</code>')
         elif isinstance(field, (serializers.DictField, serializers.JSONField)):

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -143,8 +143,10 @@ class LocationTypeTestCase(ViewTestCases.OrganizationalObjectViewTestCase):
 
         cls.csv_data = (
             "name,parent,description,content_types,nestable",
+            # Import understands foreign-keys provided as either a composite-key (for LocationType, this is .name)...
             f"Intermediate 3,{lt1.name},Another intermediate type,ipam.prefix,false",
-            f'Intermediate 4,{lt1.name},Another intermediate type,"ipam.prefix,dcim.device",false',
+            # ... or as a PK value
+            f'Intermediate 4,{lt1.pk},Another intermediate type,"ipam.prefix,dcim.device",false',
             "Root 3,,Another root type,,true",
         )
 
@@ -196,9 +198,10 @@ class LocationTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         cls.csv_data = (
             "name,location_type,parent,status,tenant,description",
+            # Mix and match composite keys and PKs to confirm that the serializer handles both correctly
             f'Root 3,"{lt1.name}",,{status.name},,',
-            f'Intermediate 2,"{lt2.name}",{loc2.composite_key},{status.name},"{tenant.name}",Hello world!',
-            f'Leaf 2,"{lt3.name}",{loc3.composite_key},{status.name},"{tenant.name}",',
+            f'Intermediate 2,"{lt2.pk}",{loc2.composite_key},{status.pk},"{tenant.name}",Hello world!',
+            f'Leaf 2,"{lt3.name}",{loc3.pk},{status.name},"{tenant.name}",',
         )
 
         cls.bulk_edit_data = {
@@ -233,9 +236,9 @@ class RackGroupTestCase(ViewTestCases.OrganizationalObjectViewTestCase):
         cls.csv_data = (
             "location,name,description",
             f"{location.composite_key},Rack Group 4,Fourth rack group",
-            f"{location.composite_key},Rack Group 5,Fifth rack group",
+            f"{location.pk},Rack Group 5,Fifth rack group",
             f"{location.composite_key},Rack Group 6,Sixth rack group",
-            f"{location.composite_key},Rack Group 7,Seventh rack group",
+            f"{location.pk},Rack Group 7,Seventh rack group",
         )
 
 
@@ -270,7 +273,7 @@ class RackReservationTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         cls.csv_data = (
             "rack,units,description",
             f'{rack.composite_key},"10,11,12",Reservation 1',
-            f"{rack.composite_key},13,Reservation 2",
+            f"{rack.pk},13,Reservation 2",
             f'{rack.composite_key},"16,17,18",Reservation 3',
         )
 
@@ -387,8 +390,8 @@ class RackTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         cls.csv_data = (
             "location,rack_group,name,width,u_height,status",
             f"{cls.locations[0].composite_key},,Rack 4,19,42,{statuses[0].name}",
-            f"{cls.locations[0].composite_key},{rackgroups[0].composite_key},Rack 5,19,42,{statuses[1].name}",
-            f"{cls.locations[1].composite_key},{rackgroups[1].composite_key},Rack 6,19,42,{statuses[2].name}",
+            f"{cls.locations[0].pk},{rackgroups[0].composite_key},Rack 5,19,42,{statuses[1].name}",
+            f"{cls.locations[1].composite_key},{rackgroups[1].pk},Rack 6,19,42,{statuses[2].pk}",
         )
 
         cls.bulk_edit_data = {
@@ -1275,7 +1278,7 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         cls.csv_data = (
             "role,device_type,status,name,location,rack,position,face,secrets_group,parent_bay",
             f"{deviceroles[0].name},{devicetypes[0].composite_key},{statuses[0].name},Device 4,{locations[0].name},{racks[0].composite_key},10,front,",
-            f"{deviceroles[0].name},{devicetypes[0].composite_key},{statuses[0].name},Device 5,{locations[0].name},{racks[0].composite_key},20,front,",
+            f"{deviceroles[0].pk},{devicetypes[0].pk},{statuses[0].pk},Device 5,{locations[0].pk},{racks[0].pk},20,front,",
             f"{deviceroles[0].name},{devicetypes[0].composite_key},{statuses[0].name},Device 6,{locations[0].name},{racks[0].composite_key},30,front,Secrets Group 2",
             f"{deviceroles[1].name},{devicetypes[1].composite_key},{statuses[0].name},Child Device,{locations[0].name},,,,,{device_bay.composite_key}",
         )
@@ -1530,7 +1533,7 @@ class ConsolePortTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.csv_data = (
             "device,name",
             f"{device.composite_key},Console Port 4",
-            f"{device.composite_key},Console Port 5",
+            f"{device.pk},Console Port 5",
             f"{device.composite_key},Console Port 6",
         )
 
@@ -1576,7 +1579,7 @@ class ConsoleServerPortTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.csv_data = (
             "device,name",
             f"{device.composite_key},Console Server Port 4",
-            f"{device.composite_key},Console Server Port 5",
+            f"{device.pk},Console Server Port 5",
             f"{device.composite_key},Console Server Port 6",
         )
 
@@ -1627,7 +1630,7 @@ class PowerPortTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.csv_data = (
             "device,name",
             f"{device.composite_key},Power Port 4",
-            f"{device.composite_key},Power Port 5",
+            f"{device.pk},Power Port 5",
             f"{device.composite_key},Power Port 6",
         )
 
@@ -1692,7 +1695,7 @@ class PowerOutletTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.csv_data = (
             "device,name",
             f"{device.composite_key},Power Outlet 4",
-            f"{device.composite_key},Power Outlet 5",
+            f"{device.pk},Power Outlet 5",
             f"{device.composite_key},Power Outlet 6",
         )
 
@@ -1806,7 +1809,7 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.csv_data = (
             "device,name,type,status",
             f"{device.composite_key},Interface 4,1000base-t,{statuses[0].name}",
-            f"{device.composite_key},Interface 5,1000base-t,{statuses[0].name}",
+            f"{device.pk},Interface 5,1000base-t,{statuses[0].name}",
             f"{device.composite_key},Interface 6,1000base-t,{statuses[0].name}",
         )
 
@@ -1864,8 +1867,8 @@ class FrontPortTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.csv_data = (
             "device,name,type,rear_port,rear_port_position",
             f"{device.composite_key},Front Port 4,8p8c,{rearports[3].composite_key},1",
-            f"{device.composite_key},Front Port 5,8p8c,{rearports[4].composite_key},1",
-            f"{device.composite_key},Front Port 6,8p8c,{rearports[5].composite_key},1",
+            f"{device.pk},Front Port 5,8p8c,{rearports[4].composite_key},1",
+            f"{device.composite_key},Front Port 6,8p8c,{rearports[5].pk},1",
         )
 
     @unittest.skip("No DeviceBulkAddFrontPortView exists at present")
@@ -1915,7 +1918,7 @@ class RearPortTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.csv_data = (
             "device,name,type,positions",
             f"{device.composite_key},Rear Port 4,8p8c,1",
-            f"{device.composite_key},Rear Port 5,8p8c,1",
+            f"{device.pk},Rear Port 5,8p8c,1",
             f"{device.composite_key},Rear Port 6,8p8c,1",
         )
 
@@ -1960,7 +1963,7 @@ class DeviceBayTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.csv_data = (
             "device,name",
             f"{device.composite_key},Device Bay 4",
-            f"{device.composite_key},Device Bay 5",
+            f"{device.pk},Device Bay 5",
             f"{device.composite_key},Device Bay 6",
         )
 
@@ -2015,7 +2018,7 @@ class InventoryItemTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.csv_data = (
             "device,name",
             f"{device.composite_key},Inventory Item 4",
-            f"{device.composite_key},Inventory Item 5",
+            f"{device.pk},Inventory Item 5",
             f"{device.composite_key},Inventory Item 6",
         )
 
@@ -2506,7 +2509,7 @@ class VirtualChassisTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         cls.csv_data = (
             "name,domain,master",
             f"VC4,Domain 4,{cls.devices[9].composite_key}",
-            f"VC5,Domain 5,{cls.devices[10].composite_key}",
+            f"VC5,Domain 5,{cls.devices[10].pk}",
             f"VC6,Domain 6,{cls.devices[11].composite_key}",
         )
 
@@ -2568,8 +2571,8 @@ class PowerPanelTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         cls.csv_data = (
             "location,rack_group,name",
             f"{locations[0].composite_key},{rackgroups[0].composite_key},Power Panel 4",
-            f"{locations[0].composite_key},{rackgroups[0].composite_key},Power Panel 5",
-            f"{locations[0].composite_key},{rackgroups[0].composite_key},Power Panel 6",
+            f"{locations[0].pk},{rackgroups[0].composite_key},Power Panel 5",
+            f"{locations[0].composite_key},{rackgroups[0].pk},Power Panel 6",
         )
 
         cls.bulk_edit_data = {
@@ -2635,7 +2638,7 @@ class PowerFeedTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         cls.csv_data = (
             "power_panel,name,voltage,amperage,max_utilization,status",
             f"{powerpanels[0].composite_key},Power Feed 4,120,20,80,{statuses[0].name}",
-            f"{powerpanels[0].composite_key},Power Feed 5,120,20,80,{statuses[0].name}",
+            f"{powerpanels[0].pk},Power Feed 5,120,20,80,{statuses[0].pk}",
             f"{powerpanels[0].composite_key},Power Feed 6,120,20,80,{statuses[1].name}",
         )
 

--- a/nautobot/docs/user-guide/platform-functionality/rest-api/overview.md
+++ b/nautobot/docs/user-guide/platform-functionality/rest-api/overview.md
@@ -224,7 +224,10 @@ Here, the `role`, `status`, `vrf`, `tenant`, and `nat_outside` fields represent 
 +/- 2.0.0
     The representation of related objects on retrieval has changed from Nautobot 1.x. The `brief` query parameter has been removed, and distinct "nested" serializers no longer exist. Instead, the `depth` parameter controls whether related objects are represented by URLs or as nested objects. Please see [Depth Query Parameter](#depth-query-parameter) for more details.
 
-When performing write API actions (`POST`, `PUT`, and `PATCH`), related objects may be specified by either UUID (primary key), or by a set of attributes sufficiently unique to return the desired object.
+When performing write API actions (`POST`, `PUT`, and `PATCH`), related objects may be specified by either UUID (primary key), or by a set of attributes sufficiently unique to return the desired object, or by their [composite key](../../../development/core/natural-keys.md).
+
++++ 2.0.0
+    Support for specifying a related object by composite-key was added.
 
 For example, when creating a new device, its rack can be specified by Nautobot ID (PK):
 
@@ -247,6 +250,16 @@ Or by a set of nested attributes which uniquely identify the rack:
         },
         "name": "R204"
     },
+    ...
+}
+```
+
+Or by the [composite key](../../../development/core/natural-keys.md) of the rack (for the Rack model, this is just its name, but this will vary by object type - you can always find this information under the Advanced tab of an object's detail view):
+
+```json
+{
+    "name": "MyNewDevice",
+    "rack": "R204",
     ...
 }
 ```

--- a/nautobot/ipam/api/serializers.py
+++ b/nautobot/ipam/api/serializers.py
@@ -14,6 +14,7 @@ from nautobot.ipam.api.fields import IPFieldSerializer
 from nautobot.ipam.choices import PrefixTypeChoices, ServiceProtocolChoices
 from nautobot.ipam import constants
 from nautobot.ipam.models import (
+    get_default_namespace,
     IPAddress,
     Namespace,
     Prefix,
@@ -53,6 +54,7 @@ class VRFSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
         model = VRF
         fields = "__all__"
         list_display_fields = ["name", "rd", "tenant", "description"]
+        extra_kwargs = {"namespace": {"default": get_default_namespace}}
 
 
 #
@@ -159,6 +161,7 @@ class PrefixSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
         ]
         extra_kwargs = {
             "ip_version": {"read_only": True},
+            "namespace": {"default": get_default_namespace},
             "prefix_length": {"read_only": True},
         }
 

--- a/nautobot/ipam/api/serializers.py
+++ b/nautobot/ipam/api/serializers.py
@@ -6,9 +6,9 @@ from rest_framework.validators import UniqueTogetherValidator
 
 from nautobot.core.api import (
     ChoiceField,
+    NautobotHyperlinkedRelatedField,
     NautobotModelSerializer,
 )
-from nautobot.core.api.serializers import NautobotHyperlinkedRelatedField
 from nautobot.extras.api.mixins import TaggedModelSerializerMixin
 from nautobot.ipam.api.fields import IPFieldSerializer
 from nautobot.ipam.choices import PrefixTypeChoices, ServiceProtocolChoices
@@ -33,8 +33,6 @@ from nautobot.ipam.models import (
 
 
 class NamespaceSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
-    url = serializers.HyperlinkedIdentityField(view_name="ipam-api:namespace-detail")
-
     class Meta:
         model = Namespace
         fields = "__all__"
@@ -208,6 +206,7 @@ class AvailablePrefixSerializer(serializers.Serializer):
 
 class IPAddressSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
     address = IPFieldSerializer()
+    # namespace is not a model field, so we have to specify it explicitly
     namespace = NautobotHyperlinkedRelatedField(
         view_name="ipam-api:namespace-detail", write_only=True, queryset=Namespace.objects.all(), required=False
     )

--- a/nautobot/ipam/migrations/0030_ipam__namespaces.py
+++ b/nautobot/ipam/migrations/0030_ipam__namespaces.py
@@ -132,7 +132,7 @@ class Migration(migrations.Migration):
             model_name="prefix",
             name="namespace",
             field=models.ForeignKey(
-                default=nautobot.ipam.models.get_default_namespace,
+                default=nautobot.ipam.models.get_default_namespace_pk,
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name="prefixes",
                 to="ipam.namespace",
@@ -161,7 +161,7 @@ class Migration(migrations.Migration):
             model_name="vrf",
             name="namespace",
             field=models.ForeignKey(
-                default=nautobot.ipam.models.get_default_namespace,
+                default=nautobot.ipam.models.get_default_namespace_pk,
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name="vrfs",
                 to="ipam.namespace",

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -74,12 +74,16 @@ class Namespace(PrimaryModel):
 
 
 def get_default_namespace():
-    """Return the Global namespace for use in default value for foreign keys."""
+    """Return the Global namespace."""
     obj, _ = Namespace.objects.get_or_create(
         name="Global", defaults={"description": "Default Global namespace. Created by Nautobot."}
     )
+    return obj
 
-    return obj.pk
+
+def get_default_namespace_pk():
+    """Return the PK of the Global namespace for use in default value for foreign keys."""
+    return get_default_namespace().pk
 
 
 @extras_features(
@@ -108,7 +112,7 @@ class VRF(PrimaryModel):
         "ipam.Namespace",
         on_delete=models.PROTECT,
         related_name="vrfs",
-        default=get_default_namespace,
+        default=get_default_namespace_pk,
     )
     devices = models.ManyToManyField(
         to="dcim.Device",
@@ -440,7 +444,7 @@ class Prefix(PrimaryModel):
         to="ipam.Namespace",
         on_delete=models.PROTECT,
         related_name="prefixes",
-        default=get_default_namespace,
+        default=get_default_namespace_pk,
     )
     tenant = models.ForeignKey(
         to="tenancy.Tenant",

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -77,7 +77,6 @@ class VRFTest(APIViewTestCases.APIViewTestCase):
                 "rd": "65000:5",
             },
             {
-                "namespace": namespace.pk,
                 "name": "VRF 6",
                 "rd": "65000:6",
             },
@@ -165,7 +164,6 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
             {
                 "prefix": "192.168.6.0/24",
                 "status": cls.status.pk,
-                "namespace": cls.namespace.pk,
             },
         ]
         cls.bulk_update_data = {


### PR DESCRIPTION
# Closes: #3976 
# What's Changed

- Slim down `NautobotCSVParser` and augment `NautobotHyperlinkedRelatedField` by moving the composite-key deconstruction and processing from the former to the latter.
  - By passing data through from the parser to the serializer-field with less parser-side processing, this makes it possible for CSV import to use the existing serializer-field support for related object specification by PK
    - Adjust existing test data in dcim/test_views to exercise this functionality
  - As a bonus, this makes it so that related objects can be specified by composite-key in the JSON REST API as well!
     - Add test coverage in core/test_api
- Fix a bug I discovered in manual testing - CSV/REST creation of VRF and Prefix indicate the `namespace` as an optional field, with the intent that if unspecified, the `Global` namespace is implied and should be used; however, this wasn't actually working in the REST (and hence CSV) case because it was defaulting to the UUID of the global namespace instead of the global namespace object itself. This is now fixed.
- Docs updates, UI enhancement.

![image](https://github.com/nautobot/nautobot/assets/5603551/f589fd60-560e-4373-8d4d-b2b54e9b245c)


# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
