### PR TITLE
Fix #4476 - add /api/extras/jobs/NAME/ REST API endpoints

### DIFF
--- a/changes/4476.added
+++ b/changes/4476.added
@@ -1,0 +1,1 @@
+Added `/api/extras/jobs/<name>/...` REST API endpoints as an alternative option to the existing `/api/extras/jobs/<uuid>/...` endpoints.

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -240,6 +240,10 @@ SPECTACULAR_SETTINGS = {
     # use sidecar - locally packaged UI files, not CDN
     "SWAGGER_UI_DIST": "SIDECAR",
     "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
+    "SWAGGER_UI_SETTINGS": {
+        "deepLinking": True,
+        "displayOperationId": True,
+    },
     "REDOC_DIST": "SIDECAR",
     # Do not list all possible enum values in the description of filter fields and the like
     # In addition to being highly verbose, it's inaccurate for filter fields like *__ic and *__re

--- a/nautobot/docs/user-guide/platform-functionality/jobs/index.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/index.md
@@ -101,20 +101,26 @@ The `class_path` is often represented as a string in the format of `<module_name
 +/- 1.3.0
     With the addition of Job database models, it is now generally possible and preferable to refer to a job by its UUID primary key, similar to other Nautobot database models, rather than its `class_path`.
 
++/- 2.0.0
+    The Job database model `name` field is now enforced to be globally unique and so is also an option for uniquely identifying Job records.
+
 ### Via the Web UI
 
 Jobs can be run via the web UI by navigating to the job, completing any required form data (if any), and clicking the "Run Job" button.
 
 Once a job has been run, the latest [`JobResult`](./models.md#job-results) for that job will be summarized in the job list view.
 
-### Via the API
+### Via the REST API
 
 --- 2.0.0
     The `commit` parameter was removed. All job input should be provided via the `data` parameter.
 
-To run a job via the REST API, issue a POST request to the job's endpoint `/api/extras/jobs/<uuid>/run/`. You can optionally provide JSON data to specify any required user input `data`, optional `task_queue`, and/or provide optional scheduling information as described in [the section on scheduling and approvals](./job-scheduling-and-approvals.md).
+To run a job via the REST API, issue a POST request to the job's endpoint `/api/extras/jobs/<uuid>/run/` **or** `/api/extras/jobs/<name>/run/`. You can optionally provide JSON data to specify any required user input `data`, optional `task_queue`, and/or provide optional scheduling information as described in [the section on scheduling and approvals](./job-scheduling-and-approvals.md).
 
-For example, to run a job with no user inputs:
++++ 2.0.0
+    The `/api/extras/jobs/<name>/` REST API endpoints were added as an alternative to `/api/extras/jobs/<uuid>/`.
+
+For example, to run a job, by UUID, with no user inputs:
 
 ```no-highlight
 curl -X POST \
@@ -124,14 +130,14 @@ curl -X POST \
 http://nautobot/api/extras/jobs/$JOB_ID/run/
 ```
 
-Or to run a job that expects user inputs:
+Or to run a job, by name, that expects user inputs:
 
 ```no-highlight
 curl -X POST \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; version=1.3; indent=4" \
-http://nautobot/api/extras/jobs/$JOB_ID/run/ \
+http://nautobot/api/extras/jobs/$JOB_NAME/run/ \
 --data '{"data": {"string_variable": "somevalue", "integer_variable": 123}}'
 ```
 
@@ -152,7 +158,7 @@ curl -X POST \
 -H 'Authorization: Token $TOKEN' \
 -H 'Content-Type: multipart/form-data' \
 -H "Accept: application/json; version=1.3; indent=4" \
-'http://nautobot/api/extras/jobs/$JOB_ID/run/' \
+'http://nautobot/api/extras/jobs/$JOB_NAME/run/' \
 -F '_schedule_interval="immediately"' \
 -F '_schedule_start_time="2022-10-18T17:31:23.698Z"' \
 -F 'interval="3"' \

--- a/nautobot/extras/api/urls.py
+++ b/nautobot/extras/api/urls.py
@@ -42,6 +42,7 @@ router.register("image-attachments", views.ImageAttachmentViewSet)
 
 # Jobs
 router.register("jobs", views.JobViewSet)
+router.register("jobs", views.JobByNameViewSet)
 
 # Job Buttons
 router.register("job-buttons", views.JobButtonViewSet)

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1118,6 +1118,20 @@ class JobTest(
             {"name": "var4", "type": "ObjectVar", "required": True, "model": "extras.role"},
         )
 
+    def test_get_job_variables_by_name(self):
+        """Test the job/<name>/variables API endpoint."""
+        self.add_permissions("extras.view_job")
+        route = get_route_for_model(self.model, "variables", api=True)
+        response = self.client.get(reverse(route, kwargs={"name": self.job_model.name}), **self.header)
+        self.assertEqual(4, len(response.data))  # 4 variables, in order
+        self.assertEqual(response.data[0], {"name": "var1", "type": "StringVar", "required": True})
+        self.assertEqual(response.data[1], {"name": "var2", "type": "IntegerVar", "required": True})
+        self.assertEqual(response.data[2], {"name": "var3", "type": "BooleanVar", "required": False})
+        self.assertEqual(
+            response.data[3],
+            {"name": "var4", "type": "ObjectVar", "required": True, "model": "extras.role"},
+        )
+
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_update_job_with_sensitive_variables_set_approval_required_to_true(self):
         job_model = Job.objects.get_for_class_path("api_test_job.APITestJob")


### PR DESCRIPTION
# Closes: #4476 
# What's Changed

- Add `/api/extras/jobs/<name>/...` REST API endpoints as a parallel alternative to `/api/extras/jobs/<pk>/`.  This is done by way of a common base class (`JobViewSetBase`) and ViewSet subclasses for the two alternative URL patterns.
   - Use `@extend_schema_view` on the new ViewSet so that drf-spectacular doesn't complain about `operation_id` collisions.
- Add `displayOperationId` to the `SWAGGER_UI_SETTINGS` configs (`deepLinking: True` is the DRF-Spectacular default if `SWAGGER_UI_SETTINGS` isn't specified)
- Fix the `notes` REST API endpoint so that it isn't hard-coded to only support `<pk>`-style URL patterns

![image](https://github.com/nautobot/nautobot/assets/5603551/30d171e9-7de2-4c39-a031-15b8849e1676)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
