### PR TITLE
Handle get_absolute_url() error in JobResult.log(), add CustomFieldChoice.get_absolute_url()

### DIFF
--- a/changes/3985.fixed
+++ b/changes/3985.fixed
@@ -1,0 +1,2 @@
+Added error handling in `JobResult.log()` for the case where an object's `get_absolute_url()` raises an exception.
+Added missing `get_absolute_url()` implementation on `CustomFieldChoice` model.

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -696,6 +696,10 @@ class CustomFieldChoice(BaseModel, ChangeLoggedModel):
     def __str__(self):
         return self.value
 
+    def get_absolute_url(self):
+        # 2.0 TODO: replace slug with pk
+        return reverse("extras:customfield", args=[self.field.slug])
+
     def clean(self):
         if self.field.type not in (CustomFieldTypeChoices.TYPE_SELECT, CustomFieldTypeChoices.TYPE_MULTISELECT):
             raise ValidationError("Custom field choices can only be assigned to selection fields.")

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -824,6 +824,15 @@ class JobResult(BaseModel, CustomFieldModel):
 
         message = sanitize(str(message))
 
+        obj_absolute_url = None
+        if obj is not None and hasattr(obj, "get_absolute_url"):
+            try:
+                absolute_url = obj.get_absolute_url()
+                if len(absolute_url) <= JOB_LOG_MAX_ABSOLUTE_URL_LENGTH:
+                    obj_absolute_url = absolute_url
+            except Exception:
+                pass
+
         log = JobLogEntry(
             job_result=self,
             log_level=level_choice,
@@ -831,9 +840,7 @@ class JobResult(BaseModel, CustomFieldModel):
             message=message,
             created=timezone.now().isoformat(),
             log_object=str(obj)[:JOB_LOG_MAX_LOG_OBJECT_LENGTH] if obj else None,
-            absolute_url=obj.get_absolute_url()[:JOB_LOG_MAX_ABSOLUTE_URL_LENGTH]
-            if hasattr(obj, "get_absolute_url")
-            else None,
+            absolute_url=obj_absolute_url,
         )
 
         # If the override is provided, we want to use the default database(pass no using argument)
@@ -853,6 +860,8 @@ class JobResult(BaseModel, CustomFieldModel):
             else:
                 log_level = logging.INFO
             logger.log(log_level, message)
+
+        return log
 
 
 #

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -23,7 +23,12 @@ from nautobot.dcim.models import (
     Platform,
     Site,
 )
-from nautobot.extras.constants import JOB_OVERRIDABLE_FIELDS
+from nautobot.extras.constants import (
+    JOB_LOG_MAX_ABSOLUTE_URL_LENGTH,
+    JOB_LOG_MAX_GROUPING_LENGTH,
+    JOB_LOG_MAX_LOG_OBJECT_LENGTH,
+    JOB_OVERRIDABLE_FIELDS,
+)
 from nautobot.extras.choices import LogLevelChoices, SecretsGroupAccessTypeChoices, SecretsGroupSecretTypeChoices
 from nautobot.extras.jobs import get_job, Job as JobClass
 from nautobot.extras.models import (
@@ -947,6 +952,54 @@ class JobResultTest(TestCase):
 
         job_result.job_id = uuid.uuid4()
         self.assertIsNone(job_result.related_object)
+
+    def test_log(self):
+        """Test that logs are rendered correctly."""
+        job_result = JobResult.objects.create(name="irrelevant", obj_type=get_job_content_type(), job_id=uuid.uuid4())
+        job_result.use_job_logs_db = False
+
+        # Most basic usage
+        log = job_result.log("Hello")
+        self.assertEqual("Hello", log.message)
+        self.assertEqual(LogLevelChoices.LOG_DEFAULT, log.log_level)
+        self.assertEqual("main", log.grouping)
+        self.assertIsNone(log.log_object)
+        self.assertIsNone(log.absolute_url)
+
+        # Advanced usage
+        obj = IPAddress.objects.create(address="1.1.1.1/32")
+        log = job_result.log("Hi", obj=obj, level_choice=LogLevelChoices.LOG_WARNING, grouping="other")
+        self.assertEqual("Hi", log.message)
+        self.assertEqual(LogLevelChoices.LOG_WARNING, log.log_level)
+        self.assertEqual("other", log.grouping)
+        self.assertEqual(str(obj), log.log_object)
+        self.assertEqual(obj.get_absolute_url(), log.absolute_url)
+
+        # Length constraints
+        class MockObject1:
+            def __str__(self):
+                return "a" * (JOB_LOG_MAX_LOG_OBJECT_LENGTH * 2)
+
+            def get_absolute_url(self):
+                return "b" * (JOB_LOG_MAX_ABSOLUTE_URL_LENGTH * 2)
+
+        obj = MockObject1()
+        log = job_result.log("Hi", obj=obj, grouping="c" * JOB_LOG_MAX_GROUPING_LENGTH * 2)
+        self.assertEqual("Hi", log.message)
+        self.assertEqual("a" * JOB_LOG_MAX_LOG_OBJECT_LENGTH, log.log_object)
+        self.assertEqual("c" * JOB_LOG_MAX_GROUPING_LENGTH, log.grouping)
+        self.assertIsNone(log.absolute_url)
+
+        # Error handling
+        class MockObject2(MockObject1):
+            def get_absolute_url(self):
+                raise NotImplementedError()
+
+        obj = MockObject2()
+        log = job_result.log("Hi", obj=obj)
+        self.assertEqual("Hi", log.message)
+        self.assertEqual("a" * JOB_LOG_MAX_LOG_OBJECT_LENGTH, log.log_object)
+        self.assertIsNone(log.absolute_url)
 
 
 class SecretTest(TestCase):


### PR DESCRIPTION
# Closes: #3985 
# What's Changed

Note that this fix is targeted at `develop` rather than `next`. The exact original symptom (an error on `CustomFieldChoice.get_absolute_url()`) is specific to `next` but the underlying issue (lack of error detection/handling for `get_absolute_url()` in `JobResult.log()`) is preexisting in `develop` and so I've chosen to fix it here.

- Add `CustomFieldChoice.get_absolute_url()` implementation, pointing to the URL of the parent `CustomField` since we don't have detail views for individual choices.
- Add logic to `JobResult.log()` to catch exceptions from `obj.get_absolute_url()`; additionally, if the `get_absolute_url()` returned string is longer than what we can store in the `JobLogEntry` record, we discard it instead of truncating it since a truncated URL is pretty useless.
- Add tests.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
