### PR TITLE
Fix object permissions enforcement on Job Buttons

### DIFF
--- a/changes/4988.housekeeping
+++ b/changes/4988.housekeeping
@@ -1,0 +1,1 @@
+Fixed some bugs in `example_plugin.jobs.ExampleComplexJobButtonReceiver`.

--- a/changes/4988.removed
+++ b/changes/4988.removed
@@ -1,0 +1,1 @@
+Removed redundant `/extras/job-button/<uuid>/run/` URL endpoint; Job Buttons now use `/extras/jobs/<uuid>/run/` endpoint like any other job.

--- a/changes/4988.security
+++ b/changes/4988.security
@@ -1,0 +1,2 @@
+Fixed missing object-level permissions enforcement when running a JobButton.
+Removed the requirement for users to have both `extras.run_job` and `extras.run_jobbutton` permissions to run a Job via a Job Button. Only `extras.run_job` permission is now required.

--- a/examples/example_plugin/example_plugin/jobs.py
+++ b/examples/example_plugin/example_plugin/jobs.py
@@ -152,18 +152,19 @@ class ExampleComplexJobButtonReceiver(JobButtonReceiver):
         # Run Device Job function
 
     def receive_job_button(self, obj):
-        user = self.request.user
+        user = self.user
         if isinstance(obj, Location):
             if not user.has_perm("dcim.add_location"):
                 self.logger.error("User '%s' does not have permission to add a Location.", user, extra={"object": obj})
             else:
                 self._run_location_job(obj)
-        if isinstance(obj, Device):
+        elif isinstance(obj, Device):
             if not user.has_perm("dcim.add_device"):
                 self.logger.error("User '%s' does not have permission to add a Device.", user, extra={"object": obj})
             else:
                 self._run_device_job(obj)
-        self.logger.error("Unable to run Job Button for type %s.", type(obj).__name__, extra={"object": obj})
+        else:
+            self.logger.error("Unable to run Job Button for type %s.", type(obj).__name__, extra={"object": obj})
 
 
 jobs = (

--- a/nautobot/docs/user-guide/platform-functionality/jobs/jobbutton.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/jobbutton.md
@@ -29,7 +29,10 @@ For any Job that is loaded into Nautobot, the Job must be enabled to run. See [E
 ## Required Permissions
 
 !!! note
-    In order to run any job via a Job Button, a user must be assigned the `extras.run_job` **as well as** the `extras.run_jobbutton` permissions. This is achieved by assigning the user (or group) a permission on the `extras > job` and `extras > jobbutton` objects and specifying the `run` action in the **Additional actions** section. Any user lacking these permissions may still see the button on the respective page(s) - if not using [conditional rendering](#conditional-rendering) - but they will be disabled.
+    In order to run any job via a Job Button, a user must be assigned the `extras.run_job` permission. This is achieved by assigning the user (or group) a permission on the `extras > job` objects and specifying the `run` action in the **Additional actions** section. Any user lacking this permissions may still see the button on the respective page(s) - if not using [conditional rendering](#conditional-rendering) - but it will be disabled.
+
++/- 2.1.0
+    In prior versions, users also had to have `extras.run_jobbutton` permission as well. This requirement has been removed.
 
 ## Context Data
 

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
-from nautobot.extras.models import JobButton
+from nautobot.extras.models import Job, JobButton
 from nautobot.core.utils.data import render_jinja2
 
 
@@ -27,7 +27,8 @@ HIDDEN_INPUTS = """
 <input type="hidden" name="csrfmiddlewaretoken" value="{csrf_token}">
 <input type="hidden" name="object_pk" value="{object_pk}">
 <input type="hidden" name="object_model_name" value="{object_model_name}">
-<input type="hidden" name="redirect_path" value="{redirect_path}">
+<input type="hidden" name="_schedule_type" value="immediately">
+<input type="hidden" name="_return_url" value="{redirect_path}">
 """
 
 NO_CONFIRM_BUTTON = """
@@ -69,18 +70,17 @@ CONFIRM_MODAL = """
 </div>
 """
 
+SAFE_EMPTY = mark_safe("")  # noqa: S308
 
-@register.simple_tag(takes_context=True)
-def job_buttons(context, obj):
-    """
-    Render all applicable job buttons for the given object.
-    """
-    content_type = ContentType.objects.get_for_model(obj)
-    buttons = JobButton.objects.filter(content_types=content_type)
-    if not buttons:
-        return ""
 
-    # Pass select context data when rendering the JobButton
+def _render_job_button_for_obj(job_button, obj, context, content_type):
+    """
+    Helper method for job_buttons templatetag to reduce repetition of code.
+
+    Returns:
+       (str, str): (button_html, form_html)
+    """
+    # Pass select context data when rendering the JobButton text as Jinja2
     button_context = {
         "obj": obj,
         "debug": context.get("debug", False),  # django.template.context_processors.debug
@@ -88,9 +88,24 @@ def job_buttons(context, obj):
         "user": context["user"],  # django.contrib.auth.context_processors.auth
         "perms": context["perms"],  # django.contrib.auth.context_processors.auth
     }
-    buttons_html = forms_html = mark_safe("")  # noqa: S308
-    group_names = OrderedDict()
+    try:
+        text_rendered = render_jinja2(job_button.text, button_context)
+    except Exception as exc:
+        return (
+            format_html(
+                '<a class="btn btn-sm btn-{}" disabled="disabled" title="{}"><i class="mdi mdi-alert"></i> {}</a>\n',
+                "default" if not job_button.group_name else "link",
+                exc,
+                job_button.name,
+            ),
+            SAFE_EMPTY,
+        )
 
+    if not text_rendered:
+        return (SAFE_EMPTY, SAFE_EMPTY)
+
+    # Disable buttons if the user doesn't have permission to run the underlying Job.
+    has_run_perm = Job.objects.check_perms(context["user"], instance=job_button.job, action="run")
     hidden_inputs = format_html(
         HIDDEN_INPUTS,
         csrf_token=context["csrf_token"],
@@ -98,86 +113,65 @@ def job_buttons(context, obj):
         object_model_name=f"{content_type.app_label}.{content_type.model}",
         redirect_path=context["request"].path,
     )
+    template_args = {
+        "button_id": job_button.pk,
+        "button_text": text_rendered,
+        "button_class": job_button.button_class if not job_button.group_name else "link",
+        "button_url": reverse("extras:job_run", kwargs={"pk": job_button.job.pk}),
+        "object": obj,
+        "job": job_button.job,
+        "hidden_inputs": hidden_inputs,
+        "disabled": "" if has_run_perm else "disabled",
+    }
+
+    if job_button.confirmation:
+        return (
+            format_html(CONFIRM_BUTTON, **template_args),
+            format_html(CONFIRM_MODAL, **template_args),
+        )
+    else:
+        return (
+            format_html(NO_CONFIRM_BUTTON, **template_args),
+            format_html(NO_CONFIRM_FORM, **template_args),
+        )
+
+
+@register.simple_tag(takes_context=True)
+def job_buttons(context, obj):
+    """
+    Render all applicable job buttons for the given object.
+    """
+    content_type = ContentType.objects.get_for_model(obj)
+    # We will enforce "run" permission later in deciding which buttons to show as disabled.
+    buttons = JobButton.objects.filter(content_types=content_type)
+    if not buttons:
+        return SAFE_EMPTY
+
+    buttons_html = forms_html = SAFE_EMPTY
+    group_names = OrderedDict()
 
     for jb in buttons:
-        template_args = {
-            "button_id": jb.pk,
-            "button_text": jb.text,
-            "button_class": jb.button_class,
-            "button_url": reverse("extras:jobbutton_run", kwargs={"pk": jb.pk}),
-            "object": obj,
-            "job": jb.job,
-            "hidden_inputs": hidden_inputs,
-            "disabled": "" if context["user"].has_perms(("extras.run_jobbutton", "extras.run_job")) else "disabled",
-        }
-
-        # Organize job buttons by group
+        # Organize job buttons by group for later processing
         if jb.group_name:
-            group_names.setdefault(jb.group_name, [])
-            group_names[jb.group_name].append(jb)
+            group_names.setdefault(jb.group_name, []).append(jb)
 
-        # Add non-grouped buttons
+        # Render and add non-grouped buttons
         else:
-            try:
-                text_rendered = render_jinja2(jb.text, button_context)
-                if text_rendered:
-                    template_args["button_text"] = text_rendered
-                    if jb.confirmation:
-                        buttons_html += format_html(CONFIRM_BUTTON, **template_args)
-                        forms_html += format_html(CONFIRM_MODAL, **template_args)
-                    else:
-                        buttons_html += format_html(NO_CONFIRM_BUTTON, **template_args)
-                        forms_html += format_html(NO_CONFIRM_FORM, **template_args)
-            except Exception as e:
-                buttons_html += format_html(
-                    '<a class="btn btn-sm btn-default" disabled="disabled" title="{}">'
-                    '<i class="mdi mdi-alert"></i> {}</a>\n',
-                    e,
-                    jb.name,
-                )
+            button_html, form_html = _render_job_button_for_obj(jb, obj, context, content_type)
+            buttons_html += button_html
+            forms_html += form_html
 
     # Add grouped buttons to template
     for group_name, buttons in group_names.items():
         group_button_class = buttons[0].button_class
 
-        buttons_rendered = mark_safe("")  # noqa: S308
+        buttons_rendered = SAFE_EMPTY
 
         for jb in buttons:
-            template_args = {
-                "button_id": jb.pk,
-                "button_text": jb.text,
-                "button_class": "link",
-                "button_url": reverse("extras:jobbutton_run", kwargs={"pk": jb.pk}),
-                "object": obj,
-                "job": jb.job,
-                "hidden_inputs": hidden_inputs,
-                "disabled": "" if context["user"].has_perms(("extras.run_jobbutton", "extras.run_job")) else "disabled",
-            }
-            try:
-                text_rendered = render_jinja2(jb.text, button_context)
-                if text_rendered:
-                    template_args["button_text"] = text_rendered
-                    if jb.confirmation:
-                        buttons_rendered += (
-                            mark_safe("<li>")  # noqa: S308
-                            + format_html(CONFIRM_BUTTON, **template_args)
-                            + mark_safe("</li>")  # noqa: S308
-                        )
-                        forms_html += format_html(CONFIRM_MODAL, **template_args)
-                    else:
-                        buttons_rendered += (
-                            mark_safe("<li>")  # noqa: S308
-                            + format_html(NO_CONFIRM_BUTTON, **template_args)
-                            + mark_safe("</li>")  # noqa: S308
-                        )
-                        forms_html += format_html(NO_CONFIRM_FORM, **template_args)
-            except Exception as e:
-                buttons_rendered += format_html(
-                    '<li><a disabled="disabled" title="{}"><span class="text-muted">'
-                    '<i class="mdi mdi-alert"></i> {}</span></a></li>',
-                    e,
-                    jb.name,
-                )
+            # Render grouped buttons as list items
+            button_html, form_html = _render_job_button_for_obj(jb, obj, context, content_type)
+            buttons_rendered += format_html("<li>{}</li>", button_html)
+            forms_html += form_html
 
         if buttons_rendered:
             buttons_html += format_html(

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -70,7 +70,7 @@ CONFIRM_MODAL = """
 </div>
 """
 
-SAFE_EMPTY = mark_safe("")  # noqa: S308
+SAFE_EMPTY_STR = mark_safe("")  # noqa: S308
 
 
 def _render_job_button_for_obj(job_button, obj, context, content_type):
@@ -98,11 +98,11 @@ def _render_job_button_for_obj(job_button, obj, context, content_type):
                 exc,
                 job_button.name,
             ),
-            SAFE_EMPTY,
+            SAFE_EMPTY_STR,
         )
 
     if not text_rendered:
-        return (SAFE_EMPTY, SAFE_EMPTY)
+        return (SAFE_EMPTY_STR, SAFE_EMPTY_STR)
 
     # Disable buttons if the user doesn't have permission to run the underlying Job.
     has_run_perm = Job.objects.check_perms(context["user"], instance=job_button.job, action="run")
@@ -145,9 +145,9 @@ def job_buttons(context, obj):
     # We will enforce "run" permission later in deciding which buttons to show as disabled.
     buttons = JobButton.objects.filter(content_types=content_type)
     if not buttons:
-        return SAFE_EMPTY
+        return SAFE_EMPTY_STR
 
-    buttons_html = forms_html = SAFE_EMPTY
+    buttons_html = forms_html = SAFE_EMPTY_STR
     group_names = OrderedDict()
 
     for jb in buttons:
@@ -165,7 +165,7 @@ def job_buttons(context, obj):
     for group_name, buttons in group_names.items():
         group_button_class = buttons[0].button_class
 
-        buttons_rendered = SAFE_EMPTY
+        buttons_rendered = SAFE_EMPTY_STR
 
         for jb in buttons:
             # Render grouped buttons as list items

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -51,6 +51,7 @@ from nautobot.extras.models import (
     Tag,
     Webhook,
 )
+from nautobot.extras.templatetags.job_buttons import NO_CONFIRM_BUTTON
 from nautobot.extras.tests.constants import BIG_GRAPHQL_DEVICE_QUERY
 from nautobot.extras.tests.test_relationships import RequiredRelationshipTestMixin
 from nautobot.extras.utils import RoleModelsQuery, TaggableClassesQuery
@@ -1995,14 +1996,24 @@ class JobButtonRenderingTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.job_button = JobButton(
-            name="JobButton",
+        self.job_button_1 = JobButton(
+            name="JobButton 1",
             text="JobButton {{ obj.name }}",
             job=Job.objects.get(job_class_name="TestJobButtonReceiverSimple"),
             confirmation=False,
         )
-        self.job_button.validated_save()
-        self.job_button.content_types.add(ContentType.objects.get_for_model(LocationType))
+        self.job_button_1.validated_save()
+        self.job_button_1.content_types.add(ContentType.objects.get_for_model(LocationType))
+
+        self.job_button_2 = JobButton(
+            name="JobButton 2",
+            text="Click me!",
+            job=Job.objects.get(job_class_name="TestJobButtonReceiverComplex"),
+            confirmation=False,
+        )
+        self.job_button_2.validated_save()
+        self.job_button_2.content_types.add(ContentType.objects.get_for_model(LocationType))
+
         self.location_type = LocationType.objects.get(name="Campus")
 
     def test_view_object_with_job_button(self):
@@ -2011,11 +2022,12 @@ class JobButtonRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
         self.assertIn(f"JobButton {self.location_type.name}", content, content)
+        self.assertIn("Click me!", content, content)
 
     def test_view_object_with_unsafe_text(self):
         """Ensure that JobButton text can't be used as a vector for XSS."""
-        self.job_button.text = '<script>alert("Hello world!")</script>'
-        self.job_button.validated_save()
+        self.job_button_1.text = '<script>alert("Hello world!")</script>'
+        self.job_button_1.validated_save()
         response = self.client.get(self.location_type.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
@@ -2023,8 +2035,8 @@ class JobButtonRenderingTestCase(TestCase):
         self.assertIn("&lt;script&gt;alert", content, content)
 
         # Make sure grouped rendering is safe too
-        self.job_button.group = '<script>alert("Goodbye")</script>'
-        self.job_button.validated_save()
+        self.job_button_1.group_name = '<script>alert("Goodbye")</script>'
+        self.job_button_1.validated_save()
         response = self.client.get(self.location_type.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
@@ -2033,14 +2045,79 @@ class JobButtonRenderingTestCase(TestCase):
 
     def test_view_object_with_unsafe_name(self):
         """Ensure that JobButton names can't be used as a vector for XSS."""
-        self.job_button.text = "JobButton {{ obj"
-        self.job_button.name = '<script>alert("Yo")</script>'
-        self.job_button.validated_save()
+        self.job_button_1.text = "JobButton {{ obj"
+        self.job_button_1.name = '<script>alert("Yo")</script>'
+        self.job_button_1.validated_save()
         response = self.client.get(self.location_type.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
         self.assertNotIn("<script>alert", content, content)
         self.assertIn("&lt;script&gt;alert", content, content)
+
+    def test_render_constrained_run_permissions(self):
+        obj_perm = ObjectPermission(
+            name="Test permission",
+            constraints={"pk": self.job_button_1.job.pk},
+            actions=["run"],
+        )
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ContentType.objects.get_for_model(Job))
+
+        with self.subTest("Ungrouped buttons"):
+            response = self.client.get(self.location_type.get_absolute_url(), follow=True)
+            self.assertEqual(response.status_code, 200)
+            content = extract_page_body(response.content.decode(response.charset))
+            self.assertInHTML(
+                NO_CONFIRM_BUTTON.format(
+                    button_id=self.job_button_1.pk,
+                    button_text=f"JobButton {self.location_type.name}",
+                    button_class=self.job_button_1.button_class,
+                    disabled="",
+                ),
+                content,
+            )
+            self.assertInHTML(
+                NO_CONFIRM_BUTTON.format(
+                    button_id=self.job_button_2.pk,
+                    button_text="Click me!",
+                    button_class=self.job_button_2.button_class,
+                    disabled="disabled",
+                ),
+                content,
+            )
+
+        with self.subTest("Grouped buttons"):
+            self.job_button_1.group_name = "Grouping"
+            self.job_button_1.validated_save()
+            self.job_button_2.group_name = "Grouping"
+            self.job_button_2.validated_save()
+
+            response = self.client.get(self.location_type.get_absolute_url(), follow=True)
+            self.assertEqual(response.status_code, 200)
+            content = extract_page_body(response.content.decode(response.charset))
+            self.assertInHTML(
+                "<li>"
+                + NO_CONFIRM_BUTTON.format(
+                    button_id=self.job_button_1.pk,
+                    button_text=f"JobButton {self.location_type.name}",
+                    button_class="link",
+                    disabled="",
+                )
+                + "</li>",
+                content,
+            )
+            self.assertInHTML(
+                "<li>"
+                + NO_CONFIRM_BUTTON.format(
+                    button_id=self.job_button_2.pk,
+                    button_text="Click me!",
+                    button_class="link",
+                    disabled="disabled",
+                )
+                + "</li>",
+                content,
+            )
 
 
 # TODO: Convert to StandardTestCases.Views

--- a/nautobot/extras/urls.py
+++ b/nautobot/extras/urls.py
@@ -479,8 +479,6 @@ urlpatterns = [
         views.JobResultDeleteView.as_view(),
         name="jobresult_delete",
     ),
-    # Job Button Run
-    path("job-button/<uuid:pk>/run/", views.JobButtonRunView.as_view(), name="jobbutton_run"),
     # Notes
     path("notes/", views.NoteListView.as_view(), name="note_list"),
     path("notes/add/", views.NoteEditView.as_view(), name="note_add"),

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1138,6 +1138,12 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
         schedule_form = forms.JobScheduleForm(request.POST)
         task_queue = request.POST.get("_task_queue")
 
+        return_url = request.POST.get("_return_url")
+        if return_url is not None and url_has_allowed_host_and_scheme(url=return_url, allowed_hosts=request.get_host()):
+            return_url = iri_to_uri(return_url)
+        else:
+            return_url = None
+
         # Allow execution only if a worker process is running and the job is runnable.
         if not get_worker_count(queue=task_queue):
             messages.error(request, "Unable to run or schedule job: Celery worker process not running.")
@@ -1210,10 +1216,10 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
 
                 if job_model.approval_required:
                     messages.success(request, f"Job {schedule_name} successfully submitted for approval")
-                    return redirect("extras:scheduledjob_approval_queue_list")
+                    return redirect(return_url if return_url else "extras:scheduledjob_approval_queue_list")
                 else:
                     messages.success(request, f"Job {schedule_name} successfully scheduled")
-                    return redirect("extras:scheduledjob_list")
+                    return redirect(return_url if return_url else "extras:scheduledjob_list")
 
             else:
                 # Enqueue job for immediate execution
@@ -1226,10 +1232,7 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
                     **job_model.job_class.serialize_data(job_kwargs),
                 )
 
-                return_url = request.POST.get("_return_url")
-                if return_url is not None and url_has_allowed_host_and_scheme(
-                    url=return_url, allowed_hosts=request.get_host()
-                ):
+                if return_url:
                     messages.info(
                         request,
                         format_html(
@@ -1237,9 +1240,12 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
                             job_result.get_absolute_url(),
                         ),
                     )
-                    return redirect(iri_to_uri(return_url))
+                    return redirect(return_url)
 
                 return redirect("extras:jobresult", pk=job_result.pk)
+
+        if return_url:
+            return redirect(return_url)
 
         template_name = "extras/job.html"
         if job_model.job_class is not None and hasattr(job_model.job_class, "template_name"):


### PR DESCRIPTION
# Closes: #4988 (will also be needed in 1.6.x)
# What's Changed

- The `job_buttons` template tag wasn't considering object-level permissions when determining whether to enable or disable each JobButton it rendered. I added the appropriate `has_perms` check.
  - There was a lot of duplicate code and logic in this function between the "ungrouped buttons" and "grouped buttons" cases, so I've extracted it into a helper function to reduce duplication.
- Similarly, the `JobButtonRunView` implementation was also not considering object-level permissions. In this case this view is redundant as a JobButton's underlying Job can be invoked just as easily through the `/extras/jobs/<id>/run/` view, which is already enforcing permissions correctly. I've therefore *removed `JobButtonRunView`* rather than attempt to fix it.
   - To keep the existing behavior where clicking a JobButton redirects back to the current page rather than redirecting to the JobResult page, I've added support for a `_return_url` parameter to the Job run view.
- Enforcing `extras.run_jobbutton` permission on top of `extras.run_job` permission was redundant, especially since a user with `extras.run_job` permission alone could still run the underlying job without going through the JobButton. I've therefore *removed `extras.run_jobbutton` as a required permission*; `extras.run_job` suffices.
- In manual testing, I found that the example plugin `ExampleComplexJobButtonReceiver` hadn't been completely/correctly updated to work under 2.0, so I fixed it.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
