### PR TITLE
Enforce upper on constance and lower on plugin values

### DIFF
--- a/changes/4470.changed
+++ b/changes/4470.changed
@@ -1,0 +1,1 @@
+Changed `get_app_settings_or_config` to enforce upper on constance and lower on plugin values per standards.

--- a/nautobot/apps/config.py
+++ b/nautobot/apps/config.py
@@ -7,6 +7,6 @@ from django.conf import settings
 def get_app_settings_or_config(app_name, variable_name):
     """Get a value from Django settings (if specified there) or Constance configuration (otherwise)."""
     # Explicitly set in settings.py or nautobot_config.py takes precedence, for now
-    if variable_name in settings.PLUGINS_CONFIG[app_name]:
-        return settings.PLUGINS_CONFIG[app_name][variable_name]
-    return getattr(config, f"{app_name}__{variable_name}")
+    if variable_name.lower() in settings.PLUGINS_CONFIG[app_name]:
+        return settings.PLUGINS_CONFIG[app_name][variable_name.lower()]
+    return getattr(config, f"{app_name}__{variable_name.upper()}")

--- a/nautobot/core/tests/test_config.py
+++ b/nautobot/core/tests/test_config.py
@@ -40,21 +40,26 @@ class GetSettingsOrConfigTestCase(TestCase):
 class GetAppSettingsOrConfigTestCase(TestCase):
     """Test the get_app_settings_or_config() helper function."""
 
-    @override_settings(PLUGINS_CONFIG={"example_plugin": {"SAMPLE_VARIABLE": "Test Samples"}})
+    @override_settings(PLUGINS_CONFIG={"example_plugin": {"sample_variable": "Test Samples"}})
     def test_settings_if_no_config(self):
         self.assertEqual(app_config.get_app_settings_or_config("example_plugin", "SAMPLE_VARIABLE"), "Test Samples")
 
-    @override_settings(PLUGINS_CONFIG={"example_plugin": {"SAMPLE_VARIABLE": "Test Samples"}})
+    @override_settings(PLUGINS_CONFIG={"example_plugin": {"sample_variable": "Test Samples"}})
     @override_config(example_plugin__SAMPLE_VARIABLE="Testing")
     def test_settings_override_config(self):
         self.assertEqual(app_config.get_app_settings_or_config("example_plugin", "SAMPLE_VARIABLE"), "Test Samples")
 
-    @override_settings(PLUGINS_CONFIG={"example_plugin": {"SAMPLE_VARIABLE": ""}})
+    @override_settings(PLUGINS_CONFIG={"example_plugin": {"sample_variable": "Test Samples"}})
+    @override_config(example_plugin__SAMPLE_VARIABLE="Testing")
+    def test_settings_override_config_using_lower(self):
+        self.assertEqual(app_config.get_app_settings_or_config("example_plugin", "sample_variable"), "Test Samples")
+
+    @override_settings(PLUGINS_CONFIG={"example_plugin": {"sample_variable": ""}})
     @override_config(example_plugin__SAMPLE_VARIABLE="Testing")
     def test_empty_settings_override_config(self):
         self.assertEqual(app_config.get_app_settings_or_config("example_plugin", "SAMPLE_VARIABLE"), "")
 
-    @override_settings(PLUGINS_CONFIG={"example_plugin": {"SAMPLE_VARIABLE": None}})
+    @override_settings(PLUGINS_CONFIG={"example_plugin": {"sample_variable": None}})
     @override_config(example_plugin__SAMPLE_VARIABLE="Testing")
     def test_null_settings_override_config(self):
         self.assertEqual(app_config.get_app_settings_or_config("example_plugin", "SAMPLE_VARIABLE"), None)


### PR DESCRIPTION

# Closes: DNE
# What's Changed

Changed `get_app_settings_or_config` to enforce upper on constance and lower on plugin values per standards.

The standards have been in all plugins I have checked for lower in plugin settings and constance enforces upper. This seemed liked the preferred opinionated approach from NTC. Others can build their own function, but this seems correct to me for how we operate.  

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Unit, Integration Tests
