### PR TITLE
Fixed error `'IPAddressBulkAddForm' has no field named 'parent'` when bulk creating IPs via UI.

### DIFF
--- a/changes/4608.fixed
+++ b/changes/4608.fixed
@@ -1,0 +1,1 @@
+Fixed error `'IPAddressBulkAddForm' has no field named 'parent'` when bulk creating IPs via UI.

--- a/nautobot/core/templates/generic/object_create.html
+++ b/nautobot/core/templates/generic/object_create.html
@@ -26,11 +26,12 @@
                 </h3>
                 {% block tabs %}{% endblock %}
                 {% block form_errors %}
-                    {% if form.non_field_errors %}
+                    {% if form.non_field_errors or model_form.non_field_errors %}
                         <div class="panel panel-danger">
                             <div class="panel-heading"><strong>Errors</strong></div>
                             <div class="panel-body">
                                 {{ form.non_field_errors }}
+                                {{ model_form.non_field_errors }}
                             </div>
                         </div>
                     {% endif %}

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -548,7 +548,6 @@ class IPAddressBulkCreateForm(BootstrapMixin, forms.Form):
 class IPAddressBulkAddForm(NautobotModelForm, TenancyForm, AddressFieldMixin):
     namespace = DynamicModelChoiceField(
         queryset=Namespace.objects.all(),
-        required=False,
         label="Namespace",
     )
 
@@ -566,6 +565,17 @@ class IPAddressBulkAddForm(NautobotModelForm, TenancyForm, AddressFieldMixin):
             "tenant",
             "tags",
         ]
+
+    def clean_namespace(self):
+        """
+        Explicitly set the Namespace on the instance so it will be used on save.
+
+        While the model does this itself on create, the model form is creating a bare instance first
+        and setting attributes individually based on the form field values. Since namespace isn't an
+        actual model field, it gets ignored by default.
+        """
+        namespace = self.cleaned_data.pop("namespace")
+        setattr(self.instance, "_namespace", namespace)
 
 
 class IPAddressBulkEditForm(

--- a/nautobot/ipam/templates/ipam/ipaddress_bulk_add.html
+++ b/nautobot/ipam/templates/ipam/ipaddress_bulk_add.html
@@ -13,6 +13,8 @@
         <div class="panel-heading"><strong>IP Addresses</strong></div>
         <div class="panel-body">
             {% render_field form.pattern %}
+            {% render_field model_form.namespace %}
+            {% render_field model_form.type %}
             {% render_field model_form.status %}
             {% render_field model_form.role %}
             {% render_field model_form.vrf %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4608 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

The bug in the code was resolved by including the `namespace` and `type` form field in the `nautobot/ipam/templates/ipam/ipaddress_bulk_add.html` file. 
The bug occurred because the Model clean function couldn't determine the `_namespace` attributed  from either the `parent` or the `namespace`, cause neither was provided.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
