### PR TITLE
Closes: #4217 - Prevent duplicate repo with duplicated `provided_content`

### DIFF
--- a/changes/4217.changed
+++ b/changes/4217.changed
@@ -1,0 +1,1 @@
+Added a restriction that two Git repositories with the same `remote_url` cannot overlap in their `provided_contents`, as such cases are highly likely to introduce data conflicts.

--- a/changes/4217.fixed
+++ b/changes/4217.fixed
@@ -1,0 +1,1 @@
+Fixed duplicated git repos providing duplicated contents in the `provided_contents` attribute, duplicate repos with the same `remote_url` cannot provide a duplicate content.

--- a/changes/4217.fixed
+++ b/changes/4217.fixed
@@ -1,1 +1,0 @@
-Fixed duplicated git repos providing duplicated contents in the `provided_contents` attribute, duplicate repos with the same `remote_url` cannot provide a duplicate content.

--- a/nautobot/docs/models/extras/gitrepository.md
+++ b/nautobot/docs/models/extras/gitrepository.md
@@ -10,6 +10,9 @@ Some text-based content is more conveniently stored in a separate Git repository
 !!! important
     Nautobot's Git integration depends on the availability of the `git` program. If `git` is not installed, Nautobot will be unable to pull data from Git repositories.
 
++/- 1.6.2
+    To proactively avoid conflicts in data, it is no longer possible to configure multiple Git repository entries that both have the same `remote_url` and also provide the same data type(s). Configuration of multiple entries with the same `remote_url` is still permitted if they are configured to provide entirely distinct types of data.
+
 ## Repository Configuration
 
 When defining a Git repository for Nautobot to consume, the `name`, `remote URL`, and `branch` parameters are mandatory - the name acts as a unique identifier, and the remote URL and branch are needed for Nautobot to be able to locate and access the specified repository. Additionally, if the repository is private you may specify a `token` and any associated `username` that can be used to grant access to the repository.

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -179,5 +179,5 @@ class GitRepository(PrimaryModel):
             q |= models.Q(provided_contents__contains=item)
         duplicate_repos = GitRepository.objects.filter(remote_url=self.remote_url).exclude(id=self.id).filter(q)
         if duplicate_repos.exists():
-            raise ValidationError(f"Duplicate GitRepository detected providing one or more duplicated content")
+            raise ValidationError("Duplicate GitRepository detected providing one or more duplicated content")
         super().clean()

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -174,10 +174,11 @@ class GitRepository(PrimaryModel):
 
     def clean(self):
         """Overload clean to enforce a repo with duplicate url does not have duplicate provided_contents."""
-        q = models.Q()
-        for item in self.provided_contents:
-            q |= models.Q(provided_contents__contains=item)
-        duplicate_repos = GitRepository.objects.filter(remote_url=self.remote_url).exclude(id=self.id).filter(q)
-        if duplicate_repos.exists():
-            raise ValidationError("Duplicate GitRepository detected providing one or more duplicated content")
+        if self.provided_contents:
+            q = models.Q()
+            for item in self.provided_contents:
+                q |= models.Q(provided_contents__contains=item)
+            duplicate_repos = GitRepository.objects.filter(remote_url=self.remote_url).exclude(id=self.id).filter(q)
+            if duplicate_repos.exists():
+                raise ValidationError("Duplicate GitRepository detected providing one or more duplicated content")
         super().clean()

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -180,5 +180,8 @@ class GitRepository(PrimaryModel):
                 q |= models.Q(provided_contents__contains=item)
             duplicate_repos = GitRepository.objects.filter(remote_url=self.remote_url).exclude(id=self.id).filter(q)
             if duplicate_repos.exists():
-                raise ValidationError("Duplicate GitRepository detected providing one or more duplicated content")
+                raise ValidationError(
+                    f"Another Git repository already configured for remote URL {self.remote_url} "
+                    "provides contents overlapping with this repository."
+                )
         super().clean()

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -897,7 +897,7 @@ class GitRepositoryTest(APIViewTestCases.APIViewTestCase):
             GitRepository(name="Repo 3", slug="repo-3", remote_url="https://example.com/repo3.git"),
         )
         for repo in cls.repos:
-            repo.save(trigger_resync=False)
+            repo.validated_save(trigger_resync=False)
 
         cls.create_data = [
             {

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -8,6 +8,7 @@ import uuid
 import yaml
 
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.test import RequestFactory
 
 from nautobot.dcim.models import Device, DeviceRole, DeviceType, LocationType, Location, Manufacturer, Site
@@ -797,3 +798,43 @@ class GitTest(TransactionTestCase):
                     clone_initially=False,
                 )
                 MockGitRepo.return_value.diff_remote.assert_called()
+
+    def test_duplicate_repo_url_with_unique_provided_contents(self, MockGitRepo):
+        """Create a duplicate repo but with unique provided_contents."""
+        remote_url = "http://localhost/duplicates.git"
+        repo1 = GitRepository(
+            name="Repo 1",
+            slug="repo-1",
+            remote_url=remote_url,
+            provided_contents=["extras.job"],
+        )
+        repo1.validated_save(trigger_resync=False)
+        repo2 = GitRepository(
+            name="Repo 2",
+            slug="repo-2",
+            remote_url=remote_url,
+            provided_contents=["extras.configcontext"],
+        )
+        repo2.validated_save(trigger_resync=False)
+        repos = GitRepository.objects.filter(remote_url=remote_url)
+        self.assertEqual(repos.count(), 2)
+
+    def test_duplicate_repo_url_with_duplicate_provided_contents(self, MockGitRepo):
+        """Create a duplicate repo but with duplicate provided_contents."""
+        remote_url = "http://localhost/duplicates.git"
+        repo1 = GitRepository(
+            name="Repo 1",
+            slug="repo-1",
+            remote_url=remote_url,
+            provided_contents=["extras.job"],
+        )
+        repo1.validated_save(trigger_resync=False)
+        repo2 = GitRepository(
+            name="Repo 2",
+            slug="repo-2",
+            remote_url=remote_url,
+            provided_contents=["extras.job"],
+        )
+
+        with self.assertRaises(ValidationError, msg="Duplicate GitRepository detected providing extras.job"):
+            repo2.validated_save(trigger_resync=False)

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -836,5 +836,11 @@ class GitTest(TransactionTestCase):
             provided_contents=["extras.job"],
         )
 
-        with self.assertRaises(ValidationError, msg="Duplicate GitRepository detected providing extras.job"):
+        with self.assertRaises(ValidationError) as cm:
             repo2.validated_save(trigger_resync=False)
+
+        self.assertIn(
+            f"Another Git repository already configured for remote URL {repo1.remote_url} "
+            "provides contents overlapping with this repository.",
+            str(cm.exception),
+        )

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -624,7 +624,7 @@ class GitRepositoryTestCase(
             "name,slug,remote_url,branch,secrets_group,provided_contents",
             "Git Repository 5,git-repo-5,https://example.com,main,,extras.configcontext",
             "Git Repository 6,git-repo-6,https://example.com,develop,Secrets Group 2,",
-            'Git Repository 7,git-repo-7,https://example.com,next,Secrets Group 2,"extras.job,extras.configcontext"',
+            'Git Repository 7,git-repo-7,https://example.com,next,Secrets Group 2,"extras.job,extras.exporttemplate"',
         )
 
         cls.slug_source = "name"


### PR DESCRIPTION
Not sure this is the best way to accomplish this, tests work but the clean method on the model feels inefficient.

# Closes: #4217
# What's Changed

Provides validation to prevent a duplicate repo (same `remote_url`) providing at least 1 duplicated content in `provided_contents`

