### PR TITLE
Fix #4377 - incorrect logic in Device and VirtualMachine API endpoints

### DIFF
--- a/changes/4377.fixed
+++ b/changes/4377.fixed
@@ -1,0 +1,2 @@
+Fixed incorrect OpenAPI schema for filters available on Device and VirtualMachine REST API endpoints.
+Fixed incorrect logic for queryset annotation on Device and VirtualMachine REST API views.

--- a/nautobot/core/tests/test_openapi.py
+++ b/nautobot/core/tests/test_openapi.py
@@ -1,0 +1,64 @@
+from drf_spectacular.renderers import OpenApiYamlRenderer
+from drf_spectacular.settings import spectacular_settings
+
+import yaml
+
+from nautobot.core.testing import TestCase
+
+
+class OpenAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        generator_class = spectacular_settings.DEFAULT_GENERATOR_CLASS
+        generator = generator_class()  # TODO: in future we may want to specify an `api_version=...` here
+        schema = generator.get_schema(request=None, public=True)
+        # We probably could stop here but let's round-trip it through the YAML renderer just for the heck of it
+        renderer = OpenApiYamlRenderer()
+        cls.binary_output = renderer.render(schema, renderer_context={})
+        cls.yaml_output = cls.binary_output.decode("utf-8")
+        cls.schema = yaml.safe_load(cls.yaml_output)
+
+    def test_filter_boolean_type(self):
+        """
+        Test that a boolean filter is correctly represented as a boolean.
+
+        Testing for regression of https://github.com/nautobot/nautobot/issues/4377.
+        """
+        query_params = self.schema["paths"]["/dcim/devices/"]["get"]["parameters"]
+        at_least_one_test = False
+        for query_param_info in query_params:
+            if query_param_info["name"].startswith("has_"):
+                self.assertEqual("boolean", query_param_info["schema"]["type"])
+                at_least_one_test = True
+        self.assertTrue(at_least_one_test)
+
+    def test_filter_datetime_type(self):
+        """
+        Test that a datetime filter is correctly represented as an array of date-time strings.
+
+        Testing for regression of https://github.com/nautobot/nautobot/issues/4377.
+        """
+        query_params = self.schema["paths"]["/dcim/devices/"]["get"]["parameters"]
+        at_least_one_test = False
+        for query_param_info in query_params:
+            if query_param_info["name"].startswith("created") or query_param_info["name"].startswith("last_updated"):
+                self.assertEqual("array", query_param_info["schema"]["type"])
+                self.assertEqual("string", query_param_info["schema"]["items"]["type"])
+                self.assertEqual("date-time", query_param_info["schema"]["items"]["format"])
+                at_least_one_test = True
+        self.assertTrue(at_least_one_test)
+
+    def test_filter_integer_type(self):
+        """
+        Test that an integer filter is correctly represented as an array of integers.
+
+        Testing for regression of https://github.com/nautobot/nautobot/issues/4377.
+        """
+        query_params = self.schema["paths"]["/dcim/devices/"]["get"]["parameters"]
+        at_least_one_test = False
+        for query_param_info in query_params:
+            if query_param_info["name"].startswith("device_redundancy_group_priority"):
+                self.assertEqual("array", query_param_info["schema"]["type"])
+                self.assertEqual("integer", query_param_info["schema"]["items"]["type"])
+                at_least_one_test = True
+        self.assertTrue(at_least_one_test)


### PR DESCRIPTION
# Closes: #4377
# What's Changed

- Because of the way `drf_spectacular` extensions work, they apply to a base class when specified (such as `NautobotFilterBackend`) but do **not** therefore automatically apply to subclasses of that base class (such as `ConfigContextFilterBackEnd`), which is why, as reported in #4377, the Device and VirtualMachine REST API endpoints (only) did not correctly list their filters in the OpenAPI schema, as these two were using `ConfigContextFilterBackend` rather than `NautobotFilterBackend`.
- I could have fixed this by adding an explicit drf_spectacular extension to `ConfigContextFilterBackend` itself, but as it turns out, after #3814 this class is no longer necessary; in fact it should have been deleted as a part of #3814 but was missed. Therefore I've deleted it.
- It turns out that there was another oversight in #3814 in adjacent code (`ConfigContextQuerySetMixin`) in this same file; this was still annotating the queryset with config-context data unless `?exclude=config_context` was present in the request, even though the logic elsewhere has been changed to omit the config-context unless `?include=config_context` is present. The impact of this error was that all Device/VM REST API queries were still taking the performance hit of calculating the config context, even though it generally wasn't actually included in the API response. I fixed this logic here and, using django-debug-toolbar, confirmed that the config-context annotations are only included in the SQL query now when `?include=config_context` is explicitly specified in the request.
- Add some basic regression tests against this portion of the OpenAPI schema; it would be good to flesh out this set of tests as and when we fix other schema inconsistencies over time.

![image](https://github.com/nautobot/nautobot/assets/5603551/bd8eb339-635c-4a35-af0c-e85c3480f2da)

![image](https://github.com/nautobot/nautobot/assets/5603551/bc29703a-409a-45c7-9900-96b7fad80853)

Note to @itdependsnetworks - it doesn't appear that this fixes the `face` filter to be enum-based as you reported was the case in 1.5.x - it's showing as an array-of-strings filter here:

![image](https://github.com/nautobot/nautobot/assets/5603551/ed785e5a-2709-4c37-8986-744a7bac2725)

Please feel free to file a followup issue if this one is considered problematic.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
