### PR TITLE
Add timeout and exception handling to send_installation_metrics

### DIFF
--- a/changes/4241.fixed
+++ b/changes/4241.fixed
@@ -1,0 +1,1 @@
+Added a timeout and exception handling to the `nautobot-server send_installation_metrics` command.

--- a/nautobot/core/management/commands/send_installation_metrics.py
+++ b/nautobot/core/management/commands/send_installation_metrics.py
@@ -64,7 +64,8 @@ class Command(BaseCommand):
         prepared_request = requests.Request("POST", METRICS_ENDPOINT, json=payload).prepare()
         try:
             with requests.Session() as session:
-                response = session.send(prepared_request, proxies=settings.HTTP_PROXIES, timeout=30)
+                # fail after just over 3 seconds if unable to connect, and take no longer than 30 seconds in total
+                response = session.send(prepared_request, proxies=settings.HTTP_PROXIES, timeout=(3.05, 27))
 
             if response.ok:
                 self.stdout.write(self.style.SUCCESS(f"Installation metrics successfully sent to '{METRICS_ENDPOINT}'"))

--- a/nautobot/core/management/commands/send_installation_metrics.py
+++ b/nautobot/core/management/commands/send_installation_metrics.py
@@ -1,6 +1,8 @@
 import hashlib
+import json
 import platform
 import requests
+import requests.exceptions
 import uuid
 
 from constance import config
@@ -57,19 +59,27 @@ class Command(BaseCommand):
         }
 
         # send the payload to the metrics endpoint
+        self.stdout.write(self.style.SUCCESS(f"Sending installation metrics to '{METRICS_ENDPOINT}':"))
+        self.stdout.write(self.style.SUCCESS(json.dumps(payload, indent=4)))
         prepared_request = requests.Request("POST", METRICS_ENDPOINT, json=payload).prepare()
-        with requests.Session() as session:
-            response = session.send(prepared_request, proxies=settings.HTTP_PROXIES)
+        try:
+            with requests.Session() as session:
+                response = session.send(prepared_request, proxies=settings.HTTP_PROXIES, timeout=30)
 
-        if response.ok:
-            self.stdout.write(self.style.SUCCESS(f"Metrics successfully sent to '{METRICS_ENDPOINT}'"))
-        else:
+            if response.ok:
+                self.stdout.write(self.style.SUCCESS(f"Installation metrics successfully sent to '{METRICS_ENDPOINT}'"))
+            else:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Failed to send installation metrics to '{METRICS_ENDPOINT}'; "
+                        f"response status {response.status_code}: {response.text}"
+                    )
+                )
+        except requests.exceptions.RequestException as exc:
+            self.stderr.write(self.style.ERROR(f"Failed to send installation metrics to '{METRICS_ENDPOINT}: {exc}"))
+        finally:
             self.stderr.write(
-                self.style.ERROR(
-                    f"Failed to send metrics to '{METRICS_ENDPOINT}'; "
-                    f"response status {response.status_code}: {response.content}"
+                self.style.NOTICE(
+                    "To disable installation metrics, set INSTALLATION_METRICS_ENABLED = False in your Nautobot config."
                 )
             )
-        self.stderr.write(
-            "To disable installation metrics, you can set INSTALLATION_METRICS_ENABLED = False in your Nautobot config."
-        )


### PR DESCRIPTION
# Closes: #4241 
# What's Changed

- Add a 30-second timeout to the POST request sent by `nautobot-server send_installation_metrics` (I'm open to suggestion as to different arbitrary numbers to use here!)
- Add a try/except for `requests.exceptions.RequestException` so that connection errors don't bubble up to the caller
- Improve verbosity of the command to make it clearer to the user what it's doing.

Success:

```
root@844eb38da0c8:/source# NAUTOBOT_INSTALLATION_METRICS_ENABLED=true nautobot-server send_installation_metrics
Sending installation metrics to 'https://nautobot.cloud/api/nautobot/installation-metric/':
{
    "deployment_id": "c39994fa-d4d2-404c-8d12-8f65672a71ab",
    "nautobot_version": "1.6.1b1",
    "python_version": "3.10.6",
    "installed_apps": {
        "3ffee4622af3aad6f78257e3ae12da99ca21d71d099f67f4a2e19e464453bee7": "1.0.0"
    },
    "debug": true
}
Installation metrics successfully sent to 'https://nautobot.cloud/api/nautobot/installation-metric/'
To disable installation metrics, set INSTALLATION_METRICS_ENABLED = False in your Nautobot config.
```

Failure (bad proxy config):

```
Sending installation metrics to 'https://nautobot.cloud/api/nautobot/installation-metric/':
{
    "deployment_id": "c39994fa-d4d2-404c-8d12-8f65672a71ab",
    "nautobot_version": "1.6.1b1",
    "python_version": "3.10.6",
    "installed_apps": {
        "3ffee4622af3aad6f78257e3ae12da99ca21d71d099f67f4a2e19e464453bee7": "1.0.0"
    },
    "debug": true
}
Failed to send metrics to 'https://nautobot.cloud/api/nautobot/installation-metric/: HTTPSConnectionPool(host='nautobot.cloud', port=443): Max retries exceeded with url: /api/nautobot/installation-metric/ (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 400 Bad Request')))
To disable installation metrics, set INSTALLATION_METRICS_ENABLED = False in your Nautobot config.
```

Failure (4xx response from server):

```
Sending installation metrics to 'https://nautobot.cloud/api/nautobot/installation-metrics/':
{
    "deployment_id": "c39994fa-d4d2-404c-8d12-8f65672a71ab",
    "nautobot_version": "1.6.1b1",
    "python_version": "3.10.6",
    "installed_apps": {
        "3ffee4622af3aad6f78257e3ae12da99ca21d71d099f67f4a2e19e464453bee7": "1.0.0"
    },
    "debug": true
}
Failed to send metrics to 'https://nautobot.cloud/api/nautobot/installation-metrics/'; response status 403: 
<!DOCTYPE html>
<html lang="en">
<head>
  <meta http-equiv="content-type" content="text/html; charset=utf-8">
  <meta name="robots" content="NONE,NOARCHIVE">
  <title>403 Forbidden</title>
  <style type="text/css">
    html * { padding:0; margin:0; }
    body * { padding:10px 20px; }
    body * * { padding:0; }
    body { font:small sans-serif; background:#eee; color:#000; }
    body>div { border-bottom:1px solid #ddd; }
    h1 { font-weight:normal; margin-bottom:.4em; }
    h1 span { font-size:60%; color:#666; font-weight:normal; }
    #info { background:#f6f6f6; }
    #info ul { margin: 0.5em 4em; }
    #info p, #summary p { padding-top:10px; }
    #summary { background: #ffc; }
    #explanation { background:#eee; border-bottom: 0px none; }
  </style>
</head>
<body>
<div id="summary">
  <h1>Forbidden <span>(403)</span></h1>
  <p>CSRF verification failed. Request aborted.</p>

  <p>You are seeing this message because this HTTPS site requires a “Referer header” to be sent by your web browser, but none was sent. This header is required for security reasons, to ensure that your browser is not being hijacked by third parties.</p>
  <p>If you have configured your browser to disable “Referer” headers, please re-enable them, at least for this site, or for HTTPS connections, or for “same-origin” requests.</p>
  <p>If you are using the &lt;meta name=&quot;referrer&quot; content=&quot;no-referrer&quot;&gt; tag or including the “Referrer-Policy: no-referrer” header, please remove them. The CSRF protection requires the “Referer” header to do strict referer checking. If you’re concerned about privacy, use alternatives like &lt;a rel=&quot;noreferrer&quot; …&gt; for links to third-party sites.</p>


</div>

<div id="explanation">
  <p><small>More information is available with DEBUG=True.</small></p>
</div>

</body>
</html>

To disable installation metrics, set INSTALLATION_METRICS_ENABLED = False in your Nautobot config.
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
