### PR TITLE
fix: table sticky headers in firefox

### DIFF
--- a/changes/4566.fixed
+++ b/changes/4566.fixed
@@ -1,0 +1,1 @@
+Fixed table sticky headers in Firefox.

--- a/nautobot/ui/src/views/generic/GenericView.js
+++ b/nautobot/ui/src/views/generic/GenericView.js
@@ -1,5 +1,4 @@
 import {
-    Box,
     Breadcrumb,
     Breadcrumbs,
     calc,
@@ -138,9 +137,16 @@ export default function GenericView({
             <Navbar appState={currentState} />
 
             <Flex flex="1" overflow="hidden">
-                <Box flex="1" overflow="auto" paddingBottom="md" paddingX="md">
+                <Flex
+                    direction="column"
+                    flex="1"
+                    overflow="auto"
+                    paddingBottom="md"
+                    paddingX="md"
+                >
                     {hasBreadcrumbs ? (
                         <Breadcrumbs
+                            flex="none"
                             marginBottom="md"
                             position="relative"
                             zIndex="5"
@@ -159,7 +165,7 @@ export default function GenericView({
                         gridAutoRows="auto"
                         {...(hasBreadcrumbs
                             ? { minHeight: "auto" }
-                            : undefined)}
+                            : { flex: "1 0 auto" })}
                         {...(isListView
                             ? {
                                   gridAutoRows:
@@ -176,7 +182,7 @@ export default function GenericView({
                             ? children(menuPath)
                             : children}
                     </NautobotGrid>
-                </Box>
+                </Flex>
 
                 <FiltersPanelContainer />
             </Flex>


### PR DESCRIPTION
# Fixes bug introduced in: #4553

# What's Changed
Fix bug with table sticky headers not working in Firefox, reported by @glennmatthews in https://github.com/nautobot/nautobot/pull/4553#issuecomment-1739881452.

| Before | After |
| - | - |
| ![image](https://github.com/nautobot/nautobot/assets/117445994/d88bf996-e822-4614-8097-2f485e9871c2) | ![image](https://github.com/nautobot/nautobot/assets/117445994/bec9141e-b4cd-4380-835e-e4186b3d91ee) |
