### PR TITLE
Fixes the ability to attach images to Locations

### DIFF
--- a/changes/4639.fixed
+++ b/changes/4639.fixed
@@ -1,0 +1,1 @@
+Fixed the ability to attach images to Locations

--- a/changes/4639.fixed
+++ b/changes/4639.fixed
@@ -1,1 +1,1 @@
-Fixed the ability to attach images to Locations
+Fixed the ability to attach images to Locations.

--- a/nautobot/dcim/templates/dcim/location.html
+++ b/nautobot/dcim/templates/dcim/location.html
@@ -234,7 +234,7 @@
         {% include 'inc/image_attachments.html' with images=object.images.all %}
         {% if perms.extras.add_imageattachment %}
             <div class="panel-footer text-right noprint">
-                <a href="{% url 'dcim:location_add_image' pk=object.pk %}" class="btn btn-primary btn-xs">
+                <a href="{% url 'dcim:location_add_image' object_id=object.pk %}" class="btn btn-primary btn-xs">
                     <span class="mdi mdi-plus-thick" aria-hidden="true"></span>
                     Attach an image
                 </a>

--- a/nautobot/dcim/urls.py
+++ b/nautobot/dcim/urls.py
@@ -79,7 +79,7 @@ urlpatterns = [
         kwargs={"model": Location},
     ),
     path(
-        "locations/<uuid:pk>/images/add/",
+        "locations/<uuid:object_id>/images/add/",
         ImageAttachmentEditView.as_view(),
         name="location_add_image",
         kwargs={"model": Location},


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4639 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
During the 2.0 changes the URL path that used to use `<slug:slug>` was changed to `<uuid:pk>`, but the `ImageAttachmentEditView.alter_obj` method does not currently look for `pk`. This PR changes the kwarg to `object_id` to match Devices and Racks

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
