### PR TITLE
Fix Node.js deprecated install script

### DIFF
--- a/changes/4407.fixed
+++ b/changes/4407.fixed
@@ -1,0 +1,1 @@
+Fixed Dockerfile Node.js `setup_XX.x` [deprecated script](https://github.com/nodesource/distributions#new-update-%EF%B8%8F).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,25 +49,34 @@ ENV PYTHONUNBUFFERED=1 \
     NAUTOBOT_ROOT=/opt/nautobot \
     prometheus_multiproc_dir=/prom_cache
 
+ARG NODE_MAJOR=18
+
 # DL3008 - Require pinned dependencies for apt install
 # DL3009 - Delete the apt-get lists after installing something
-# DL3013 - pin all Python package versions
-# DL3042 - run pip install with --no-cache-dir (https://github.com/hadolint/hadolint/issues/497)
 # DL4006 - Set the SHELL option -o pipefail before RUN with a pipe in
-# hadolint ignore=DL3008,DL3009,DL3013,DL3042,DL4006
-RUN --mount=type=cache,target="/root/.cache/pip",sharing=locked \
+# hadolint ignore=DL3008,DL3009,DL4006
+RUN --mount=type=cache,target="/var/cache/apt",sharing=locked \
+    --mount=type=cache,target="/var/lib/apt/lists",sharing=locked \
+    apt-get update && \
+    apt-get install --no-install-recommends -y ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install --no-install-recommends -y git mime-support libxml2 libmariadb3 openssl nodejs && \
-    apt-get autoremove -y && \
-    apt-get clean all && \
-    rm -rf /var/lib/apt/lists/* && \
-    npm install -g npm@latest && \
-    rm -rf /root/.npm && \
-    pip install --upgrade pip wheel && \
-    rm -rf /tmp/tmp*
+    apt-get autoremove -y
+
+RUN --mount=type=cache,target="/root/.npm",sharing=locked \
+    npm install -g npm@latest
+
+# DL3013 - pin all Python package versions
+# DL3042 - run pip install with --no-cache-dir (https://github.com/hadolint/hadolint/issues/497)
+# hadolint ignore=DL3013,DL3042
+RUN --mount=type=cache,target="/root/.cache/pip",sharing=locked \
+    --mount=type=cache,target="/tmp",sharing=locked \
+    pip install --upgrade pip wheel
 
 HEALTHCHECK --interval=5s --timeout=5s --start-period=5s --retries=1 CMD curl --fail http://localhost:8080/health/ || exit 1
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,6 @@ RUN --mount=type=cache,target="/var/cache/apt",sharing=locked \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y curl && \
     apt-get install --no-install-recommends -y git mime-support libxml2 libmariadb3 openssl nodejs && \
     apt-get autoremove -y
 


### PR DESCRIPTION
# Closes: NaN

## What's Changed

- Fixed Dockerfile Node.js `setup_XX.x` [deprecated script](https://github.com/nodesource/distributions#new-update-%EF%B8%8F).
- Split Dockerfile RUN into separate apt, npm and pip instructions for better readability.

## Justification

There was 1 minute timeout during container build:

```
#12 14.37 ================================================================================
#12 14.37 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
#12 14.37 ================================================================================
#12 14.37 
#12 14.37                            SCRIPT DEPRECATION WARNING                    
#12 14.37 
#12 14.37   
#12 14.37   This script, located at https://deb.nodesource.com/setup_X, used to
#12 14.37   install Node.js is deprecated now and will eventually be made inactive.
#12 14.37 
#12 14.37   Please visit the NodeSource distributions Github and follow the
#12 14.37   instructions to migrate your repo.
#12 14.37   https://github.com/nodesource/distributions
#12 14.37 
#12 14.37   The NodeSource Node.js Linux distributions GitHub repository contains
#12 14.37   information about which versions of Node.js and which Linux distributions
#12 14.37   are supported and how to install it.
#12 14.37   https://github.com/nodesource/distributions
#12 14.37 
#12 14.37 
#12 14.37                           SCRIPT DEPRECATION WARNING
#12 14.37 
#12 14.37 ================================================================================
#12 14.37 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
#12 14.37 ================================================================================
#12 14.37 
#12 14.37 TO AVOID THIS WAIT MIGRATE THE SCRIPT
#12 14.37 Continuing in 60 seconds (press Ctrl-C to abort) ...
#12 14.37 
#12 74.37 
#12 74.37 ## Installing the NodeSource Node.js 18.x repo...
```
