### PR TITLE
Fixed warning message when trying to use bulk edit with no items selected.

### DIFF
--- a/changes/4262.fixed
+++ b/changes/4262.fixed
@@ -1,0 +1,1 @@
+Fixed warning message when trying to use bulk edit with no items selected.

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -949,7 +949,7 @@ class ObjectBulkUpdateViewMixin(NautobotViewSetMixin, BulkUpdateModelMixin):
         if not table.rows:
             messages.warning(
                 request,
-                f"No {queryset.model._meta.verbose_name_plural} were selected for deletion.",
+                f"No {queryset.model._meta.verbose_name_plural} were selected to update.",
             )
             return redirect(self.get_return_url(request))
         data.update({"table": table})


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4262
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Minor change to fix warning message wording.

