### PR TITLE
fixes issue where unneccessary git operations were performed in `ensu…

### DIFF
--- a/changes/4142.fixed
+++ b/changes/4142.fixed
@@ -1,0 +1,1 @@
+Fixed unnecessary git operations when calling `ensure_git_repository` while the desired commit is already checked out.

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -5,6 +5,8 @@ import logging
 import mimetypes
 import os
 import re
+from contextlib import suppress
+from pathlib import Path
 from urllib.parse import quote
 
 from django.conf import settings
@@ -13,6 +15,7 @@ from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import transaction
 from django.utils.text import slugify
 import yaml
+from git import Repo, InvalidGitRepositoryError
 
 from nautobot.core.celery import nautobot_task
 from nautobot.dcim.models import Device, DeviceRole, DeviceType, Location, Platform, Region, Site
@@ -284,11 +287,21 @@ def ensure_git_repository(
       logger (logging.Logger): Optional Logger to additionally log results to.
       head (str): Optional Git commit hash to check out instead of pulling branch latest.
     """
+    # We want to check if the repo is already checked out at head. We also want to avoid calling
+    # get_repo_from_url_to_path_and_from_branch, because it will cause the URL to be rebuilt causing calls to a secrets
+    # backend. As such, if head is None, we can't perform these checks.
+    if head is not None:
+        # If the repo exists and has HEAD already checked out, the repo is present and has the correct branch selected.
+        with suppress(InvalidGitRepositoryError):
+            if (
+                Path(repository_record.filesystem_path).exists()
+                and Repo(repository_record.filesystem_path).head == head
+            ):
+                return
 
     from_url, to_path, from_branch = get_repo_from_url_to_path_and_from_branch(
         repository_record, logger=logger, job_result=job_result
     )
-
     try:
         repo_helper = GitRepo(to_path, from_url)
         head = repo_helper.checkout(from_branch, head)


### PR DESCRIPTION
# Closes: #4142
# What's Changed

`ensure_git_repository` runs once per job. If you more than 1 job per repository this can quickly cause performance issues, especially when using secrets backends because each repo sync is >=1 round trip with the secrets backend.

I tested this like this:

- Fork `demo-git-datasource` into `https://github.com/Kircheneer/demo-git-datasource`
- Sync from `nautobot-jobs` branch
- Delete the hostname validation job
- Sync again
	- Result: `Marking Job record as no longer installed` ✔️ 
- Then I added a log statement
- _Without_ resyncing, I ran the job
	 - The log statement didn't run ✔️ 
- Then I resynced, ran the job
	- The log statement ran ✔️ 
- Then I commented out my change
- Then I added another log statement and ran the job again
	- The new log statement didn't run ✔️ 

This proves that:
- Repository content is properly refreshed when actively syncing ✔️ 
- Repository content is _not_ refreshed automatically when running a job (both before _and_ after the change) ✔️ 

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
