### PR TITLE
[1.6] Exclude docs source and animated gifs from built package

### DIFF
--- a/changes/4799.dependencies
+++ b/changes/4799.dependencies
@@ -1,0 +1,1 @@
+Updated `mkdocs` development dependency to `1.5.3`.

--- a/changes/4799.fixed
+++ b/changes/4799.fixed
@@ -1,0 +1,1 @@
+Reduced size of Nautobot `sdist` and `wheel` packages from 86 MB to 31 MB.

--- a/changes/4799.fixed
+++ b/changes/4799.fixed
@@ -1,1 +1,1 @@
-Reduced size of Nautobot `sdist` and `wheel` packages from 86 MB to 31 MB.
+Reduced size of Nautobot `sdist` and `wheel` packages from 69 MB to 29 MB.

--- a/changes/4799.housekeeping
+++ b/changes/4799.housekeeping
@@ -1,0 +1,1 @@
+Updated docs configuration for `examples/example_plugin`.

--- a/examples/example_plugin/docs/requirements.txt
+++ b/examples/example_plugin/docs/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs==1.3.1
-mkdocs-material==8.4.2
-mkdocstrings==0.19
-mkdocstrings-python==0.7.1
-Jinja2==3.0.3
-mkdocs-include-markdown-plugin==3.6.1
+Jinja2==3.1.2
+mkdocs==1.5.3
+mkdocs-include-markdown-plugin==4.0.4
+mkdocs-material==9.1.18
+mkdocstrings==0.22.0
+mkdocstrings-python==1.3.0

--- a/examples/example_plugin/mkdocs.yml
+++ b/examples/example_plugin/mkdocs.yml
@@ -11,12 +11,13 @@ theme:
     - "django"
     - "yaml"
   features:
-    - "navigation.tracking"
+    - "navigation.footer"
     - "navigation.tabs"
     - "navigation.tabs.sticky"
-    - "search.suggest"
+    - "navigation.tracking"
     - "search.highlight"
     - "search.share"
+    - "search.suggest"
   favicon: "assets/favicon.ico"
   logo: "assets/nautobot_logo.svg"
   palette:
@@ -35,6 +36,10 @@ theme:
       toggle:
         icon: "material/weather-night"
         name: "Switch to light mode"
+validation:
+  absolute_links: warn
+  omitted_files: warn
+  unrecognized_links: warn
 extra_css:
   - "assets/extra.css"
 extra:
@@ -73,3 +78,5 @@ plugins:
 
 nav:
   - Introduction: "index.md"
+  - Models:
+    - Example Model: "models/examplemodel.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,17 @@ theme:
       toggle:
         icon: "material/weather-night"
         name: "Switch to light mode"
+
+# The animated *.gif files in nautobot/docs/media are only used in the README.
+# Since their file size is quite large, we exclude them from the built docs.
+exclude_docs: |
+  /media/*.gif
+
+validation:
+  absolute_links: warn
+  omitted_files: warn
+  unrecognized_links: warn
+
 extra_css:
   - "assets/extra.css"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,11 @@ plugins:
             show_root_heading: true
             show_root_members_full_path: true
 
+not_in_nav: |
+  installation/centos.md
+  installation/ubuntu.md
+  installation/selinux-troubleshooting.md
+
 nav:
   - Overview: "index.md"
   - Documentation:

--- a/nautobot/docs/requirements.txt
+++ b/nautobot/docs/requirements.txt
@@ -1,7 +1,7 @@
 griffe==0.31.0
 Jinja2==3.1.2
 Markdown==3.3.7
-mkdocs==1.4.3
+mkdocs==1.5.3
 mkdocs-gen-files==0.5.0
 mkdocs-include-markdown-plugin==4.0.4
 mkdocs-material==9.1.18

--- a/poetry.lock
+++ b/poetry.lock
@@ -2010,13 +2010,13 @@ files = [
 
 [[package]]
 name = "mkdocs"
-version = "1.4.3"
+version = "1.5.3"
 description = "Project documentation with Markdown."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "mkdocs-1.4.3-py3-none-any.whl", hash = "sha256:6ee46d309bda331aac915cd24aab882c179a933bd9e77b80ce7d2eaaa3f689dd"},
-    {file = "mkdocs-1.4.3.tar.gz", hash = "sha256:5955093bbd4dd2e9403c5afaf57324ad8b04f16886512a3ee6ef828956481c57"},
+    {file = "mkdocs-1.5.3-py3-none-any.whl", hash = "sha256:3b3a78e736b31158d64dbb2f8ba29bd46a379d0c6e324c2246c3bc3d2189cfc1"},
+    {file = "mkdocs-1.5.3.tar.gz", hash = "sha256:eb7c99214dcb945313ba30426c2451b735992c73c2e10838f76d09e39ff4d0e2"},
 ]
 
 [package.dependencies]
@@ -2025,16 +2025,19 @@ colorama = {version = ">=0.4", markers = "platform_system == \"Windows\""}
 ghp-import = ">=1.0"
 importlib-metadata = {version = ">=4.3", markers = "python_version < \"3.10\""}
 jinja2 = ">=2.11.1"
-markdown = ">=3.2.1,<3.4"
+markdown = ">=3.2.1"
+markupsafe = ">=2.0.1"
 mergedeep = ">=1.3.4"
 packaging = ">=20.5"
+pathspec = ">=0.11.1"
+platformdirs = ">=2.2.0"
 pyyaml = ">=5.1"
 pyyaml-env-tag = ">=0.1"
 watchdog = ">=2.0"
 
 [package.extras]
 i18n = ["babel (>=2.9.0)"]
-min-versions = ["babel (==2.9.0)", "click (==7.0)", "colorama (==0.4)", "ghp-import (==1.0)", "importlib-metadata (==4.3)", "jinja2 (==2.11.1)", "markdown (==3.2.1)", "markupsafe (==2.0.1)", "mergedeep (==1.3.4)", "packaging (==20.5)", "pyyaml (==5.1)", "pyyaml-env-tag (==0.1)", "typing-extensions (==3.10)", "watchdog (==2.0)"]
+min-versions = ["babel (==2.9.0)", "click (==7.0)", "colorama (==0.4)", "ghp-import (==1.0)", "importlib-metadata (==4.3)", "jinja2 (==2.11.1)", "markdown (==3.2.1)", "markupsafe (==2.0.1)", "mergedeep (==1.3.4)", "packaging (==20.5)", "pathspec (==0.11.1)", "platformdirs (==2.2.0)", "pyyaml (==5.1)", "pyyaml-env-tag (==0.1)", "typing-extensions (==3.10)", "watchdog (==2.0)"]
 
 [[package]]
 name = "mkdocs-autorefs"
@@ -3969,4 +3972,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "e83efa3841327951c5c07f8c7e4718072996d43871080e4ba627820053048954"
+content-hash = "613ed75e90d9c9a0f1a4450fc2c4763ef79d4654c03a2066176408c6064d7661"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,12 @@ packages = [
     {include = "nautobot"}
 ]
 include = [
-    "CHANGELOG.md",
-    "CONTRIBUTING.md",
-    "LICENSE.txt",
-    "NOTICE",
-    # Poetry by default will exclude these files as they are in .gitignore
+    # Rendered documentation - Poetry by default would exclude these files as they are in .gitignore
     "nautobot/project-static/docs/**/*",
+]
+exclude = [
+    # Source code of the documentation doesn't need to be included since we package the rendered docs
+    "nautobot/docs/**/*",
 ]
 
 [tool.poetry.dependencies]
@@ -176,7 +176,7 @@ watchdog = "~3.0.0"
 # Helper for parsing docstrings
 griffe = "~0.31.0"
 # Rendering docs to HTML
-mkdocs = "~1.4.3"
+mkdocs = "~1.5.3"
 # Automatically generate some files as part of mkdocs build
 mkdocs-gen-files = "~0.5.0"
 # Allow Markdown files to include other files


### PR DESCRIPTION
# Closes: N/A, counterpart to #4799 for `ltm-1.6`
# What's Changed

Same as #4799, with the exception that there are three supplemental docs files in 1.6 that don't have a logical location in the nav hierarchy, so I've added `not_in_nav` configs to `mkdocs.yml` so that those three files don't make the docs build fail.

Reduces the built package size from 69M to 29M.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/aAttached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
