### PR TITLE
Fixed dependencies required for saml support missing in final docker image

### DIFF
--- a/changes/4093.fixed
+++ b/changes/4093.fixed
@@ -1,0 +1,1 @@
+Fixed dependencies required for saml support missing in final docker image.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ ARG PYTHON_VER
 #      dev     final-dev
 #
 #  The design philosphy for this image hierarchy is:
-#  
+#
 #  - pyproject.toml is the source of truth for dependencies
 #  - Non-intermediate image targets (final, final-dev, dev) will not contain files they don't need
 #      - EX: No dev dependencies in final image
@@ -73,7 +73,7 @@ ARG PYTHON_VER
 #
 # dependencies-dev (intermediate build target)
 #   copies built Nautobot wheel and files from build-nautobot
-#   installs Markdownlint 
+#   installs Markdownlint
 #   adds files and configuration for Nautobot development server to run
 #
 # dev (development environment for Nautobot core)
@@ -103,7 +103,7 @@ ENV PYTHONUNBUFFERED=1 \
 # hadolint ignore=DL3005,DL3008,DL3013
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y git mime-support curl libxml2 libmariadb3 openssl && \
+    apt-get install --no-install-recommends -y git mime-support curl libxml2 libmariadb3 openssl libxmlsec1-dev libxmlsec1-openssl && \
     apt-get autoremove -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/* && \
@@ -126,7 +126,7 @@ ARG POETRY_PARALLEL
 # Install development/install-time OS dependencies
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y build-essential libssl-dev libxmlsec1-dev libxmlsec1-openssl pkg-config libldap-dev libsasl2-dev libmariadb-dev && \
+    apt-get install --no-install-recommends -y build-essential libssl-dev pkg-config libldap-dev libsasl2-dev libmariadb-dev && \
     apt-get autoremove -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4093
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Moved installation of dependencies required for `python3-saml` from the `dependencies` stage to the `base` stage so they're available in the `final` stage:

- libxmlsec1-dev
- libxmlsec1-openssl

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
