### PR TITLE
Add `isnull` Filter on Nullable Fields via Filter Field Factory

### DIFF
--- a/changes/4378.added
+++ b/changes/4378.added
@@ -1,0 +1,1 @@
+Added the ability to automatically apply `isnull` filters when model field is nullable.

--- a/nautobot/core/filters.py
+++ b/nautobot/core/filters.py
@@ -642,10 +642,14 @@ class BaseFilterSet(django_filters.FilterSet):
         if field is None:
             return magic_filters
 
+        field_type = None
         try:
-            field_type = cls._meta.model._meta.get_field(field_name)
+            if hasattr(cls._meta.model, field_name):
+                field_type = cls._meta.model._meta.get_field(field_name)
         except FieldDoesNotExist:
-            field_type = None
+            # Will get error like:
+            # `FieldDoesNotExist: RelationshipAssociation has no field named 'relationship__key'`
+            pass
 
         # If the field allows null values, add an `isnull`` check
         if field.null and isinstance(field_type, NULLABLE_CLASSES):

--- a/nautobot/core/filters.py
+++ b/nautobot/core/filters.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.forms.utils import ErrorDict, ErrorList
+from django.utils.module_loading import import_string
 import django_filters
 from django_filters.constants import EMPTY_VALUES
 from django_filters.utils import get_model_field, resolve_field
@@ -644,8 +645,12 @@ class BaseFilterSet(django_filters.FilterSet):
 
         field_type = None
         try:
-            if hasattr(cls._meta.model, field_name):
-                field_type = cls._meta.model._meta.get_field(field_name)
+            field_type = cls._meta.model._meta.get_field(field_name)
+            # TODO: This should not be needed, there seems to be some behavior changes with
+            # RoleFilter filters that haven't been migrated, which is beyond the scope of this change
+            # Working around it for now
+            if isinstance(filter_field, import_string("nautobot.extras.filters.mixins.RoleFilter")):
+                field_type = None
         except FieldDoesNotExist:
             # Will get error like:
             # `FieldDoesNotExist: RelationshipAssociation has no field named 'relationship__key'`

--- a/nautobot/core/filters.py
+++ b/nautobot/core/filters.py
@@ -5,6 +5,7 @@ import uuid
 
 from django import forms as django_forms
 from django.conf import settings
+from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.forms.utils import ErrorDict, ErrorList
 import django_filters
@@ -19,6 +20,17 @@ from nautobot.core.models import fields as core_fields
 from nautobot.core.utils import data as data_utils
 
 logger = logging.getLogger(__name__)
+
+NULLABLE_CLASSES = (
+    models.CharField,
+    models.DateField,
+    models.DecimalField,
+    models.ForeignKey,
+    models.FloatField,
+    models.IntegerField,
+    models.TextField,
+    models.UUIDField,
+)
 
 
 def multivalue_field_factory(field_class, widget=django_forms.SelectMultiple):
@@ -630,15 +642,28 @@ class BaseFilterSet(django_filters.FilterSet):
         if field is None:
             return magic_filters
 
+        try:
+            field_type = cls._meta.model._meta.get_field(field_name)
+        except FieldDoesNotExist:
+            field_type = None
+
+        # If the field allows null values, add an `isnull`` check
+        if field.null and isinstance(field_type, NULLABLE_CLASSES):
+            # Use this method vs extend as the `lookup_map` variable is generally one of
+            # the constants which we do not want to update
+            lookup_map = dict(lookup_map, **{"isnull": "isnull"})
+
         # Create new filters for each lookup expression in the map
         for lookup_name, lookup_expr in lookup_map.items():
             new_filter_name = f"{filter_name}__{lookup_name}"
 
             try:
-                if filter_name in cls.declared_filters:
-                    # The filter field has been explicity defined on the filterset class so we must manually
+                if filter_name in cls.declared_filters and lookup_expr not in {"isnull"}:
+                    # The filter field has been explicitly defined on the filterset class so we must manually
                     # create the new filter with the same type because there is no guarantee the defined type
-                    # is the same as the default type for the field
+                    # is the same as the default type for the field. This does not apply to apply if the filter
+                    # should retain the original lookup_expr type, such as `isnull` using a boolean field on a
+                    # char or date object.
                     resolve_field(field, lookup_expr)  # Will raise FieldLookupError if the lookup is invalid
                     new_filter = type(filter_field)(
                         field_name=field_name,
@@ -649,7 +674,7 @@ class BaseFilterSet(django_filters.FilterSet):
                         **filter_field.extra,
                     )
                 else:
-                    # The filter field is listed in Meta.fields so we can safely rely on default behaviour
+                    # The filter field is listed in Meta.fields so we can safely rely on default behavior
                     # Will raise FieldLookupError if the lookup is invalid
                     new_filter = cls.filter_for_field(field, field_name, lookup_expr)
             except django_filters.exceptions.FieldLookupError:

--- a/nautobot/core/tests/test_filters.py
+++ b/nautobot/core/tests/test_filters.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
@@ -9,6 +11,8 @@ from django.test.utils import isolate_apps
 import django_filters
 from tree_queries.models import TreeNodeForeignKey
 
+from nautobot.circuits.filters import CircuitFilterSet
+from nautobot.circuits.models import Circuit, CircuitType, Provider
 from nautobot.core import filters, testing
 from nautobot.core.models import fields as core_fields
 from nautobot.core.utils import lookup
@@ -1448,6 +1452,129 @@ class SearchFilterTest(TestCase, testing.NautobotTestCaseMixin):
 
             class InvalidLocationFilterSet(dcim_filters.LocationFilterSet):  # pylint: disable=unused-variable
                 q = filters.SearchFilter(filter_predicates={"asn": ["icontains"]})
+
+
+class LookupIsNullTest(TestCase, testing.NautobotTestCaseMixin):
+    """
+    Validate isnull is properly applied and filtering.
+    """
+
+    platform_queryset = dcim_models.Platform.objects.all()
+    platform_filterset = dcim_filters.PlatformFilterSet
+    circuit_queryset = Circuit.objects.all()
+    circuit_filterset = CircuitFilterSet
+    device_queryset = dcim_models.Device.objects.all()
+    device_filterset = dcim_filters.DeviceFilterSet
+
+    @classmethod
+    def setUpTestData(cls):
+        location_type = dcim_models.LocationType.objects.create(name="Location Type 1")
+        location_status = extras_models.Status.objects.get_for_model(dcim_models.Location).first()
+        location = dcim_models.Location.objects.create(
+            name="Location 1",
+            location_type=location_type,
+            status=location_status,
+        )
+        manufacturer = dcim_models.Manufacturer.objects.create(name="Manufacturer 1")
+        dcim_models.Platform.objects.create(name="Platform 1")
+        platform = dcim_models.Platform.objects.create(name="Platform 2", manufacturer=manufacturer)
+
+        device_type = dcim_models.DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model="Model 1",
+            is_full_depth=True,
+        )
+        device_role = extras_models.Role.objects.create(name="Active Test")
+        device_role.content_types.add(ContentType.objects.get_for_model(dcim_models.Device))
+
+        device_status = extras_models.Status.objects.get_for_model(dcim_models.Device).first()
+
+        dcim_models.Device.objects.create(
+            name="Device 1",
+            device_type=device_type,
+            role=device_role,
+            platform=platform,
+            location=location,
+            status=device_status,
+        )
+        dcim_models.Device.objects.create(
+            device_type=device_type,
+            role=device_role,
+            platform=platform,
+            location=location,
+            status=device_status,
+        )
+
+        provider = Provider.objects.create(name="provider 1", asn=1)
+        circuit_type = CircuitType.objects.create(name="Circuit Type 1")
+        circuit_status = extras_models.Status.objects.get_for_model(dcim_models.Location).first()
+
+        Circuit.objects.create(
+            cid="Circuit 1",
+            provider=provider,
+            install_date=datetime.date(2020, 1, 1),
+            commit_rate=1000,
+            circuit_type=circuit_type,
+            status=circuit_status,
+        )
+        Circuit.objects.create(
+            cid="Circuit 2",
+            provider=provider,
+            circuit_type=circuit_type,
+            status=circuit_status,
+        )
+
+    def test_isnull_on_fk(self):
+        """Test that the `isnull` filter is applied for True and False queries on foreign key fields."""
+        params = {"manufacturer__isnull": True}
+        self.assertQuerysetEqualAndNotEmpty(
+            dcim_filters.PlatformFilterSet(params, self.platform_queryset).qs,
+            dcim_models.Platform.objects.filter(manufacturer__isnull=True),
+        )
+        params = {"manufacturer__isnull": False}
+        self.assertQuerysetEqualAndNotEmpty(
+            dcim_filters.PlatformFilterSet(params, self.platform_queryset).qs,
+            dcim_models.Platform.objects.filter(manufacturer__isnull=False),
+        )
+
+    def test_isnull_on_integer(self):
+        """Test that the `isnull` filter is applied for True and False queries on integer fields."""
+        params = {"commit_rate__isnull": True}
+        self.assertQuerysetEqualAndNotEmpty(
+            CircuitFilterSet(params, self.circuit_queryset).qs,
+            Circuit.objects.filter(commit_rate__isnull=True),
+        )
+        params = {"commit_rate__isnull": False}
+        self.assertQuerysetEqualAndNotEmpty(
+            CircuitFilterSet(params, self.circuit_queryset).qs,
+            Circuit.objects.filter(commit_rate__isnull=False),
+        )
+
+    def test_isnull_on_date(self):
+        """Test that the `isnull` filter is applied for True and False queries on datetime fields."""
+        params = {"install_date__isnull": True}
+        self.assertQuerysetEqualAndNotEmpty(
+            CircuitFilterSet(params, self.circuit_queryset).qs,
+            Circuit.objects.filter(install_date__isnull=True),
+        )
+        params = {"install_date__isnull": False}
+        self.assertQuerysetEqualAndNotEmpty(
+            CircuitFilterSet(params, self.circuit_queryset).qs,
+            Circuit.objects.filter(install_date__isnull=False),
+        )
+
+    def test_isnull_on_char(self):
+        """Test that the `isnull` filter is applied for True and False queries on char fields."""
+        params = {"name__isnull": True}
+        self.assertQuerysetEqualAndNotEmpty(
+            dcim_filters.DeviceFilterSet(params, self.device_queryset).qs,
+            dcim_models.Device.objects.filter(name__isnull=True),
+        )
+        params = {"name__isnull": False}
+        self.assertQuerysetEqualAndNotEmpty(
+            dcim_filters.DeviceFilterSet(params, self.device_queryset).qs,
+            dcim_models.Device.objects.filter(name__isnull=False),
+        )
 
 
 class FilterTypeTest(TestCase):

--- a/nautobot/core/tests/test_openapi.py
+++ b/nautobot/core/tests/test_openapi.py
@@ -60,6 +60,9 @@ class OpenAPITest(TestCase):
         query_params = self.schema["paths"]["/dcim/devices/"]["get"]["parameters"]
         at_least_one_test = False
         for query_param_info in query_params:
+            if query_param_info["name"].endswith("_isnull"):
+                # The broad catch below does not apply to isnull, which will return a boolean.
+                continue
             if query_param_info["name"].startswith("device_redundancy_group_priority"):
                 self.assertEqual("array", query_param_info["schema"]["type"])
                 self.assertEqual("integer", query_param_info["schema"]["items"]["type"])

--- a/nautobot/core/tests/test_openapi.py
+++ b/nautobot/core/tests/test_openapi.py
@@ -41,6 +41,9 @@ class OpenAPITest(TestCase):
         query_params = self.schema["paths"]["/dcim/devices/"]["get"]["parameters"]
         at_least_one_test = False
         for query_param_info in query_params:
+            if query_param_info["name"].endswith("_isnull"):
+                # The broad catch below does not apply to isnull, which will return a boolean.
+                continue
             if query_param_info["name"].startswith("created") or query_param_info["name"].startswith("last_updated"):
                 self.assertEqual("array", query_param_info["schema"]["type"])
                 self.assertEqual("string", query_param_info["schema"]["items"]["type"])

--- a/nautobot/docs/user-guide/platform-functionality/rest-api/filtering.md
+++ b/nautobot/docs/user-guide/platform-functionality/rest-api/filtering.md
@@ -73,10 +73,28 @@ Custom fields can be mixed with built-in fields to further narrow results. When 
 
 ## Lookup Expressions
 
-Certain model fields (including, in Nautobot 1.4.0 and later, custom fields of type `text`, `url`, `select`, `integer`, and `date`) also support filtering using additional lookup expressions. This allows
-for negation and other context-specific filtering.
+Certain model fields (including, in Nautobot 1.4.0 and later, custom fields of type `text`, `url`, `select`, `integer`, and `date`) also support filtering using additional lookup expressions. This allows for negation and other context-specific filtering.
 
 These lookup expressions can be applied by adding a suffix to the desired field's name, e.g. `mac_address__n`. In this case, the filter expression is for negation and it is separated by two underscores. Below are the lookup expressions that are supported across different field types.
+
+### Nullable Fields
+
+The `isnull` lookup expression is automatically added when the following three conditions are met:
+
+1. A FilterSet that inherits `nautobot.apps.filters.BaseFilterSet`
+2. The model field is set to `Null = True`
+3. A model field that is or inherits from one of:
+    - `django.db.models.CharField`
+    - `django.db.models.DateField`
+    - `django.db.models.DecimalField`
+    - `django.db.models.ForeignKey`
+    - `django.db.models.FloatField`
+    - `django.db.models.IntegerField`
+    - `django.db.models.TextField`
+    - `django.db.models.UUIDField`
+
++/- 2.0.0
+    This feature was only added in Nautobot 2.0.0.
 
 ### Numeric Fields
 


### PR DESCRIPTION
# Closes: #1905
# What's Changed

Added the ability to automatically apply `isnull` filters when model field is nullable


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)

@glennmatthews I know we spoke about another approach, it quickly got complicated to consider what to do in various situations, such as an empty string vs null check on a char or 0 on an integer. This seemed to be a reasonable approach considering that it is basically 5 lines of code (not including comments, blackified spacing, tests, etc.), follows an established pattern, and works for plugins, api, graphql immediately. 

That being said, I didn't want to spend the time building tests without confirmation that this approach makes sense.  
