### PR TITLE
Fixed GraphQL UI unable to load when some ComputedField instances have non-graphql-safe keys.

### DIFF
--- a/changes/4854.changed
+++ b/changes/4854.changed
@@ -1,0 +1,1 @@
+Moved `ComputedField` key string validation from clean() to save()

--- a/changes/4854.fixed
+++ b/changes/4854.fixed
@@ -1,0 +1,1 @@
+Fixed GraphQL UI unable to load when some ComputedField instances have non-graphql-safe keys.

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -112,8 +112,8 @@ class ComputedField(BaseModel, ChangeLoggedModel, NotesMixin):
             logger.warning("Failed to render computed field %s: %s", self.key, exc)
             return self.fallback_value
 
-    def clean(self):
-        super().clean()
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
         if self.key != "":
             check_if_key_is_graphql_safe(self.__class__.__name__, self.key)
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4854
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Fixed GraphQL UI unable to load when some ComputedField instances have non-graphql-safe keys.
Moved `ComputedField` key string validation from clean() to save()


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
