### PR TITLE
Fixed `invoke eslint` not running against local development environment.

### DIFF
--- a/changes/4523.fixed
+++ b/changes/4523.fixed
@@ -1,0 +1,1 @@
+Fixed `invoke eslint` not running against local development environment.

--- a/tasks.py
+++ b/tasks.py
@@ -979,7 +979,7 @@ def eslint(context, autoformat=False):
         docker_compose(
             context,
             "run --workdir='/opt/nautobot/ui' -e NODE_ENV=test "
-            f"--entrypoint '{eslint_command} /opt/nautobot/ui' nautobot",
+            f"--entrypoint '{eslint_command} /opt/nautobot/ui' nodejs",
         )
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4523 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Cannot run eslint on `/source/nautobot/ui` in the nautobot container because `node_modules` is never installed there.
- Cannot run eslint on `/opt/nautobot/ui` in the nautobot container because the local `nautobot/ui` is not mounted there.
- This change runs eslint on `/opt/nautobot/ui` in the `nodejs` container.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
