### PR TITLE
Fixed the error that occurred when fetching the API response for CircuitTermination with a cable connected to CircuitTermination, FrontPort, or RearPort.

### DIFF
--- a/changes/3179.fixed
+++ b/changes/3179.fixed
@@ -1,0 +1,1 @@
+Fixed the error that occurred when fetching the API response for CircuitTermination with a cable connected to CircuitTermination, FrontPort, or RearPort.

--- a/nautobot/circuits/api/serializers.py
+++ b/nautobot/circuits/api/serializers.py
@@ -4,7 +4,6 @@ from nautobot.circuits.models import Provider, Circuit, CircuitTermination, Circ
 from nautobot.core.api import WritableNestedSerializer
 from nautobot.dcim.api.nested_serializers import (
     NestedCableSerializer,
-    NestedInterfaceSerializer,
     NestedLocationSerializer,
     NestedSiteSerializer,
 )

--- a/nautobot/circuits/api/serializers.py
+++ b/nautobot/circuits/api/serializers.py
@@ -96,12 +96,13 @@ class CircuitTypeSerializer(NautobotModelSerializer):
         ]
 
 
-class CircuitCircuitTerminationSerializer(WritableNestedSerializer, NotesSerializerMixin):
+class CircuitCircuitTerminationSerializer(
+    WritableNestedSerializer, PathEndpointModelSerializerMixin, NotesSerializerMixin
+):
     url = serializers.HyperlinkedIdentityField(view_name="circuits-api:circuittermination-detail")
     site = NestedSiteSerializer()
     location = NestedLocationSerializer(required=False, allow_null=True)
     provider_network = NestedProviderNetworkSerializer()
-    connected_endpoint = NestedInterfaceSerializer()
 
     class Meta:
         model = CircuitTermination

--- a/nautobot/circuits/tests/test_api.py
+++ b/nautobot/circuits/tests/test_api.py
@@ -220,12 +220,6 @@ class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
         CircuitTermination.objects.create(circuit=circuits[0], site=sites[1], term_side=SIDE_Z)
         CircuitTermination.objects.create(circuit=circuits[1], site=sites[0], term_side=SIDE_A)
         CircuitTermination.objects.create(circuit=circuits[1], site=sites[1], term_side=SIDE_Z)
-        CircuitTermination.objects.create(
-            circuit=circuits[2], site=sites[0], term_side=CircuitTerminationSideChoices.SIDE_A
-        )
-        CircuitTermination.objects.create(
-            circuit=circuits[2], site=sites[0], term_side=CircuitTerminationSideChoices.SIDE_Z
-        )
 
         cls.create_data = [
             {
@@ -263,6 +257,13 @@ class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
         rearport1 = RearPort.objects.create(device=device, name="Rear Port 1", positions=1)
         frontport1 = FrontPort.objects.create(
             device=device, name="Front Port 1", rear_port=rearport1, rear_port_position=1
+        )
+
+        CircuitTermination.objects.create(
+            circuit=circuits[2], site=self.sites[0], term_side=CircuitTerminationSideChoices.SIDE_A
+        )
+        CircuitTermination.objects.create(
+            circuit=circuits[2], site=self.sites[0], term_side=CircuitTerminationSideChoices.SIDE_Z
         )
 
         with self.subTest("Assert CircuitTermination Cable connected to an Interface and Rear Port"):

--- a/nautobot/circuits/tests/test_api.py
+++ b/nautobot/circuits/tests/test_api.py
@@ -2,7 +2,8 @@ from django.urls import reverse
 
 from nautobot.circuits.choices import CircuitTerminationSideChoices
 from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, Provider, ProviderNetwork
-from nautobot.dcim.models import Site
+from nautobot.dcim.choices import InterfaceTypeChoices
+from nautobot.dcim.models import Cable, Device, DeviceType, DeviceRole, FrontPort, Interface, RearPort, Site
 from nautobot.extras.models import Status
 from nautobot.utilities.testing import APITestCase, APIViewTestCases
 
@@ -203,6 +204,7 @@ class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
             Site.objects.first(),
             Site.objects.last(),
         )
+        cls.sites = sites
 
         provider = Provider.objects.create(name="Provider 1", slug="provider-1")
         circuit_type = CircuitType.objects.create(name="Circuit Type 1", slug="circuit-type-1")
@@ -212,11 +214,18 @@ class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
             Circuit.objects.create(cid="Circuit 2", provider=provider, type=circuit_type),
             Circuit.objects.create(cid="Circuit 3", provider=provider, type=circuit_type),
         )
+        cls.circuits = circuits
 
         CircuitTermination.objects.create(circuit=circuits[0], site=sites[0], term_side=SIDE_A)
         CircuitTermination.objects.create(circuit=circuits[0], site=sites[1], term_side=SIDE_Z)
         CircuitTermination.objects.create(circuit=circuits[1], site=sites[0], term_side=SIDE_A)
         CircuitTermination.objects.create(circuit=circuits[1], site=sites[1], term_side=SIDE_Z)
+        CircuitTermination.objects.create(
+            circuit=circuits[2], site=sites[0], term_side=CircuitTerminationSideChoices.SIDE_A
+        )
+        CircuitTermination.objects.create(
+            circuit=circuits[2], site=sites[0], term_side=CircuitTerminationSideChoices.SIDE_Z
+        )
 
         cls.create_data = [
             {
@@ -234,3 +243,65 @@ class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
         ]
 
         cls.bulk_update_data = {"port_speed": 123456}
+
+    def test_circuit_termination_connected_endpoint(self):
+        """Assert that API response for CircuitTermination connected cables to CircuitTermination, Interface, FortPort, or RearPort does not raise any errors"""
+        # Fix for https://github.com/nautobot/nautobot/issues/3179
+        self.add_permissions("circuits.view_circuittermination")
+
+        status = Status.objects.get_for_model(Cable).first()
+        device_type = DeviceType.objects.exclude(manufacturer__isnull=True).first()
+        device_role = DeviceRole.objects.first()
+        device = Device.objects.create(
+            device_type=device_type, device_role=device_role, name="Device 2", site=self.sites[0]
+        )
+        circuits = self.circuits
+
+        interface = Interface.objects.create(
+            device=device, type=InterfaceTypeChoices.TYPE_1GE_FIXED, name="Interface 001"
+        )
+        rearport1 = RearPort.objects.create(device=device, name="Rear Port 1", positions=1)
+        frontport1 = FrontPort.objects.create(
+            device=device, name="Front Port 1", rear_port=rearport1, rear_port_position=1
+        )
+
+        with self.subTest("Assert CircuitTermination Cable connected to an Interface and Rear Port"):
+            Cable.objects.create(
+                termination_a=circuits[0].termination_a, termination_b=interface, label="Cable 1", status=status
+            )
+            Cable.objects.create(
+                termination_a=circuits[0].termination_z, termination_b=rearport1, label="Cable 2", status=status
+            )
+
+            response = self.client.get(
+                f"/api{circuits[0].termination_a.get_absolute_url()}",
+                **self.header,
+            )
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get(
+                f"/api{circuits[0].termination_z.get_absolute_url()}",
+                **self.header,
+            )
+            self.assertEqual(response.status_code, 200)
+
+        with self.subTest("Assert CircuitTermination Cable connected to a FrontPort and CircuitTermination"):
+            Cable.objects.create(
+                termination_a=circuits[2].termination_a,
+                termination_b=circuits[1].termination_z,
+                label="Cable 3",
+                status=status,
+            )
+            Cable.objects.create(
+                termination_a=circuits[2].termination_z, termination_b=frontport1, label="Cable 4", status=status
+            )
+
+            response = self.client.get(
+                f"/api{circuits[2].termination_a.get_absolute_url()}",
+                **self.header,
+            )
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get(
+                f"/api{circuits[2].termination_z.get_absolute_url()}",
+                **self.header,
+            )
+            self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3179 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
