### PR TITLE
Fixes issue where not specifying a 'failover_strategy' when creating …

### DIFF
--- a/changes/4645.fixed
+++ b/changes/4645.fixed
@@ -1,0 +1,1 @@
+Fixed a bug where the `failover-strategy` field was required for the device redundancy group api.

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -1213,7 +1213,11 @@ class DeviceBaySerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
 
 class DeviceRedundancyGroupSerializer(NautobotModelSerializer, TaggedModelSerializerMixin, StatusModelSerializerMixin):
     url = serializers.HyperlinkedIdentityField(view_name="dcim-api:deviceredundancygroup-detail")
-    failover_strategy = ChoiceField(choices=DeviceRedundancyGroupFailoverStrategyChoices)
+    failover_strategy = ChoiceField(
+        choices=DeviceRedundancyGroupFailoverStrategyChoices,
+        allow_blank=True,
+        default=DeviceRedundancyGroupFailoverStrategyChoices.FAILOVER_UNSPECIFIED,
+    )
 
     class Meta:
         model = DeviceRedundancyGroup

--- a/nautobot/dcim/choices.py
+++ b/nautobot/dcim/choices.py
@@ -1399,10 +1399,12 @@ class DeviceRedundancyGroupStatusChoices(ChoiceSet):
 
 
 class DeviceRedundancyGroupFailoverStrategyChoices(ChoiceSet):
+    FAILOVER_UNSPECIFIED = ""
     FAILOVER_ACTIVE_ACTIVE = "active-active"
     FAILOVER_ACTIVE_PASSIVE = "active-passive"
 
     CHOICES = (
+        (FAILOVER_UNSPECIFIED, "(unspecified)"),
         (FAILOVER_ACTIVE_ACTIVE, "Active/Active"),
         (FAILOVER_ACTIVE_PASSIVE, "Active/Passive"),
     )

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from constance.test import override_config
 
 from nautobot.dcim.choices import (
+    DeviceRedundancyGroupFailoverStrategyChoices,
     InterfaceModeChoices,
     InterfaceStatusChoices,
     InterfaceTypeChoices,
@@ -2614,17 +2615,26 @@ class DeviceRedundancyGroupTest(APIViewTestCases.APIViewTestCase):
     create_data = [
         {
             "name": "Device Redundancy Group 4",
-            "failover_strategy": "active-active",
+            "failover_strategy": DeviceRedundancyGroupFailoverStrategyChoices.FAILOVER_ACTIVE_ACTIVE,
             "status": "active",
         },
         {
             "name": "Device Redundancy Group 5",
-            "failover_strategy": "active-passive",
+            "failover_strategy": DeviceRedundancyGroupFailoverStrategyChoices.FAILOVER_ACTIVE_PASSIVE,
             "status": "planned",
         },
         {
             "name": "Device Redundancy Group 6",
-            "failover_strategy": "active-active",
+            "failover_strategy": DeviceRedundancyGroupFailoverStrategyChoices.FAILOVER_ACTIVE_ACTIVE,
+            "status": "staging",
+        },
+        {
+            "name": "Device Redundancy Group 7",
+            "failover_strategy": DeviceRedundancyGroupFailoverStrategyChoices.FAILOVER_UNSPECIFIED,
+            "status": "staging",
+        },
+        {
+            "name": "Device Redundancy Group 8",
             "status": "staging",
         },
     ]


### PR DESCRIPTION
…a device redundancy group via the REST API resulted in an error (#4645)

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4645
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Allows the `failover_strategy` to be empty when creating a device redundancy group via the API. This is effectively a backport from the 2.0 branch.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
