### PR TITLE
Fixed the bug that prevented the user from adding tags without member objects as DynamicGroup `tags` filters.

### DIFF
--- a/changes/4680.fixed
+++ b/changes/4680.fixed
@@ -1,1 +1,1 @@
-Fixed the bug that prevented the user from adding tags without member devices to DynamicGroup `tags` filter field.
+Fixed the bug that prevented the user from adding tags without member objects as DynamicGroup `tags` filters.

--- a/changes/4680.fixed
+++ b/changes/4680.fixed
@@ -1,0 +1,1 @@
+Fixed the bug that prevented the user from adding tags without member devices to DynamicGroup `tags` filter field.

--- a/nautobot/core/forms/fields.py
+++ b/nautobot/core/forms/fields.py
@@ -784,7 +784,7 @@ class TagFilterField(DynamicModelMultipleChoiceField):
         from nautobot.extras.models import Tag
 
         if queryset is None:
-            queryset = Tag.objects.filter(content_types=ContentType.objects.get_for_model(model))
+            queryset = Tag.objects.get_for_model(model)
         query_params = query_params or {}
         query_params.update({"content_types": model._meta.label_lower})
         super().__init__(

--- a/nautobot/core/forms/fields.py
+++ b/nautobot/core/forms/fields.py
@@ -781,8 +781,10 @@ class TagFilterField(DynamicModelMultipleChoiceField):
     """
 
     def __init__(self, model, *args, query_params=None, queryset=None, **kwargs):
+        from nautobot.extras.models import Tag
+
         if queryset is None:
-            queryset = model.tags.all()
+            queryset = Tag.objects.filter(content_types=ContentType.objects.get_for_model(model))
         query_params = query_params or {}
         query_params.update({"content_types": model._meta.label_lower})
         super().__init__(

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -972,8 +972,14 @@ class DynamicGroupModelTest(DynamicGroupTestBase):  # TODO: BaseModelTestCase mi
         this_dg.validated_save()
 
     def test_unapplied_tags_can_be_added_to_dynamic_group_filters(self):
+        """
+        Test that tags without being applied to any member instances can still be added as filters on DynamicGroups
+        """
         dg = self.groups[0]
-        dg.filter.update({"tags": [Tag.objects.filter(content_types=ContentType.objects.get_for_model(Device)).first()]})
+        unapplied_tag = Tag.objects.create(name="Unapplied Tag")
+        unapplied_tag.content_types.set([ContentType.objects.get_for_model(Device)])
+        unapplied_tag.save()
+        dg.filter["tags"] = [unapplied_tag.pk]
         dg.validated_save()
 
     def test_member_caching_output(self):

--- a/nautobot/extras/tests/test_dynamicgroups.py
+++ b/nautobot/extras/tests/test_dynamicgroups.py
@@ -40,6 +40,7 @@ from nautobot.extras.models import (
     RelationshipAssociation,
     Role,
     Status,
+    Tag,
 )
 from nautobot.ipam.models import Prefix
 from nautobot.tenancy.models import Tenant
@@ -969,6 +970,11 @@ class DynamicGroupModelTest(DynamicGroupTestBase):  # TODO: BaseModelTestCase mi
 
         this_dg.set_filter({"example_plugin_prefix_tenant_name": [a_tenant]})
         this_dg.validated_save()
+
+    def test_unapplied_tags_can_be_added_to_dynamic_group_filters(self):
+        dg = self.groups[0]
+        dg.filter.update({"tags": [Tag.objects.filter(content_types=ContentType.objects.get_for_model(Device)).first()]})
+        dg.validated_save()
 
     def test_member_caching_output(self):
         group = self.first_child


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4680 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
