### PR TITLE
[2.1] Drop support for PostgreSQL versions before 12.0

### DIFF
--- a/changes/4757.added
+++ b/changes/4757.added
@@ -1,0 +1,1 @@
+Added system check for minimum PostgreSQL version.

--- a/changes/4757.removed
+++ b/changes/4757.removed
@@ -1,0 +1,1 @@
+Dropped support for PostgreSQL versions before 12.0.

--- a/nautobot/core/management/commands/post_upgrade.py
+++ b/nautobot/core/management/commands/post_upgrade.py
@@ -99,6 +99,7 @@ class Command(BaseCommand):
             self.stdout.write("Performing database migrations...")
             call_command(
                 "migrate",
+                skip_checks=False,  # make sure Postgres version check and others are applied
                 interactive=False,
                 traceback=options["traceback"],
                 verbosity=options["verbosity"],

--- a/nautobot/core/templates/exceptions/programming_error.html
+++ b/nautobot/core/templates/exceptions/programming_error.html
@@ -12,6 +12,6 @@
     <p>
         <i class="mdi mdi-alert"></i> <strong>Unsupported PostgreSQL version</strong> - Ensure that PostgreSQL version 12.0 or higher is in use. You
         can check this by connecting to the database using Nautobot's credentials and issuing a query for
-        <code>SELECT VERSION()</code>.
+        <code>SELECT VERSION();</code>.
     </p>
 {% endblock %}

--- a/nautobot/core/templates/exceptions/programming_error.html
+++ b/nautobot/core/templates/exceptions/programming_error.html
@@ -10,7 +10,7 @@
         <code>nautobot-server migrate</code> from the command line.
     </p>
     <p>
-        <i class="mdi mdi-alert"></i> <strong>Unsupported PostgreSQL version</strong> - Ensure that PostgreSQL version 9.6 or higher is in use. You
+        <i class="mdi mdi-alert"></i> <strong>Unsupported PostgreSQL version</strong> - Ensure that PostgreSQL version 12.0 or higher is in use. You
         can check this by connecting to the database using Nautobot's credentials and issuing a query for
         <code>SELECT VERSION()</code>.
     </p>

--- a/nautobot/docs/index.md
+++ b/nautobot/docs/index.md
@@ -71,7 +71,7 @@ Nautobot is built on the [Django](https://djangoproject.com/) Python Web framewo
 | HTTP service       | NGINX                           |
 | WSGI service       | uWSGI or Gunicorn               |
 | Application        | Django/Python                   |
-| Database           | PostgreSQL 9.6+ or MySQL 8.0+   |
+| Database           | PostgreSQL 12.0+ or MySQL 8.0+  |
 | Cache              | Django/Redis                    |
 | Task queuing       | Redis/Celery                    |
 | Live device access | NAPALM                          |
@@ -82,6 +82,9 @@ Nautobot is built on the [Django](https://djangoproject.com/) Python Web framewo
 --- 2.0.0
     - `django-rq` support was removed.
     - `django-cacheops` usage was removed and replaced with Django's native caching features.
+
+--- 2.1.0
+    Support for versions of PostgreSQL older than 12.0 was removed.
 
 The following diagram displays how data travels through Nautobot's application stack.
 

--- a/nautobot/docs/release-notes/version-2.1.md
+++ b/nautobot/docs/release-notes/version-2.1.md
@@ -37,7 +37,11 @@ The Nautobot UI has been updated with a customized theme, giving it a brand new 
 
 ### Removed
 
-#### Remove HIDE_RESTRICTED_UI toggle ([#4787](https://github.com/nautobot/nautobot/issues/4787))
+#### Drop Support for Legacy PostgreSQL Versions ([#4757](https://github.com/nautobot/nautobot/issues/4757))
+
+Support for versions of PostgreSQL prior to 12.0 has been removed as these versions are no longer maintained. The `nautobot-server migrate` or `nautobot-server post_upgrade` commands will now abort when detecting an unsupported PostgreSQL version.
+
+#### Remove `HIDE_RESTRICTED_UI` Toggle ([#4787](https://github.com/nautobot/nautobot/issues/4787))
 
 Support for `HIDE_RESTRICTED_UI` has been removed. UI elements requiring specific permissions will now always be hidden from users lacking those permissions. Additionally, users not logged in will now be automatically redirected to the login page.
 

--- a/nautobot/docs/release-notes/version-2.1.md
+++ b/nautobot/docs/release-notes/version-2.1.md
@@ -39,7 +39,7 @@ The Nautobot UI has been updated with a customized theme, giving it a brand new 
 
 #### Drop Support for Legacy PostgreSQL Versions ([#4757](https://github.com/nautobot/nautobot/issues/4757))
 
-Support for versions of PostgreSQL prior to 12.0 has been removed as these versions are no longer maintained. The `nautobot-server migrate` or `nautobot-server post_upgrade` commands will now abort when detecting an unsupported PostgreSQL version.
+Support for versions of PostgreSQL prior to 12.0 has been removed as these versions are no longer maintained and contain bugs that prevent migrations from running in certain scenarios. The `nautobot-server migrate` or `nautobot-server post_upgrade` commands will now abort when detecting an unsupported PostgreSQL version.
 
 #### Remove `HIDE_RESTRICTED_UI` Toggle ([#4787](https://github.com/nautobot/nautobot/issues/4787))
 

--- a/nautobot/docs/user-guide/administration/installation/index.md
+++ b/nautobot/docs/user-guide/administration/installation/index.md
@@ -15,7 +15,7 @@ The following minimum versions are required for Nautobot to operate:
 | Dependency | Role         | Minimum Version |
 |------------|--------------|-----------------|
 | Python     | Application  | 3.8             |
-| PostgreSQL | Database     | 9.6             |
+| PostgreSQL | Database     | 12.0            |
 | MySQL      | Database     | 8.0             |
 | Redis      | Cache, Queue | 4.0             |
 | Git        | Additional   | 2.0             |
@@ -35,6 +35,9 @@ The following minimum versions are required for Nautobot to operate:
 
 +/- 1.6.0
     Python 3.11 support was added and Python 3.7 support was removed.
+
+--- 2.1.0
+    Support for versions of PostgreSQL older than 12.0 was removed.
 
 Nautobot will not work without these dependencies.
 

--- a/nautobot/docs/user-guide/administration/upgrading/upgrading.md
+++ b/nautobot/docs/user-guide/administration/upgrading/upgrading.md
@@ -53,16 +53,19 @@ Please see the [official MySQL documentation on migrating collation encoding set
 
 ## Update Prerequisites to Required Versions
 
-Nautobot v2.0.0 and later requires the following:
+Nautobot v2.1.0 and later requires the following:
 
 | Dependency | Minimum Version |
 | ---------- | --------------- |
 | Python     | 3.8             |
-| PostgreSQL | 9.6             |
+| PostgreSQL | 12.0            |
 | Redis      | 4.0             |
 
 --- 1.6.0
     Support for Python 3.7 was removed.
+
+--- 2.1.0
+    Support for versions of PostgreSQL older than 12.0 was removed.
 
 Nautobot v1.1.0 and later can optionally support the following:
 


### PR DESCRIPTION

# Closes: #4757 
# What's Changed

- Update documentation to indicate Postgres 12.0 is the minimum supported version for Nautobot 2.1
- Add a system check to enforce this requirement when running `post_upgrade` or `migrate`.

Testing by setting the minimum version to 14.0 temporarily (as our dev environment runs version 13 currently):

```
nautobot-nautobot-1  | Performing database migrations...
nautobot-nautobot-1  | SystemCheckError: System check identified some issues:
nautobot-nautobot-1  | 
nautobot-nautobot-1  | ERRORS:
nautobot-nautobot-1  | connections[default]: (nautobot.core.E006) PostgreSQL version less than 140000 (i.e. 14.0) is not supported by this version of Nautobot
nautobot-nautobot-1  | 	HINT: Detected version is 130002 (major version 13)
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
