### PR TITLE
Change DynamicGroup cleaning to respect 'exclude' parameter

### DIFF
--- a/changes/3949.changed
+++ b/changes/3949.changed
@@ -1,0 +1,1 @@
+Moved DynamicGroup `clean_filter()` call from `clean()` to `clean_fields()`, which has the impact that it will still be called by `full_clean()` and `validated_save()` but no longer called on a simple `clean()`.

--- a/changes/3949.fixed
+++ b/changes/3949.fixed
@@ -1,0 +1,2 @@
+Fixed a ValueError when editing an existing DynamicGroup that has invalid `filter` data.
+Fixed `DynamicGroup.clean_fields()` so that it will respect an `exclude=["filter"]` kwarg by not validating the `filter` field.

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -520,6 +520,15 @@ class DynamicGroup(OrganizationalModel):
             )
         return super().delete(*args, **kwargs)
 
+    def clean_fields(self, exclude=None):
+        if exclude is None:
+            exclude = []
+
+        if "filter" not in exclude:
+            self.clean_filter()
+
+        super().clean_fields(exclude=exclude)
+
     def clean(self):
         super().clean()
 
@@ -529,9 +538,6 @@ class DynamicGroup(OrganizationalModel):
 
             if self.content_type != database_object.content_type:
                 raise ValidationError({"content_type": "ContentType cannot be changed once created"})
-
-        # Validate `filter` dict
-        self.clean_filter()
 
     def generate_query_for_filter(self, filter_field, value):
         """

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -213,7 +213,7 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
             instance.content_type = self.dynamicgroup_ct
             instance.validated_save()
 
-    def test_clean_filter_not_dict(self):
+    def test_full_clean_filter_not_dict(self):
         """Test that invalid filter types raise errors."""
         instance = self.groups[0]
         with self.assertRaises(ValidationError):
@@ -228,14 +228,26 @@ class DynamicGroupModelTest(DynamicGroupTestBase):
             instance.filter = "site=ams01"
             instance.validated_save()
 
-    def test_clean_filter_not_valid(self):
+    def test_full_clean_filter_not_valid(self):
         """Test that an invalid filter dict raises an error."""
         instance = self.groups[0]
         with self.assertRaises(ValidationError):
             instance.filter = {"site": -42}
             instance.validated_save()
 
-    def test_clean_valid(self):
+    def test_clean_fields_exclude_filter(self):
+        """Test that filter validation is skipped when an appropriate `exclude` parameter is provided."""
+        instance = self.groups[0]
+        instance.filter = {"platform": -42}
+        instance.clean_fields(exclude=["filter"])
+        instance.full_clean(exclude=["filter"])
+
+        with self.assertRaises(ValidationError):
+            instance.clean_fields()
+        with self.assertRaises(ValidationError):
+            instance.full_clean()
+
+    def test_full_clean_valid(self):
         """Test a clean validation."""
         group = self.groups[0]
         group.refresh_from_db()


### PR DESCRIPTION
# Closes: #3949 
# What's Changed

Move the `DynamicGroup` `clean_filter()` call from `clean()` (which always runs unconditionally) to `clean_fields()` (which, like its parent `full_clean()`,  has a standard `exclude=...` kwarg that we should be respecting). This makes it so that `DynamicGroupForm.is_valid()` (which calls `instance.full_clean(exclude=["filter", ...])` implicitly) won't itself raise an exception if the existing `filter` field is invalid, fixing #3949.

*This change may have impact to app/job developers if they're programmatically constructing DynamicGroups and expecting `clean()` alone to warn if a group's `filter` is invalid. I consider this an acceptable risk as we already document clearly that `full_clean()` or `validated_save()` should generally be used.*

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
