### PR TITLE
Removed `custom_fields` from InterfaceRedundancyGroupAssociation.

### DIFF
--- a/changes/4797.removed
+++ b/changes/4797.removed
@@ -1,1 +1,1 @@
-Removed `custom_fields` from InterfaceRedundancyGroupAssociation.invoke start
+Removed erroneous `custom_fields` decorator from InterfaceRedundancyGroupAssociation as it's not a supported feature for this model.

--- a/changes/4797.removed
+++ b/changes/4797.removed
@@ -1,0 +1,1 @@
+Removed `custom_fields` from InterfaceRedundancyGroupAssociation.invoke start

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -895,7 +895,6 @@ class InterfaceRedundancyGroup(StatusModel, PrimaryModel):  # pylint: disable=to
 
 @extras_features(
     "relationships",
-    "custom_fields",
 )
 class InterfaceRedundancyGroupAssociation(BaseModel, ChangeLoggedModel):
     """Intermediary model for associating Interface(s) to InterfaceRedundancyGroup(s)."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4797 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
