### PR TITLE
Fix InterfaceRedundancyGroup fields

### DIFF
--- a/changes/4684.fixed
+++ b/changes/4684.fixed
@@ -1,0 +1,2 @@
+Fixed InterfaceRedundancyGroup.status to no longer be nullable.
+Fixed InterfaceRedundancyGroupAssociation.created to be a DateTimeField.

--- a/nautobot/dcim/migrations/0050_fix_interface_redundancy_group_association_created.py
+++ b/nautobot/dcim/migrations/0050_fix_interface_redundancy_group_association_created.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dcim", "0022_interface_redundancy_group"),
+        ("dcim", "0049_remove_slugs_and_change_device_primary_ip_fields"),
+    ]
+
+    operations = [
+        # Migration 0022 diverged between 1.6 and 2.0 so we must copy the created field to a new field
+        # in order to change it without losing data.
+        migrations.AddField(
+            model_name="interfaceredundancygroupassociation",
+            name="created_datetimefield",
+            field=models.DateTimeField(auto_now_add=True, null=True),
+        ),
+    ]

--- a/nautobot/dcim/migrations/0051_interface_redundancy_group_nullable_status.py
+++ b/nautobot/dcim/migrations/0051_interface_redundancy_group_nullable_status.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+from nautobot.extras.utils import fixup_null_statuses
+
+
+def migrate_null_statuses(apps, schema):
+    Status = apps.get_model("extras", "Status")
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    InterfaceRedundancyGroup = apps.get_model("dcim", "interfaceredundancygroup")
+    interface_redundancy_group_ct = ContentType.objects.get_for_model(InterfaceRedundancyGroup)
+    fixup_null_statuses(
+        model=InterfaceRedundancyGroup, model_contenttype=interface_redundancy_group_ct, status_model=Status
+    )
+
+
+def copy_created_to_created_datetimefield(apps, schema):
+    InterfaceRedundancyGroupAssociation = apps.get_model("dcim", "interfaceredundancygroupassociation")
+    InterfaceRedundancyGroupAssociation.objects.update(created_datetimefield=models.F("created"))
+
+
+def revert_copy_created_to_created_datetimefield(apps, schema):
+    InterfaceRedundancyGroupAssociation = apps.get_model("dcim", "interfaceredundancygroupassociation")
+    InterfaceRedundancyGroupAssociation.objects.update(created_datetimefield=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dcim", "0022_interface_redundancy_group"),
+        ("dcim", "0050_fix_interface_redundancy_group_association_created"),
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("extras", "0001_initial_part_1"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_null_statuses, migrations.RunPython.noop),
+        migrations.RunPython(copy_created_to_created_datetimefield, revert_copy_created_to_created_datetimefield),
+    ]

--- a/nautobot/dcim/migrations/0052_fix_interface_redundancy_group_created.py
+++ b/nautobot/dcim/migrations/0052_fix_interface_redundancy_group_created.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+
+import nautobot.extras.models.statuses
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dcim", "0022_interface_redundancy_group"),
+        ("dcim", "0051_interface_redundancy_group_nullable_status"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="interfaceredundancygroupassociation",
+            name="created",
+        ),
+        migrations.RenameField(
+            model_name="interfaceredundancygroupassociation",
+            old_name="created_datetimefield",
+            new_name="created",
+        ),
+        # Migration 0022 diverged between 1.6 and 2.0 so we must make the status field nullable here
+        # to force Django to recognize that the field has changed.
+        migrations.AlterField(
+            model_name="interfaceredundancygroup",
+            name="status",
+            field=nautobot.extras.models.statuses.StatusField(
+                null=True,
+                on_delete=models.deletion.PROTECT,
+                related_name="interface_redundancy_groups",
+                to="extras.status",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="interfaceredundancygroup",
+            name="status",
+            field=nautobot.extras.models.statuses.StatusField(
+                on_delete=models.deletion.PROTECT,
+                related_name="interface_redundancy_groups",
+                to="extras.status",
+            ),
+        ),
+    ]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4684
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

- Fixed InterfaceRedundancyGroup.status to no longer be nullable
- Fixed InterfaceRedundancyGroupAssociation.created to be a DateTimeField

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
