### PR TITLE
Bugfix 4718 drg priority not null when drg deleted

### DIFF
--- a/changes/4718.fixed
+++ b/changes/4718.fixed
@@ -1,0 +1,1 @@
+Fixed bug in which a device's device redundancy group priority was not being set to `None` when the device redundancy group was deleted.

--- a/nautobot/dcim/signals.py
+++ b/nautobot/dcim/signals.py
@@ -11,6 +11,7 @@ from .models import (
     Cable,
     CablePath,
     Device,
+    DeviceRedundancyGroup,
     PathEndpoint,
     PowerPanel,
     Rack,
@@ -169,6 +170,22 @@ def handle_rack_site_location_change(instance, created, raw=False, **kwargs):
 
             if changed:
                 device.save()
+
+
+#
+# Device redundancy group
+#
+
+
+@receiver(pre_delete, sender=DeviceRedundancyGroup)
+def clear_deviceredundancygroup_members(instance, **kwargs):
+    """
+    When a DeviceRedundancyGroup is deleted, nullify the device_redundancy_group_priority field of its prior members.
+    """
+    devices = Device.objects.filter(device_redundancy_group=instance.pk)
+    for device in devices:
+        device.device_redundancy_group_priority = None
+        device.save()
 
 
 #


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4718 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Sets device_redundancy_group_priority to `None` for all devices in a given device redundancy group when the device redundancy group is deleted.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
