### PR TITLE
Updates to LTM branch to replace ltm/1.6 with ltm-1.6

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable
       - "main"
       - "develop"
       - "next"
-      - "ltm/*"
+      - "ltm-*"
   workflow_call: {}
 
 jobs:
@@ -286,7 +286,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     if: |
       github.event_name == 'push' &&
-      (github.ref_name == 'develop' || github.ref_name == 'next' || github.ref_name == 'ltm/1.6')
+      (github.ref_name == 'develop' || github.ref_name == 'next' || github.ref_name == 'ltm-1.6')
     needs:
       - "integration-test"
     strategy:
@@ -298,11 +298,7 @@ jobs:
         id: "config"
         shell: "bash"
         run: |
-          if [[ "${{ github.ref_name }}" == "ltm/1.6" ]]; then
-            export BRANCH="ltm-1.6"
-          else
-            export BRANCH="${{ github.ref_name }}"
-          fi
+          export BRANCH="${{ github.ref_name }}"
           export TAG_LATEST="false"
           export TAG_LATEST_FOR_BRANCH="false"
           export TAG_LATEST_FOR_PY="false"

--- a/.github/workflows/plugin_upstream_testing_base.yml
+++ b/.github/workflows/plugin_upstream_testing_base.yml
@@ -20,13 +20,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nautobot-version: ["next", "develop", "ltm/1.6"]
+        nautobot-version: ["next", "develop", "ltm-1.6"]
     runs-on: "ubuntu-20.04"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
         with:
-          ref: "${{ matrix.nautobot-version == 'next' && 'next-2.0' || matrix.nautobot-version == 'ltm/1.6' && 'ltm/1.6' || env.GITHUB_REF_NAME || 'develop' }}"
+          ref: "${{ matrix.nautobot-version == 'next' && 'next-2.0' || matrix.nautobot-version == 'ltm-1.6' && 'ltm-1.6' || env.GITHUB_REF_NAME || 'develop' }}"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v2"
       - name: "Set up Docker Buildx"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # Ensure CI has passed
   ci:
-    uses: nautobot/nautobot/.github/workflows/ci_integration.yml@ltm/1.6
+    uses: nautobot/nautobot/.github/workflows/ci_integration.yml@ltm-1.6
 
   # Publish to GitHub followed by pypi
   publish_python:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # Ensure CI has passed
   ci:
-    uses: nautobot/nautobot/.github/workflows/ci_integration.yml@ltm/1.6
+    uses: nautobot/nautobot/.github/workflows/ci_integration.yml@ltm-1.6
 
   # Publish to GitHub followed by pypi
   publish_python:

--- a/changes/4638.changed
+++ b/changes/4638.changed
@@ -1,0 +1,1 @@
+Renamed `ltm/1.6` branch to `ltm-1.6`

--- a/changes/4638.changed
+++ b/changes/4638.changed
@@ -1,1 +1,1 @@
-Renamed `ltm/1.6` branch to `ltm-1.6`
+Renamed `ltm/1.6` branch to `ltm-1.6`.

--- a/nautobot/docs/docker/index.md
+++ b/nautobot/docs/docker/index.md
@@ -57,7 +57,7 @@ The following tags are available on both Docker Hub and the GitHub Container Reg
 
 ### Developer Tags
 
-Additionally, GitHub Actions are used to automatically build "developer" images corresponding to each commit to the `ltm/1.6`, `develop`, and `next` branches. These images are named `networktocode/nautobot-dev:${TAG}` and `ghcr.io/nautobot/nautobot-dev:${TAG}`, and provide the development dependencies needed to build Nautobot; they can be used as a base for development to develop your own Nautobot apps but should **NOT** be used in production.
+Additionally, GitHub Actions are used to automatically build "developer" images corresponding to each commit to the `ltm-1.6`, `develop`, and `next` branches. These images are named `networktocode/nautobot-dev:${TAG}` and `ghcr.io/nautobot/nautobot-dev:${TAG}`, and provide the development dependencies needed to build Nautobot; they can be used as a base for development to develop your own Nautobot apps but should **NOT** be used in production.
 
 In addition to all tags described in the previous section, the following additional tags are available from the GitHub Container Registry, only for the `ghcr.io/nautobot/nautobot-dev` images:
 
@@ -67,8 +67,8 @@ In addition to all tags described in the previous section, the following additio
 | `latest-py${PYTHON_VER}`                             | `develop`, the latest commit | As specified   |
 | `develop`                                            | `develop`, the latest commit | 3.11           |
 | `develop-py${PYTHON_VER}`                            | `develop`, the latest commit | As specified   |
-| `ltm-1.6`                                            | `ltm/1.6`, the latest commit | 3.11           |
-| `ltm-1.6-py${PYTHON_VER}`                            | `ltm/1.6`, the latest commit | As specified   |
+| `ltm-1.6`                                            | `ltm-1.6`, the latest commit | 3.11           |
+| `ltm-1.6-py${PYTHON_VER}`                            | `ltm-1.6`, the latest commit | As specified   |
 | `next`                                               | `next`, the latest commit    | 3.11           |
 | `next-py${PYTHON_VER}`                               | `next`, the latest commit    | As specified   |
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "baseBranches": ["develop", "next", "ltm/*"],
+  "baseBranches": ["develop", "next", "ltm-*"],
   "enabledManagers": ["pip_requirements", "poetry"],
   "extends": [
     "config:base"
@@ -21,7 +21,7 @@
     {
       "description": "Group patch-only updates to develop weekly to cut down on PR noise.",
       "groupName": "Lock-file Patch Releases for LTM branches",
-      "matchBaseBranches": ["ltm/*"],
+      "matchBaseBranches": ["ltm-*"],
       "extends": ["schedule:monthly"],
       "major": {"enabled": false},
       "minor": {"enabled": false}


### PR DESCRIPTION
# Closes: #4638 (will have another PR for `develop` as well)
## What's Changed

PR into newly created `ltm-1.6` branch to make the updates necessary within this branch for it to replace the `ltm/1.6` branch.