### PR TITLE
Disable install metrics for local dev as well as dev and final-dev Docker

### DIFF
--- a/changes/4242.changed
+++ b/changes/4242.changed
@@ -1,2 +1,2 @@
-Changed `development/nautobot_config.py` to default installation metrics to disabled for developer environments.
+Changed `development/nautobot_config.py` to disable installation metrics for developer environments by default.
 Changed behavior of `dev` and `final-dev` Docker images to disable installation metrics by default.

--- a/changes/4242.changed
+++ b/changes/4242.changed
@@ -1,0 +1,2 @@
+Changed `development/nautobot_config.py` to default installation metrics to disabled for developer environments.
+Changed behavior of `dev` and `final-dev` Docker images to disable installation metrics by default.

--- a/development/dev.env
+++ b/development/dev.env
@@ -37,6 +37,3 @@ NAUTOBOT_SELENIUM_HOST=nautobot
 
 # Allow self signed git repositories for config contexts, export templates, ...
 # GIT_SSL_NO_VERIFY="1"
-
-# Reduce noise
-NAUTOBOT_INSTALLATION_METRICS_ENABLED=false

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -19,6 +19,9 @@ if DEBUG:
     # For the Docker dev environment, we don't know in advance what that IP may be, so override to skip that check
     DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG}
 
+# Do *not* send anonymized install metrics when post_upgrade or send_installation_metrics management commands are run
+INSTALLATION_METRICS_ENABLED = is_truthy(os.getenv("NAUTOBOT_INSTALLATION_METRICS_ENABLED", "False"))
+
 #
 # Logging for the development environment, taking into account the redefinition of DEBUG above
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -266,6 +266,9 @@ RUN --mount=type=cache,target="/root/.cache/pip" \
     rm -rf /source && \
     rm -rf /tmp/tmp*
 
+# Don't send install metrics as this is a development target, not a deployment one
+ENV NAUTOBOT_INSTALLATION_METRICS_ENABLED=false
+
 COPY development/nautobot_config.py /opt/nautobot/nautobot_config.py
 
 ################################ Stage: final-dev (development environment for Nautobot plugins)
@@ -276,6 +279,9 @@ RUN pip install --no-deps --no-cache-dir /source/dist/*.whl && \
     rm -rf /source
 
 WORKDIR /opt/nautobot
+
+# Don't send install metrics as this is a development target, not a deployment one
+ENV NAUTOBOT_INSTALLATION_METRICS_ENABLED=false
 
 RUN nautobot-server init
 

--- a/nautobot/docs/development/getting-started.md
+++ b/nautobot/docs/development/getting-started.md
@@ -423,7 +423,11 @@ nautobot-server init
 Example output:
 
 ```no-highlight
-Configuration file created at '/home/example/.nautobot/nautobot_config.py'
+Nautobot would like to send anonymized installation metrics to the project's maintainers.
+These metrics include the installed Nautobot version, the Python version in use, an anonymous "deployment ID", and a list of one-way-hashed names of enabled Nautobot Apps and their versions.
+Allow Nautobot to send these metrics? [y/n]: n
+Installation metrics will not be sent by default.
+Configuration file created at /home/example/.nautobot/nautobot_config.py
 ```
 
 You may also specify alternate file locations. Please refer to [Configuring Nautobot](../configuration/index.md) for how to do that.

--- a/nautobot/docs/installation/nautobot.md
+++ b/nautobot/docs/installation/nautobot.md
@@ -193,8 +193,16 @@ However, because we've set the `NAUTOBOT_ROOT`, this command will automatically 
 
 ```no-highlight
 nautobot-server init
-Configuration file created at '/opt/nautobot/nautobot_config.py'
+
+Nautobot would like to send anonymized installation metrics to the project's maintainers.
+These metrics include the installed Nautobot version, the Python version in use, an anonymous "deployment ID", and a list of one-way-hashed names of enabled Nautobot Apps and their versions.
+Allow Nautobot to send these metrics? [y/n]: y
+Installation metrics will be sent when running 'nautobot-server post_upgrade'. Thank you!
+Configuration file created at /opt/nautobot/nautobot_config.py
 ```
+
++++ 1.6.0
+    The `nautobot-server init` command will now prompt you to set the initial value for the [`INSTALLATION_METRICS_ENABLED`](../configuration/optional-settings.md#installation_metrics_enabled) setting. See the [send_installation_metrics](../administration/nautobot-server.md#send_installation_metrics) command for more information about the feature that this setting toggles.
 
 ### Required Settings
 


### PR DESCRIPTION
# Closes: #4242 
# What's Changed

- Add `ENV NAUTOBOT_INSTALLATION_METRICS_ENABLED=false` to the `dev` and `final-dev` (but not `final`) Docker image targets.
- Change the default in `development/nautobot_config.py` for `INSTALLATION_METRICS_ENABLED` to `False` for the benefit of local (non-Docker) development environments.
- Remove now-redundant explicit declaration of `NAUTOBOT_INSTALLATION_METRICS_ENABLED` from `development/dev.env`.
- Update a couple of docs sections that were referencing `nautobot-server init` that hadn't yet been updated with the new behavior.

```
❯ docker logs -f -n20 nautobot-nautobot-1
Performing database migrations...
Operations to perform:
  Apply all migrations: admin, auth, circuits, contenttypes, database, dcim, django_celery_beat, django_rq, extras, ipam, sessions, social_django, taggit, tenancy, users, virtualization
Running migrations:
  No migrations to apply.

Generating cable paths...
Found no missing circuit termination paths; skipping
Found no missing console port paths; skipping
Found no missing console server port paths; skipping
Found no missing interface paths; skipping
Found no missing power feed paths; skipping
Found no missing power outlet paths; skipping
Found no missing power port paths; skipping
Finished.

Collecting static files...

739 static files copied to '/opt/nautobot/static'.

Removing stale content types...

Removing expired sessions...

Sending installation metrics...
Installation metrics are disabled by INSTALLATION_METRICS_ENABLED setting, skipping.
```

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
