### PR TITLE
[develop] Replace ltm/1.6 with ltm-1.6, fix upstream apps CI branch pairings

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -251,7 +251,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     if: |
       github.event_name == 'push' &&
-      (github.ref_name == 'develop' || github.ref_name == 'next' || github.ref_name == 'ltm/1.6')
+      (github.ref_name == 'develop' || github.ref_name == 'next' || github.ref_name == 'ltm-1.6')
     needs:
       - "check-schema"
       - "integration-test"
@@ -269,11 +269,7 @@ jobs:
         id: "config"
         shell: "bash"
         run: |
-          if [[ "${{ github.ref_name }}" == "ltm/1.6" ]]; then
-            export BRANCH="ltm-1.6"
-          else
-            export BRANCH="${{ github.ref_name }}"
-          fi
+          export BRANCH="${{ github.ref_name }}"
           export TAG_LATEST="false"
           export TAG_LATEST_FOR_BRANCH="false"
           export TAG_LATEST_FOR_PY="false"

--- a/.github/workflows/plugin_upstream_testing_base.yml
+++ b/.github/workflows/plugin_upstream_testing_base.yml
@@ -26,7 +26,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
         with:
-          ref: "${{ matrix.nautobot-version == 'develop' && 'next-2.0' || matrix.nautobot-version == 'ltm-1.6' && 'develop' || env.GITHUB_REF_NAME || 'develop' }}"
+          ref: "${{ matrix.nautobot-version == 'develop' && 'develop' || matrix.nautobot-version == 'ltm-1.6' && 'ltm-1.6' || env.GITHUB_REF_NAME || 'develop' }}"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v2"
       - name: "Set up Docker Buildx"

--- a/changes/4638.housekeeping
+++ b/changes/4638.housekeeping
@@ -1,0 +1,1 @@
+Updated Apps upstream testing CI to use the correct branch pairings post-2.0.

--- a/nautobot/docs/user-guide/administration/installation/docker.md
+++ b/nautobot/docs/user-guide/administration/installation/docker.md
@@ -57,7 +57,7 @@ The following tags are available on both Docker Hub and the GitHub Container Reg
 
 ### Developer Tags
 
-Additionally, GitHub Actions are used to automatically build "developer" images corresponding to each commit to the `ltm/1.6`, `develop`, and `next` branches. These images are named `networktocode/nautobot-dev:${TAG}` and `ghcr.io/nautobot/nautobot-dev:${TAG}`, and provide the development dependencies needed to build Nautobot; they can be used as a base for development to develop your own Nautobot apps but should **NOT** be used in production.
+Additionally, GitHub Actions are used to automatically build "developer" images corresponding to each commit to the `ltm-1.6`, `develop`, and `next` branches. These images are named `networktocode/nautobot-dev:${TAG}` and `ghcr.io/nautobot/nautobot-dev:${TAG}`, and provide the development dependencies needed to build Nautobot; they can be used as a base for development to develop your own Nautobot apps but should **NOT** be used in production.
 
 In addition to all tags described in the previous section, the following additional tags are available from the GitHub Container Registry, only for the `ghcr.io/nautobot/nautobot-dev` images:
 
@@ -67,8 +67,8 @@ In addition to all tags described in the previous section, the following additio
 | `latest-py${PYTHON_VER}`                             | `develop`, the latest commit | As specified   |
 | `develop`                                            | `develop`, the latest commit | 3.11           |
 | `develop-py${PYTHON_VER}`                            | `develop`, the latest commit | As specified   |
-| `ltm-1.6`                                            | `ltm/1.6`, the latest commit | 3.11           |
-| `ltm-1.6-py${PYTHON_VER}`                            | `ltm/1.6`, the latest commit | As specified   |
+| `ltm-1.6`                                            | `ltm-1.6`, the latest commit | 3.11           |
+| `ltm-1.6-py${PYTHON_VER}`                            | `ltm-1.6`, the latest commit | As specified   |
 | `next`                                               | `next`, the latest commit    | 3.11           |
 | `next-py${PYTHON_VER}`                               | `next`, the latest commit    | As specified   |
 


### PR DESCRIPTION
 Closes: #4638 
# What's Changed

Counterpart to #4715, for `develop`.

- Replace references to `ltm/1.6` with references to `ltm-1.6`
- Update `.github/workflows/plugin_upstream_testing_base.yml` to have the correct post-2.0 branch pairings between core and apps.