### PR TITLE
Fixed REST API error that interpreted rack_group as a required field when creating a rack.

### DIFF
--- a/changes/4790.fixed
+++ b/changes/4790.fixed
@@ -1,0 +1,1 @@
+Fixed REST API error that interpreted `rack_group` as a required field when creating a rack.

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -277,6 +277,7 @@ class RackSerializer(
         list_display_fields = ["name", "location", "rack_group", "status", "facility_id", "tenant", "role", "u_height"]
         # Omit the UniqueTogetherValidators that would be automatically added to validate (rack_group, facility_id) and (rack_group, name).
         # This prevents facility_id and rack_group from being interpreted as required fields.
+        validators = []
         detail_view_config = {
             "layout": [
                 {

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -275,9 +275,8 @@ class RackSerializer(
         model = Rack
         fields = "__all__"
         list_display_fields = ["name", "location", "rack_group", "status", "facility_id", "tenant", "role", "u_height"]
-        # Omit the UniqueTogetherValidator that would be automatically added to validate (rack_group, facility_id).
-        # This prevents facility_id from being interpreted as a required field.
-        validators = [UniqueTogetherValidator(queryset=Rack.objects.all(), fields=("rack_group", "name"))]
+        # Omit the UniqueTogetherValidators that would be automatically added to validate (rack_group, facility_id) and (rack_group, name).
+        # This prevents facility_id and rack_group from being interpreted as a required field.
         detail_view_config = {
             "layout": [
                 {
@@ -294,8 +293,12 @@ class RackSerializer(
         }
 
     def validate(self, data):
+        # Validate uniqueness of (rack_group, name) since we omitted the automatically-created validator above.
+        if data.get("rack_group", None):
+            validator = UniqueTogetherValidator(queryset=Rack.objects.all(), fields=("rack_group", "name"))
+            validator(data, self)
         # Validate uniqueness of (rack_group, facility_id) since we omitted the automatically-created validator above.
-        if data.get("facility_id", None):
+        if data.get("facility_id", None) and data.get("rack_group", None):
             validator = UniqueTogetherValidator(queryset=Rack.objects.all(), fields=("rack_group", "facility_id"))
             validator(data, self)
 

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -276,7 +276,7 @@ class RackSerializer(
         fields = "__all__"
         list_display_fields = ["name", "location", "rack_group", "status", "facility_id", "tenant", "role", "u_height"]
         # Omit the UniqueTogetherValidators that would be automatically added to validate (rack_group, facility_id) and (rack_group, name).
-        # This prevents facility_id and rack_group from being interpreted as a required field.
+        # This prevents facility_id and rack_group from being interpreted as required fields.
         detail_view_config = {
             "layout": [
                 {

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -506,6 +506,13 @@ class RackTest(APIViewTestCases.APIViewTestCase):
                 "role": rack_roles[1].pk,
                 "status": statuses[1].pk,
             },
+            # Make sure rack_group is not interpreted as a required field
+            {
+                "name": "Test Rack 7",
+                "location": locations[1].pk,
+                "role": rack_roles[1].pk,
+                "status": statuses[1].pk,
+            },
         ]
         cls.bulk_update_data = {
             "status": statuses[1].pk,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4790 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Fixed REST API error that interpreted rack_group as a required field when creating a rack.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Unit, Integration Tests
