### PR TITLE
Refine new-UI DeviceType detail view

### DIFF
--- a/changes/4017.changed
+++ b/changes/4017.changed
@@ -1,0 +1,2 @@
+Refined new-UI DeviceType detail view.
+Moved `object_type` to the Advanced tab of new-UI detail views in general.

--- a/changes/4017.removed
+++ b/changes/4017.removed
@@ -1,0 +1,1 @@
+Removed `notes_url` from new-UI object detail views.

--- a/nautobot/core/api/metadata.py
+++ b/nautobot/core/api/metadata.py
@@ -196,7 +196,7 @@ class NautobotMetadata(SimpleMetadata):
     """
 
     view_serializer = None
-    advanced_tab_fields = ["id", "url", "composite_key", "created", "last_updated"]
+    advanced_tab_fields = ["id", "url", "object_type", "composite_key", "created", "last_updated"]
 
     def determine_actions(self, request, view):
         """Generate the actions and return the names of the allowed methods."""
@@ -343,7 +343,7 @@ class NautobotMetadata(SimpleMetadata):
         """
         if detail:
             # TODO(timizuo): Add a standardized way of handling `tenant` and `tags` fields, Possible should be on last items on second col.
-            fields_to_remove = ["display", "status"]
+            fields_to_remove = ["display", "status", "notes_url"]
             fields_to_remove += self.get_advanced_tab_fields(serializer)
         else:
             fields_to_remove = []

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -388,6 +388,35 @@ class DeviceTypeSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
         fields = "__all__"
         list_display_fields = ["model", "manufacturer", "part_number", "u_height", "is_full_depth", "device_count"]
 
+        detail_view_config = {
+            "layout": [
+                {
+                    "Chassis": {
+                        "fields": [
+                            "manufacturer",
+                            "model",
+                            "part_number",
+                            "u_height",
+                            "is_full_depth",
+                            "subdevice_role",
+                            "front_image",
+                            "rear_image",
+                            "device_count",
+                        ]
+                    },
+                },
+                {
+                    "Tags": {
+                        "fields": ["tags"],
+                    },
+                    "Comments": {
+                        "fields": ["comments"],
+                    },
+                },
+            ],
+            "include_others": True,
+        }
+
 
 class ConsolePortTemplateSerializer(NautobotModelSerializer):
     type = ChoiceField(choices=ConsolePortTypeChoices, allow_blank=True, required=False)

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -605,8 +605,6 @@ class RackTest(APIViewTestCases.APIViewTestCase):
                         "desc_units",
                         "device_count",
                         "facility_id",
-                        "notes_url",
-                        "object_type",
                         "outer_depth",
                         "outer_unit",
                         "outer_width",


### PR DESCRIPTION
# Closes: #4017
# What's Changed

- Move `object_type` field to the Advanced tab in the new UI
- Exclude `notes_url` from the new UI altogether
  - Notes tab still renders correctly in the new UI using this information, it's just not rendered as a table field any more
- Refine DeviceType view in new UI
  - Caveats:
     - Legacy UI used "Parent/Child" for the `subdevice_role` field, which the new UI is auto-labeling as "Subdevice role" - I think the latter is clearer but it is a difference.
     - Front/rear images are currently presented as raw URLs rather than rendering as images; per #4017 this is fine for now
     - The `Device count` value is not currently hyperlinked to a filtered Device list view; we don't currently have a pattern for attributing a hyperlink to what (in the REST API) is just a raw number value. Future work?

![image](https://github.com/nautobot/nautobot/assets/5603551/4e1d1530-779e-404a-a4ab-f6df04508656)

![image](https://github.com/nautobot/nautobot/assets/5603551/9d3098e2-7bbb-4fe0-99fe-287c096499d5)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
