### PR TITLE
Data Export as system Job

### DIFF
--- a/changes/4745.added
+++ b/changes/4745.added
@@ -1,0 +1,1 @@
+Added `ExportObjectList` system Job.

--- a/changes/4745.changed
+++ b/changes/4745.changed
@@ -1,0 +1,1 @@
+Changed object export (CSV, YAML, export-template) to run as a background task, avoiding HTTP timeouts when exporting thousands of objects in a single operation.

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -134,7 +134,15 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializ
     natural_keys_values = None
     natural_slug = serializers.SerializerMethodField()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, force_csv=False, **kwargs):
+        """
+        Instantiate a BaseModelSerializer.
+
+        The force_csv kwarg allows you to force _is_csv_request() to evaluate True without passing a Request object,
+        which is necessary to be able to export appropriately structured CSV from a Job that doesn't have a Request.
+        """
+        self._force_csv = force_csv
+
         super().__init__(*args, **kwargs)
         # If it is not a Nested Serializer, we should set the depth argument to whatever is in the request's context
         if not self.is_nested:
@@ -270,6 +278,8 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializ
 
     def _is_csv_request(self):
         """Return True if this a CSV export request"""
+        if self._force_csv:
+            return True
         request = self.context.get("request")
         return hasattr(request, "accepted_media_type") and "text/csv" in request.accepted_media_type
 

--- a/nautobot/core/jobs/__init__.py
+++ b/nautobot/core/jobs/__init__.py
@@ -113,7 +113,7 @@ class ExportObjectList(Job):
         # TODO: ideally the ObjectListView should strip its non_filter_params (which may vary by view!)
         #       such that they never are even seen here.
         query_params = QueryDict(query_string)
-        self.logger.debug("Parsed query_params: `%s`", query_params)
+        self.logger.debug("Parsed query_params: `%s`", query_params.dict())
         default_non_filter_params = ("export", "page", "per_page", "sort")
         filter_params = get_filterable_params_from_filter_params(
             query_params, default_non_filter_params, filterset_class()

--- a/nautobot/core/jobs/__init__.py
+++ b/nautobot/core/jobs/__init__.py
@@ -1,7 +1,15 @@
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.http import QueryDict
+
+from nautobot.core.api.renderers import NautobotCSVRenderer
+from nautobot.core.api.utils import get_serializer_for_model
 from nautobot.core.celery import app, register_jobs
+from nautobot.core.utils.lookup import get_filterset_for_model
+from nautobot.core.utils.requests import get_filterable_params_from_filter_params
 from nautobot.extras.datasources import ensure_git_repository, git_repository_dry_run, refresh_datasource_content
-from nautobot.extras.jobs import Job, ObjectVar
-from nautobot.extras.models import GitRepository
+from nautobot.extras.jobs import Job, ObjectVar, StringVar
+from nautobot.extras.models import ExportTemplate, GitRepository
 
 name = "System Jobs"
 
@@ -59,5 +67,108 @@ class GitRepositoryDryRun(Job):
             self.logger.info(f"Repository dry run completed in {job_result.duration}")
 
 
-jobs = [GitRepositorySync, GitRepositoryDryRun]
+class ExportObjectList(Job):
+    """System Job to export a list of objects via CSV or ExportTemplate."""
+
+    content_type = ObjectVar(
+        model=ContentType,
+        description="Type of objects to export",
+        label="Content Type",
+    )
+    query_string = StringVar(
+        description='Filterset parameters to apply, in URL query parameter format e.g. "name=test&status=Active"',
+        label="Filterset Parameters",
+        default="",
+        required=False,
+    )
+    export_template = ObjectVar(
+        model=ExportTemplate,
+        query_params={"content_type": "$content_type"},
+        display_field="name",
+        description="Export Template to use (if unspecified, will export to generic CSV instead)",
+        label="Export Template",
+        default=None,
+        required=False,
+    )
+
+    class Meta:
+        name = "Export Object List"
+        has_sensitive_variables = False
+
+    def run(self, *, content_type, query_string="", export_template=None):
+        if not self.user.has_perm(f"{content_type.app_label}.view_{content_type.model}"):
+            self.logger.error('User "%s" does not have permission to view %s objects', self.user, content_type.model)
+            raise Exception("User does not have view permissions on the requested content-type")
+
+        model = content_type.model_class()
+
+        # Start with all objects of the requested type
+        queryset = model.objects.all()
+        # Enforce user permissions
+        queryset = queryset.restrict(self.user, "view")
+
+        # Filter the queryset based on the provided query_string
+        filterset_class = get_filterset_for_model(model)
+        self.logger.debug("Found filterset class: `%s`", filterset_class.__name__)
+        # TODO: ideally the ObjectListView should strip its non_filter_params (which may vary by view!)
+        #       such that they never are even seen here.
+        query_params = QueryDict(query_string)
+        self.logger.debug("Parsed query_params: `%s`", query_params)
+        default_non_filter_params = ("export", "page", "per_page", "sort")
+        filter_params = get_filterable_params_from_filter_params(
+            query_params, default_non_filter_params, filterset_class()
+        )
+        self.logger.debug("Filter params: `%s`", filter_params)
+        filterset = filterset_class(filter_params, queryset)
+        if not filterset.is_valid():
+            self.logger.error("Invalid filters were specified: %s", filterset.errors)
+            raise Exception("Invalid query_string value for this content_type")
+        queryset = filterset.qs
+
+        filename = f"{settings.BRANDING_PREPENDED_FILENAME}{model._meta.verbose_name_plural.lower().replace(' ', '_')}"
+
+        # If query_string == "export", then query_params["export"] will be [""], rather than [] or "" as might expect
+        if export_template is None and query_params.get("export", [""]) != [""]:
+            try:
+                export_template = ExportTemplate.objects.get(content_type=content_type, name=query_params.get("export"))
+            except ExportTemplate.DoesNotExist as err:
+                self.logger.error(
+                    "ExportTemplate %s not found for content-type %s", query_params.get("export"), content_type
+                )
+                raise Exception("Requested export-template not found") from err
+
+        if export_template is not None:
+            # Export templates
+            if export_template.content_type != content_type:
+                self.logger.error("ExportTemplate %s doesn't apply to %s", export_template, content_type)
+                raise Exception("ExportTemplate ContentType mismatch")
+            self.logger.info("Exporting based on ExportTemplate", extra={"object": export_template})
+            try:
+                output = export_template.render(queryset)
+            except Exception as e:
+                self.logger.error("Error when rendering ExportTemplate: %s", e)
+                raise
+            if export_template.file_extension:
+                filename += f".{export_template.file_extension}"
+            self.create_file(filename, output)
+
+        elif "export" in query_params and hasattr(model, "to_yaml"):
+            # Device-type YAML export
+            self.logger.info("Exporting to YAML")
+            yaml_data = [obj.to_yaml() for obj in queryset]
+            self.create_file(filename + ".yaml", "---\n".join(yaml_data))
+
+        else:
+            # Generic CSV export
+            self.logger.info("Exporting to CSV")
+            serializer_class = get_serializer_for_model(model)
+            self.logger.debug("Found serializer class: `%s`", serializer_class.__name__)
+            # The force_csv=True attribute is a hack, but much easier than trying to construct a valid HttpRequest
+            # object from scratch that passes all implicit and explicit assumptions in Django and DRF.
+            serializer = serializer_class(queryset, many=True, context={"request": None}, force_csv=True)
+            output = NautobotCSVRenderer().render(serializer.data)
+            self.create_file(filename + ".csv", output)
+
+
+jobs = [ExportObjectList, GitRepositorySync, GitRepositoryDryRun]
 register_jobs(*jobs)

--- a/nautobot/core/templates/buttons/export.html
+++ b/nautobot/core/templates/buttons/export.html
@@ -1,5 +1,5 @@
 {% if export_url %}
-    {% if export_templates %}
+    {% if export_templates or include_yaml_option %}
         <div class="btn-group">
             <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <span class="mdi mdi-database-export" aria-hidden="true"></span>
@@ -7,7 +7,6 @@
             </button>
             <ul class="dropdown-menu dropdown-menu-right">
                 <li>
-                    <!-- CSV export, no export-template -->
                     <form action="{{ export_url }}" method="post">
                         {% csrf_token %}
                         <input type="hidden" name="content_type" value="{{ content_type.pk }}">
@@ -16,21 +15,35 @@
                         <button type="submit" class="btn btn-link">CSV format</button>
                     </form>
                 </li>
-                <li class="divider"></li>
-                {% for et in export_templates %}
+                {% if include_yaml_option %}
                     <li>
                         <form action="{{ export_url }}" method="post">
                             {% csrf_token %}
                             <input type="hidden" name="content_type" value="{{ content_type.pk }}">
-                            <input type="hidden" name="export_template" value="{{ et.pk }}">
                             <input type="hidden" name="query_string" value="{{ query_string }}">
+                            <input type="hidden" name="export_format" value="yaml">
                             <input type="hidden" name="_schedule_type" value="immediately">
-                            <button type="submit" class="btn btn-link"
-                                {% if et.description %}title="{{ et.description }}"{% endif %}
-                            >{{ et.name }}</button>
+                            <button type="submit" class="btn btn-link">YAML format</button>
                         </form>
                     </li>
-                {% endfor %}
+                {% endif %}
+                {% if export_templates %}
+                    <li class="divider"></li>
+                    {% for et in export_templates %}
+                        <li>
+                            <form action="{{ export_url }}" method="post">
+                                {% csrf_token %}
+                                <input type="hidden" name="content_type" value="{{ content_type.pk }}">
+                                <input type="hidden" name="export_template" value="{{ et.pk }}">
+                                <input type="hidden" name="query_string" value="{{ query_string }}">
+                                <input type="hidden" name="_schedule_type" value="immediately">
+                                <button type="submit" class="btn btn-link"
+                                    {% if et.description %}title="{{ et.description }}"{% endif %}
+                                >{{ et.name }}</button>
+                            </form>
+                        </li>
+                    {% endfor %}
+                {% endif %}
             </ul>
         </div>
     {% else %}

--- a/nautobot/core/templates/buttons/export.html
+++ b/nautobot/core/templates/buttons/export.html
@@ -25,7 +25,9 @@
                             <input type="hidden" name="export_template" value="{{ et.pk }}">
                             <input type="hidden" name="query_string" value="{{ query_string }}">
                             <input type="hidden" name="_schedule_type" value="immediately">
-                            <button type="submit" class="btn btn-link">{{ et.name }}</button>
+                            <button type="submit" class="btn btn-link"
+                                {% if et.description %}title="{{ et.description }}"{% endif %}
+                            >{{ et.name }}</button>
                         </form>
                     </li>
                 {% endfor %}

--- a/nautobot/core/templates/buttons/export.html
+++ b/nautobot/core/templates/buttons/export.html
@@ -6,16 +6,12 @@
         </button>
         <ul class="dropdown-menu dropdown-menu-right">
             {% if export_url %}
-                <li>
-                    <a href="{{ export_url }}?{% if url_params %}{{ url_params.urlencode }}&{% endif %}format=csv">
-                        Default format
-                    </a>
-                </li>
+                <li><a href="{{ export_url }}{% if url_params %}?{{ url_params }}{% endif %}">Default format </a></li>
             {% endif %}
             <li class="divider"></li>
             {% for et in export_templates %}
                 <li>
-                    <a href="?{% if url_params %}{{ url_params.urlencode }}&{% endif %}export={{ et.name }}"
+                    <a href="{{ export_url }}?{% if url_params %}{{ url_params }}&{% endif %}export_template={{ et.pk }}"
                        {% if et.description %} title="{{ et.description }}"{% endif %}
                     >
                         {{ et.name }}
@@ -25,9 +21,7 @@
         </ul>
     </div>
 {% elif export_url %}
-    <a href="{{ export_url }}?{% if url_params %}{{ url_params.urlencode }}&{% endif %}format=csv"
-       class="btn btn-success"
-    >
+    <a href="{{ export_url }}{% if url_params %}?{{ url_params }}{% endif %}" class="btn btn-success">
         <span class="mdi mdi-database-export" aria-hidden="true"></span> Export
     </a>
 {% endif %}

--- a/nautobot/core/templates/buttons/export.html
+++ b/nautobot/core/templates/buttons/export.html
@@ -1,27 +1,45 @@
-{% if export_templates %}
-    <div class="btn-group">
-        <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class="mdi mdi-database-export" aria-hidden="true"></span>
-            Export <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu dropdown-menu-right">
-            {% if export_url %}
-                <li><a href="{{ export_url }}{% if url_params %}?{{ url_params }}{% endif %}">Default format </a></li>
-            {% endif %}
-            <li class="divider"></li>
-            {% for et in export_templates %}
+{% if export_url %}
+    {% if export_templates %}
+        <div class="btn-group">
+            <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="mdi mdi-database-export" aria-hidden="true"></span>
+                Export <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-right">
                 <li>
-                    <a href="{{ export_url }}?{% if url_params %}{{ url_params }}&{% endif %}export_template={{ et.pk }}"
-                       {% if et.description %} title="{{ et.description }}"{% endif %}
-                    >
-                        {{ et.name }}
-                    </a>
+                    <!-- CSV export, no export-template -->
+                    <form action="{{ export_url }}" method="post">
+                        {% csrf_token %}
+                        <input type="hidden" name="content_type" value="{{ content_type.pk }}">
+                        <input type="hidden" name="query_string" value="{{ query_string }}">
+                        <input type="hidden" name="_schedule_type" value="immediately">
+                        <button type="submit" class="btn btn-link">CSV format</button>
+                    </form>
                 </li>
-            {% endfor %}
-        </ul>
-    </div>
-{% elif export_url %}
-    <a href="{{ export_url }}{% if url_params %}?{{ url_params }}{% endif %}" class="btn btn-success">
-        <span class="mdi mdi-database-export" aria-hidden="true"></span> Export
-    </a>
+                <li class="divider"></li>
+                {% for et in export_templates %}
+                    <li>
+                        <form action="{{ export_url }}" method="post">
+                            {% csrf_token %}
+                            <input type="hidden" name="content_type" value="{{ content_type.pk }}">
+                            <input type="hidden" name="export_template" value="{{ et.pk }}">
+                            <input type="hidden" name="query_string" value="{{ query_string }}">
+                            <input type="hidden" name="_schedule_type" value="immediately">
+                            <button type="submit" class="btn btn-link">{{ et.name }}</button>
+                        </form>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% else %}
+        <form style="display: inline-block" action="{{ export_url }}" method="post">
+            {% csrf_token %}
+            <input type="hidden" name="content_type" value="{{ content_type.pk }}">
+            <input type="hidden" name="query_string" value="{{ query_string }}">
+            <input type="hidden" name="_schedule_type" value="immediately">
+            <button type="submit" class="btn btn-success">
+                <span class="mdi mdi-database-export" aria-hidden="true"></span> Export
+            </button>
+        </form>
+    {% endif %}
 {% endif %}

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlencode
-
 from django import template
 from django.urls import NoReverseMatch, reverse
 

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from django import template
 from django.urls import NoReverseMatch, reverse
 
@@ -114,15 +116,19 @@ def export_button(context, content_type=None):
         user = context["request"].user
         export_templates = models.ExportTemplate.objects.restrict(user, "view").filter(content_type=content_type)
         try:
-            export_url = reverse(lookup.get_route_for_model(content_type.model_class(), "list", api=True))
+            export_url = reverse(
+                "extras:job_run_by_class_path", kwargs={"class_path": "nautobot.core.jobs.ExportObjectList"}
+            )
         except NoReverseMatch:
             export_url = None
     else:
         export_templates = []
         export_url = None
 
+    url_params = urlencode({"query_string": context["request"].GET.urlencode(), "content_type": content_type.pk})
+
     return {
         "export_url": export_url,
-        "url_params": context["request"].GET,
+        "url_params": url_params,
         "export_templates": export_templates,
     }

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -125,10 +125,9 @@ def export_button(context, content_type=None):
         export_templates = []
         export_url = None
 
-    url_params = urlencode({"query_string": context["request"].GET.urlencode(), "content_type": content_type.pk})
-
     return {
         "export_url": export_url,
-        "url_params": url_params,
+        "query_string": context["request"].GET.urlencode(),
+        "content_type": content_type,
         "export_templates": export_templates,
     }

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -119,6 +119,7 @@ def export_button(context, content_type=None):
             )
         except NoReverseMatch:
             export_url = None
+        include_yaml_option = hasattr(content_type.model_class(), "to_yaml")
     else:
         export_templates = []
         export_url = None
@@ -128,4 +129,5 @@ def export_button(context, content_type=None):
         "query_string": context["request"].GET.urlencode(),
         "content_type": content_type,
         "export_templates": export_templates,
+        "include_yaml_option": include_yaml_option,
     }

--- a/nautobot/core/tests/test_jobs.py
+++ b/nautobot/core/tests/test_jobs.py
@@ -1,0 +1,63 @@
+from django.contrib.contenttypes.models import ContentType
+
+from nautobot.core.jobs import ExportObjectList
+from nautobot.core.testing import TransactionTestCase, create_job_result_and_run_job, get_job_class_and_model
+from nautobot.extras.choices import JobResultStatusChoices, LogLevelChoices
+from nautobot.extras.models import JobLogEntry, Status
+from nautobot.users.models import ObjectPermission
+
+
+class ExportObjectListTest(TransactionTestCase):
+    """
+    Test the ExportObjectList system job.
+    """
+
+    databases = ("default", "job_logs")
+
+    def test_export_without_permission(self):
+        """Job should enforce user permissions on the content-type being asked for export."""
+        job_result = create_job_result_and_run_job(
+            "nautobot.core.jobs",
+            "ExportObjectList",
+            username=self.user.username,  # otherwise run_job_for_testing defaults to a superuser account
+            content_type=ContentType.objects.get_for_model(Status).pk,
+        )
+        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        log_error = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
+        self.assertEqual(log_error.message, f'User "{self.user}" does not have permission to view status objects')
+
+    def test_export_with_constrained_permission(self):
+        """Job should only allow the user to export objects they have permission to view."""
+        instance1, instance2 = Status.objects.all()[:2]
+        obj_perm = ObjectPermission(
+            name="Test permission",
+            constraints={"pk": instance1.pk},
+            actions=["view"],
+        )
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ContentType.objects.get_for_model(Status))
+        job_result = create_job_result_and_run_job(
+            "nautobot.core.jobs",
+            "ExportObjectList",
+            username=self.user.username,  # otherwise run_job_for_testing defaults to a superuser account
+            content_type=ContentType.objects.get_for_model(Status).pk,
+        )
+        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertTrue(job_result.files.exists())
+        csv_data = job_result.files.first().file.read().decode("utf-8")
+        self.assertIn(str(instance1.pk), csv_data)
+        self.assertNotIn(str(instance2.pk), csv_data)
+
+    def test_export_all_to_csv(self):
+        """By default, job should export all instances to CSV."""
+        job_result = create_job_result_and_run_job(
+            "nautobot.core.jobs",
+            "ExportObjectList",
+            content_type=ContentType.objects.get_for_model(Status).pk,
+        )
+        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertTrue(job_result.files.exists())
+        csv_data = job_result.files.first().file.read().decode("utf-8")
+        # May be more than one line per Status if they have newlines in their description strings
+        self.assertGreaterEqual(len(csv_data.split("\n")), Status.objects.count() + 1, csv_data)  # +1 for CSV header

--- a/nautobot/core/tests/test_jobs.py
+++ b/nautobot/core/tests/test_jobs.py
@@ -1,9 +1,12 @@
-from django.contrib.contenttypes.models import ContentType
+from pathlib import Path
 
-from nautobot.core.jobs import ExportObjectList
-from nautobot.core.testing import TransactionTestCase, create_job_result_and_run_job, get_job_class_and_model
+from django.contrib.contenttypes.models import ContentType
+import yaml
+
+from nautobot.core.testing import TransactionTestCase, create_job_result_and_run_job
+from nautobot.dcim.models import DeviceType, Manufacturer
 from nautobot.extras.choices import JobResultStatusChoices, LogLevelChoices
-from nautobot.extras.models import JobLogEntry, Status
+from nautobot.extras.models import ExportTemplate, JobLogEntry, Status
 from nautobot.users.models import ObjectPermission
 
 
@@ -25,6 +28,7 @@ class ExportObjectListTest(TransactionTestCase):
         self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
         log_error = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertEqual(log_error.message, f'User "{self.user}" does not have permission to view status objects')
+        self.assertFalse(job_result.files.exists())
 
     def test_export_with_constrained_permission(self):
         """Job should only allow the user to export objects they have permission to view."""
@@ -45,6 +49,7 @@ class ExportObjectListTest(TransactionTestCase):
         )
         self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertTrue(job_result.files.exists())
+        self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_statuses.csv")
         csv_data = job_result.files.first().file.read().decode("utf-8")
         self.assertIn(str(instance1.pk), csv_data)
         self.assertNotIn(str(instance2.pk), csv_data)
@@ -58,6 +63,50 @@ class ExportObjectListTest(TransactionTestCase):
         )
         self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertTrue(job_result.files.exists())
+        self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_statuses.csv")
         csv_data = job_result.files.first().file.read().decode("utf-8")
         # May be more than one line per Status if they have newlines in their description strings
         self.assertGreaterEqual(len(csv_data.split("\n")), Status.objects.count() + 1, csv_data)  # +1 for CSV header
+
+    def test_export_all_via_export_template(self):
+        """When an export-template is specified, it should be used."""
+        et = ExportTemplate.objects.create(
+            content_type=ContentType.objects.get_for_model(Status),
+            name="Simple Export Template",
+            template_code="{% for obj in queryset %}{{ obj.name }}\n{% endfor %}",
+            file_extension="txt",
+        )
+        job_result = create_job_result_and_run_job(
+            "nautobot.core.jobs",
+            "ExportObjectList",
+            content_type=ContentType.objects.get_for_model(Status).pk,
+            export_template=et.pk,
+        )
+        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertTrue(job_result.files.exists())
+        self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_statuses.txt")
+        text_data = job_result.files.first().file.read().decode("utf-8")
+        self.assertEqual(len(text_data.split("\n")), Status.objects.count() + 1)
+        for status in Status.objects.iterator():
+            self.assertIn(status.name, text_data)
+
+    def test_export_devicetype_to_yaml(self):
+        """Export device-type to YAML."""
+        mfr = Manufacturer.objects.create(name="Cisco")
+        DeviceType.objects.create(
+            manufacturer=mfr,
+            model="Cisco CSR1000v",
+            u_height=0,
+        )
+        job_result = create_job_result_and_run_job(
+            "nautobot.core.jobs",
+            "ExportObjectList",
+            content_type=ContentType.objects.get_for_model(DeviceType).pk,
+            export_format="yaml",
+        )
+        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertTrue(job_result.files.exists())
+        self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_device_types.yaml")
+        yaml_data = job_result.files.first().file.read().decode("utf-8")
+        data = yaml.safe_load(yaml_data)
+        self.assertEqual(data["manufacturer"], "Cisco")

--- a/nautobot/core/utils/requests.py
+++ b/nautobot/core/utils/requests.py
@@ -114,13 +114,12 @@ def get_filterable_params_from_filter_params(filter_params, non_filter_params, f
     Returns:
         (QueryDict): Filter param querydict with only queryset filterable params
     """
-    for non_filter_param in non_filter_params:
-        filter_params.pop(non_filter_param, None)
-
     # Some FilterSet field only accept single choice not multiple choices
     # e.g datetime field, bool fields etc.
     final_filter_params = {}
     for field in filter_params.keys():
+        if field in non_filter_params:
+            continue
         if filter_params.get(field):
             # `is_single_choice_field` implements `get_filterset_field`, which throws an exception if a field is not found.
             # If an exception is thrown, instead of throwing an exception, set `_is_single_choice_field` to 'False'

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -158,7 +158,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
     template_name = "generic/object_list.html"
     action_buttons = ("add", "import", "export")
     non_filter_params = (
-        "export",  # trigger for CSV/export-template/YAML export
+        "export",  # trigger for CSV/export-template/YAML export # 3.0 TODO: remove, irrelevant after #4746
         "page",  # used by django-tables2.RequestConfig
         "per_page",  # used by get_paginate_count
         "sort",  # table sorting
@@ -172,7 +172,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
     def get_required_permission(self):
         return get_permission_for_model(self.queryset.model, "view")
 
-    # TODO: remove this as well?
+    # 3.0 TODO: remove, irrelevant after #4746
     def queryset_to_yaml(self):
         """
         Export the queryset of objects as concatenated YAML documents.
@@ -235,7 +235,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
                 filter_form = self.filterset_form(filter_params, label_suffix="")
 
         # Check for export template rendering
-        if request.GET.get("export"):
+        if request.GET.get("export"):  # 3.0 TODO: remove, irrelevant after #4746
             et = get_object_or_404(
                 ExportTemplate,
                 content_type=content_type,
@@ -250,7 +250,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
                 )
 
         # Check for YAML export support
-        elif "export" in request.GET and hasattr(model, "to_yaml"):
+        elif "export" in request.GET and hasattr(model, "to_yaml"):  # 3.0 TODO: remove, irrelevant after #4746
             response = HttpResponse(self.queryset_to_yaml(), content_type="text/yaml")
             filename = f"{settings.BRANDING_PREPENDED_FILENAME}{self.queryset.model._meta.verbose_name_plural}.yaml"
             response["Content-Disposition"] = f'attachment; filename="{filename}"'

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -605,7 +605,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
     filterset_class = None
     filterset_form_class = None
     non_filter_params = (
-        "export",  # trigger for CSV/export-template/YAML export
+        "export",  # trigger for CSV/export-template/YAML export # 3.0 TODO: remove, irrelevant after #4746
         "page",  # used by django-tables2.RequestConfig
         "per_page",  # used by get_paginate_count
         "sort",  # table sorting
@@ -627,6 +627,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
                 queryset = queryset.none()
         return queryset
 
+    # 3.0 TODO: remove, irrelevant after #4746
     def check_for_export(self, request, model, content_type):
         # Check for export template rendering
         queryset = self.filter_queryset(self.get_queryset())
@@ -653,6 +654,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
 
         return None
 
+    # 3.0 TODO: remove, irrelevant after #4746
     def queryset_to_yaml(self):
         """
         Export the queryset of objects as concatenated YAML documents.
@@ -667,7 +669,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
         List the model instances.
         """
         context = {"use_new_ui": True}
-        if "export" in request.GET:
+        if "export" in request.GET:  # 3.0 TODO: remove, irrelevant after #4746
             queryset = self.get_queryset()
             model = queryset.model
             content_type = ContentType.objects.get_for_model(model)

--- a/nautobot/docs/release-notes/version-2.1.md
+++ b/nautobot/docs/release-notes/version-2.1.md
@@ -6,9 +6,20 @@ This document describes all new features and changes in Nautobot 2.1.
 
 ### Added
 
-#### Job file outputs ([#3352](https://github.com/nautobot/nautobot/issues/3352))
+#### Job File Outputs ([#3352](https://github.com/nautobot/nautobot/issues/3352))
 
 The `Job` base class now includes a [`create_file(filename, content)`](../development/jobs/index.md#file-output) method which can be called by a Job to create a persistent file with the provided content when run. This file will be linked from the Job Result detail view for subsequent download by users.
 
 !!! info
     The specific storage backend used to retain such files is controlled by the [`JOB_FILE_IO_STORAGE`](../user-guide/administration/configuration/optional-settings.md#job_file_io_storage) settings variable. The default value of this setting uses the Nautobot database to store output files, which should work in all deployments but is generally not optimal and better alternatives may exist in your specific deployment. Refer to the documentation link above for more details.
+
+### Changed
+
+#### Data Exports as System Job ([#4745](https://github.com/nautobot/nautobot/issues/4745))
+
+The data export functionality in all object list views (allowing export of all or a filtered subset of objects to CSV, YAML, and/or as defined by an `ExportTemplate`) has been changed from a synchronous operation to an asynchronous background task, leveraging the new `ExportObjectList` system Job. As a result, exports of thousands of objects in a single operation will no longer fail due to browser timeout.
+
+!!! tip
+    Users now must have `run_job` permission for the `nautobot.core.jobs.ExportObjectList` Job in order to export objects, in addition to the normal `view_<object_type>` permissions for the objects being exported.
+
+<!-- towncrier release notes start -->

--- a/nautobot/docs/release-notes/version-2.1.md
+++ b/nautobot/docs/release-notes/version-2.1.md
@@ -15,7 +15,7 @@ The `Job` base class now includes a [`create_file(filename, content)`](../develo
 
 ### Changed
 
-#### Data Exports as System Job ([#4745](https://github.com/nautobot/nautobot/issues/4745))
+#### Data Exports as a System Job ([#4745](https://github.com/nautobot/nautobot/issues/4745))
 
 The data export functionality in all object list views (allowing export of all or a filtered subset of objects to CSV, YAML, and/or as defined by an `ExportTemplate`) has been changed from a synchronous operation to an asynchronous background task, leveraging the new `ExportObjectList` system Job. As a result, exports of thousands of objects in a single operation will no longer fail due to browser timeout.
 


### PR DESCRIPTION
# Closes: #4745 
# What's Changed

- Implement a System Job to handle export to CSV/YAML/Export-Templates as a background task.
- Update "Export" button/dropdown template so that clicking it runs this Job instead of hitting the REST API or the `export` special case of `ObjectListView`.
  - I haven't removed the export-case code from `ObjectListView` and its counterpart in `ObjectListViewMixin` at this time, just in case Apps are relying on either.
  - [x] I should probably add a `3.0 TODO` comment to these though.
- There's no performance optimization at this time - it sure would be nice (especially in the export-template case) if we had a "smart" queryset that would automatically include `select_related`/`prefetch_related` as appropriate.
- It'd be nice to have progress logs during the export process, but:
  - Not feasible at all for ExportTemplate case (the template processes the entire queryset as a single Jinja2 template rendering operation)
  - Due to DRF setup overhead, switching CSV to iterate over the queryset and serialize each record individually was about a factor of 3 slower than serializing the entire queryset in a single pass

![image](https://github.com/nautobot/nautobot/assets/5603551/31be2340-0282-48e9-9a19-1c38304c49a8)

![image](https://github.com/nautobot/nautobot/assets/5603551/b788f0ae-6e2f-4e6a-8dde-5a75058e7b19)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
