### PR TITLE
Fix inadvertent modification of `forms.ChoiceField` class definition

### DIFF
--- a/changes/4222.fixed
+++ b/changes/4222.fixed
@@ -1,0 +1,1 @@
+Fixed a bug in which `Job` `ChoiceVars` could sometimes get rendered incorrectly in the UI as multiple-choice fields.

--- a/nautobot/utilities/tests/test_utils.py
+++ b/nautobot/utilities/tests/test_utils.py
@@ -490,10 +490,14 @@ class LookupRelatedFunctionTest(TestCase):
                 form_field = get_filterset_parameter_form_field(Site, field_name)
                 self.assertIsInstance(form_field, forms.ChoiceField)
 
-            device_fields = ["has_console_ports", "has_interfaces", "face"]
+            device_fields = ["has_console_ports", "has_interfaces"]
             for field_name in device_fields:
                 form_field = get_filterset_parameter_form_field(Device, field_name)
                 self.assertIsInstance(form_field, forms.ChoiceField)
+
+        with self.subTest("Test MultipleChoiceField"):
+            form_field = get_filterset_parameter_form_field(Device, "face")
+            self.assertIsInstance(form_field, forms.MultipleChoiceField)
 
         with self.subTest("Test DateTimePicker"):
             form_field = get_filterset_parameter_form_field(Site, "last_updated")

--- a/nautobot/utilities/utils.py
+++ b/nautobot/utilities/utils.py
@@ -915,17 +915,9 @@ def get_filterset_parameter_form_field(model, parameter, filterset=None):
                 choices_as_strings=True, queryset=queryset_map[plural_name]().as_queryset()
             )
     elif isinstance(field, (filters.MultipleChoiceFilter, filters.ChoiceFilter)) and "choices" in field.extra:
-        form_field_class = forms.ChoiceField
-        form_field_class.widget = StaticSelect2Multiple()
-        form_attr = {"choices": field.extra.get("choices")}
-
-        form_field = form_field_class(**form_attr)
+        form_field = forms.MultipleChoiceField(choices=field.extra.get("choices"), widget=StaticSelect2Multiple)
     elif isinstance(field, (BooleanFilter,)):  # Yes / No choice
-        form_field_class = forms.ChoiceField
-        form_field_class.widget = StaticSelect2()
-        form_attr = {"choices": BOOLEAN_CHOICES}
-
-        form_field = form_field_class(**form_attr)
+        form_field = forms.ChoiceField(choices=BOOLEAN_CHOICES, widget=StaticSelect2)
     elif isinstance(field, DateTimeFilter):
         form_field.widget = DateTimePicker()
     elif isinstance(field, DateFilter):


### PR DESCRIPTION
# Closes: #4222 
# What's Changed

Avoid directly modifying the `forms.ChoiceField` class with a custom `widget` default; instead, pass the widget class through when instantiating specific instances of ChoiceField.

Verified through manual testing following the steps described in #4222 and confirming that filter fields like `face` and `has_interfaces` are still represented by the correct widgets but Job variables do not change presentation as a result.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
