### PR TITLE
Fixed a 500 error caused by `PrefixForm` when `prefix_length` was omtted from `prefix` input.

### DIFF
--- a/changes/4550.fixed
+++ b/changes/4550.fixed
@@ -1,0 +1,1 @@
+Fixed a 500 error caused by `PrefixForm` when `prefix_length` was omitted from `prefix` input.

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -251,6 +251,10 @@ class PrefixForm(LocatableModelFormMixin, NautobotModelForm, TenancyForm, Prefix
             "namespace": "$namespace",
         },
     )
+    # It is required to add prefix_length here and set it to required=False and hidden input so that
+    # form validation doesn't complain and that it doesn't show in forms.
+    # Ref:  https://github.com/nautobot/nautobot/issues/4550
+    prefix_length = forms.IntegerField(required=False, widget=forms.HiddenInput())
 
     class Meta:
         model = Prefix

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -1,5 +1,4 @@
 """Test IPAM forms."""
-from unittest import skip
 
 from django.test import TestCase
 

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -25,14 +25,14 @@ class BaseNetworkFormTest:
             prefix="192.168.1.0/24", namespace=self.namespace, status=self.prefix_status
         )
         self.parent2 = Prefix.objects.create(
-            prefix="192.168.0.0/24", namespace=self.namespace, status=self.prefix_status
+            prefix="192.168.0.0/16", namespace=self.namespace, status=self.prefix_status
         )
         self.parent6 = Prefix.objects.create(
             prefix="2001:0db8::/40", namespace=self.namespace, status=self.prefix_status
         )
 
     def test_valid_ip_address(self):
-        data = {self.field_name: "192.168.1.0/24", "namespace": self.namespace, "status": self.status}
+        data = {self.field_name: "192.168.2.0/24", "namespace": self.namespace, "status": self.status}
         data.update(self.extra_data)
         form = self.form_class(data)
 
@@ -64,7 +64,6 @@ class BaseNetworkFormTest:
         self.assertEqual("CIDR mask (e.g. /24) is required.", form.errors[self.field_name][0])
 
 
-@skip("Needs to be updated for Namespaces")
 class PrefixFormTest(BaseNetworkFormTest, TestCase):
     form_class = forms.PrefixForm
     field_name = "prefix"


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4550 
# What's Changed
- An overload for the `prefix_length` field was added to `PrefixForm` to mark it as not required to allow the form validation to function correctly.
- The `nautobot.ipam.tests.test_forms.PrefixFormTest` test case was still being skipped, preventing this from being caught! It is no longer being skiped.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
