### PR TITLE
[1.6] Remove `NAUTOBOT_DYNAMIC_GROUPS_MEMBER_CACHE_TIMEOUT` documentation

### DIFF
--- a/changes/4700.housekeeping
+++ b/changes/4700.housekeeping
@@ -1,0 +1,1 @@
+Removed `NAUTOBOT_DYNAMIC_GROUPS_MEMBER_CACHE_TIMEOUT` reference from Environment Variable in docs as its not an environment variable.

--- a/changes/4700.housekeeping
+++ b/changes/4700.housekeeping
@@ -1,1 +1,1 @@
-Removed `NAUTOBOT_DYNAMIC_GROUPS_MEMBER_CACHE_TIMEOUT` reference from Environment Variable in docs as its not an environment variable.
+Removed incorrect `NAUTOBOT_DYNAMIC_GROUPS_MEMBER_CACHE_TIMEOUT` environment variable reference from settings documentation.

--- a/nautobot/docs/configuration/optional-settings.md
+++ b/nautobot/docs/configuration/optional-settings.md
@@ -399,8 +399,6 @@ A later release of Nautobot will address the underlying performance issues, and 
 
 Default: `0` (disabled)
 
-Environment Variable: `NAUTOBOT_DYNAMIC_GROUPS_MEMBER_CACHE_TIMEOUT`
-
 The number of seconds to cache the member list of dynamic groups. With large datasets (those in scope of a Dynamic Group and number of Dynamic Groups themselves), users will encounter a performance penalty using or accessing the membership lists. This setting allows users to accept a cached list for common use cases (particularly in the UI) that expires after the configured time. Set this to `0` to disable caching.
 
 ---


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4700 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
