### PR TITLE
Replace deprecated is_safe_url() with url_has_allowed_host_and_scheme()

### DIFF
--- a/changes/4945.housekeeping
+++ b/changes/4945.housekeeping
@@ -1,0 +1,1 @@
+Replaced calls to deprecated `is_safe_url()` Django API with `url_has_allowed_host_and_scheme()` replacement API.

--- a/nautobot/circuits/views.py
+++ b/nautobot/circuits/views.py
@@ -2,7 +2,6 @@ from django.contrib import messages
 from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.http import is_safe_url
 from django_tables2 import RequestConfig
 
 
@@ -82,14 +81,8 @@ class CircuitTerminationUIViewSet(
         return obj
 
     def get_return_url(self, request, obj=None):
-        # First, see if `return_url` was specified as a query parameter or form data. Use this URL only if it's
-        # considered safe.
-        query_param = request.GET.get("return_url") or request.POST.get("return_url")
-        if query_param and is_safe_url(url=query_param, allowed_hosts=request.get_host()):
-            return query_param
-
         if obj is not None and obj.present_in_database and obj.pk:
-            return obj.circuit.get_absolute_url()
+            return super().get_return_url(request, obj=obj.circuit)
 
         return super().get_return_url(request, obj=obj)
 

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -16,8 +16,9 @@ from django.db.models import ManyToManyField, ProtectedError
 from django.forms import Form, ModelMultipleChoiceField, MultipleHiddenInput
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.encoding import iri_to_uri
 from django.utils.html import format_html
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic import View
 from django_tables2 import RequestConfig
 from rest_framework.exceptions import ParseError
@@ -432,8 +433,8 @@ class ObjectEditView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
                     return redirect(request.get_full_path())
 
                 return_url = form.cleaned_data.get("return_url")
-                if return_url is not None and is_safe_url(url=return_url, allowed_hosts=request.get_host()):
-                    return redirect(return_url)
+                if url_has_allowed_host_and_scheme(url=return_url, allowed_hosts=request.get_host()):
+                    return redirect(iri_to_uri(return_url))
                 else:
                     return redirect(self.get_return_url(request, obj))
 
@@ -516,8 +517,8 @@ class ObjectDeleteView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
             messages.success(request, msg)
 
             return_url = form.cleaned_data.get("return_url")
-            if return_url is not None and is_safe_url(url=return_url, allowed_hosts=request.get_host()):
-                return redirect(return_url)
+            if url_has_allowed_host_and_scheme(url=return_url, allowed_hosts=request.get_host()):
+                return redirect(iri_to_uri(return_url))
             else:
                 return redirect(self.get_return_url(request, obj))
 
@@ -758,8 +759,8 @@ class ObjectImportView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
                     return redirect(request.get_full_path())
 
                 return_url = form.cleaned_data.get("return_url")
-                if return_url is not None and is_safe_url(url=return_url, allowed_hosts=request.get_host()):
-                    return redirect(return_url)
+                if url_has_allowed_host_and_scheme(url=return_url, allowed_hosts=request.get_host()):
+                    return redirect(iri_to_uri(return_url))
                 else:
                     return redirect(self.get_return_url(request, obj))
 

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -18,7 +18,8 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import select_template, TemplateDoesNotExist
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
-from django.utils.http import is_safe_url
+from django.utils.encoding import iri_to_uri
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.html import format_html
 from django.views.generic.edit import FormView
 
@@ -178,8 +179,8 @@ class GetReturnURLMixin:
         # First, see if `return_url` was specified as a query parameter or form data. Use this URL only if it's
         # considered safe.
         query_param = request.GET.get("return_url") or request.POST.get("return_url")
-        if query_param and is_safe_url(url=query_param, allowed_hosts=request.get_host()):
-            return query_param
+        if url_has_allowed_host_and_scheme(url=query_param, allowed_hosts=request.get_host()):
+            return iri_to_uri(query_param)
 
         # Next, check if the object being modified (if any) has an absolute URL.
         # Note that the use of both `obj.present_in_database` and `obj.pk` is correct here because this conditional
@@ -759,8 +760,8 @@ class ObjectEditViewMixin(NautobotViewSetMixin, mixins.CreateModelMixin, mixins.
                 self.success_url = request.get_full_path()
             else:
                 return_url = form.cleaned_data.get("return_url")
-                if return_url is not None and is_safe_url(url=return_url, allowed_hosts=request.get_host()):
-                    self.success_url = return_url
+                if url_has_allowed_host_and_scheme(url=return_url, allowed_hosts=request.get_host()):
+                    self.success_url = iri_to_uri(return_url)
                 else:
                     self.success_url = self.get_return_url(request, obj)
 

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -13,8 +13,9 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import TemplateDoesNotExist, get_template
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.encoding import iri_to_uri
 from django.utils.html import format_html
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic import View
 from django_tables2 import RequestConfig
 from jsonschema.validators import Draft7Validator
@@ -427,8 +428,8 @@ class CustomFieldEditView(generic.ObjectEditView):
                     return redirect(request.get_full_path())
 
                 return_url = form.cleaned_data.get("return_url")
-                if return_url is not None and is_safe_url(url=return_url, allowed_hosts=request.get_host()):
-                    return redirect(return_url)
+                if url_has_allowed_host_and_scheme(url=return_url, allowed_hosts=request.get_host()):
+                    return redirect(iri_to_uri(return_url))
                 else:
                     return redirect(self.get_return_url(request, obj))
 
@@ -665,8 +666,8 @@ class DynamicGroupEditView(generic.ObjectEditView):
                     return redirect(request.get_full_path())
 
                 return_url = form.cleaned_data.get("return_url")
-                if return_url is not None and is_safe_url(url=return_url, allowed_hosts=request.get_host()):
-                    return redirect(return_url)
+                if url_has_allowed_host_and_scheme(url=return_url, allowed_hosts=request.get_host()):
+                    return redirect(iri_to_uri(return_url))
                 else:
                     return redirect(self.get_return_url(request, obj))
 
@@ -2050,8 +2051,8 @@ class SecretsGroupEditView(generic.ObjectEditView):
                     return redirect(request.get_full_path())
 
                 return_url = form.cleaned_data.get("return_url")
-                if return_url is not None and is_safe_url(url=return_url, allowed_hosts=request.get_host()):
-                    return redirect(return_url)
+                if url_has_allowed_host_and_scheme(url=return_url, allowed_hosts=request.get_host()):
+                    return redirect(iri_to_uri(return_url))
                 else:
                     return redirect(self.get_return_url(request, obj))
 

--- a/nautobot/users/views.py
+++ b/nautobot/users/views.py
@@ -11,8 +11,9 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils.encoding import iri_to_uri
 from django.utils.decorators import method_decorator
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import View
 
@@ -83,12 +84,12 @@ class LoginView(View):
         else:
             redirect_to = request.GET.get("next", reverse("home"))
 
-        if redirect_to and not is_safe_url(url=redirect_to, allowed_hosts=request.get_host()):
+        if redirect_to and not url_has_allowed_host_and_scheme(url=redirect_to, allowed_hosts=request.get_host()):
             logger.warning(f"Ignoring unsafe 'next' URL passed to login form: {redirect_to}")
             redirect_to = reverse("home")
 
         logger.debug(f"Redirecting user to {redirect_to}")
-        return HttpResponseRedirect(redirect_to)
+        return HttpResponseRedirect(iri_to_uri(redirect_to))
 
 
 class LogoutView(View):


### PR DESCRIPTION
# Closes: #DNE
# What's Changed

Some groundwork towards moving to Django 4 - in Django 3 `is_safe_url()` is deprecated in favor of `url_has_allowed_host_and_scheme()`, and in 4.0 `is_safe_url` is removed entirely.

Additionally, I've added calls to `iri_to_uri()` anywhere we use `url_has_allowed_host_and_scheme()` as this is a documented Django best practice to protect against punycode-type attacks.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
