### PR TITLE
Fix #4149 - correct logic in RackForm

### DIFF
--- a/changes/4149.fixed
+++ b/changes/4149.fixed
@@ -1,0 +1,1 @@
+Fixed a bug that prevented renaming a `Rack` if it contained any devices whose names were not globally unique.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -696,7 +696,7 @@ class RackForm(LocatableModelFormMixin, NautobotModelForm, TenancyForm):
         cleaned_data = self.cleaned_data
         site = cleaned_data.get("site")
 
-        if self.instance and site != self.instance.site:
+        if self.instance and self.instance.present_in_database and site != self.instance.site:
             # If the site is changed, the rack post save signal attempts to update the rack devices,
             # which may result in an Exception if the updated devices conflict with existing devices at this site.
             # To avoid an unhandled exception in the signal, check for this scenario here.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.forms.array import SimpleArrayField
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db.models import Count, Q
+from django.db.models import Q
 from django.utils.safestring import mark_safe
 from netaddr import EUI
 from netaddr.core import AddrFormatError

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -696,21 +696,21 @@ class RackForm(LocatableModelFormMixin, NautobotModelForm, TenancyForm):
         cleaned_data = self.cleaned_data
         site = cleaned_data.get("site")
 
-        if self.instance:
+        if self.instance and site != self.instance.site:
             # If the site is changed, the rack post save signal attempts to update the rack devices,
-            # which may result in an Exception.
-            # To avoid an unhandled exception in signal, catch this error here.
-            duplicate_devices_names = (
-                Device.objects.values_list("name", flat=True)
-                .annotate(name_count=Count("name"))
-                .filter(name_count__gt=1)
-            )
-            duplicate_devices = Device.objects.filter(site=site, name__in=list(duplicate_devices_names)).values_list(
-                "name", flat=True
-            )
+            # which may result in an Exception if the updated devices conflict with existing devices at this site.
+            # To avoid an unhandled exception in the signal, check for this scenario here.
+            duplicate_devices = set()
+            for device in self.instance.devices.all():
+                qs = Device.objects.exclude(pk=device.pk).filter(site=site, tenant=device.tenant, name=device.name)
+                if qs.exists():
+                    duplicate_devices.add(qs.first().name)
             if duplicate_devices:
                 raise ValidationError(
-                    {"site": f"Device with `name` in {list(duplicate_devices)} and site={site} already exists."}
+                    {
+                        "site": f"Device(s) {sorted(duplicate_devices)} already exist in site {site} and "
+                        "would conflict with same-named devices in this rack."
+                    }
                 )
         return cleaned_data
 

--- a/nautobot/dcim/tests/test_forms.py
+++ b/nautobot/dcim/tests/test_forms.py
@@ -444,5 +444,21 @@ class RackTestCase(TestCase):
         form = RackForm(data=data, instance=racks[0])
         self.assertEqual(
             str(form.errors.as_data()["site"][0]),
-            str(["Device with `name` in ['device1'] and site=Site-2 already exists."]),
+            str(
+                [
+                    "Device(s) ['device1'] already exist in site Site-2 and "
+                    "would conflict with same-named devices in this rack."
+                ]
+            ),
         )
+
+        # Check for https://github.com/nautobot/nautobot/issues/4149
+        data = {
+            "name": "New name",
+            "site": racks[0].site.pk,
+            "status": racks[0].status.pk,
+            "u_height": 48,
+            "width": RackWidthChoices.WIDTH_19IN,
+        }
+        form = RackForm(data=data, instance=racks[0])
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
# Closes: #4149
# What's Changed

- Logic in `RackForm` introduced in #4025 was incorrect - it would cause form validation to fail if any Device in the target site shared a non-globally-unique name with any other device in the database, which was not the intent.
  - Fixed the logic so that it will only fail if a device *in the rack being edited* has a name *and tenant* conflict with an existing device *in the target site*
  - Furthermore, we only need to run this check at all if the form is changing a Rack's `site` attribute, so I added a check for that as well.
- Added a check for #4149 in the `dcim.test_forms.RackTestCase` and verified that it failed before my changes and passes now.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
