### PR TITLE
Fix incorrect column ordering in LocationTable

### DIFF
--- a/nautobot/dcim/tables/locations.py
+++ b/nautobot/dcim/tables/locations.py
@@ -68,7 +68,6 @@ class LocationTable(StatusTableMixin, BaseTable):
             "parent",
             "tenant",
             "description",
-            "actions",
             "facility",
             "asn",
             "time_zone",
@@ -80,6 +79,7 @@ class LocationTable(StatusTableMixin, BaseTable):
             "contact_phone",
             "contact_email",
             "tags",
+            "actions",
         )
         default_columns = ("pk", "name", "status", "parent", "tenant", "description", "tags", "actions")
         orderable = False

--- a/nautobot/docs/development/core/extending-models.md
+++ b/nautobot/docs/development/core/extending-models.md
@@ -64,6 +64,9 @@ All filtersets should inherit from `BaseFilterSet` or `NautobotFilterSet` as app
 
 If the new field will be included in the object list view, add a column to the model's table. For simple fields, adding the field name to `Meta.fields` will be sufficient. More complex fields may require declaring a custom column.
 
+!!! tip
+    In the vast majority of cases, a table's `Meta.fields` should have `"pk"` as the first entry and (if present as a column) `"actions"` as the last entry, so that these two columns appear correctly at the far left and far right of the table. When adding new entries to `Meta.fields` please be sure to follow this pattern.
+
 ## Update the UI templates
 
 Edit the object's view template to display the new field. There may also be a custom add/edit form template that needs to be updated.


### PR DESCRIPTION
# Closes: #n/a
# What's Changed

LocationTable had its `"actions"` column in the wrong location in `Meta.fields`, resulting in incorrect table rendering (`actions` should always be the rightmost column, but here columns like `tags` were appearing to the right of it). 

![image](https://github.com/nautobot/nautobot/assets/5603551/97fee232-37e5-41e3-9d0e-2e61736d37ea)

This fixes that issue.

![image](https://github.com/nautobot/nautobot/assets/5603551/d8a65c52-c9fb-4c47-ba18-e448ffd7e0fd)

I looked through the rest of the code and the other tables appear to all be correct in this regard.

Interestingly, *if* the user has a custom table configuration, the actions column is correctly placed at the right, due to [this block of code](https://github.com/nautobot/nautobot/blob/develop/nautobot/core/tables.py#L83-L101). I did some exploratory coding around possibly generalizing that logic but couldn't quickly get it working correctly.

Longer-term we should consider either:
- Adding a pylint-nautobot rule to enforce for all tables that `Meta.fields` should start with `pk` and end with `actions`
- Adding logic to `BaseTable` to guarantee that `self.sequence` (which is auto-derived from `Meta.fields` in most cases by django-tables2) always has `pk` and `actions` in the correct positions

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
