### PR TITLE
Fixed JSON custom field being returned as a `repr()` string when usin…

### DIFF
--- a/changes/4627.fixed
+++ b/changes/4627.fixed
@@ -1,0 +1,1 @@
+Fixed JSON custom field being returned as a `repr()` string when using GraphQL.

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -22,7 +22,7 @@ from nautobot.core.graphql.generators import (
     generate_schema_type,
     generate_null_choices_resolver,
 )
-from nautobot.core.graphql.types import ContentTypeType
+from nautobot.core.graphql.types import ContentTypeType, JSON
 from nautobot.dcim.graphql.types import (
     CableType,
     CablePathType,
@@ -82,6 +82,7 @@ CUSTOM_FIELD_MAPPING = {
     CustomFieldTypeChoices.TYPE_DATE: graphene.Date(),
     CustomFieldTypeChoices.TYPE_URL: graphene.String(),
     CustomFieldTypeChoices.TYPE_SELECT: graphene.String(),
+    CustomFieldTypeChoices.TYPE_JSON: JSON(),
 }
 
 

--- a/nautobot/core/graphql/types.py
+++ b/nautobot/core/graphql/types.py
@@ -22,3 +22,13 @@ class ContentTypeType(OptimizedNautobotObjectType):
 
     class Meta:
         model = ContentType
+
+
+class JSON(graphene.Scalar):
+    @staticmethod
+    def serialize_data(dt):
+        return dt
+
+    serialize = serialize_data
+    parse_value = serialize_data
+    parse_literal = serialize_data


### PR DESCRIPTION
…g GraphQL.

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4627 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
