### PR TITLE
Fix #4552 - improve test failure messages

### DIFF
--- a/changes/4552.housekeeping
+++ b/changes/4552.housekeeping
@@ -1,0 +1,1 @@
+Improved `test_bulk_delete_form_contains_all_filtered` and `test_bulk_edit_form_contains_all_filterered` generic tests to fail more gracefully if insufficient test data is available.

--- a/changes/4552.housekeeping
+++ b/changes/4552.housekeeping
@@ -1,1 +1,1 @@
-Improved `test_bulk_delete_form_contains_all_filtered` and `test_bulk_edit_form_contains_all_filterered` generic tests to fail more gracefully if insufficient test data is available.
+Improved `test_bulk_delete_form_contains_all_filtered` and `test_bulk_edit_form_contains_all_filtered` generic tests to fail more gracefully if insufficient test data is available.

--- a/nautobot/core/testing/views.py
+++ b/nautobot/core/testing/views.py
@@ -1061,9 +1061,12 @@ class ViewTestCases:
             self.add_permissions(f"{self.model._meta.app_label}.change_{self.model._meta.model_name}")
 
             pk_iter = iter(self._get_queryset().values_list("pk", flat=True))
-            first_pk = next(pk_iter)
-            second_pk = next(pk_iter)
-            third_pk = next(pk_iter)
+            try:
+                first_pk = next(pk_iter)
+                second_pk = next(pk_iter)
+                third_pk = next(pk_iter)
+            except StopIteration:
+                self.fail(f"Test requires at least three instances of {self.model._meta.model_name} to be defined.")
 
             post_data = testing.post_data(self.bulk_edit_data)
 
@@ -1219,9 +1222,12 @@ class ViewTestCases:
             self.add_permissions(f"{self.model._meta.app_label}.delete_{self.model._meta.model_name}")
 
             pk_iter = iter(self._get_queryset().values_list("pk", flat=True))
-            first_pk = next(pk_iter)
-            second_pk = next(pk_iter)
-            third_pk = next(pk_iter)
+            try:
+                first_pk = next(pk_iter)
+                second_pk = next(pk_iter)
+                third_pk = next(pk_iter)
+            except StopIteration:
+                self.fail(f"Test requires at least three instances of {self.model._meta.model_name} to be defined.")
 
             # Open bulk delete form with first two objects
             selected_data = {


### PR DESCRIPTION
# Closes: #4552 
# What's Changed

Catch `StopIteration` exception and fail gracefully with a clearer error message in these two tests.

```
======================================================================
FAIL: test_bulk_delete_form_contains_all_filtered (nautobot.dcim.tests.test_views.RackGroupTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/source/nautobot/core/testing/views.py", line 1228, in test_bulk_delete_form_contains_all_filtered
    third_pk = next(pk_iter)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/django/test/utils.py", line 387, in inner
    return func(*args, **kwargs)
  File "/source/nautobot/core/testing/views.py", line 1230, in test_bulk_delete_form_contains_all_filtered
    self.fail(f"Test requires at least three instances of {self.model._meta.model_name} to be defined.")
AssertionError: Test requires at least three instances of rackgroup to be defined.

----------------------------------------------------------------------
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
