### PR TITLE
Fix rendering of TagFilterField with large number of tags (#4216)

### DIFF
--- a/changes/4216.changed
+++ b/changes/4216.changed
@@ -1,0 +1,1 @@
+Changed the rendering of `TagFilterField` to prevent very slow rendering of pages when large numbers of tags are defined.

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -21,7 +21,6 @@ from nautobot.extras.querysets import DynamicGroupQuerySet, DynamicGroupMembersh
 from nautobot.extras.utils import extras_features
 from nautobot.utilities.config import get_settings_or_config
 from nautobot.utilities.forms.constants import BOOLEAN_WITH_BLANK_CHOICES
-from nautobot.utilities.forms.fields import TagFilterField
 from nautobot.utilities.forms.widgets import StaticSelect2
 from nautobot.utilities.utils import get_filterset_for_model, get_form_for_model
 
@@ -438,11 +437,9 @@ class DynamicGroup(OrganizationalModel):
             field = declared_form.declared_fields.get(field_name, filterset_form.fields[field_name])
             field_value = filterset_form.cleaned_data[field_name]
 
-            # `tag` on FilterForms is not a ModelMultipleChoiceField, so we need to handle it.
-            # On `FilterSetForm.tag`, it is a ModelMultipleChoiceField.
             # TODO: This could/should check for both "convenience" FilterForm fields (ex: DynamicModelMultipleChoiceField)
             # and literal FilterSet fields (ex: MultiValueCharFilter).
-            if isinstance(field, (forms.ModelMultipleChoiceField, TagFilterField)):
+            if isinstance(field, forms.ModelMultipleChoiceField):
                 field_to_query = field.to_field_name or "pk"
                 new_value = [getattr(item, field_to_query) for item in field_value]
 

--- a/nautobot/extras/tests/integration/test_tagfilter.py
+++ b/nautobot/extras/tests/integration/test_tagfilter.py
@@ -1,0 +1,65 @@
+import time
+
+from django.contrib.contenttypes.models import ContentType
+
+from nautobot.circuits.models import Provider
+from nautobot.extras.models import Tag
+from nautobot.utilities.testing.integration import SeleniumTestCase
+
+
+class TagFilterTestCase(SeleniumTestCase):
+    """
+    Integration test to check behavior of TagFilter in the UI after https://github.com/nautobot/nautobot/issues/4216.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user.is_superuser = True
+        self.user.save()
+        self.login(self.user.username, self.password)
+
+        # Dynamic model dropdowns like TagFilter default to 50 items at a time from the API
+        provider_ct = ContentType.objects.get_for_model(Provider)
+        for i in range(1, 52):
+            self.tag = Tag.objects.create(name=f"A Provider Tag {i:02d}")
+            self.tag.content_types.add(provider_ct)
+
+    def tearDown(self):
+        self.logout()
+        super().tearDown()
+
+    def test_tag_matching_content_type(self):
+        # Navigate to the Provider list view
+        self.browser.links.find_by_partial_text("Circuits").click()
+        self.browser.links.find_by_partial_text("Providers").click()
+
+        # Open the filter form
+        self.browser.find_by_id("id__filterbtn").click()
+        time.sleep(0.5)
+
+        # Find the "Tags" field and select it
+        self.browser.find_by_xpath("//label[@for='id_tag']").click()
+        self.browser.driver.switch_to.active_element.click()
+        # Wait for choices to load
+        time.sleep(0.5)
+        # Each of first 50 tags should appear in the dropdown
+        for i in range(1, 51):
+            self.assertTrue(self.browser.is_text_present(f"A Provider Tag {i:02d}"))
+        self.assertFalse(self.browser.is_text_present("A Provider Tag 51"))
+
+    def test_tag_not_matching_content_type(self):
+        # Navigate to the Location list view
+        self.browser.links.find_by_partial_text("Organization").click()
+        self.browser.links.find_by_partial_text("Locations").click()
+
+        # Open the filter form
+        self.browser.find_by_id("id__filterbtn").click()
+        time.sleep(0.5)
+
+        # Find the "Tags" field and select it
+        self.browser.find_by_xpath("//label[@for='id_tag']").click()
+        self.browser.driver.switch_to.active_element.click()
+        # Wait for choices to load
+        time.sleep(0.5)
+        # Tags should not appear in the dropdown since they don't apply to Locations
+        self.assertFalse(self.browser.is_text_present("A Provider Tag"))

--- a/nautobot/utilities/filters.py
+++ b/nautobot/utilities/filters.py
@@ -173,6 +173,7 @@ class TagFilter(django_filters.ModelMultipleChoiceFilter):
         kwargs.setdefault("field_name", "tags__slug")
         kwargs.setdefault("to_field_name", "slug")
         kwargs.setdefault("conjoined", True)
+        kwargs.setdefault("label", "Tags")
         kwargs.setdefault("queryset", Tag.objects.all())
 
         super().__init__(*args, **kwargs)

--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.forms import SimpleArrayField
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist, ValidationError
-from django.db.models import Count, Q
+from django.db.models import Q
 from django.forms.fields import BoundField, JSONField as _JSONField, InvalidJSONInput
 from django.urls import reverse
 
@@ -435,26 +435,6 @@ class SlugField(forms.SlugField):
         self.widget.attrs["slug-source"] = slug_source
 
 
-class TagFilterField(forms.MultipleChoiceField):
-    """
-    A filter field for the tags of a model. Only the tags used by a model are displayed.
-
-    :param model: The model of the filter
-    """
-
-    widget = widgets.StaticSelect2Multiple
-
-    def __init__(self, model, *args, **kwargs):
-        def get_choices():
-            tags = model.tags.annotate(count=Count("extras_taggeditem_items")).order_by("name")
-            return [(str(tag.slug), f"{tag.name} ({tag.count})") for tag in tags]
-
-        # Choices are fetched each time the form is initialized
-        super().__init__(label="Tags", choices=get_choices, required=False, *args, **kwargs)
-
-    to_field_name = "slug"
-
-
 class DynamicModelChoiceMixin:
     """
     :param display_field: The name of the attribute of an API response object to display in the selection list
@@ -788,3 +768,25 @@ class MultiMatchModelMultipleChoiceField(django_filters.fields.ModelMultipleChoi
         if null:
             result += [self.null_value]
         return result
+
+
+class TagFilterField(DynamicModelMultipleChoiceField):
+    """
+    A filter field for the tags of a model. Only the tags used by a model are displayed.
+
+    :param model: The model of the filter
+    """
+
+    def __init__(self, model, *args, query_params=None, queryset=None, **kwargs):
+        queryset = queryset or model.tags.all()
+        query_params = query_params or {}
+        query_params.update({"content_types": model._meta.label_lower})
+        super().__init__(
+            label="Tags",
+            query_params=query_params,
+            queryset=queryset,
+            required=False,
+            to_field_name="slug",
+            *args,
+            **kwargs,
+        )

--- a/nautobot/utilities/forms/fields.py
+++ b/nautobot/utilities/forms/fields.py
@@ -778,7 +778,8 @@ class TagFilterField(DynamicModelMultipleChoiceField):
     """
 
     def __init__(self, model, *args, query_params=None, queryset=None, **kwargs):
-        queryset = queryset or model.tags.all()
+        if queryset is None:
+            queryset = model.tags.all()
         query_params = query_params or {}
         query_params.update({"content_types": model._meta.label_lower})
         super().__init__(

--- a/nautobot/utilities/tests/test_forms.py
+++ b/nautobot/utilities/tests/test_forms.py
@@ -742,7 +742,7 @@ class DynamicFilterFormTest(TestCase):
                     ("shipping_address", "Shipping address"),
                     ("slug", "Slug"),
                     ("status", "Status"),
-                    ("tag", "Tags slug"),
+                    ("tag", "Tags"),
                     ("tenant_id", 'Tenant (ID) (deprecated, use "tenant" filter instead)'),
                     ("tenant", "Tenant (slug or ID)"),
                     ("tenant_group_id", "Tenant Group (ID)"),
@@ -754,7 +754,8 @@ class DynamicFilterFormTest(TestCase):
             )
 
         with self.subTest(
-            "Assert that the `filterset_filters` property of DynamicFilterForm instance gets the accurate `filterset_class` filters"
+            "Assert that the `filterset_filters` property of DynamicFilterForm instance "
+            "gets the accurate `filterset_class` filters"
         ):
 
             def get_dict_of_field_and_value_class_from_filters(filters):


### PR DESCRIPTION
# Closes: #4216
# What's Changed

- Change `TagFilterField` to a `DynamicModelMultipleChoiceField` so that it retrieves and renders tags 50-at-a-time from the API like most other filter fields, instead of statically rendering **all** applicable tags during page render time.
- Add integration tests to confirm this behavior.

*This will be a minor pain to merge up into `next` due to code reorganization. Sorry!*

![image](https://github.com/nautobot/nautobot/assets/5603551/1f07852f-f364-465c-8b70-9acc4764b20f)

![image](https://github.com/nautobot/nautobot/assets/5603551/479b86f9-276f-490b-b438-6bf4473a7b01)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
