### PR TITLE
Added VRF to interface bulk edit form.

### DIFF
--- a/changes/4708.added
+++ b/changes/4708.added
@@ -1,0 +1,1 @@
+Added VRF to interface bulk edit form.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -2429,8 +2429,9 @@ class InterfaceBulkEditForm(
         )
         devices = Device.objects.filter(interfaces__in=interfaces).only("pk").distinct()
         locations = Location.objects.without_tree_fields().order_by().filter(devices__in=devices).only("pk").distinct()
+        device_count = devices.count()
 
-        if devices.count() > 0:
+        if device_count > 0:
             device = devices.first()
 
             # Limit VRF choices to only VRFs available on the first parent device
@@ -2444,7 +2445,7 @@ class InterfaceBulkEditForm(
                 self.fields["tagged_vlans"].widget.add_query_param("location", location.pk)
 
         # Restrict parent/bridge/LAG interface assignment by device (or VC master)
-        if devices.count() == 1:
+        if device_count == 1:
             self.fields["parent_interface"].widget.add_query_param("device_with_common_vc", device.pk)
             self.fields["bridge"].widget.add_query_param("device_with_common_vc", device.pk)
             self.fields["lag"].widget.add_query_param("device_with_common_vc", device.pk)

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -2422,12 +2422,7 @@ class InterfaceBulkEditForm(
         if "pk" not in self.initial:
             return
 
-        interfaces = (
-            Interface.objects.filter(pk__in=self.initial["pk"])
-            .select_related("device__location")
-            .only("id", "device", "device__location")
-        )
-        devices = Device.objects.filter(interfaces__in=interfaces).only("pk").distinct()
+        devices = Device.objects.filter(interfaces__in=self.initial["pk"]).only("pk").distinct()
         locations = Location.objects.without_tree_fields().order_by().filter(devices__in=devices).only("pk").distinct()
         device_count = devices.count()
 

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -2361,12 +2361,6 @@ class InterfaceBulkEditForm(
     NautobotBulkEditForm,
 ):
     pk = forms.ModelMultipleChoiceField(queryset=Interface.objects.all(), widget=forms.MultipleHiddenInput())
-    device = forms.ModelChoiceField(
-        queryset=Device.objects.all(),
-        required=False,
-        disabled=True,
-        widget=forms.HiddenInput(),
-    )
     enabled = forms.NullBooleanField(required=False, widget=BulkEditNullBooleanSelect)
     parent_interface = DynamicModelChoiceField(
         queryset=Interface.objects.all(),
@@ -2401,6 +2395,12 @@ class InterfaceBulkEditForm(
             "location": "null",
         },
     )
+    vrf = forms.ModelChoiceField(
+        queryset=VRF.objects.all(),
+        label="VRF",
+        required=False,
+        widget=StaticSelect2(),
+    )
 
     class Meta:
         nullable_fields = [
@@ -2414,42 +2414,43 @@ class InterfaceBulkEditForm(
             "mode",
             "untagged_vlan",
             "tagged_vlans",
+            "vrf",
         ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Limit LAG choices to interfaces which belong to the parent device (or VC master)
-        if "device" in self.initial:
-            device = Device.objects.filter(pk=self.initial["device"]).first()
+        if "pk" not in self.initial:
+            return
 
-            # Restrict parent/bridge/LAG interface assignment by device
+        interfaces = (
+            Interface.objects.filter(pk__in=self.initial["pk"])
+            .select_related("device__location")
+            .only("id", "device", "device__location")
+        )
+        devices = Device.objects.order_by().filter(interfaces__in=interfaces).only("pk").distinct()
+        locations = Location.objects.without_tree_fields().order_by().filter(devices__in=devices).only("pk").distinct()
+
+        if devices.count() > 0:
+            # Limit VRF choices to only VRFs available on all parent devices
+            vrf_choices = VRF.objects.order_by().all()
+            for parent_device in devices:
+                vrf_choices = vrf_choices.filter(devices=parent_device)
+            self.fields["vrf"].choices = add_blank_choice(vrf_choices.values_list("pk", "name"))
+
+            # Limit VLAN choices by Location
+            if locations.count() == 1:
+                location = locations.first()
+                self.fields["untagged_vlan"].widget.add_query_param("location", location.pk)
+                self.fields["tagged_vlans"].widget.add_query_param("location", location.pk)
+
+        # Restrict parent/bridge/LAG interface assignment by device (or VC master)
+        if devices.count() == 1:
+            device = devices.first()
             self.fields["parent_interface"].widget.add_query_param("device_with_common_vc", device.pk)
             self.fields["bridge"].widget.add_query_param("device_with_common_vc", device.pk)
             self.fields["lag"].widget.add_query_param("device_with_common_vc", device.pk)
-
-            # Add current location to VLANs query params
-            self.fields["untagged_vlan"].widget.add_query_param("location", device.location.pk)
-            self.fields["tagged_vlans"].widget.add_query_param("location", device.location.pk)
         else:
-            # See netbox-community/netbox#4523
-            if "pk" in self.initial:
-                location = None
-                interfaces = Interface.objects.filter(pk__in=self.initial["pk"]).select_related("device__location")
-
-                # Check interface locations.  First interface should set location, further interfaces will either continue the
-                # loop or reset back to no location and break the loop.
-                for interface in interfaces:
-                    if location is None:
-                        location = interface.device.location
-                    elif interface.device.location is not location:
-                        location = None
-                        break
-
-                if location is not None:
-                    self.fields["untagged_vlan"].widget.add_query_param("location", location.pk)
-                    self.fields["tagged_vlans"].widget.add_query_param("location", location.pk)
-
             self.fields["parent_interface"].choices = ()
             self.fields["parent_interface"].widget.attrs["disabled"] = True
             self.fields["bridge"].choices = ()

--- a/nautobot/dcim/templates/dcim/device/interfaces.html
+++ b/nautobot/dcim/templates/dcim/device/interfaces.html
@@ -24,7 +24,7 @@
                     <button type="submit" name="_rename" formaction="{% url 'dcim:interface_bulk_rename' %}?return_url={% url 'dcim:device_interfaces' pk=object.pk %}" class="btn btn-warning btn-xs">
                         <span class="mdi mdi-pencil" aria-hidden="true"></span> Rename
                     </button>
-                    <button type="submit" name="_edit" formaction="{% url 'dcim:interface_bulk_edit' %}?device={{ object.pk }}&return_url={% url 'dcim:device_interfaces' pk=object.pk %}" class="btn btn-warning btn-xs">
+                    <button type="submit" name="_edit" formaction="{% url 'dcim:interface_bulk_edit' %}?return_url={% url 'dcim:device_interfaces' pk=object.pk %}" class="btn btn-warning btn-xs">
                         <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit
                     </button>
                     <button type="submit" name="_disconnect" formaction="{% url 'dcim:interface_bulk_disconnect' %}?return_url={% url 'dcim:device_interfaces' pk=object.pk %}" class="btn btn-danger btn-xs">

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -85,7 +85,7 @@ from nautobot.extras.models import (
     Tag,
 )
 from nautobot.ipam.choices import IPAddressTypeChoices
-from nautobot.ipam.models import IPAddress, Namespace, Prefix, VLAN, VLANGroup
+from nautobot.ipam.models import IPAddress, Namespace, Prefix, VLAN, VLANGroup, VRF
 from nautobot.tenancy.models import Tenant
 from nautobot.users.models import ObjectPermission
 
@@ -1821,6 +1821,9 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
     @classmethod
     def setUpTestData(cls):
         device = create_test_device("Device 1")
+        vrfs = list(VRF.objects.all()[:3])
+        for vrf in vrfs:
+            vrf.add_device(device)
 
         statuses = Status.objects.get_for_model(Interface)
         status_active = statuses[0]
@@ -1892,6 +1895,7 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             "tagged_vlans": [v.pk for v in vlans[1:4]],
             "tags": [t.pk for t in Tag.objects.get_for_model(Interface)],
             "status": status_active.pk,
+            "vrf": vrfs[0].pk,
         }
 
         cls.bulk_add_data = {
@@ -1906,6 +1910,7 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             "description": "An Interface",
             "mode": InterfaceModeChoices.MODE_TAGGED,
             "tags": [],
+            "vrf": vrfs[1].pk,
         }
 
         cls.bulk_edit_data = {
@@ -1920,6 +1925,7 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             "untagged_vlan": vlans[0].pk,
             "tagged_vlans": [v.pk for v in vlans[1:4]],
             "status": status_active.pk,
+            "vrf": vrfs[2].pk,
         }
 
         cls.csv_data = (


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4708
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

I refactored to combine the code paths for the different ways of accessing the interface bulk edit view

Previously if you wanted to bulk edit the parent interface, bridge interface or lag interface fields you had to go to the DeviceInterfacesView and perform the bulk edit there. With these changes, if you attempt to bulk edit interfaces that all belong to the same device from any view, you will be able to edit those fields. 

This also moves the count of distinct `device__location` from python to the database.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
