### PR TITLE
Feature invoke cli command #4495

### DIFF
--- a/changes/4495.added
+++ b/changes/4495.added
@@ -1,0 +1,1 @@
+Added `command` parameter to `invoke cli` command.

--- a/tasks.py
+++ b/tasks.py
@@ -154,7 +154,7 @@ def docker_compose(context, command, **kwargs):
         **kwargs: Passed through to the context.run() call.
     """
     compose_command_tokens = [
-        "docker-compose",
+        "docker compose",
         f'--project-name "{context.nautobot.project_name}"',
         f'--project-directory "{context.nautobot.compose_dir}"',
     ]

--- a/tasks.py
+++ b/tasks.py
@@ -14,6 +14,7 @@ limitations under the License.
 
 import os
 import re
+from shlex import quote
 
 from invoke import Collection, task as invoke_task
 from invoke.exceptions import Exit
@@ -446,12 +447,12 @@ def nbshell(context):
     help={
         "service": "Name of the service to shell into",
         "root": "Launch shell as root",
+        "command": "Command to run in container. (Default: bash)",
     }
 )
-def cli(context, service="nautobot", root=False):
+def cli(context, service="nautobot", root=False, command="bash"):
     """Launch a bash shell inside the running Nautobot (or other) Docker container."""
     context.nautobot.local = False
-    command = "bash"
 
     run_command(context, command, service=service, pty=True, root=root)
 

--- a/tasks.py
+++ b/tasks.py
@@ -14,7 +14,6 @@ limitations under the License.
 
 import os
 import re
-from shlex import quote
 
 from invoke import Collection, task as invoke_task
 from invoke.exceptions import Exit
@@ -155,7 +154,7 @@ def docker_compose(context, command, **kwargs):
         **kwargs: Passed through to the context.run() call.
     """
     compose_command_tokens = [
-        "docker compose",
+        "docker-compose",
         f'--project-name "{context.nautobot.project_name}"',
         f'--project-directory "{context.nautobot.compose_dir}"',
     ]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4495 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
New parameter -c, --command is added to `invoke cli` command.

```bash
invoke --help cli
Usage: inv[oke] [--core-opts] cli [--options] [other tasks here ...]

Docstring:
  Launch a bash shell inside the running Nautobot (or other) Docker container.

Options:
  -c STRING, --command=STRING   Command to run in container. (Default: bash)
  -r, --root                    Launch shell as root
  -s STRING, --service=STRING   Name of the service to shell into
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
