### PR TITLE
Fix #4436 - allow non-physical interfaces as parents

### DIFF
--- a/changes/4436.fixed
+++ b/changes/4436.fixed
@@ -1,0 +1,1 @@
+Allowed Interfaces of type `Virtual`, `LAG`, and `Bridge` to be selected as a virtual Interface's `parent`.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -2139,9 +2139,6 @@ class InterfaceForm(InterfaceCommonForm, NautobotModelForm):
         queryset=Interface.objects.all(),
         required=False,
         label="Parent interface",
-        query_params={
-            "kind": "physical",
-        },
         help_text="Assigned parent interface",
     )
     bridge = DynamicModelChoiceField(

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -604,16 +604,11 @@ class Interface(CableTermination, PathEndpoint, ComponentModel, BaseInterface):
             # An interface cannot be its own parent
             if self.parent_interface_id == self.pk:
                 raise ValidationError({"parent_interface": "An interface cannot be its own parent."})
+
             # A physical interface cannot have a parent interface
             if hasattr(self, "type") and self.type != InterfaceTypeChoices.TYPE_VIRTUAL:
                 raise ValidationError(
                     {"parent_interface": "Only virtual interfaces may be assigned to a parent interface."}
-                )
-
-            # A virtual interface cannot be a parent interface
-            if getattr(self.parent_interface, "type", None) == InterfaceTypeChoices.TYPE_VIRTUAL:
-                raise ValidationError(
-                    {"parent_interface": "Virtual interfaces may not be parents of other interfaces."}
                 )
 
             # An interface's parent must belong to the same device or virtual chassis


### PR DESCRIPTION
# Closes: #4436 
# What's Changed

- Remove Interface form restriction that blocked non-physical interfaces from appearing as options for parent_interface
- Remove interface model validation check that blocked Virtual interfaces specifically from being parent interfaces
- Add testing

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
