### PR TITLE
Dynamic groups should fail closed if filter is invalid

### DIFF
--- a/changes/4559.fixed
+++ b/changes/4559.fixed
@@ -1,0 +1,1 @@
+Fixed behavior of a `DynamicGroup` with an invalid `filter` to fail closed rather than failing open.

--- a/nautobot/core/management/commands/audit_dynamic_groups.py
+++ b/nautobot/core/management/commands/audit_dynamic_groups.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
 
 from nautobot.core.utils.lookup import get_filterset_for_model
@@ -14,20 +15,26 @@ class Command(BaseCommand):
         dynamic_groups = DynamicGroup.objects.all().order_by("name")
         is_valid = True
         for dynamic_group in dynamic_groups:
+            try:
+                dynamic_group.clean_filter()
+            except ValidationError as err:
+                self.stderr.write(f'    DynamicGroup "{dynamic_group}" has an invalid filter: {err}')
+                is_valid = False
+                continue
             dynamic_group_model = dynamic_group.content_type.model_class()
             dynamic_group_model_filter = get_filterset_for_model(dynamic_group_model)
             valid_filterset_fields = dynamic_group_model_filter().filters
             filter_data = dynamic_group.filter
             for filter_field in filter_data.keys():
                 if filter_field not in valid_filterset_fields:
-                    self.stdout.write(
-                        f"    DynamicGroup instance with name `{dynamic_group.name}` and content type `{dynamic_group.content_type}` has an invalid filter `{filter_field}`"
+                    self.stderr.write(
+                        f'    DynamicGroup "{dynamic_group}" has an invalid filter field "{filter_field}"'
                     )
                     is_valid = False
         if is_valid:
             self.stdout.write("\n>>> All DynamicGroup filters are validated successfully!")
         else:
-            self.stdout.write(
+            self.stderr.write(
                 "\n>>> Please fix the broken filters stated above according to the documentation available at:\n"
                 "<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes\n"
             )

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -302,6 +302,10 @@ class DynamicGroup(OrganizationalModel):
             raise RuntimeError(f"Could not determine queryset for model '{model}'")
 
         filterset = self.filterset_class(self.filter, model.objects.all())
+        if not filterset.is_valid():
+            logger.warning('Filter for DynamicGroup "%s" is not valid', self)
+            return model.objects.none()
+
         qs = filterset.qs
 
         # Make sure that this instance can't be a member of its own group.


### PR DESCRIPTION
# Closes: #N/A but see also https://github.com/nautobot/nautobot-plugin-golden-config/issues/626
# What's Changed

- If a DynamicGroup has an invalid `filter`, its `members()` was failing open (all objects returned) instead of closed (no objects returned). This adds logic to call `filterset.is_valid()` and fail closed if the filterset is invalid.
- Enhance the `audit_dynamic_groups` command to call `DynamicGroup.clean_filter()` to also flag groups with invalid `filter` values.

```
>>> Auditing existing DynamicGroup data for invalid filters ...
    DynamicGroup "Bad Filter" has an invalid filter: {'platform': ['Enter a list of values.']}

>>> Please fix the broken filters stated above according to the documentation available at:
<nautobot-home>/static/docs/installation/upgrading-from-nautobot-v1.html#ui-graphql-and-rest-api-filter-changes
```

This is important for 2.0 as many existing DGs may have filters that become invalid as a result of the upgrade and should fail closed instead of failing open.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
