### PR TITLE
fixes early return conditional in ensure_git_repository

### DIFF
--- a/changes/4977.fixed
+++ b/changes/4977.fixed
@@ -1,1 +1,1 @@
-Fixed early return conditional in ensure_git_repository
+Fixed early return conditional in `ensure_git_repository`.

--- a/changes/4977.fixed
+++ b/changes/4977.fixed
@@ -1,0 +1,1 @@
+Fixed early return conditional in ensure_git_repository

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -147,7 +147,7 @@ def ensure_git_repository(repository_record, logger=None, head=None):  # pylint:
         with suppress(InvalidGitRepositoryError):
             if (
                 Path(repository_record.filesystem_path).exists()
-                and Repo(repository_record.filesystem_path).head == head
+                and Repo(repository_record.filesystem_path).rev_parse("HEAD") == head
             ):
                 return False
 


### PR DESCRIPTION

# Closes: #4142
# What's Changed

This function used to compare git.Repo.head against the commit hash, which means comparing a Python object against the commit hash. Now we are using git.Repo.rev_parse("HEAD") which returns the commit hash of HEAD.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
