### PR TITLE
Implemented `.natural_slug` property on all models that inherit from `BaseModel`.

### DIFF
--- a/changes/4346.added
+++ b/changes/4346.added
@@ -1,0 +1,1 @@
+Implemented `.natural_slug` property on all models.

--- a/nautobot/core/api/metadata.py
+++ b/nautobot/core/api/metadata.py
@@ -196,7 +196,7 @@ class NautobotMetadata(SimpleMetadata):
     """
 
     view_serializer = None
-    advanced_tab_fields = ["id", "url", "object_type", "composite_key", "created", "last_updated"]
+    advanced_tab_fields = ["id", "url", "object_type", "composite_key", "created", "last_updated", "natural_slug"]
 
     def determine_actions(self, request, view):
         """Generate the actions and return the names of the allowed methods."""

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -24,9 +24,9 @@ from nautobot.core.api.utils import (
     dict_to_filter_params,
     nested_serializer_factory,
 )
-from nautobot.core.models.constants import COMPOSITE_KEY_SEPARATOR
+from nautobot.core.models.constants import NATURAL_SLUG_SEPARATOR
 from nautobot.core.models.managers import TagsManager
-from nautobot.core.models.utils import construct_composite_key
+from nautobot.core.models.utils import construct_natural_slug
 from nautobot.core.utils.lookup import get_route_for_model
 from nautobot.core.utils.requests import normalize_querydict
 from nautobot.extras.api.relationships import RelationshipsDataField
@@ -121,7 +121,7 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializ
 
     display = serializers.SerializerMethodField(read_only=True, help_text="Human friendly display value")
     object_type = ObjectTypeField()
-    composite_key = serializers.SerializerMethodField()
+    natural_slug = serializers.SerializerMethodField()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -144,12 +144,12 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializ
     @extend_schema_field(
         {
             "type": "string",
-            "example": COMPOSITE_KEY_SEPARATOR.join(["attribute1", "attribute2"]),
+            "example": NATURAL_SLUG_SEPARATOR.join(["attribute1", "attribute2"]),
         }
     )
-    def get_composite_key(self, instance):
+    def get_natural_slug(self, instance):
         try:
-            return getattr(instance, "composite_key", construct_composite_key(instance.natural_key()))
+            return getattr(instance, "natural_slug", construct_natural_slug(instance.natural_key(), pk=instance.pk))
         except (AttributeError, NotImplementedError):
             return "unknown"
 

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -24,9 +24,9 @@ from nautobot.core.api.utils import (
     dict_to_filter_params,
     nested_serializer_factory,
 )
-from nautobot.core.models.constants import NATURAL_SLUG_SEPARATOR
+from nautobot.core.models import constants
 from nautobot.core.models.managers import TagsManager
-from nautobot.core.models.utils import construct_natural_slug
+from nautobot.core.models.utils import construct_composite_key, construct_natural_slug
 from nautobot.core.utils.lookup import get_route_for_model
 from nautobot.core.utils.requests import normalize_querydict
 from nautobot.extras.api.relationships import RelationshipsDataField
@@ -121,6 +121,7 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializ
 
     display = serializers.SerializerMethodField(read_only=True, help_text="Human friendly display value")
     object_type = ObjectTypeField()
+    composite_key = serializers.SerializerMethodField()
     natural_slug = serializers.SerializerMethodField()
 
     def __init__(self, *args, **kwargs):
@@ -141,10 +142,24 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializ
         """
         return getattr(instance, "display", str(instance))
 
+    # TODO(jathan): Rip out composite key after natural key fields for import/export work has been
+    # completed (See: https://github.com/nautobot/nautobot/issues/4367)
     @extend_schema_field(
         {
             "type": "string",
-            "example": NATURAL_SLUG_SEPARATOR.join(["attribute1", "attribute2"]),
+            "example": constants.COMPOSITE_KEY_SEPARATOR.join(["attribute1", "attribute2"]),
+        }
+    )
+    def get_composite_key(self, instance):
+        try:
+            return getattr(instance, "composite_key", construct_composite_key(instance.natural_key()))
+        except (AttributeError, NotImplementedError):
+            return "unknown"
+
+    @extend_schema_field(
+        {
+            "type": "string",
+            "example": constants.NATURAL_SLUG_SEPARATOR.join(["attribute1", "attribute2"]),
         }
     )
     def get_natural_slug(self, instance):

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -153,7 +153,8 @@ class BaseModel(models.Model):
     def natural_slug(self) -> str:
         """
         Automatic "slug" string derived from this model's natural key. This differs from composite
-        key in that it must human-readable and therefore lossy. This value is not guaranteed to be
+        key in that it must be human-readable and comply with a very limited character set, and is therefore lossy.
+        This value is not guaranteed to be
         unique although a best effort is made by appending a fragment of the primary key to the
         natural slug value.
         """

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -20,7 +20,7 @@ __all__ = (
     "CompositeKeyQuerySetMixin",
     "RestrictedQuerySet",
     "construct_composite_key",
-    "construct_natural_key",
+    "construct_natural_slug",
     "deconstruct_composite_key",
 )
 

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -20,6 +20,7 @@ __all__ = (
     "CompositeKeyQuerySetMixin",
     "RestrictedQuerySet",
     "construct_composite_key",
+    "construct_natural_key",
     "deconstruct_composite_key",
 )
 
@@ -153,9 +154,10 @@ class BaseModel(models.Model):
         """
         Automatic "slug" string derived from this model's natural key. This differs from composite
         key in that it must human-readable and therefore lossy. This value is not guaranteed to be
-        unique.
+        unique although a best effort is made by appending a fragment of the primary key to the
+        natural slug value.
         """
-        return construct_natural_slug(self.natural_key())
+        return construct_natural_slug(self.natural_key(), pk=self.pk)
 
     @classproperty  # https://github.com/PyCQA/pylint-django/issues/240
     def natural_key_field_lookups(cls):  # pylint: disable=no-self-argument

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -11,7 +11,7 @@ from django.utils.functional import classproperty
 
 from nautobot.core.models.managers import BaseManager
 from nautobot.core.models.querysets import CompositeKeyQuerySetMixin, RestrictedQuerySet
-from nautobot.core.models.utils import construct_composite_key, deconstruct_composite_key
+from nautobot.core.models.utils import construct_composite_key, construct_natural_slug, deconstruct_composite_key
 from nautobot.core.utils.lookup import get_route_for_model
 
 __all__ = (
@@ -147,6 +147,15 @@ class BaseModel(models.Model):
         A less naïve implementation than django-natural-keys provides by default, based around URL percent-encoding.
         """
         return construct_composite_key(self.natural_key())
+
+    @property
+    def natural_slug(self) -> str:
+        """
+        Automatic "slug" string derived from this model's natural key. This differs from composite
+        key in that it must human-readable and therefore lossy. This value is not guaranteed to be
+        unique.
+        """
+        return construct_natural_slug(self.natural_key())
 
     @classproperty  # https://github.com/PyCQA/pylint-django/issues/240
     def natural_key_field_lookups(cls):  # pylint: disable=no-self-argument

--- a/nautobot/core/models/constants.py
+++ b/nautobot/core/models/constants.py
@@ -11,3 +11,6 @@
 # 3. Safe in a URL query string component (so that we can do URLs like "/dcim/devices/?location=<composite_key>"
 #    This rules out "&" and "="
 COMPOSITE_KEY_SEPARATOR = ";"
+
+# For the natural slug separator, it's much simpler and we can just go with "_".
+NATURAL_SLUG_SEPARATOR = "_"

--- a/nautobot/core/models/utils.py
+++ b/nautobot/core/models/utils.py
@@ -9,6 +9,7 @@ from django.core.serializers import serialize
 from django.utils.tree import Node
 
 from nautobot.core.models.constants import COMPOSITE_KEY_SEPARATOR
+from nautobot.core.models.fields import slugify_dots_to_dashes
 
 
 def array_to_string(array):
@@ -203,3 +204,22 @@ def deconstruct_composite_key(composite_key):
     values = [unquote_plus(value) for value in composite_key.split(COMPOSITE_KEY_SEPARATOR)]
     values = [value if value != "\0" else None for value in values]
     return values
+
+
+def construct_natural_slug(values):
+    """
+    Convert the given list of natural key values to a single human-readable string.
+
+    Django's built-in lossy `slugify()` function is used to convert each natural key value to a
+    slug, and then they are joined with an underscore.
+
+    - Spaces or repeated dashes are converted to single dashes.
+    - Remove characters that are not alphanumerics, underscores, or hyphens.
+    - Converted to lowercase.
+    - Strips leading/trailing whitespace, dashes, and underscores.
+    - Each natural key value in the list is separated by underscores.
+
+    This value is not reversible, lossy, and is not guaranteed to be unique.
+    """
+    values = [str(value) if value is not None else "\0" for value in values]
+    return "_".join(slugify_dots_to_dashes(value) for value in values)

--- a/nautobot/core/models/utils.py
+++ b/nautobot/core/models/utils.py
@@ -10,7 +10,8 @@ from django.utils.tree import Node
 import emoji
 from slugify import slugify
 
-from nautobot.core.models.constants import COMPOSITE_KEY_SEPARATOR
+from nautobot.core.models import constants
+from nautobot.core.utils.data import is_uuid
 
 
 def array_to_string(array):
@@ -189,7 +190,7 @@ def construct_composite_key(values):
     # . and : are generally "safe enough" to use in URL parameters, and are common in some natural key fields,
     # so we don't quote them by default (although `deconstruct_composite_key` will work just fine if you do!)
     # / is a bit trickier to handle in URL paths, so for now we *do* quote it, even though it appears in IPAddress, etc.
-    values = COMPOSITE_KEY_SEPARATOR.join(quote_plus(value, safe=".:") for value in values)
+    values = constants.COMPOSITE_KEY_SEPARATOR.join(quote_plus(value, safe=".:") for value in values)
     return values
 
 
@@ -202,14 +203,17 @@ def deconstruct_composite_key(composite_key):
 
     Inverse operation of `construct_composite_key()`.
     """
-    values = [unquote_plus(value) for value in composite_key.split(COMPOSITE_KEY_SEPARATOR)]
+    values = [unquote_plus(value) for value in composite_key.split(constants.COMPOSITE_KEY_SEPARATOR)]
     values = [value if value != "\0" else None for value in values]
     return values
 
 
-def construct_natural_slug(values):
+def construct_natural_slug(values, pk=None):
     """
-    Convert the given list of natural key values to a single human-readable string.
+    Convert the given list of natural key `values` to a single human-readable string.
+
+    If `pk` is provided, it will be appended to the end of the natural slug. If the PK is a UUID,
+    only the first four characters will be appended.
 
     A third-party lossy `slugify()` function is used to convert each natural key value to a
     slug, and then they are joined with an underscore.
@@ -224,6 +228,19 @@ def construct_natural_slug(values):
 
     This value is not reversible, lossy, and is not guaranteed to be unique.
     """
-    values = [str(value) if value is not None else "\0" for value in values]
-    # This attempts to replace any emojis with their string name, and then slugify that.
-    return "_".join(slugify(emoji.replace_emoji(value, unicodedata.name)) for value in values)
+    # In some cases the natural key might not be a list.
+    if isinstance(values, tuple):
+        values = list(values)
+
+    # If a pk is passed through, append it to the values.
+    if pk is not None:
+        pk = str(pk)
+        # Keep the first 4 characters of the UUID.
+        if is_uuid(pk):
+            pk = pk[:4]
+        values.append(pk)
+
+    values = (str(value) if value is not None else "\0" for value in values)
+    # Replace any emojis with their string name, and then slugify that.
+    values = (slugify(emoji.replace_emoji(value, unicodedata.name)) for value in values)
+    return constants.NATURAL_SLUG_SEPARATOR.join(values)

--- a/nautobot/core/models/utils.py
+++ b/nautobot/core/models/utils.py
@@ -226,7 +226,7 @@ def construct_natural_slug(values, pk=None):
     - Each natural key value in the list is separated by underscores.
     - Emojis will be converted to their registered name.
 
-    This value is not reversible, lossy, and is not guaranteed to be unique.
+    This value is not reversible, is lossy, and is not guaranteed to be unique.
     """
     # In some cases the natural key might not be a list.
     if isinstance(values, tuple):

--- a/nautobot/core/models/utils.py
+++ b/nautobot/core/models/utils.py
@@ -215,7 +215,8 @@ def construct_natural_slug(values):
     slug, and then they are joined with an underscore.
 
     - Spaces or repeated dashes are converted to single dashes.
-    - Remove characters that are not alphanumerics, underscores, or hyphens.
+    - Accents and ligatures from Unicode characters are reduced to ASCII.
+    - Remove remaining characters that are not alphanumerics, underscores, or hyphens.
     - Converted to lowercase.
     - Strips leading/trailing whitespace, dashes, and underscores.
     - Each natural key value in the list is separated by underscores.

--- a/nautobot/core/templates/inc/object_details_advanced_panel.html
+++ b/nautobot/core/templates/inc/object_details_advanced_panel.html
@@ -16,13 +16,13 @@
                         </span>
                     </td>
                 </tr>
-                {% if object.composite_key %}
+                {% if object.natural_slug %}
                     <tr>
-                        <td>Composite Key</td>
+                        <td>Natural Slug</td>
                         <td>
                             <span class="hover_copy">
-                                <span id="composite_key_copy">{{ object.composite_key }}</span>
-                                <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#composite_key_copy">
+                                <span id="natural_slug_copy">{{ object.natural_slug }}</span>
+                                <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#natural_slug_copy">
                                     <span class="mdi mdi-content-copy"></span>
                                 </button>
                             </span>

--- a/nautobot/core/testing/api.py
+++ b/nautobot/core/testing/api.py
@@ -139,6 +139,7 @@ class APIViewTestCases:
             self.assertEqual(str(response.data["id"]), str(instance1.pk))  # coerce to str to handle both int and uuid
             self.assertIn("url", response.data)
             self.assertIn("display", response.data)
+            self.assertIn("natural_slug", response.data)
             self.assertIsInstance(response.data["display"], str)
             # Fields that should be present in appropriate model serializers:
             if issubclass(self.model, extras_models.ChangeLoggedModel):

--- a/nautobot/core/tests/test_models.py
+++ b/nautobot/core/tests/test_models.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 
 from unittest.mock import patch
 
@@ -41,6 +42,8 @@ class ModelUtilsTestCase(TestCase):
 
     def test_construct_natural_slug(self):
         """Test that `construct_natural_slug()` works as expected."""
+        pk = uuid.uuid4()
+        pk4 = str(pk)[:4]
         for values, expected_natural_slug in (
             (["Alpha"], "alpha"),  # simplest case
             (["alpha", "beta"], "alpha_beta"),  # multiple inputs
@@ -50,7 +53,8 @@ class ModelUtilsTestCase(TestCase):
             (["💩", "Everyone's favorite!"], "pile-of-poo_everyone-s-favorite"),  # Emojis and unsafe ASCII
         ):
             with self.subTest(values=values):
-                natural_slug = construct_natural_slug(values)
+                expected_natural_slug += f"_{pk4}"
+                natural_slug = construct_natural_slug(values, pk=pk)
                 self.assertEqual(natural_slug, expected_natural_slug)
 
 

--- a/nautobot/core/tests/test_models.py
+++ b/nautobot/core/tests/test_models.py
@@ -80,9 +80,9 @@ class NaturalKeyTestCase(BaseModelTest):
     def test_natural_slug(self):
         """Test the natural_slug default implementation with some representative models."""
         mfr = Manufacturer.objects.first()
-        self.assertEqual(mfr.natural_slug, construct_natural_slug(mfr.natural_key()))
+        self.assertEqual(mfr.natural_slug, construct_natural_slug(mfr.natural_key(), pk=mfr.pk))
         dt = DeviceType.objects.first()
-        self.assertEqual(dt.natural_slug, construct_natural_slug(dt.natural_key()))
+        self.assertEqual(dt.natural_slug, construct_natural_slug(dt.natural_key(), pk=dt.pk))
 
     def test_natural_key_field_lookups(self):
         """Test the natural_key_field_lookups default implementation with some representative models."""

--- a/nautobot/core/tests/test_models.py
+++ b/nautobot/core/tests/test_models.py
@@ -39,6 +39,19 @@ class ModelUtilsTestCase(TestCase):
                 self.assertEqual(composite_key, expected_composite_key)
                 self.assertEqual(deconstruct_composite_key(composite_key), values)
 
+    def test_construct_natural_slug(self):
+        """Test that `construct_natural_slug()` works as expected."""
+        for values, expected_natural_slug in (
+            (["Alpha"], "alpha"),  # simplest case
+            (["alpha", "beta"], "alpha_beta"),  # multiple inputs
+            (["10.1.1.1/24", "fe80::1"], "10-1-1-1-24_fe80-1"),  # URL-safe ASCII characters, / is *not* path safe
+            ([None, "Hello", None], "_hello_"),  # Null values
+            (["💩", "Everyone's favorite!"], "pile-of-poo_everyone-s-favorite"),  # Emojis and unsafe ASCII
+        ):
+            with self.subTest(values=values):
+                natural_slug = construct_natural_slug(values)
+                self.assertEqual(natural_slug, expected_natural_slug)
+
 
 class NaturalKeyTestCase(BaseModelTest):
     """Test the various natural-key APIs for a few representative models."""

--- a/nautobot/core/tests/test_models.py
+++ b/nautobot/core/tests/test_models.py
@@ -73,7 +73,7 @@ class NaturalKeyTestCase(BaseModelTest):
         self.assertEqual(dt.composite_key, construct_composite_key(dt.natural_key()))
 
     def test_natural_slug(self):
-        """Test the natural_slug default implementation with some represenatitive models."""
+        """Test the natural_slug default implementation with some representative models."""
         mfr = Manufacturer.objects.first()
         self.assertEqual(mfr.natural_slug, construct_natural_slug(mfr.natural_key()))
         dt = DeviceType.objects.first()

--- a/nautobot/core/tests/test_models.py
+++ b/nautobot/core/tests/test_models.py
@@ -8,7 +8,7 @@ from django.test import override_settings
 from django.test.utils import isolate_apps
 
 from nautobot.core.models import BaseModel
-from nautobot.core.models.utils import construct_composite_key, deconstruct_composite_key
+from nautobot.core.models.utils import construct_composite_key, construct_natural_slug, deconstruct_composite_key
 from nautobot.core.testing import TestCase
 from nautobot.dcim.models import DeviceType, Manufacturer
 
@@ -58,6 +58,13 @@ class NaturalKeyTestCase(BaseModelTest):
         self.assertEqual(mfr.composite_key, construct_composite_key(mfr.natural_key()))
         dt = DeviceType.objects.first()
         self.assertEqual(dt.composite_key, construct_composite_key(dt.natural_key()))
+
+    def test_natural_slug(self):
+        """Test the natural_slug default implementation with some represenatitive models."""
+        mfr = Manufacturer.objects.first()
+        self.assertEqual(mfr.natural_slug, construct_natural_slug(mfr.natural_key()))
+        dt = DeviceType.objects.first()
+        self.assertEqual(dt.natural_slug, construct_natural_slug(dt.natural_key()))
 
     def test_natural_key_field_lookups(self):
         """Test the natural_key_field_lookups default implementation with some representative models."""

--- a/nautobot/core/tests/test_models.py
+++ b/nautobot/core/tests/test_models.py
@@ -44,6 +44,7 @@ class ModelUtilsTestCase(TestCase):
         for values, expected_natural_slug in (
             (["Alpha"], "alpha"),  # simplest case
             (["alpha", "beta"], "alpha_beta"),  # multiple inputs
+            (["Über Ålpha"], "uber-alpha"),  # accents/ligatures
             (["10.1.1.1/24", "fe80::1"], "10-1-1-1-24_fe80-1"),  # URL-safe ASCII characters, / is *not* path safe
             ([None, "Hello", None], "_hello_"),  # Null values
             (["💩", "Everyone's favorite!"], "pile-of-poo_everyone-s-favorite"),  # Emojis and unsafe ASCII

--- a/nautobot/docs/release-notes/version-2.0.md
+++ b/nautobot/docs/release-notes/version-2.0.md
@@ -30,6 +30,10 @@ Added the `?depth` query parameter in Nautobot v2.X to replace the `?brief` para
 
 Nautobot's `BaseModel` base class and related classes now implement automatic support for Django [natural keys](https://docs.djangoproject.com/en/3.2/topics/serialization/#natural-keys) for lookup and referencing, as well as supporting a `composite_key` concept similar to that introduced by `django-natural-keys`. (Nautobot does not depend on `django-natural-keys` but its implementation is heavily inspired by that project.) For example:
 
+<!-- TODO(jathan): Remove this admonition before v2.0.0 final release. -->
+!!! warning
+    Composite Key will be removed in the final release of Nautobot. Existing references may still exist in RC3.
+
 ```python
 >>> DeviceType.objects.first().natural_key()
 ['MegaCorp', 'Model 9000']

--- a/poetry.lock
+++ b/poetry.lock
@@ -1138,6 +1138,20 @@ gmpy = ["gmpy"]
 gmpy2 = ["gmpy2"]
 
 [[package]]
+name = "emoji"
+version = "2.8.0"
+description = "Emoji for Python"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "emoji-2.8.0-py2.py3-none-any.whl", hash = "sha256:a8468fd836b7ecb6d1eac054c9a591701ce0ccd6c6f7779ad71b66f76664df90"},
+    {file = "emoji-2.8.0.tar.gz", hash = "sha256:8d8b5dec3c507444b58890e598fc895fcec022b3f5acb49497c6ccc5208b8b00"},
+]
+
+[package.extras]
+dev = ["coverage", "coveralls", "pytest"]
+
+[[package]]
 name = "example-plugin"
 version = "1.0.0"
 description = "Nautobot example plugin that does a whole lot of nothing."
@@ -1864,6 +1878,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -2830,6 +2854,23 @@ pyasn1 = ">=0.3.7"
 pyasn1_modules = ">=0.1.5"
 
 [[package]]
+name = "python-slugify"
+version = "8.0.1"
+description = "A Python slugify application that also handles Unicode"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-slugify-8.0.1.tar.gz", hash = "sha256:ce0d46ddb668b3be82f4ed5e503dbc33dd815d83e2eb6824211310d3fb172a27"},
+    {file = "python_slugify-8.0.1-py2.py3-none-any.whl", hash = "sha256:70ca6ea68fe63ecc8fa4fcf00ae651fc8a5d02d93dcd12ae6d4fc7ca46c4d395"},
+]
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
+
+[[package]]
 name = "python3-openid"
 version = "3.2.0"
 description = "OpenID support for modern servers and consumers."
@@ -2942,6 +2983,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -2949,8 +2991,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -2967,6 +3016,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -2974,6 +3024,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -3968,4 +4019,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "551925584b397df57a21116094b61d9ac21f1f8d35a8606bc1ae091df91d2285"
+content-hash = "bf93cc557e1586eb6db22221a97f0c80905b525fce44342f261d1add7ab4c5b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ djangorestframework = "~3.14.0"
 drf-react-template-framework = "^0.0.17"
 # OpenAPI 3.0 schema generation for the REST API
 drf-spectacular = {version = "0.26.3", extras = ["sidecar"]}
+# Emoji terminal output for Python.
+emoji = "~2.8.0"
 # Git integrations for Python
 GitPython = "~3.1.32"
 # GraphQL support
@@ -119,6 +121,8 @@ prometheus-client = "~0.17.1"
 # PostgreSQL database adapter
 # NOTE: psycopg3 is avaiable now and nominally replaces psycopg2
 psycopg2-binary = "~2.9.6"
+# A Python slugify application that handles unicode.
+python-slugify = "~8.0.1"
 # The uWSGI WSGI HTTP server as a Python module
 pyuwsgi = "~2.0.21"
 # YAML parsing and rendering


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4346 
# What's Changed

- Implemented a new utility called `construct_natural_slug()` which is kind of like `construct_composite_key()` but not reversible, is lossy, and is prioritizing human-readability over uniqueness.
- Added a `.natural_slug` property to all models that inherit from `BaseModel` which generates the value from the natural key for the object.
- Effectively `slugify_dots_to_dashes()` is used on each member item in the list of natural key values for an instance, and then joined together with underscores.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
