### PR TITLE
Fixed a permissions issue when using `final-dev` containers 

### DIFF
--- a/changes/4300.fixed
+++ b/changes/4300.fixed
@@ -1,1 +1,1 @@
-Fixed a permissions issue when using `final-dev` containers by  switching to root user before exposing port and entrypoint.
+Fixed a permission issue when using `final-dev` containers by switching to root user before exposing port and entrypoint.

--- a/changes/4300.fixed
+++ b/changes/4300.fixed
@@ -1,0 +1,1 @@
+Fixed a permissions issue when using `final-dev` containers by  switching to root user before exposing port and entrypoint.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -245,6 +245,10 @@ ENV NAUTOBOT_INSTALLATION_METRICS_ENABLED=false
 RUN nautobot-server init && \
     nautobot-server build_ui
 
+# switch to root user for final-dev stage: https://github.com/nautobot/nautobot/issues/4300
+# hadolint ignore=DL3002
+USER root
+
 # Run Nautobot development server by default
 EXPOSE 8080
 CMD ["nautobot-server", "runserver", "0.0.0.0:8080", "--insecure"]


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4300 
# What's Changed

This addresses potential filesystem permissions issues on mounted volumes for Nautobot App developers using Linux native Docker workflows. 

A `USER root` statement is added to the `final-dev` build stage before the `EXPOSE  8080` command identically to how it was solved for the `dev stage.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
