### PR TITLE
fixes slow performance on location hierarchy HTML template

### DIFF
--- a/changes/4917.fixed
+++ b/changes/4917.fixed
@@ -1,0 +1,1 @@
+Fixed slow performance on location hierarchy HTMl template.

--- a/changes/4917.fixed
+++ b/changes/4917.fixed
@@ -1,1 +1,1 @@
-Fixed slow performance on location hierarchy HTMl template.
+Fixed slow performance on location hierarchy html template.

--- a/changes/4921.fixed
+++ b/changes/4921.fixed
@@ -1,0 +1,1 @@
+Fixed inefficient queries in `Location.base_site`.

--- a/nautobot/dcim/models/locations.py
+++ b/nautobot/dcim/models/locations.py
@@ -237,7 +237,13 @@ class Location(TreeModel, StatusModel, PrimaryModel):
     @property
     def base_site(self):
         """The site that this Location belongs to, if any, or that its root ancestor belongs to, if any."""
-        return self.site or self.ancestors().first().site
+        if self.site:
+            return self.site
+        current_location = self
+        while current_location := current_location.parent:
+            if current_location.site:
+                return current_location.site
+        return None
 
     def validate_unique(self, exclude=None):
         # Check for a duplicate name on a Location with no parent.

--- a/nautobot/dcim/templates/dcim/inc/location_hierarchy.html
+++ b/nautobot/dcim/templates/dcim/inc/location_hierarchy.html
@@ -17,7 +17,7 @@
             <li>{{ region|hyperlinked_object }} (Region)
                 <ul>
         {% endfor %}
-        {% if site %}
+        {% if site and site.region %}
             <li>{{ site.region|hyperlinked_object }} (Region)
                 <ul>
         {% endif %}

--- a/nautobot/dcim/templates/dcim/inc/location_hierarchy.html
+++ b/nautobot/dcim/templates/dcim/inc/location_hierarchy.html
@@ -1,5 +1,6 @@
 {% load helpers %}
 {% if location is not None %}
+{% with site=location.base_site ancestors=location.ancestors %}
     <style>
         .location-hierarchy {
             list-style-type: none;
@@ -12,32 +13,33 @@
         }
     </style>
     <ul class="location-hierarchy">
-        {% for region in location.base_site.region.get_ancestors %}
+        {% for region in site.region.get_ancestors %}
             <li>{{ region|hyperlinked_object }} (Region)
                 <ul>
         {% endfor %}
-        {% if location.base_site.region %}
-            <li>{{ location.base_site.region|hyperlinked_object }} (Region)
+        {% if site %}
+            <li>{{ site.region|hyperlinked_object }} (Region)
                 <ul>
         {% endif %}
-            <li>{{ location.base_site|hyperlinked_object }} (Site)
+            <li>{{ site|hyperlinked_object }} (Site)
                 <ul>
-        {% for ancestor in location.ancestors %}
+        {% for ancestor in ancestors %}
             <li>{{ ancestor|hyperlinked_object:"name" }} ({{ ancestor.location_type|hyperlinked_object:"name" }})
                 <ul>
         {% endfor %}
         <li><strong>{{ location|hyperlinked_object:"name" }} ({{ location.location_type|hyperlinked_object:"name" }})</strong></li>
-        {% for ancestor in location.ancestors %}
+        {% for ancestor in ancestors %}
                 </ul>
             </li>
         {% endfor %}
                 </ul>
             </li>
-        {% for region in location.base_site.region.get_ancestors %}
+        {% for region in site.region.get_ancestors %}
                 </ul>
             </li>
         {% endfor %}
     </ul>
+{% endwith %}
 {% else %}
     {{ location|placeholder }}
 {% endif %}


### PR DESCRIPTION
# Closes: #4917, #4921
# What's Changed
- Employs variables in template to avoid re-calculation of location tree/region tree multiple times
- Avoid calculating the entire location tree via `Location.ancestors` when instead we can iterate over the foreign key relationships


# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
