### PR TITLE
Removed `stable` tagging for container builds in LTM release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,6 @@ jobs:
             type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.11 }}
             type=semver,pattern={{major}}.{{minor}}-py${{ matrix.python-version }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.python-version == 3.11 }}
-            type=raw,value=stable,enable=${{ matrix.python-version == 3.11 }}
-            type=raw,value=stable-py${{ matrix.python-version }}
           labels: |
             org.opencontainers.image.title=Nautobot
       - name: "Build"
@@ -120,8 +118,6 @@ jobs:
             type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.11 }}
             type=semver,pattern={{major}}.{{minor}}-py${{ matrix.python-version }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.python-version == 3.11 }}
-            type=raw,value=stable,enable=${{ matrix.python-version == 3.11 }}
-            type=raw,value=stable-py${{ matrix.python-version }}
           labels: |
             org.opencontainers.image.title=Nautobot
       - name: "Build Dev Containers"

--- a/changes/4595.removed
+++ b/changes/4595.removed
@@ -1,0 +1,1 @@
+Removed `stable` tagging for container builds in LTM release workflow.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4595
# What's Changed

This removes the `stable` and `stable-py*` tags from being published on container builds for LTM releases so they don't clobber 2.x tags.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
