### PR TITLE
avoid crash when syncing a git repo without a worker

### DIFF
--- a/changes/4779.fixed
+++ b/changes/4779.fixed
@@ -1,0 +1,1 @@
+Avoid crashing when syncing a git repo without a worker running.

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -904,6 +904,7 @@ def check_and_call_git_repository_function(request, pk, func):
     # Allow execution only if a worker process is running.
     if not get_worker_count():
         messages.error(request, "Unable to run job: Celery worker process not running.")
+        return redirect(request.get_full_path(), permanent=False)
     else:
         repository = get_object_or_404(GitRepository, pk=pk)
         job_result = func(repository, request.user)


### PR DESCRIPTION
If a worker is not available and you attempt to sync a git repo, a crash will happen because you fall through to the case to redirecting based on the job_result variable. But there is no job_result variable in scope at this point. Instead return an HTTP 400 Bad Request to the user.