### PR TITLE
ReIntroduce "Assign IPAddress" on Device Interface List View.

### DIFF
--- a/changes/3636.changed
+++ b/changes/3636.changed
@@ -1,1 +1,1 @@
-ReIntroduce Assign IPAddress on Device Interface List View.
+Reintroduced "Assign IP Address" button to Device Interfaces list view.

--- a/changes/3636.changed
+++ b/changes/3636.changed
@@ -1,0 +1,1 @@
+ReIntroduce Assign IPAddress on Device Interface List View.

--- a/nautobot/dcim/tables/template_code.py
+++ b/nautobot/dcim/tables/template_code.py
@@ -191,7 +191,7 @@ POWEROUTLET_BUTTONS = """
 """
 
 INTERFACE_BUTTONS = """
-{% if perms.ipam.add_ipaddress %}
+{% if perms.ipam.add_ipaddress and perms.dcim.change_interface %}
     <a href="{% url 'ipam:ipaddress_add' %}?interface={{ record.pk }}&return_url={% url 'dcim:device_interfaces' pk=object.pk %}" class="btn btn-xs btn-success" title="Add IP address">
         <i class="mdi mdi-plus-thick" aria-hidden="true"></i>
     </a>

--- a/nautobot/dcim/tables/template_code.py
+++ b/nautobot/dcim/tables/template_code.py
@@ -190,14 +190,11 @@ POWEROUTLET_BUTTONS = """
 {% endif %}
 """
 
-# TODO: re-introduce assign ip address button?
 INTERFACE_BUTTONS = """
 {% if perms.ipam.add_ipaddress %}
-    <!--
     <a href="{% url 'ipam:ipaddress_add' %}?interface={{ record.pk }}&return_url={% url 'dcim:device_interfaces' pk=object.pk %}" class="btn btn-xs btn-success" title="Add IP address">
         <i class="mdi mdi-plus-thick" aria-hidden="true"></i>
     </a>
-    -->
 {% endif %}
 {% if record.cable %}
     <a href="{% url 'dcim:interface_trace' pk=record.pk %}" class="btn btn-primary btn-xs" title="Trace"><i class="mdi mdi-transit-connection-variant"></i></a>

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1360,7 +1360,7 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         response_body = response.content.decode(response.charset)
         # Count the number of occurrences of "Add IP address" in the response_body
         count = response_body.count("Add IP address")
-        # Assert that "Add IP address" appears three times for each of the interfaces
+        # Assert that "Add IP address" appears for each of the three interfaces
         self.assertEqual(count, 3)
 
         with self.subTest("Assert Create and Assign IPAddress"):

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1373,7 +1373,7 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             )
             form_data = {
                 "namespace": namespace.pk,
-                "address": IPNetwork("192.0.2.99/24"),
+                "address": "192.0.2.99/24",
                 "tenant": None,
                 "status": Status.objects.get_for_model(IPAddress).first().pk,
                 "type": IPAddressTypeChoices.TYPE_DHCP,

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1244,6 +1244,14 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             IPAddress.objects.create(address="3.3.3.3/32", namespace=namespace, status=cls.ipaddr_status),
         )
 
+        intf_status = Status.objects.get_for_model(Interface).first()
+
+        cls.interfaces = (
+            Interface.objects.create(device=devices[0], name="Interface 1", status=intf_status),
+            Interface.objects.create(device=devices[0], name="Interface 2", status=intf_status),
+            Interface.objects.create(device=devices[0], name="Interface 3", status=intf_status),
+        )
+
         for device, ipaddress in zip(devices, ipaddresses):
             RelationshipAssociation(
                 relationship=cls.relationships[0], source=device, destination=ipaddress
@@ -1347,13 +1355,6 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         device = Device.objects.first()
         self.add_permissions("ipam.add_ipaddress", "dcim.change_interface")
 
-        intf_status = Status.objects.get_for_model(Interface).first()
-        interfaces = (
-            Interface.objects.create(device=device, name="Interface 1", status=intf_status),
-            Interface.objects.create(device=device, name="Interface 2", status=intf_status),
-            Interface.objects.create(device=device, name="Interface 3", status=intf_status),
-        )
-
         url = reverse("dcim:device_interfaces", kwargs={"pk": device.pk})
         response = self.client.get(url)
         self.assertHttpStatus(response, 200)
@@ -1363,50 +1364,71 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         # Assert that "Add IP address" appears for each of the three interfaces
         self.assertEqual(count, 3)
 
+    def test_device_interface_assign_ipaddress(self):
+        device = Device.objects.first()
+        self.add_permissions(
+            "ipam.add_ipaddress", "extras.view_status", "ipam.view_namespace", "dcim.view_device", "dcim.view_interface"
+        )
+        device_list_url = reverse("dcim:device_interfaces", args=(device.pk,))
+        namespace = Namespace.objects.first()
+        ipaddresses = [str(ipadress) for ipadress in IPAddress.objects.values_list("pk", flat=True)[:3]]
+        add_new_ip_form_data = {
+            "namespace": namespace.pk,
+            "address": "1.1.1.7/24",
+            "tenant": None,
+            "status": Status.objects.get_for_model(IPAddress).first().pk,
+            "type": IPAddressTypeChoices.TYPE_DHCP,
+            "role": None,
+            "nat_inside": None,
+            "dns_name": None,
+            "description": None,
+            "tags": [],
+            "interface": self.interfaces[0].id,
+        }
+        add_new_ip_request = {
+            "path": reverse("ipam:ipaddress_add") + f"?interface={self.interfaces[0].id}&return_url={device_list_url}",
+            "data": post_data(add_new_ip_form_data),
+        }
+        assign_ip_form_data = {"pk": ipaddresses}
+        assign_ip_request = {
+            "path": reverse("ipam:ipaddress_assign")
+            + f"?interface={self.interfaces[1].id}&return_url={device_list_url}",
+            "data": post_data(assign_ip_form_data),
+        }
+
+        with self.subTest("Assert Cannnot assign IPAddress('Add New') without permission"):
+            # Assert Add new IPAddress
+            response = self.client.post(**add_new_ip_request, follow=True)
+            response_body = response.content.decode(response.charset)
+            self.assertHttpStatus(response, 200)
+            self.interfaces[0].refresh_from_db()
+            self.assertEqual(self.interfaces[0].ip_addresses.all().count(), 0)
+            self.assertIn(f"Interface with id &quot;{self.interfaces[0].pk}&quot; not found", response_body)
+
+        with self.subTest("Assert Cannnot assign IPAddress(Exsisting IP) without permission"):
+            # Assert Assign Exsisting IPAddress
+            response = self.client.post(**assign_ip_request, follow=True)
+            response_body = response.content.decode(response.charset)
+            self.assertHttpStatus(response, 200)
+            self.interfaces[1].refresh_from_db()
+            self.assertEqual(self.interfaces[1].ip_addresses.all().count(), 0)
+            self.assertIn(f"Interface with id &quot;{self.interfaces[1].pk}&quot; not found", response_body)
+
+        self.add_permissions("dcim.change_interface", "ipam.view_ipaddress")
+
         with self.subTest("Assert Create and Assign IPAddress"):
-            # Assest assigning ipadress to interface
-            namespace = Namespace.objects.create(name="ipam_test_views_ip_address_test")
-            prefix_status = Status.objects.get_for_model(Prefix).first()
-            Prefix.objects.get_or_create(
-                prefix="192.0.2.0/24",
-                defaults={"namespace": namespace, "status": prefix_status, "type": "network"},
+            self.assertHttpStatus(self.client.post(**add_new_ip_request), 302)
+            self.interfaces[0].refresh_from_db()
+            self.assertEqual(
+                str(self.interfaces[0].ip_addresses.all().first().address), add_new_ip_form_data["address"]
             )
-            form_data = {
-                "namespace": namespace.pk,
-                "address": "192.0.2.99/24",
-                "tenant": None,
-                "status": Status.objects.get_for_model(IPAddress).first().pk,
-                "type": IPAddressTypeChoices.TYPE_DHCP,
-                "role": None,
-                "nat_inside": None,
-                "dns_name": None,
-                "description": None,
-                "tags": [],
-                "interface": interfaces[0].id
-            }
 
-            request = {
-                "path": reverse("ipam:ipaddress_add") + f"?interface={interfaces[0].id}",
-                "data": post_data(form_data),
-            }
-            self.assertHttpStatus(self.client.post(**request), 302)
-            interfaces[0].refresh_from_db()
-            self.assertEqual(str(interfaces[0].ip_addresses.all().first().address), "192.0.2.99/24")
-
-        with self.subTest("Assertx Assign IPAddress"):
-            ipaddresses = [str(ipadress) for ipadress in IPAddress.objects.values_list("pk", flat=True)[:3]]
-            form_data = {"pk": ipaddresses}
-            device_list_url = reverse("dcim:device_interfaces", args=(interfaces[1].pk,))
-            url = reverse("ipam:ipaddress_assign") + f"?interface={interfaces[1].id}&return_url={device_list_url}"
-            request = {
-                "path": url,
-                "data": post_data(form_data),
-            }
-            response = self.client.post(**request)
+        with self.subTest("Assert Assign IPAddress"):
+            response = self.client.post(**assign_ip_request)
             self.assertHttpStatus(response, 302)
-            interfaces[1].refresh_from_db()
-            self.assertEqual(interfaces[1].ip_addresses.count(), 3)
-            interface_ips = [str(ip) for ip in interfaces[1].ip_addresses.values_list("pk", flat=True)]
+            self.interfaces[1].refresh_from_db()
+            self.assertEqual(self.interfaces[1].ip_addresses.count(), 3)
+            interface_ips = [str(ip) for ip in self.interfaces[1].ip_addresses.values_list("pk", flat=True)]
             self.assertEqual(
                 sorted(ipaddresses),
                 sorted(interface_ips),

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.test import override_settings
 from django.urls import reverse
-from netaddr import EUI, IPNetwork
+from netaddr import EUI
 
 from nautobot.circuits.choices import CircuitTerminationSideChoices
 from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, Provider
@@ -1382,6 +1382,7 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
                 "dns_name": None,
                 "description": None,
                 "tags": [],
+                "interface": interfaces[0].id
             }
 
             request = {

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1505,8 +1505,7 @@ class DeviceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         # Create an interface and assign an IP to it.
         device = Device.objects.first()
-        intf_status = Status.objects.get_for_model(Interface).first()
-        interface = Interface.objects.create(device=device, name="Interface 1", status=intf_status)
+        interface = Interface.objects.first()
         namespace = Namespace.objects.first()
         Prefix.objects.create(prefix="1.2.3.0/24", namespace=namespace, status=self.prefix_status)
         ip_address = IPAddress.objects.create(address="1.2.3.4/32", namespace=namespace, status=self.ipaddr_status)

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -507,12 +507,14 @@ class IPAddressDetailTable(IPAddressTable):
 
 
 class IPAddressAssignTable(StatusTableMixin, BaseTable):
+    pk = ToggleColumn(visible=True)
     address = tables.TemplateColumn(template_code=IPADDRESS_ASSIGN_COPY_LINK, verbose_name="IP Address")
     # TODO: add interface M2M
 
     class Meta(BaseTable.Meta):
         model = IPAddress
         fields = (
+            "pk",
             "address",
             "dns_name",
             "type",

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -516,6 +516,7 @@ class IPAddressAssignTable(StatusTableMixin, BaseTable):
         fields = (
             "pk",
             "address",
+            "parent__namespace",
             "dns_name",
             "type",
             "status",

--- a/nautobot/ipam/templates/ipam/ipaddress_assign.html
+++ b/nautobot/ipam/templates/ipam/ipaddress_assign.html
@@ -39,10 +39,20 @@
     </form>
     {% if table %}
         <div class="row">
-            <div class="col-md-12" style="margin-top: 20px">
-                <h3>Search Results</h3>
-                {% include 'utilities/obj_table.html' with table_template='panel_table.html' %}
-            </div>
+            <form action="{% querystring request %}" method="post" class="form form-horizontal">
+                {% csrf_token %}
+                <div class="col-md-12" style="margin-top: 20px">
+                    <h3>Search Results</h3>
+                    {% include 'utilities/obj_table.html' with table_template='panel_table.html' %}
+                    <div class="pull-left noprint">
+                        {% if perms.dcim.change_interface %}
+                            <button type="submit" name="_edit" formaction="#" class="btn btn-primary btn-sm">
+                                <span class="mdi mdi-clipboard-tick" aria-hidden="true"></span> Assign Selected IPAddresses to Interface
+                            </button>
+                        {% endif %}
+                    </div>
+                </div>
+            </form>
         </div>
     {% endif %}
 {% endblock %}

--- a/nautobot/ipam/templates/ipam/ipaddress_assign.html
+++ b/nautobot/ipam/templates/ipam/ipaddress_assign.html
@@ -10,10 +10,10 @@
         {% for field in form.hidden_fields %}
             {{ field }}
         {% endfor %}
-        {% for k, v_list in request.GET.lists %}
-            {% if k != 'q' %}
-                {% for v in v_list %}
-                    <input type="hidden" name="{{ k }}" value="{{ v }}" />
+        {% for field_name, field_values in request.GET.lists %}
+            {% if field_name != 'q' %}
+                {% for field_value in field_values %}
+                    <input type="hidden" name="{{ field_name }}" value="{{ field_value }}" />
                 {% endfor %}
             {% endif %}
         {% endfor %}

--- a/nautobot/ipam/templates/ipam/ipaddress_assign.html
+++ b/nautobot/ipam/templates/ipam/ipaddress_assign.html
@@ -3,6 +3,8 @@
 {% load form_helpers %}
 {% load helpers %}
 
+{% block title %}Assign an IP address{% endblock %}
+
 {% block content %}
     <form action="{% querystring request %}" method="post" class="form form-horizontal">
         {% csrf_token %}

--- a/nautobot/ipam/templates/ipam/ipaddress_assign.html
+++ b/nautobot/ipam/templates/ipam/ipaddress_assign.html
@@ -6,10 +6,16 @@
 {% block title %}Assign an IP address{% endblock %}
 
 {% block content %}
-    <form action="{% querystring request %}" method="post" class="form form-horizontal">
-        {% csrf_token %}
+    <form action="#" method="get" class="form form-horizontal">
         {% for field in form.hidden_fields %}
             {{ field }}
+        {% endfor %}
+        {% for k, v_list in request.GET.lists %}
+            {% if k != 'q' %}
+                {% for v in v_list %}
+                    <input type="hidden" name="{{ k }}" value="{{ v }}" />
+                {% endfor %}
+            {% endif %}
         {% endfor %}
         <div class="row">
             <div class="col-md-6 col-md-offset-3">
@@ -26,7 +32,6 @@
             <div class="panel panel-default">
                 <div class="panel-heading"><strong>Select IP Address</strong></div>
                 <div class="panel-body">
-                    {% render_field form.vrf_id %}
                     {% render_field form.q %}
                 </div>
             </div>
@@ -45,7 +50,7 @@
                 {% csrf_token %}
                 <div class="col-md-12" style="margin-top: 20px">
                     <h3>Search Results</h3>
-                    {% include 'utilities/obj_table.html' with table_template='panel_table.html' %}
+                    {% include 'utilities/obj_table.html' with table_template='panel_table.html' disable_pagination=True %}
                     <div class="pull-left noprint">
                         {% if perms.dcim.change_interface %}
                             <button type="submit" name="_edit" formaction="#" class="btn btn-primary btn-sm">
@@ -55,6 +60,7 @@
                     </div>
                 </div>
             </form>
+            {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
         </div>
     {% endif %}
 {% endblock %}

--- a/nautobot/ipam/utils/__init__.py
+++ b/nautobot/ipam/utils/__init__.py
@@ -1,8 +1,10 @@
 import netaddr
 
+from nautobot.dcim.models import Interface
 from nautobot.extras.models import RelationshipAssociation
 from nautobot.ipam.constants import VLAN_VID_MAX, VLAN_VID_MIN
 from nautobot.ipam.models import Prefix, VLAN
+from nautobot.virtualization.models import VMInterface
 
 
 def add_available_prefixes(parent, prefix_list):
@@ -243,3 +245,24 @@ def handle_relationship_changes_when_merging_ips(merged_ip, merged_attributes, c
                     RelationshipAssociation.objects.filter(
                         relationship=relationship, destination_id=merged_ip.pk
                     ).delete()
+
+
+def retrieve_interface_or_vminterface_from_request(request):
+    """
+    Retrieve either an Interface or VMInterface based on the provided request's GET parameters.
+
+    Parameters:
+        - request (HttpRequest): The HTTP request object.
+
+    Returns:
+        tuple:
+            - Interface/VMInterface or None: The found interface object, or None if not found.
+            - str or None: An error message if the interface is not found, otherwise None.
+    """
+    interface_model = Interface if "interface" in request.GET else VMInterface
+    interface_id = request.GET.get("interface") or request.GET.get("vminterface")
+    try:
+        obj = interface_model.objects.restrict(request.user, "change").get(id=interface_id)
+        return obj, None
+    except interface_model.DoesNotExist:
+        return None, f'{interface_model.__name__} with id "{interface_id}" not found.'

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -568,7 +568,7 @@ class PrefixEditView(generic.ObjectEditView):
     model_form = forms.PrefixForm
     template_name = "ipam/prefix_edit.html"
 
-    def successful_post(self, request, obj, created, logger):
+    def successful_post(self, request, obj, created, _logger):
         """Check for data that will be invalid in a future Nautobot release and warn the user if found."""
         # 3.0 TODO: remove these checks after enabling strict enforcement of the equivalent logic in Prefix.save()
         edit_url = reverse("ipam:prefix_edit", kwargs={"pk": obj.pk})
@@ -659,7 +659,7 @@ class PrefixEditView(generic.ObjectEditView):
                     ),
                 )
 
-        super().successful_post(request, obj, created, logger)
+        super().successful_post(request, obj, created, _logger)
 
 
 class PrefixDeleteView(generic.ObjectDeleteView):
@@ -754,7 +754,7 @@ class IPAddressEditView(generic.ObjectEditView):
 
         return super().dispatch(request, *args, **kwargs)
 
-    def successful_post(self, request, obj, created, logger):
+    def successful_post(self, request, obj, created, _logger):
         """Check for data that will be invalid in a future Nautobot release and warn the user if found."""
         # 3.0 TODO: remove this check after enabling strict enforcement of the equivalent logic in IPAddress.save()
         if obj.parent.type == choices.PrefixTypeChoices.TYPE_CONTAINER:
@@ -801,7 +801,7 @@ class IPAddressEditView(generic.ObjectEditView):
             interface, _ = retrieve_interface_or_vminterface_from_request(request)
             interface.ip_addresses.add(obj)
 
-        super().successful_post(request, obj, created, logger)
+        super().successful_post(request, obj, created, _logger)
 
     def alter_obj(self, obj, request, url_args, url_kwargs):
         # TODO: update to work with interface M2M
@@ -874,7 +874,7 @@ class IPAddressAssignView(generic.ObjectView):
         interface, _ = retrieve_interface_or_vminterface_from_request(request)
 
         if pks := request.POST.getlist("pk"):
-            ip_addresses = IPAddress.objects.filter(pk__in=pks)
+            ip_addresses = IPAddress.objects.restrict(request.user, "view").filter(pk__in=pks)
             interface.ip_addresses.add(*ip_addresses)
             return redirect(request.GET.get("return_url"))
 

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -758,7 +758,7 @@ class IPAddressEditView(generic.ObjectEditView):
                 interface = Interface.objects.get(id=interface_id)
                 interface.ip_addresses.add(obj)
             except Interface.DoesNotExist:
-                messages.warning(f'Interface with id "{interface_id}" not found.')
+                messages.warning(request, f'Interface with id "{interface_id}" not found.')
         elif vminterface_id := request.GET.get("vminterface"):
             try:
                 vminterface = VMInterface.objects.get(id=interface_id)

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -764,7 +764,7 @@ class IPAddressEditView(generic.ObjectEditView):
                 vminterface = VMInterface.objects.get(id=interface_id)
                 vminterface.ip_addresses.add(obj)
             except VMInterface.DoesNotExist:
-                messages.warning(f'VMInterface with id "{vminterface_id}" not found.')
+                messages.warning(request, f'VMInterface with id "{vminterface_id}" not found.')
 
         super().successful_post(request, obj, created, logger)
 

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -758,7 +758,7 @@ class IPAddressEditView(generic.ObjectEditView):
                 interface = Interface.objects.get(id=interface_id)
                 interface.ip_addresses.add(obj)
             except Interface.DoesNotExist:
-                messages.warning("Interface with id `{interface_id}` no found.")
+                messages.warning(f'Interface with id "{interface_id}" not found.')
         super().successful_post(request, obj, created, logger)
 
     def alter_obj(self, obj, request, url_args, url_kwargs):

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -845,7 +845,7 @@ class IPAddressAssignView(generic.ObjectView):
         interface_model = Interface if "interface" in request.GET else VMInterface
         interface_id = request.GET.get("interface") or request.GET.get("vminterface")
         interface = interface_model.objects.get(id=interface_id)
-        interface.ip_addresses.set(ip_addresses)
+        interface.ip_addresses.add(*ip_addresses)
         return redirect(request.GET.get("return_url"))
 
 

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -795,7 +795,7 @@ class IPAddressAssignView(generic.ObjectView):
     """
 
     queryset = IPAddress.objects.all()
-    
+
     def _get_interface_type_and_model(self, request):
         interface_model = Interface if "interface" in request.GET else VMInterface
         interface_id = request.GET.get("interface") or request.GET.get("vminterface")

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -752,6 +752,13 @@ class IPAddressEditView(generic.ObjectEditView):
                     ),
                 )
 
+        # Add IpAddress to interface if interface is in query_params
+        if interface_id := request.GET.get("interface"):
+            try:
+                interface = Interface.objects.get(id=interface_id)
+                interface.ip_addresses.add(obj)
+            except Interface.DoesNotExist:
+                messages.warning("Interface with id `{interface_id}` no found.")
         super().successful_post(request, obj, created, logger)
 
     def alter_obj(self, obj, request, url_args, url_kwargs):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3636

- ReIntroduce the Add icon in the Device Interface List View table
- Change the "Assign an IP Address" View Table as follows: Add a checkbox to the table so that users may choose which IP addresses to assign to the interface.

<img width="1261" alt="Screenshot 2023-08-08 at 1 13 42 PM" src="https://github.com/nautobot/nautobot/assets/94907097/3e6ce989-e1ca-4afe-81ef-cc5f1cfd7dff">

# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
