### PR TITLE
Fixed token exposure in `JobResult` traceback and result output when `GitRepositorySync` job fails.

### DIFF
--- a/changes/4673.fixed
+++ b/changes/4673.fixed
@@ -1,0 +1,1 @@
+Fixed token exposure in `JobResult` traceback and result output when a `GitRepositorySync` job fails.

--- a/changes/4673.fixed
+++ b/changes/4673.fixed
@@ -1,1 +1,0 @@
-Fixed token exposure in `JobResult` traceback and result output when a `GitRepositorySync` job fails.

--- a/changes/4673.security
+++ b/changes/4673.security
@@ -1,1 +1,1 @@
-Fixed token exposure in `JobResult` traceback and result output when a `GitRepositorySync` job fails in scertain ways.
+Fixed token exposure in `JobResult` traceback and result output when a `GitRepositorySync` job fails in certain ways.

--- a/changes/4673.security
+++ b/changes/4673.security
@@ -1,0 +1,1 @@
+Fixed token exposure in `JobResult` traceback and result output when a `GitRepositorySync` job fails in scertain ways.

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -660,14 +660,12 @@ class JobResult(BaseModel, CustomFieldModel):
             redirect_logger = get_logger("celery.redirected")
             proxy = LoggingProxy(redirect_logger, app.conf.worker_redirect_stdouts_level)
             with contextlib.redirect_stdout(proxy), contextlib.redirect_stderr(proxy):
-                eager_result = job_model.job_task.apply(
+                job_model.job_task.apply(
                     args=job_args, kwargs=job_kwargs, task_id=str(job_result.id), **job_celery_kwargs
                 )
 
             # copy fields from eager result to job result
             job_result.refresh_from_db()
-            for field in ["status", "result", "traceback", "worker"]:
-                setattr(job_result, field, getattr(eager_result, field, None))
             job_result.date_done = timezone.now()
             job_result.save()
         else:

--- a/nautobot/extras/test_jobs/fail.py
+++ b/nautobot/extras/test_jobs/fail.py
@@ -20,4 +20,33 @@ class TestFail(Job):
         raise RunJobTaskFailed("Test failure")
 
 
-register_jobs(TestFail)
+class TestFailWithSanitization(Job):
+    """
+    Job with fail result that should be sanitized.
+
+    This raises an exception that appears to have a password in it.
+    """
+
+    description = "Validate job failure sanitization"
+
+    def run(self):
+        logger.info("I'm a test job that fails and sanitizes the exception!")
+        exc = RunJobTaskFailed(
+            "fatal: could not read Password for 'https://abc123@github.com': terminal prompts disabled"
+        )
+        exc.args = (
+            [
+                "git",
+                "clone",
+                "-v",
+                "--",
+                "https://*****@github.com/jathanism/nautobot-git-example",
+                "/Users/jathan/.nautobot/git/git_test",
+            ],
+            128,
+            b"Cloning into '/Users/jathan/.nautobot/git/git_test'...\nfatal: could not read Password for https://abc123@github.com': terminal prompts disabled\n",
+        )
+        raise exc
+
+
+register_jobs(TestFail, TestFailWithSanitization)

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -235,6 +235,20 @@ class JobTransactionTest(TransactionTestCase):
         job_result = create_job_result_and_run_job(module, name)
         self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
 
+    def test_job_fail_with_sanitization(self):
+        """
+        Job test with fail result that is sanitized.
+        """
+        module = "fail"
+        name = "TestFailWithSanitization"
+        job_result = create_job_result_and_run_job(module, name)
+        json_result = json.dumps(job_result.result)
+        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertIn("(redacted)@github.com", json_result)
+        self.assertNotIn("abc123@github.com", json_result)
+        self.assertIn("(redacted)@github.com", job_result.traceback)
+        self.assertNotIn("abc123@github.com", job_result.traceback)
+
     def test_atomic_transaction_decorator_job_pass(self):
         """
         Job with @transaction.atomic decorator test with pass result.


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4673 
# What's Changed

- Updated `NautobotDatabaseBackend._get_extended_properties` to always sanitize the traceback output if it is set.
- Overloaded `NautobotDatabaseBackend.prepare_exception()` to always sanitize the CLI error output message when a exception's message payload is a list or tuple. The output from this method is what gets stored as the `result` of the job in such error cases.
 

## Example fetch
<img width="1615" alt="Cursor_and_Notification_Center" src="https://github.com/nautobot/nautobot/assets/138052/dee541bf-f39b-4f9a-b615-76a115fde262">

## Example clone
<img width="1620" alt="Cursor_and_Notification_Center" src="https://github.com/nautobot/nautobot/assets/138052/2c073b46-d305-421c-a412-0b2752c6d536">


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
