### PR TITLE
Add DEVICE_NAME_AS_NATURAL_KEY and LOCATION_NAME_AS_NATURAL_KEY settings

### DIFF
--- a/changes/3977.added
+++ b/changes/3977.added
@@ -1,0 +1,1 @@
+Added `DEVICE_NAME_AS_NATURAL_KEY` and `LOCATION_NAME_AS_NATURAL_KEY` optional config settings to allow the use of simplified natural keys for Device and Location models.

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -557,10 +557,25 @@ CONSTANCE_CONFIG = {
         help_text="Number of days to retain object changelog history.\nSet this to 0 to retain changes indefinitely.",
         field_type=int,
     ),
+    "DEVICE_NAME_AS_NATURAL_KEY": ConstanceConfigItem(
+        default=False,
+        help_text="Device names are not guaranteed globally-unique by Nautobot but in practice they often are. "
+        "Set this to True to use the device name alone as the natural key for Device objects. "
+        "Set this to False to use the sequence (name, tenant, location) as the natural key instead.",
+        field_type=bool,
+    ),
     "HIDE_RESTRICTED_UI": ConstanceConfigItem(
         default=False,
         help_text="If set to True, users with limited permissions will not be shown menu items and home-page elements that "
         "they do not have permission to access.",
+        field_type=bool,
+    ),
+    "LOCATION_NAME_AS_NATURAL_KEY": ConstanceConfigItem(
+        default=False,
+        help_text="Location names are not guaranteed globally-unique by Nautobot but in practice they often are. "
+        "Set this to True to use the location name alone as the natural key for Location objects. "
+        "Set this to False to use the sequence (name, parent__name, parent__parent__name, ...) "
+        "as the natural key instead.",
         field_type=bool,
     ),
     "MAX_PAGE_SIZE": ConstanceConfigItem(
@@ -618,6 +633,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
     "Banners": ["BANNER_LOGIN", "BANNER_TOP", "BANNER_BOTTOM"],
     "Change Logging": ["CHANGELOG_RETENTION"],
     "Device Connectivity": ["PREFER_IPV4"],
+    "Natural Keys": ["DEVICE_NAME_AS_NATURAL_KEY", "LOCATION_NAME_AS_NATURAL_KEY"],
     "Pagination": ["PAGINATE_COUNT", "MAX_PAGE_SIZE", "PER_PAGE_DEFAULTS"],
     "Rack Elevation Rendering": ["RACK_ELEVATION_DEFAULT_UNIT_HEIGHT", "RACK_ELEVATION_DEFAULT_UNIT_WIDTH"],
     "Release Checking": ["RELEASE_CHECK_URL", "RELEASE_CHECK_TIMEOUT"],

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -291,6 +291,12 @@ SECRET_KEY = os.getenv("NAUTOBOT_SECRET_KEY", "{{ secret_key }}")
 #     r'^(https?://)?(\w+\.)?example\.com$',
 # ]
 
+# Device names are not guaranteed globally-unique by Nautobot but in practice they often are.
+# Set this to True to use the device name alone as the natural key for Device objects.
+# Set this to False to use the sequence (name, tenant, location) as the natural key instead.
+#
+# DEVICE_NAME_AS_NATURAL_KEY = False
+
 # Set to True to disable rendering of the IP prefix hierarchy in the the IPAM prefix list view.
 # Useful in case of poor performance when rendering this page.
 #
@@ -338,6 +344,12 @@ SECRET_KEY = os.getenv("NAUTOBOT_SECRET_KEY", "{{ secret_key }}")
 # Directory where Jobs can be discovered.
 #
 # JOBS_ROOT = os.getenv("NAUTOBOT_JOBS_ROOT", os.path.join(NAUTOBOT_ROOT, "jobs").rstrip("/"))
+
+# Location names are not guaranteed globally-unique by Nautobot but in practice they often are.
+# Set this to True to use the location name alone as the natural key for Location objects.
+# Set this to False to use the sequence (name, parent__name, parent__parent__name, ...) as the natural key instead.
+#
+# LOCATION_NAME_AS_NATURAL_KEY = False
 
 # Log Nautobot deprecation warnings. Note that this setting is ignored (deprecation logs always enabled) if DEBUG = True
 #

--- a/nautobot/docs/release-notes/version-2.0.md
+++ b/nautobot/docs/release-notes/version-2.0.md
@@ -46,7 +46,7 @@ Nautobot's `BaseModel` base class and related classes now implement automatic su
 
 Developers can refer to the [documentation on natural keys](../development/core/natural-keys.md) for details on how to support and use this feature.
 
-Two new configuration settings, [`DEVICE_NAMES_AS_NATURAL_KEYS`](../user-guide/administration/configuration/optional-settings.md#device_name_as_natural_key) and [`LOCATION_NAMES_AS_NATURAL_KEYS`](../user-guide/administration/configuration/optional-settings.md#location_name_as_natural_key), have been added to allow an administrator to customize the natural-key behavior of these two widely used models.
+Two new configuration settings, [`DEVICE_NAME_AS_NATURAL_KEY`](../user-guide/administration/configuration/optional-settings.md#device_name_as_natural_key) and [`LOCATION_NAME_AS_NATURAL_KEY`](../user-guide/administration/configuration/optional-settings.md#location_name_as_natural_key), have been added to allow an administrator to customize the natural-key behavior of these two widely-used models.
 
 ### Changed
 

--- a/nautobot/docs/release-notes/version-2.0.md
+++ b/nautobot/docs/release-notes/version-2.0.md
@@ -46,6 +46,8 @@ Nautobot's `BaseModel` base class and related classes now implement automatic su
 
 Developers can refer to the [documentation on natural keys](../development/core/natural-keys.md) for details on how to support and use this feature.
 
+Two new configuration settings, [`DEVICE_NAMES_AS_NATURAL_KEYS`](../user-guide/administration/configuration/optional-settings.md#device_name_as_natural_key) and [`LOCATION_NAMES_AS_NATURAL_KEYS`](../user-guide/administration/configuration/optional-settings.md#location_name_as_natural_key), have been added to allow an administrator to customize the natural-key behavior of these two widely used models.
+
 ### Changed
 
 #### Aggregate model Migrated to Prefix ([#3302](https://github.com/nautobot/nautobot/issues/3302))

--- a/nautobot/docs/user-guide/administration/configuration/optional-settings.md
+++ b/nautobot/docs/user-guide/administration/configuration/optional-settings.md
@@ -10,7 +10,9 @@ A number of settings can alternatively be configured via the Nautobot Admin UI. 
 * [BANNER_LOGIN](#banner_login)
 * [BANNER_TOP](#banner_top)
 * [CHANGELOG_RETENTION](#changelog_retention)
+* [DEVICE_NAME_AS_NATURAL_KEY](#device_name_as_natural_key)
 * [HIDE_RESTRICTED_UI](#hide_restricted_ui)
+* [LOCATION_NAME_AS_NATURAL_KEY](#location_name_as_natural_key)
 * [MAX_PAGE_SIZE](#max_page_size)
 * [PAGINATE_COUNT](#paginate_count)
 * [PER_PAGE_DEFAULTS](#per_page_defaults)
@@ -329,6 +331,16 @@ Previously this setting was called `CORS_ORIGIN_REGEX_WHITELIST`, which still wo
 
 ---
 
+## DEVICE_NAME_AS_NATURAL_KEY
+
++++ 2.0.0
+
+Default: `False`
+
+`Device` names are not guaranteed globally-unique by Nautobot but in practice they often are. Set this to `True` to use the device `name` alone as the natural key for `Device` objects. Set this to `False` to use the sequence `(name, tenant, location)` as the natural key instead.
+
+---
+
 ## EXEMPT_VIEW_PERMISSIONS
 
 Default: `[]` (Empty list)
@@ -492,6 +504,16 @@ The file path to a directory where [Jobs](../../platform-functionality/jobs/inde
 
 !!! caution
     This directory **must** contain an `__init__.py` file.
+
+---
+
+## LOCATION_NAME_AS_NATURAL_KEY
+
++++ 2.0.0
+
+Default: `False`
+
+`Location` names are not guaranteed globally-unique by Nautobot but in practice they often are. Set this to `True` to use the location `name` alone as the natural key for `Location` objects. Set this to `False` to use the sequence `(name, parent__name, parent__parent__name, ...)` as the natural key instead.
 
 ---
 


### PR DESCRIPTION
# Closes: #3977 
# What's Changed

- Add settings/Constance configs `DEVICE_NAME_AS_NATURAL_KEY` and `LOCATION_NAME_AS_NATURAL_KEY`. These default to False (existing behavior) but when set to True change the natural-key definitions for Device/Location respectively to use simply the `name` field (as opposed to `(name, tenant, location)` for Device and `(name, parent__name, parent__parent__name, ...)` for Location).
   - Setting these flags in no way influences data validation or uniqueness constraints, so if you set them but have duplicate names in your DB, you will get `MultipleObjectsReturned` errors when doing lookups by natural-key or composite-key.
   - These changes automatically inherit to dependent models that include these in their own natural keys, e.g. setting `LOCATION_NAME_AS_NATURAL_KEY=True` will change the default Device natural-key from `(name, tenant, location__name, location__parent__name, location__parent__parent__name, ...)` to `(name, tenant, location__name)`; similarly setting `DEVICE_NAME_AS_NATURAL_KEY=True` will change the default Interface natural-key from `(name, device__name, device__tenant__name, device__location__name, ...)` to `(name, device__name)`.

![image](https://github.com/nautobot/nautobot/assets/5603551/a6b7559b-bec9-43bc-b743-1cb37c27cb8f)

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
