### PR TITLE
Release 1.6.4

### DIFF
--- a/changes/4313.changed
+++ b/changes/4313.changed
@@ -1,1 +1,0 @@
-Updated device search to include manufacturer name.

--- a/changes/4361.added
+++ b/changes/4361.added
@@ -1,1 +1,0 @@
-Added `SUPPORT_MESSAGE` configuration setting.

--- a/changes/4573.added
+++ b/changes/4573.added
@@ -1,1 +1,0 @@
-Added caching for `display` property of `Location` and `LocationType`, mitigating duplicated SQL queries in the related API views.

--- a/changes/4595.removed
+++ b/changes/4595.removed
@@ -1,1 +1,0 @@
-Removed `stable` tagging for container builds in LTM release workflow.

--- a/changes/4619.housekeeping
+++ b/changes/4619.housekeeping
@@ -1,1 +1,0 @@
-Fixed broken links in Nautobot README.md.

--- a/nautobot/docs/release-notes/version-1.6.md
+++ b/nautobot/docs/release-notes/version-1.6.md
@@ -72,6 +72,25 @@ The default Python version for Nautobot Docker images has been changed from 3.7 
 As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support installation or operation under Python 3.7.
 
 <!-- towncrier release notes start -->
+## v1.6.4 (2023-10-17)
+
+### Added
+
+- [#4361](https://github.com/nautobot/nautobot/issues/4361) - Added `SUPPORT_MESSAGE` configuration setting.
+- [#4573](https://github.com/nautobot/nautobot/issues/4573) - Added caching for `display` property of `Location` and `LocationType`, mitigating duplicated SQL queries in the related API views.
+
+### Changed
+
+- [#4313](https://github.com/nautobot/nautobot/issues/4313) - Updated device search to include manufacturer name.
+
+### Housekeeping
+
+- [#4619](https://github.com/nautobot/nautobot/issues/4619) - Fixed broken links in Nautobot README.md.
+
+### Removed
+
+- [#4595](https://github.com/nautobot/nautobot/issues/4595) - Removed `stable` tagging for container builds in LTM release workflow.
+
 ## v1.6.3 (2023-10-03)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "1.6.3"
+version = "1.6.4"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Added

- [#4361](https://github.com/nautobot/nautobot/issues/4361) - Added `SUPPORT_MESSAGE` configuration setting.
- [#4573](https://github.com/nautobot/nautobot/issues/4573) - Added caching for `display` property of `Location` and `LocationType`, mitigating duplicated SQL queries in the related API views.

### Changed

- [#4313](https://github.com/nautobot/nautobot/issues/4313) - Updated device search to include manufacturer name.

### Housekeeping

- [#4619](https://github.com/nautobot/nautobot/issues/4619) - Fixed broken links in Nautobot README.md.

### Removed

- [#4595](https://github.com/nautobot/nautobot/issues/4595) - Removed `stable` tagging for container builds in LTM release workflow.