### PR TITLE
Fix #4726

### DIFF
--- a/changes/4726.fixed
+++ b/changes/4726.fixed
@@ -1,0 +1,1 @@
+Fixed the bug caused by Tenant Edit View template accessing `group` instead of `tenant_group`.

--- a/nautobot/tenancy/templates/tenancy/tenant_edit.html
+++ b/nautobot/tenancy/templates/tenancy/tenant_edit.html
@@ -7,7 +7,7 @@
         <div class="panel-heading"><strong>Tenant</strong></div>
         <div class="panel-body">
             {% render_field form.name %}
-            {% render_field form.group %}
+            {% render_field form.tenant_group %}
             {% render_field form.description %}
         </div>
     </div>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4726
# What's Changed
tenant_group field is missing from the edit page template - https://github.com/nautobot/nautobot/blob/develop/nautobot/tenancy/templates/tenancy/tenant_edit.html#L10 should be form.tenant_group not form.group

