### PR TITLE
feature: implement table sticky headers

### DIFF
--- a/changes/4553.added
+++ b/changes/4553.added
@@ -1,0 +1,1 @@
+Implement table sticky headers.

--- a/nautobot/ui/src/components/LoadingWidget.js
+++ b/nautobot/ui/src/components/LoadingWidget.js
@@ -1,24 +1,14 @@
-import { Text, StatusIndicator } from "@nautobot/nautobot-ui";
-import { Spinner } from "@chakra-ui/react";
+import { Flex, Text, Spinner } from "@nautobot/nautobot-ui";
 
 // A helpful, consistent loading widget
 export function LoadingWidget({ name = "" }) {
     const display_name = name.length > 0 ? " " + name : "";
+
     return (
-        <div
-            style={{
-                textAlign: "center",
-                width: "100%",
-                position: "relative",
-                gridColumn: "2 / span 2",
-            }}
-        >
-            <StatusIndicator variant="action" breathe={true} />
-            <Spinner size="lg" color="blue.500" />
-            <Text ml={1} color="gray-3">
-                Loading{display_name}...
-            </Text>
-        </div>
+        <Flex align="center" gap="sm" justify="center">
+            <Spinner size="lg" color="blue-1" />
+            <Text color="gray-3">Loading{display_name}...</Text>
+        </Flex>
     );
 }
 export default LoadingWidget;

--- a/nautobot/ui/src/components/ObjectTable/ObjectListTable.js
+++ b/nautobot/ui/src/components/ObjectTable/ObjectListTable.js
@@ -3,8 +3,10 @@ import { useLocation } from "react-router-dom";
 import { useEffect, useRef, useState } from "react";
 import {
     Box,
+    calc,
     Divider,
     Flex,
+    getCssVar,
     Heading,
     NtcThumbnailIcon,
     MeatballsIcon,
@@ -172,7 +174,7 @@ export default function ObjectListTable({
     );
 
     return (
-        <Box borderRadius="md" ref={topRef}>
+        <Box borderRadius="md" height="full" ref={topRef}>
             {!include_button ? null : (
                 <Flex align="center">
                     <Heading
@@ -187,16 +189,13 @@ export default function ObjectListTable({
                     </Heading>
                     <Spacer />
                     {!data_fetched ? (
-                        <Box pr="sm">
+                        <Box marginRight="md">
                             <LoadingWidget name={tableTitle} />
                         </Box>
-                    ) : (
-                        () => {}
-                    )}
+                    ) : null}
                     <Box>
                         <ButtonGroup alignItems="center" spacing="md">
                             <UIButton
-                                size="sm"
                                 variant={
                                     activeFiltersCount > 0
                                         ? "primary"
@@ -252,16 +251,41 @@ export default function ObjectListTable({
             )}
 
             <SkeletonText
-                endColor="gray.200"
-                noOfLines={parseInt(page_size)}
-                skeletonHeight="25"
-                spacing="3"
-                marginTop="md"
+                borderRadius="md"
+                endColor="gray-0"
+                height={calc.subtract(
+                    getCssVar("sizes.full"),
+                    // The following compensate for the section header.
+                    getCssVar("lineHeights.tall"),
+                    getCssVar("space.md"),
+                    // The following compensate for the pagination component.
+                    getCssVar("space.md"),
+                    getCssVar("sizes.40")
+                )}
                 isLoaded={data_fetched}
+                marginTop="md"
+                noOfLines={parseInt(page_size, 10)}
+                overflow="hidden"
+                skeletonHeight={calc.subtract(
+                    calc.add(
+                        getCssVar("lineHeights.normal"),
+                        calc.multiply(getCssVar("space.sm"), 2)
+                    ),
+                    "1px"
+                )}
+                spacing="1px"
+                startColor="gray-1"
+                sx={{
+                    ">": {
+                        _first: data_fetched
+                            ? { height: "full" }
+                            : { ">": { _first: { display: "none" } } },
+                    },
+                }}
             >
                 <TableRenderer
                     table={table}
-                    containerProps={{ overflow: "auto" }}
+                    containerProps={{ height: "full" }}
                 />
             </SkeletonText>
             <Pagination

--- a/nautobot/ui/src/components/ObjectTable/ObjectTableItem.js
+++ b/nautobot/ui/src/components/ObjectTable/ObjectTableItem.js
@@ -1,6 +1,6 @@
 // import Badge from 'react-bootstrap/Badge';
 import { Link } from "@components/RouterLink";
-import { Button, CheckIcon, CloseIcon } from "@nautobot/nautobot-ui";
+import { Button, CheckIcon, CloseIcon, Flex } from "@nautobot/nautobot-ui";
 import { calculateLuminance } from "@utils/color";
 
 function TextOrButton({ obj }) {
@@ -21,7 +21,6 @@ function TextOrButton({ obj }) {
                 borderRadius="sm"
                 pl="xs"
                 pr="xs"
-                m="xs"
             >
                 {display}
             </Button>
@@ -38,11 +37,11 @@ function TableColumnDisplay({ obj }) {
     } else if (Array.isArray(obj)) {
         if (typeof obj[0] == "object") {
             return (
-                <>
+                <Flex gap="xs">
                     {obj.map((item, idx) => (
                         <TextOrButton obj={item} key={idx} />
                     ))}
-                </>
+                </Flex>
             );
         } else {
             return obj.join(", ");

--- a/nautobot/ui/src/views/Home.js
+++ b/nautobot/ui/src/views/Home.js
@@ -44,7 +44,9 @@ export default function Home() {
     if (isLoading) {
         return (
             <GenericView>
-                <LoadingWidget />
+                <NautobotGridItem colSpan="4">
+                    <LoadingWidget />
+                </NautobotGridItem>
             </GenericView>
         );
     }
@@ -52,7 +54,9 @@ export default function Home() {
     if (isError) {
         return (
             <GenericView>
-                <Text>Error loading.</Text>
+                <NautobotGridItem colSpan="4">
+                    <Text textAlign="center">Error loading.</Text>
+                </NautobotGridItem>
             </GenericView>
         );
     }

--- a/nautobot/ui/src/views/generic/GenericView.js
+++ b/nautobot/ui/src/views/generic/GenericView.js
@@ -2,14 +2,20 @@ import {
     Box,
     Breadcrumb,
     Breadcrumbs,
+    calc,
     Flex,
+    getCssVar,
     NautobotGrid,
 } from "@nautobot/nautobot-ui";
 import { FiltersPanelContainer } from "@components/FiltersPanel";
 import { Navbar } from "@components/Navbar";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
-import { Link as ReactRouterLink, useLocation } from "react-router-dom";
+import {
+    Link as ReactRouterLink,
+    useLocation,
+    useParams,
+} from "react-router-dom";
 
 import { useGetUIMenuQuery } from "@utils/api";
 import { uiUrl } from "@utils/url";
@@ -88,6 +94,8 @@ export default function GenericView({
     const BREADCRUMB_KEY_HOME = "0_home";
 
     const { pathname } = useLocation();
+    const { app_label, model_name, object_id } = useParams();
+
     const { data: menu, isSuccess } = useGetUIMenuQuery();
 
     // Using useMemo to prevent unnecessary re-execution of findMenuPathRecursive
@@ -115,6 +123,8 @@ export default function GenericView({
 
     const hasBreadcrumbs =
         breadcrumbs.length > 0 && breadcrumbs[0].key !== BREADCRUMB_KEY_HOME;
+
+    const isListView = Boolean(app_label && model_name && !object_id);
 
     return (
         <Flex
@@ -149,6 +159,17 @@ export default function GenericView({
                         gridAutoRows="auto"
                         {...(hasBreadcrumbs
                             ? { minHeight: "auto" }
+                            : undefined)}
+                        {...(isListView
+                            ? {
+                                  gridAutoRows:
+                                      getCssVar("sizes.full").reference,
+                                  maxHeight: calc.subtract(
+                                      getCssVar("sizes.full"),
+                                      getCssVar("lineHeights.normal"),
+                                      getCssVar("space.md")
+                                  ),
+                              }
                             : undefined)}
                     >
                         {typeof children === "function"

--- a/nautobot/ui/src/views/generic/ObjectList.js
+++ b/nautobot/ui/src/views/generic/ObjectList.js
@@ -79,7 +79,7 @@ export default function GenericObjectListView() {
         return (
             <GenericView gridBackground="white-0">
                 {(menuPath) => (
-                    <NautobotGridItem>
+                    <NautobotGridItem height="full">
                         <ObjectListTable
                             tableData={{}}
                             defaultHeaders={[]}
@@ -115,7 +115,7 @@ export default function GenericObjectListView() {
     return (
         <GenericView gridBackground="white-0">
             {(menuPath) => (
-                <NautobotGridItem>
+                <NautobotGridItem height="full">
                     {/* TODO(timizuo): Use @component/ObjectTable instead, after pagination control has been added to @component/ObjectTable */}
                     <ObjectListTable
                         tableData={listData.results}


### PR DESCRIPTION
# Implements: https://github.com/nautobot/nautobot-ui/issues/39

# What's Changed
Implement table sticky headers from `nautobot-ui` library. Apart from the obvious, the changes are following:
* List view layout components are now explicitly sized and they don't exceed the viewport size
* Skeleton loader slightly changed to better reflect the content being loaded
* Loader widget has inlined spinner and text
* The following React error with rendering invalid component is fixed:
  ![image](https://github.com/nautobot/nautobot/assets/117445994/34d9129d-333e-4fa9-8101-3c216a465a85)
* The tags are no longer getting excessive margins which made their containing table cells too large:
  ![image](https://github.com/nautobot/nautobot/assets/117445994/bde20c9c-41f1-454c-ad74-152fe18e04cb)

| Loading | Table |
| - | - |
| ![image](https://github.com/nautobot/nautobot/assets/117445994/b09096e3-d428-4822-9728-32452f3a9fc1) | ![image](https://github.com/nautobot/nautobot/assets/117445994/04b5f2b1-141f-4f02-8548-96d72bdadd32) |
