### PR TITLE
Fix display of "Collapse All" button in Job list view

### DIFF
--- a/changes/3488.fixed
+++ b/changes/3488.fixed
@@ -1,0 +1,1 @@
+Corrected positioning and style of "Collapse All" button in Jobs list view.

--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block buttons %}
-<button type="button" class="btn btn-primary pull-right" id="accordion-toggle-all">Collapse All</button>
+<button type="button" class="btn btn-default" id="accordion-toggle-all">Collapse All</button>
 {% endblock %}
 
 {% block javascript %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3488 
# What's Changed

Don't use `pull-right` as a way to forcibly reorder the buttons in this view as it doesn't result in the correct whitespace. Instead just let it be where it is:

![image](https://github.com/nautobot/nautobot/assets/5603551/05d90384-b9f7-460b-8c22-c6ef6d4a411d)

I also changed it from a `primary` button to a `default` button as it relates to the other UI-altering buttons it's next to and isn't so urgently important that it needs to be brightly colored.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
