### PR TITLE
Address #4173: unpin drf-spectacular

### DIFF
--- a/changes/4173.dependencies
+++ b/changes/4173.dependencies
@@ -1,0 +1,1 @@
+Updated `drf-spectacular` to `0.26.4`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1204,14 +1204,14 @@ pytz = "*"
 
 [[package]]
 name = "drf-spectacular"
-version = "0.26.3"
+version = "0.26.4"
 description = "Sane and flexible OpenAPI 3 schema generation for Django REST framework"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "drf-spectacular-0.26.3.tar.gz", hash = "sha256:b907a72a0244e5dcfeca625e9632cd8ebccdbe2cb528b7c1de1191708be6f31e"},
-    {file = "drf_spectacular-0.26.3-py3-none-any.whl", hash = "sha256:1d84ac70522baaadd6d84a25ce5fe5ea50cfcba0387856689f98ac536f14aa32"},
+    {file = "drf-spectacular-0.26.4.tar.gz", hash = "sha256:8f5a8f87353d1bb8dcb3f3909b7109b2dcbe1d91f3e069409cf322963e140bd6"},
+    {file = "drf_spectacular-0.26.4-py3-none-any.whl", hash = "sha256:afeccc6533dcdb4e78afbfcc49f3c5e9c369aeb62f965e4d1a43b165449c147a"},
 ]
 
 [package.dependencies]
@@ -1229,14 +1229,14 @@ sidecar = ["drf-spectacular-sidecar"]
 
 [[package]]
 name = "drf-spectacular-sidecar"
-version = "2023.7.1"
+version = "2023.8.1"
 description = "Serve self-contained distribution builds of Swagger UI and Redoc with Django"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "drf-spectacular-sidecar-2023.7.1.tar.gz", hash = "sha256:fae346a00636a57aa164d2778e7162cfaff1f59af8133c2b6a8403c8211a167b"},
-    {file = "drf_spectacular_sidecar-2023.7.1-py3-none-any.whl", hash = "sha256:4466e396a875182ac568872cd7a6658fefc386a764272adf088ce7a8d80c795a"},
+    {file = "drf-spectacular-sidecar-2023.8.1.tar.gz", hash = "sha256:79b928d75b8f7c07d2188dda33ea10ca90d4f7234af5788dda58dc4434cd27f8"},
+    {file = "drf_spectacular_sidecar-2023.8.1-py3-none-any.whl", hash = "sha256:aa9027e8aadb907bb6be486a7219f1474ab678914cae8aebf34445f02e80bdca"},
 ]
 
 [package.dependencies]
@@ -4141,4 +4141,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "c7015a88b3b08371dd641ee9f10c4d9070a7d539789267fd96163f29429d2330"
+content-hash = "c84fdd1d33eb7fcdf412738a75dcc198e8c1e210c89cf3b696aad0c10f8f1b2e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ django-webserver = "~1.2.0"
 # REST API framework
 djangorestframework = "~3.14.0"
 # OpenAPI 3.0 schema generation for the REST API
-drf-spectacular = {version = "0.26.3", extras = ["sidecar"]}
+drf-spectacular = {version = "~0.26.4", extras = ["sidecar"]}
 # 2.0 TODO: no longer used, but retained for now to avoid breaking plugin expectations
 drf-yasg = {version = "^1.20.0", extras = ["validation"]}
 # Git integrations for Python


### PR DESCRIPTION
# Closes: #4173
# What's Changed

Unpin `drf-spectacular` from an exact version of 0.26.3, move to 0.26.4 and allow forward-looking versions again.

No actual code-change is needed at this time, as the schema generation was already fixed in #4177 (https://github.com/nautobot/nautobot/commit/cb1df3c847325f3749260d40a3a403da32bc1d61#diff-3bf7f134e78905fe256146baca5ff9f7d8c0bfe13b7de8f49ed8d48eb5e40a13R65).


# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
