### PR TITLE
Make ipam 0025 migration more robust.

### DIFF
--- a/changes/4968.fixed
+++ b/changes/4968.fixed
@@ -1,0 +1,1 @@
+Fixed some cases in which the `ipam.0025` data migration might throw an exception due to invalid data.

--- a/nautobot/ipam/migrations/0025_interface_ipaddress_m2m_data_migration.py
+++ b/nautobot/ipam/migrations/0025_interface_ipaddress_m2m_data_migration.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from django.db import migrations
 
 
@@ -7,22 +8,22 @@ def migrate_ipaddress_to_m2m(apps, schema_editor):
     Interface = apps.get_model("dcim", "Interface")
     VMInterface = apps.get_model("virtualization", "VMInterface")
 
-    for ip_address in IPAddress.objects.filter(assigned_object_id__isnull=False):
+    for ip_address in IPAddress.objects.filter(assigned_object_id__isnull=False, assigned_object_type__isnull=False):
         related_ct = ip_address.assigned_object_type
         if related_ct.app_label == "dcim" and related_ct.model == "interface":
-            related_obj = Interface.objects.get(id=ip_address.assigned_object_id)
-            IPAddressToInterface.objects.create(
-                ip_address=ip_address,
-                interface=related_obj,
-            )
+            with suppress(Interface.DoesNotExist):
+                related_obj = Interface.objects.get(id=ip_address.assigned_object_id)
+                IPAddressToInterface.objects.create(
+                    ip_address=ip_address,
+                    interface=related_obj,
+                )
         elif related_ct.app_label == "virtualization" and related_ct.model == "vminterface":
-            related_obj = VMInterface.objects.get(id=ip_address.assigned_object_id)
-            IPAddressToInterface.objects.create(
-                ip_address=ip_address,
-                vm_interface=related_obj,
-            )
-        else:
-            continue
+            with suppress(VMInterface.DoesNotExist):
+                related_obj = VMInterface.objects.get(id=ip_address.assigned_object_id)
+                IPAddressToInterface.objects.create(
+                    ip_address=ip_address,
+                    vm_interface=related_obj,
+                )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
# Closes: #DNE
# What's Changed

GenericForeignKeys being what they are, it's very possible for `IPAddress.assigned_object_type` to be NULL or for `IPAddress.assigned_object_id` to be a UUID that doesn't actually correspond to an existing DB object. We've had a couple of users report issues in migrating to 2.0 as a result of such cases causing IPAM migration 0025 to throw an exception and abort. This PR adds some additional validation and logic to hopefully protect against such cases.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
