### PR TITLE
Bugfix 4728: LTM JobResult filter exact date matches

### DIFF
--- a/changes/4728.fixed
+++ b/changes/4728.fixed
@@ -1,0 +1,1 @@
+Fixed bug with JobResultFilterSet and ScheduledJobFilterSet using django_filters.DateTimeFilter for only exact date matches.

--- a/nautobot/extras/filters/__init__.py
+++ b/nautobot/extras/filters/__init__.py
@@ -661,8 +661,6 @@ class JobResultFilterSet(BaseFilterSet, CustomFieldModelFilterSetMixin):
         label="Job (ID) - Deprecated (use job_model filter)",
     )
     obj_type = ContentTypeFilter()
-    created = django_filters.DateTimeFilter()
-    completed = django_filters.DateTimeFilter()
     status = django_filters.MultipleChoiceFilter(choices=JobResultStatusChoices, null_value=None)
 
     class Meta:
@@ -702,12 +700,9 @@ class ScheduledJobFilterSet(BaseFilterSet):
         label="Job (ID) - Deprecated (use job_model filter)",
     )
 
-    first_run = django_filters.DateTimeFilter()
-    last_run = django_filters.DateTimeFilter()
-
     class Meta:
         model = ScheduledJob
-        fields = ["id", "name", "total_run_count"]
+        fields = ["id", "name", "total_run_count", "start_time", "last_run_at"]
 
 
 #


### PR DESCRIPTION
# Closes: #4728
# What's Changed
Removed django_filters.DateTimeFilter from date fields in JobResultFilterSet and ScheduledJobFilterSet, to use default of MultiValueDateTimeFilter. The DateTimeFilter was allowing only exact date matches for date fields.

This is an LTM 1.6 PR for the 2.0 fix in PR #4731 which has already been approved. I have tested on 1.6 as well and got the same results.

# TODO
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
