### PR TITLE
Fixed a bug that makes ConfigContexts applied to parent locations missing from rendered config context of child location Devices/Virtual Machines.

### DIFF
--- a/changes/4388.fixed
+++ b/changes/4388.fixed
@@ -1,0 +1,1 @@
+Fixed a bug that makes ConfigContexts applied to parent locations missing from rendered config context of child location Devices/Virtual Machines.

--- a/nautobot/docs/user-guide/core-data-model/extras/configcontext.md
+++ b/nautobot/docs/user-guide/core-data-model/extras/configcontext.md
@@ -67,6 +67,9 @@ When the context data for a device at this location is rendered, the second, hig
 
 Data from the higher-weight context overwrites conflicting data from the lower-weight context, while the non-conflicting portion of the lower-weight context (the list of NTP servers) is preserved.
 
+!!! warning
+    ConfigContexts can be applied to parents and descendants of TreeModels such as Locations and RackGroups. The inheritance of ConfigContext will always be determined by the value of the weight attribute. You may see unexpected behavior if you have ConfigContext of the same weight applied to the parents and the descendants of TreeModels.
+
 ## Local Context Data
 
 Devices and virtual machines may also have a local config context defined. This local context will _always_ take precedence over any separate config context objects which apply to the device/VM. This is useful in situations where we need to call out a specific deviation in the data for a particular object.

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -205,12 +205,12 @@ class ConfigContextModel(models.Model, ConfigContextSchemaValidationMixin):
             location_config_context_queryset = ConfigContext.objects.none()
             if self._meta.model_name == "device":
                 location_config_context_queryset = ConfigContext.objects.filter(
-                    Q(locations__in=self.location.ancestors(include_self=True))
+                    locations__in=self.location.ancestors(include_self=True)
                 ).distinct()
             else:
                 if self.cluster and self.cluster.location:
                     location_config_context_queryset = ConfigContext.objects.filter(
-                        Q(locations__in=self.cluster.location.ancestors(include_self=True))
+                        locations__in=self.cluster.location.ancestors(include_self=True)
                     ).distinct()
 
             # Annotation has keys "weight" and "name" (used for ordering) and "data" (the actual config context data)

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -204,12 +204,12 @@ class ConfigContextModel(models.Model, ConfigContextSchemaValidationMixin):
             # We append the missing parent location query here as a patch.
             if self._meta.model_name == "device":
                 location_config_context_queryset = ConfigContext.objects.filter(
-                    Q(locations__in=self.location.ancestors(include_self=True)) | Q(locations=None),
+                    Q(locations__in=self.location.ancestors(include_self=True))
                 ).distinct()
             else:
                 if self.cluster:
                     location_config_context_queryset = ConfigContext.objects.filter(
-                        Q(locations__in=self.cluster.location.ancestors(include_self=True)) | Q(locations=None),
+                        Q(locations__in=self.cluster.location.ancestors(include_self=True))
                     ).distinct()
 
             # Annotation has keys "weight" and "name" (used for ordering) and "data" (the actual config context data)

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -9,6 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models import Q
 from django.http import HttpResponse
 from graphene_django.settings import graphene_settings
 from graphql import get_default_backend
@@ -196,7 +197,24 @@ class ConfigContextModel(models.Model, ConfigContextSchemaValidationMixin):
             config_context_data = ConfigContext.objects.get_for_object(self).values_list("data", flat=True)
         else:
             config_context_data = self.config_context_data or []
+            # Device and VirtualMachine's Location has its own ConfigContext and its parent Locations' ConfigContext, if any, should
+            # also be applied. However, since moving from mptt to django-tree-queries https://github.com/nautobot/nautobot/issues/510,
+            # we lost the ability to query the ancestors for a particular tree node for subquery https://github.com/matthiask/django-tree-queries/issues/54.
+            # So instead of constructing the location related query in ConfigContextModelQueryset._get_config_context_filters(), which is complicated across databases
+            # We append the missing parent location query here as a patch.
+            if self._meta.model_name == "device":
+                location_config_context_queryset = ConfigContext.objects.filter(
+                    Q(locations__in=self.location.ancestors(include_self=True)) | Q(locations=None),
+                ).distinct()
+            else:
+                if self.cluster:
+                    location_config_context_queryset = ConfigContext.objects.filter(
+                        Q(locations__in=self.cluster.location.ancestors(include_self=True)) | Q(locations=None),
+                    ).distinct()
+
             # Annotation has keys "weight" and "name" (used for ordering) and "data" (the actual config context data)
+            for cc in location_config_context_queryset:
+                config_context_data.append({"data": cc.data, "name": cc.name, "weight": cc.weight})
             config_context_data = [
                 c["data"] for c in sorted(config_context_data, key=lambda k: (k["weight"], k["name"]))
             ]

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -9,7 +9,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Q
 from django.http import HttpResponse
 from graphene_django.settings import graphene_settings
 from graphql import get_default_backend

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -202,12 +202,13 @@ class ConfigContextModel(models.Model, ConfigContextSchemaValidationMixin):
             # we lost the ability to query the ancestors for a particular tree node for subquery https://github.com/matthiask/django-tree-queries/issues/54.
             # So instead of constructing the location related query in ConfigContextModelQueryset._get_config_context_filters(), which is complicated across databases
             # We append the missing parent location query here as a patch.
+            location_config_context_queryset = ConfigContext.objects.none()
             if self._meta.model_name == "device":
                 location_config_context_queryset = ConfigContext.objects.filter(
                     Q(locations__in=self.location.ancestors(include_self=True))
                 ).distinct()
             else:
-                if self.cluster:
+                if self.cluster and self.cluster.location:
                     location_config_context_queryset = ConfigContext.objects.filter(
                         Q(locations__in=self.cluster.location.ancestors(include_self=True))
                     ).distinct()

--- a/nautobot/extras/querysets.py
+++ b/nautobot/extras/querysets.py
@@ -83,6 +83,9 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
 
         Order By clause in Subquery is not guaranteed to be respected within the aggregated JSON array, which is why
         we include "weight" and "name" into the result so that we can sort it within Python to ensure correctness.
+
+        TODO This method is broken because of the reasons stated in _get_config_context_filters()
+        Do not use this method by itself, use get_config_context() method directly on ConfigContextModel instead.
         """
         from nautobot.extras.models import ConfigContext
 

--- a/nautobot/extras/querysets.py
+++ b/nautobot/extras/querysets.py
@@ -104,7 +104,12 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
         ).distinct()
 
     def _get_config_context_filters(self):
-        # Construct the set of Q objects for the specific object types
+        """
+        This method is constructing the set of Q objects for the specific object types.
+        NOTE that locations filters are not included in the method because the filter needs the
+        ability to query the ancestors for a particular tree node for subquery and we lost it since
+        moving from mptt to django-tree-queries https://github.com/matthiask/django-tree-queries/issues/54.
+        """
         tag_query_filters = {
             "object_id": OuterRef(OuterRef("pk")),
             "content_type__app_label": self.model._meta.app_label,

--- a/nautobot/extras/querysets.py
+++ b/nautobot/extras/querysets.py
@@ -127,6 +127,11 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
                 (Q(device_redundancy_groups=OuterRef("device_redundancy_group")) | Q(device_redundancy_groups=None)),
                 Q.AND,
             )
+            # This is necessary to prevent location related config context to be applied now.
+            base_query.add((Q(locations=None)), Q.AND)
+        elif self.model._meta.model_name == "virtualmachine":
+            # This is necessary to prevent location related config context to be applied now.
+            base_query.add((Q(locations=None)), Q.AND)
 
         return base_query
 

--- a/nautobot/extras/querysets.py
+++ b/nautobot/extras/querysets.py
@@ -84,7 +84,7 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
         Order By clause in Subquery is not guaranteed to be respected within the aggregated JSON array, which is why
         we include "weight" and "name" into the result so that we can sort it within Python to ensure correctness.
 
-        TODO This method is broken because of the reasons stated in _get_config_context_filters()
+        TODO This method does not accurately reflect location inheritance because of the reasons stated in _get_config_context_filters()
         Do not use this method by itself, use get_config_context() method directly on ConfigContextModel instead.
         """
         from nautobot.extras.models import ConfigContext

--- a/nautobot/extras/querysets.py
+++ b/nautobot/extras/querysets.py
@@ -106,7 +106,7 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
     def _get_config_context_filters(self):
         """
         This method is constructing the set of Q objects for the specific object types.
-        NOTE that locations filters are not included in the method because the filter needs the
+        Note that locations filters are not included in the method because the filter needs the
         ability to query the ancestors for a particular tree node for subquery and we lost it since
         moving from mptt to django-tree-queries https://github.com/matthiask/django-tree-queries/issues/54.
         """
@@ -133,9 +133,11 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
                 Q.AND,
             )
             # This is necessary to prevent location related config context to be applied now.
+            # The location hierarchy cannot be processed by the database and must be added by `ConfigContextModel.get_config_context`
             base_query.add((Q(locations=None)), Q.AND)
         elif self.model._meta.model_name == "virtualmachine":
             # This is necessary to prevent location related config context to be applied now.
+            # The location hierarchy cannot be processed by the database and must be added by `ConfigContextModel.get_config_context`
             base_query.add((Q(locations=None)), Q.AND)
 
         return base_query

--- a/nautobot/extras/querysets.py
+++ b/nautobot/extras/querysets.py
@@ -127,10 +127,6 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
                 (Q(device_redundancy_groups=OuterRef("device_redundancy_group")) | Q(device_redundancy_groups=None)),
                 Q.AND,
             )
-            base_query.add((Q(locations=OuterRef("location")) | Q(locations=None)), Q.AND)
-
-        elif self.model._meta.model_name == "virtualmachine":
-            base_query.add((Q(locations=OuterRef("cluster__location")) | Q(locations=None)), Q.AND)
 
         return base_query
 

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -298,11 +298,11 @@ class ConfigContextTest(ModelTestCases.BaseModelTestCase):
             self.assertIn(key, device_context)
 
     def test_annotation_same_as_get_for_object_device_relations_in_child_locations(self):
-        location_context = ConfigContext.objects.create(name="root-location", weight=100, data={"location": 1})
+        location_context = ConfigContext.objects.create(name="root-location", weight=100, data={"location-1": 1})
         location_context.locations.add(self.root_location)
-        location_context = ConfigContext.objects.create(name="parent-location", weight=100, data={"location": 2})
+        location_context = ConfigContext.objects.create(name="parent-location", weight=100, data={"location-2": 2})
         location_context.locations.add(self.parent_location)
-        location_context = ConfigContext.objects.create(name="location", weight=100, data={"location": 3})
+        location_context = ConfigContext.objects.create(name="location", weight=100, data={"location-3": 3})
         location_context.locations.add(self.location)
         device = Device.objects.create(
             name="Child Location Device",
@@ -311,10 +311,8 @@ class ConfigContextTest(ModelTestCases.BaseModelTestCase):
             status=self.device_status,
             device_type=self.devicetype,
         )
-        annotated_queryset = Device.objects.filter(name=device.name).annotate_config_context_data()
         device_context = device.get_config_context()
-        self.assertEqual(device_context, annotated_queryset[0].get_config_context())
-        for key in ["location"]:
+        for key in ["location-1", "location-2", "location-3"]:
             self.assertIn(key, device_context)
 
     def test_annotation_same_as_get_for_object_virtualmachine_relations(self):
@@ -375,18 +373,14 @@ class ConfigContextTest(ModelTestCases.BaseModelTestCase):
             self.assertIn(key, vm_context)
 
     def test_annotation_same_as_get_for_object_virtualmachine_relations_in_child_locations(self):
-        location_context = ConfigContext.objects.create(name="root-location", weight=100, data={"location": 1})
+        location_context = ConfigContext.objects.create(name="root-location", weight=100, data={"location-1": 1})
         location_context.locations.add(self.root_location)
-        location_context = ConfigContext.objects.create(name="parent-location", weight=100, data={"location": 2})
+        location_context = ConfigContext.objects.create(name="parent-location", weight=100, data={"location-2": 2})
         location_context.locations.add(self.parent_location)
-        location_context = ConfigContext.objects.create(name="location", weight=100, data={"location": 3})
+        location_context = ConfigContext.objects.create(name="location", weight=100, data={"location-3": 3})
         location_context.locations.add(self.location)
         vm_status = Status.objects.get_for_model(VirtualMachine).first()
         cluster_group = ClusterGroup.objects.create(name="Cluster Group")
-        cluster_group_context = ConfigContext.objects.create(
-            name="cluster group", weight=100, data={"cluster_group": 1}
-        )
-        cluster_group_context.cluster_groups.add(cluster_group)
         cluster_type = ClusterType.objects.create(name="Cluster Type 1")
         cluster = Cluster.objects.create(
             name="Cluster",
@@ -400,13 +394,11 @@ class ConfigContextTest(ModelTestCases.BaseModelTestCase):
             role=self.devicerole,
             status=vm_status,
         )
-        annotated_queryset = VirtualMachine.objects.filter(name=virtual_machine.name).annotate_config_context_data()
         vm_context = virtual_machine.get_config_context()
-
-        self.assertEqual(vm_context, annotated_queryset[0].get_config_context())
         for key in [
-            "location",
-            "cluster_group",
+            "location-1",
+            "location-2",
+            "location-3",
         ]:
             self.assertIn(key, vm_context)
 

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -176,9 +176,19 @@ class ConfigContextTest(ModelTestCases.BaseModelTestCase):
         manufacturer = Manufacturer.objects.first()
         cls.devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="Device Type 1")
         cls.devicerole = Role.objects.get_for_model(Device).first()
-        location_type = LocationType.objects.create(name="Location Type 1")
+        root_location_type = LocationType.objects.create(name="Root Location Type")
+        parent_location_type = LocationType.objects.create(name="Parent Location Type", parent=root_location_type)
+        location_type = LocationType.objects.create(name="Location Type 1", parent=parent_location_type)
         location_status = Status.objects.get_for_model(Location).first()
-        cls.location = Location.objects.create(name="Location 1", location_type=location_type, status=location_status)
+        cls.root_location = Location.objects.create(
+            name="Root Location", location_type=root_location_type, status=location_status
+        )
+        cls.parent_location = Location.objects.create(
+            name="Parent Location", location_type=parent_location_type, status=location_status, parent=cls.root_location
+        )
+        cls.location = Location.objects.create(
+            name="Location 1", location_type=location_type, status=location_status, parent=cls.parent_location
+        )
         cls.platform = Platform.objects.first()
         cls.tenant = Tenant.objects.first()
         cls.tenantgroup = cls.tenant.tenant_group
@@ -287,6 +297,26 @@ class ConfigContextTest(ModelTestCases.BaseModelTestCase):
         for key in ["location", "platform", "tenant_group", "tenant", "tag", "dynamic_group"]:
             self.assertIn(key, device_context)
 
+    def test_annotation_same_as_get_for_object_device_relations_in_child_locations(self):
+        location_context = ConfigContext.objects.create(name="root-location", weight=100, data={"location": 1})
+        location_context.locations.add(self.root_location)
+        location_context = ConfigContext.objects.create(name="parent-location", weight=100, data={"location": 2})
+        location_context.locations.add(self.parent_location)
+        location_context = ConfigContext.objects.create(name="location", weight=100, data={"location": 3})
+        location_context.locations.add(self.location)
+        device = Device.objects.create(
+            name="Child Location Device",
+            location=self.location,
+            role=self.devicerole,
+            status=self.device_status,
+            device_type=self.devicetype,
+        )
+        annotated_queryset = Device.objects.filter(name=device.name).annotate_config_context_data()
+        device_context = device.get_config_context()
+        self.assertEqual(device_context, annotated_queryset[0].get_config_context())
+        for key in ["location"]:
+            self.assertIn(key, device_context)
+
     def test_annotation_same_as_get_for_object_virtualmachine_relations(self):
         location_context = ConfigContext.objects.create(name="location", weight=100, data={"location": 1})
         location_context.locations.add(self.location)
@@ -341,6 +371,42 @@ class ConfigContextTest(ModelTestCases.BaseModelTestCase):
             "cluster_group",
             "cluster",
             "vm_dynamic_group",
+        ]:
+            self.assertIn(key, vm_context)
+
+    def test_annotation_same_as_get_for_object_virtualmachine_relations_in_child_locations(self):
+        location_context = ConfigContext.objects.create(name="root-location", weight=100, data={"location": 1})
+        location_context.locations.add(self.root_location)
+        location_context = ConfigContext.objects.create(name="parent-location", weight=100, data={"location": 2})
+        location_context.locations.add(self.parent_location)
+        location_context = ConfigContext.objects.create(name="location", weight=100, data={"location": 3})
+        location_context.locations.add(self.location)
+        vm_status = Status.objects.get_for_model(VirtualMachine).first()
+        cluster_group = ClusterGroup.objects.create(name="Cluster Group")
+        cluster_group_context = ConfigContext.objects.create(
+            name="cluster group", weight=100, data={"cluster_group": 1}
+        )
+        cluster_group_context.cluster_groups.add(cluster_group)
+        cluster_type = ClusterType.objects.create(name="Cluster Type 1")
+        cluster = Cluster.objects.create(
+            name="Cluster",
+            cluster_group=cluster_group,
+            cluster_type=cluster_type,
+            location=self.location,
+        )
+        virtual_machine = VirtualMachine.objects.create(
+            name="Child Location VM",
+            cluster=cluster,
+            role=self.devicerole,
+            status=vm_status,
+        )
+        annotated_queryset = VirtualMachine.objects.filter(name=virtual_machine.name).annotate_config_context_data()
+        vm_context = virtual_machine.get_config_context()
+
+        self.assertEqual(vm_context, annotated_queryset[0].get_config_context())
+        for key in [
+            "location",
+            "cluster_group",
         ]:
             self.assertIn(key, vm_context)
 

--- a/nautobot/ui/package-lock.json
+++ b/nautobot/ui/package-lock.json
@@ -103,9 +103,9 @@
             }
         },
         "node_modules/@adobe/css-tools": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
-            "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA=="
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+            "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg=="
         },
         "node_modules/@alloc/quick-lru": {
             "version": "5.2.0",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4388 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

The root cause of the issue is in `ConfigContextModelQuerySet._get_config_context_filters()`. The function only takes into account the location that the Device/VM is in and not its parent locations. Device and VirtualMachine's Location has its own ConfigContext and its parent Locations' ConfigContext, if any, should
also be applied. However, since moving from `mptt` to `django-tree-queries `https://github.com/nautobot/nautobot/issues/510, we lost the ability to query the ancestors for a particular tree node for subquery https://github.com/matthiask/django-tree-queries/issues/54.
So instead of constructing the location-related query in `ConfigContextModelQueryset._get_config_context_filters()` with `OuterRef` and `Subquery`, which is complicated if not impossible across multiple databases. We append the location query process in `ConfigContextModel.get_config_context()` as a patch.
![Screen Shot 2023-09-07 at 5 13 18 PM](https://github.com/nautobot/nautobot/assets/46973263/efeb27c7-d554-4c32-b582-006bbf656308)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
