### PR TITLE
Add table_inc_template to panel_table.html

### DIFF
--- a/nautobot/core/templates/panel_table.html
+++ b/nautobot/core/templates/panel_table.html
@@ -7,7 +7,7 @@
         </div>
     {% endif %}
     {% if table.rows %}
-        {% render_table table 'inc/table.html' %}
+        {% render_table table table_inc_template|default:'inc/table.html' %}
     {% else %}
         <div class="panel-body text-muted">None</div>
     {% endif %}


### PR DESCRIPTION
# Closes: #n/a
# What's Changed

Fix a regression introduced by #4775 - specifically, we were no longer respecting the `table_inc_template` optional context variable used to override the default table rendering for the Jobs table.

demo.nautobot.com:

![image](https://github.com/nautobot/nautobot/assets/5603551/2a9ecd42-9511-473d-b576-92e40ce862cc)

next.demo.nautobot.com (showing the regression):

![image](https://github.com/nautobot/nautobot/assets/5603551/d1ba9df0-4ddc-435e-9ff0-41841c2cd772)

locally fixed:

![image](https://github.com/nautobot/nautobot/assets/5603551/58d25804-da72-4e25-b338-2c8a326dd215)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
