### PR TITLE
[1.6] Fix object permissions enforcement on Job Buttons

### DIFF
--- a/changes/4988.housekeeping
+++ b/changes/4988.housekeeping
@@ -1,0 +1,1 @@
+Fixed some bugs in `example_plugin.jobs.ExampleComplexJobButtonReceiver`.

--- a/changes/4988.removed
+++ b/changes/4988.removed
@@ -1,0 +1,1 @@
+Removed redundant `/extras/job-button/<uuid>/run/` URL endpoint; Job Buttons now use `/extras/jobs/<uuid>/run/` endpoint like any other job.

--- a/changes/4988.security
+++ b/changes/4988.security
@@ -1,0 +1,2 @@
+Fixed missing object-level permissions enforcement when running a JobButton.
+Removed the requirement for users to have both `extras.run_job` and `extras.run_jobbutton` permissions to run a Job via a Job Button. Only `extras.run_job` permission is now required.

--- a/examples/example_plugin/example_plugin/jobs.py
+++ b/examples/example_plugin/example_plugin/jobs.py
@@ -113,12 +113,13 @@ class ExampleComplexJobButtonReceiver(JobButtonReceiver):
                 self.log_failure(obj=obj, message=f"User '{user}' does not have permission to add a Site.")
             else:
                 self._run_site_job(obj)
-        if isinstance(obj, Device):
+        elif isinstance(obj, Device):
             if not user.has_perm("dcim.add_device"):
                 self.log_failure(obj=obj, message=f"User '{user}' does not have permission to add a Device.")
             else:
                 self._run_device_job(obj)
-        self.log_failure(obj=obj, message=f"Unable to run Job Button for type {type(obj).__name__}.")
+        else:
+            self.log_failure(obj=obj, message=f"Unable to run Job Button for type {type(obj).__name__}.")
 
 
 jobs = (

--- a/nautobot/docs/models/extras/jobbutton.md
+++ b/nautobot/docs/models/extras/jobbutton.md
@@ -29,7 +29,10 @@ For any Job that is loaded into Nautobot, the Job must be enabled to run. See [E
 ## Required Permissions
 
 !!! note
-    In order to run any job via a Job Button, a user must be assigned the `extras.run_job` **as well as** the `extras.run_jobbutton` permissions. This is achieved by assigning the user (or group) a permission on the `extras > job` and `extras > jobbutton` objects and specifying the `run` action in the **Additional actions** section. Any user lacking these permissions may still see the button on the respective page(s) - if not using [conditional rendering](#conditional-rendering) - but they will be disabled.
+    In order to run any job via a Job Button, a user must be assigned the `extras.run_job` permission. This is achieved by assigning the user (or group) a permission on the `extras > job` objects and specifying the `run` action in the **Additional actions** section. Any user lacking this permissions may still see the button on the respective page(s) - if not using [conditional rendering](#conditional-rendering) - but it will be disabled.
+
++/- 1.6.8
+    In prior versions, users also had to have `extras.run_jobbutton` permission as well. This requirement has been removed.
 
 ## Context Data
 

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
-from nautobot.extras.models import JobButton
+from nautobot.extras.models import Job, JobButton
 from nautobot.utilities.utils import render_jinja2
 
 
@@ -27,7 +27,8 @@ HIDDEN_INPUTS = """
 <input type="hidden" name="csrfmiddlewaretoken" value="{csrf_token}">
 <input type="hidden" name="object_pk" value="{object_pk}">
 <input type="hidden" name="object_model_name" value="{object_model_name}">
-<input type="hidden" name="redirect_path" value="{redirect_path}">
+<input type="hidden" name="_schedule_type" value="immediately">
+<input type="hidden" name="_return_url" value="{redirect_path}">
 """
 
 NO_CONFIRM_BUTTON = """
@@ -69,18 +70,17 @@ CONFIRM_MODAL = """
 </div>
 """
 
+SAFE_EMPTY = mark_safe("")  # noqa: S308
 
-@register.simple_tag(takes_context=True)
-def job_buttons(context, obj):
-    """
-    Render all applicable job buttons for the given object.
-    """
-    content_type = ContentType.objects.get_for_model(obj)
-    buttons = JobButton.objects.filter(content_types=content_type)
-    if not buttons:
-        return ""
 
-    # Pass select context data when rendering the JobButton
+def _render_job_button_for_obj(job_button, obj, context, content_type):
+    """
+    Helper method for job_buttons templatetag to reduce repetition of code.
+
+    Returns:
+       (str, str): (button_html, form_html)
+    """
+    # Pass select context data when rendering the JobButton text as Jinja2
     button_context = {
         "obj": obj,
         "debug": context.get("debug", False),  # django.template.context_processors.debug
@@ -88,9 +88,24 @@ def job_buttons(context, obj):
         "user": context["user"],  # django.contrib.auth.context_processors.auth
         "perms": context["perms"],  # django.contrib.auth.context_processors.auth
     }
-    buttons_html = forms_html = mark_safe("")  # noqa: S308
-    group_names = OrderedDict()
+    try:
+        text_rendered = render_jinja2(job_button.text, button_context)
+    except Exception as exc:
+        return (
+            format_html(
+                '<a class="btn btn-sm btn-{}" disabled="disabled" title="{}"><i class="mdi mdi-alert"></i> {}</a>\n',
+                "default" if not job_button.group_name else "link",
+                exc,
+                job_button.name,
+            ),
+            SAFE_EMPTY,
+        )
 
+    if not text_rendered:
+        return (SAFE_EMPTY, SAFE_EMPTY)
+
+    # Disable buttons if the user doesn't have permission to run the underlying Job.
+    has_run_perm = Job.objects.check_perms(context["user"], instance=job_button.job, action="run")
     hidden_inputs = format_html(
         HIDDEN_INPUTS,
         csrf_token=context["csrf_token"],
@@ -98,86 +113,65 @@ def job_buttons(context, obj):
         object_model_name=f"{content_type.app_label}.{content_type.model}",
         redirect_path=context["request"].path,
     )
+    template_args = {
+        "button_id": job_button.pk,
+        "button_text": text_rendered,
+        "button_class": job_button.button_class if not job_button.group_name else "link",
+        "button_url": reverse("extras:job_run", kwargs={"slug": job_button.job.slug}),
+        "object": obj,
+        "job": job_button.job,
+        "hidden_inputs": hidden_inputs,
+        "disabled": "" if has_run_perm else "disabled",
+    }
+
+    if job_button.confirmation:
+        return (
+            format_html(CONFIRM_BUTTON, **template_args),
+            format_html(CONFIRM_MODAL, **template_args),
+        )
+    else:
+        return (
+            format_html(NO_CONFIRM_BUTTON, **template_args),
+            format_html(NO_CONFIRM_FORM, **template_args),
+        )
+
+
+@register.simple_tag(takes_context=True)
+def job_buttons(context, obj):
+    """
+    Render all applicable job buttons for the given object.
+    """
+    content_type = ContentType.objects.get_for_model(obj)
+    # We will enforce "run" permission later in deciding which buttons to show as disabled.
+    buttons = JobButton.objects.filter(content_types=content_type)
+    if not buttons:
+        return SAFE_EMPTY
+
+    buttons_html = forms_html = SAFE_EMPTY
+    group_names = OrderedDict()
 
     for jb in buttons:
-        template_args = {
-            "button_id": jb.pk,
-            "button_text": jb.text,
-            "button_class": jb.button_class,
-            "button_url": reverse("extras:jobbutton_run", kwargs={"pk": jb.pk}),
-            "object": obj,
-            "job": jb.job,
-            "hidden_inputs": hidden_inputs,
-            "disabled": "" if context["user"].has_perms(("extras.run_jobbutton", "extras.run_job")) else "disabled",
-        }
-
-        # Organize job buttons by group
+        # Organize job buttons by group for later processing
         if jb.group_name:
-            group_names.setdefault(jb.group_name, [])
-            group_names[jb.group_name].append(jb)
+            group_names.setdefault(jb.group_name, []).append(jb)
 
-        # Add non-grouped buttons
+        # Render and add non-grouped buttons
         else:
-            try:
-                text_rendered = render_jinja2(jb.text, button_context)
-                if text_rendered:
-                    template_args["button_text"] = text_rendered
-                    if jb.confirmation:
-                        buttons_html += format_html(CONFIRM_BUTTON, **template_args)
-                        forms_html += format_html(CONFIRM_MODAL, **template_args)
-                    else:
-                        buttons_html += format_html(NO_CONFIRM_BUTTON, **template_args)
-                        forms_html += format_html(NO_CONFIRM_FORM, **template_args)
-            except Exception as e:
-                buttons_html += format_html(
-                    '<a class="btn btn-sm btn-default" disabled="disabled" title="{}">'
-                    '<i class="mdi mdi-alert"></i> {}</a>\n',
-                    e,
-                    jb.name,
-                )
+            button_html, form_html = _render_job_button_for_obj(jb, obj, context, content_type)
+            buttons_html += button_html
+            forms_html += form_html
 
     # Add grouped buttons to template
     for group_name, buttons in group_names.items():
         group_button_class = buttons[0].button_class
 
-        buttons_rendered = mark_safe("")  # noqa: S308
+        buttons_rendered = SAFE_EMPTY
 
         for jb in buttons:
-            template_args = {
-                "button_id": jb.pk,
-                "button_text": jb.text,
-                "button_class": "link",
-                "button_url": reverse("extras:jobbutton_run", kwargs={"pk": jb.pk}),
-                "object": obj,
-                "job": jb.job,
-                "hidden_inputs": hidden_inputs,
-                "disabled": "" if context["user"].has_perms(("extras.run_jobbutton", "extras.run_job")) else "disabled",
-            }
-            try:
-                text_rendered = render_jinja2(jb.text, button_context)
-                if text_rendered:
-                    template_args["button_text"] = text_rendered
-                    if jb.confirmation:
-                        buttons_rendered += (
-                            mark_safe("<li>")  # noqa: S308
-                            + format_html(CONFIRM_BUTTON, **template_args)
-                            + mark_safe("</li>")  # noqa: S308
-                        )
-                        forms_html += format_html(CONFIRM_MODAL, **template_args)
-                    else:
-                        buttons_rendered += (
-                            mark_safe("<li>")  # noqa: S308
-                            + format_html(NO_CONFIRM_BUTTON, **template_args)
-                            + mark_safe("</li>")  # noqa: S308
-                        )
-                        forms_html += format_html(NO_CONFIRM_FORM, **template_args)
-            except Exception as e:
-                buttons_rendered += format_html(
-                    '<li><a disabled="disabled" title="{}"><span class="text-muted">'
-                    '<i class="mdi mdi-alert"></i> {}</span></a></li>',
-                    e,
-                    jb.name,
-                )
+            # Render grouped buttons as list items
+            button_html, form_html = _render_job_button_for_obj(jb, obj, context, content_type)
+            buttons_rendered += format_html("<li>{}</li>", button_html)
+            forms_html += form_html
 
         if buttons_rendered:
             buttons_html += format_html(

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -70,7 +70,7 @@ CONFIRM_MODAL = """
 </div>
 """
 
-SAFE_EMPTY = mark_safe("")  # noqa: S308
+SAFE_EMPTY_STR = mark_safe("")  # noqa: S308
 
 
 def _render_job_button_for_obj(job_button, obj, context, content_type):
@@ -98,11 +98,11 @@ def _render_job_button_for_obj(job_button, obj, context, content_type):
                 exc,
                 job_button.name,
             ),
-            SAFE_EMPTY,
+            SAFE_EMPTY_STR,
         )
 
     if not text_rendered:
-        return (SAFE_EMPTY, SAFE_EMPTY)
+        return (SAFE_EMPTY_STR, SAFE_EMPTY_STR)
 
     # Disable buttons if the user doesn't have permission to run the underlying Job.
     has_run_perm = Job.objects.check_perms(context["user"], instance=job_button.job, action="run")
@@ -145,9 +145,9 @@ def job_buttons(context, obj):
     # We will enforce "run" permission later in deciding which buttons to show as disabled.
     buttons = JobButton.objects.filter(content_types=content_type)
     if not buttons:
-        return SAFE_EMPTY
+        return SAFE_EMPTY_STR
 
-    buttons_html = forms_html = SAFE_EMPTY
+    buttons_html = forms_html = SAFE_EMPTY_STR
     group_names = OrderedDict()
 
     for jb in buttons:
@@ -165,7 +165,7 @@ def job_buttons(context, obj):
     for group_name, buttons in group_names.items():
         group_button_class = buttons[0].button_class
 
-        buttons_rendered = SAFE_EMPTY
+        buttons_rendered = SAFE_EMPTY_STR
 
         for jb in buttons:
             # Render grouped buttons as list items

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -56,6 +56,7 @@ from nautobot.extras.models import (
     Tag,
     Webhook,
 )
+from nautobot.extras.templatetags.job_buttons import NO_CONFIRM_BUTTON
 from nautobot.extras.tests.constants import BIG_GRAPHQL_DEVICE_QUERY
 from nautobot.extras.tests.test_relationships import RequiredRelationshipTestMixin
 from nautobot.extras.utils import get_job_content_type, TaggableClassesQuery
@@ -2012,14 +2013,24 @@ class JobButtonRenderingTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.job_button = JobButton(
-            name="JobButton",
+        self.job_button_1 = JobButton(
+            name="JobButton 1",
             text="JobButton {{ obj.name }}",
             job=Job.objects.get(job_class_name="TestJobButtonReceiverSimple"),
             confirmation=False,
         )
-        self.job_button.validated_save()
-        self.job_button.content_types.add(ContentType.objects.get_for_model(LocationType))
+        self.job_button_1.validated_save()
+        self.job_button_1.content_types.add(ContentType.objects.get_for_model(LocationType))
+
+        self.job_button_2 = JobButton(
+            name="JobButton 2",
+            text="Click me!",
+            job=Job.objects.get(job_class_name="TestJobButtonReceiverComplex"),
+            confirmation=False,
+        )
+        self.job_button_2.validated_save()
+        self.job_button_2.content_types.add(ContentType.objects.get_for_model(LocationType))
+
         self.location_type = LocationType.objects.get(name="Campus")
 
     def test_view_object_with_job_button(self):
@@ -2028,11 +2039,12 @@ class JobButtonRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
         self.assertIn(f"JobButton {self.location_type.name}", content, content)
+        self.assertIn("Click me!", content, content)
 
     def test_view_object_with_unsafe_text(self):
         """Ensure that JobButton text can't be used as a vector for XSS."""
-        self.job_button.text = '<script>alert("Hello world!")</script>'
-        self.job_button.validated_save()
+        self.job_button_1.text = '<script>alert("Hello world!")</script>'
+        self.job_button_1.validated_save()
         response = self.client.get(self.location_type.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
@@ -2040,8 +2052,8 @@ class JobButtonRenderingTestCase(TestCase):
         self.assertIn("&lt;script&gt;alert", content, content)
 
         # Make sure grouped rendering is safe too
-        self.job_button.group = '<script>alert("Goodbye")</script>'
-        self.job_button.validated_save()
+        self.job_button_1.group_name = '<script>alert("Goodbye")</script>'
+        self.job_button_1.validated_save()
         response = self.client.get(self.location_type.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
@@ -2050,14 +2062,79 @@ class JobButtonRenderingTestCase(TestCase):
 
     def test_view_object_with_unsafe_name(self):
         """Ensure that JobButton names can't be used as a vector for XSS."""
-        self.job_button.text = "JobButton {{ obj"
-        self.job_button.name = '<script>alert("Yo")</script>'
-        self.job_button.validated_save()
+        self.job_button_1.text = "JobButton {{ obj"
+        self.job_button_1.name = '<script>alert("Yo")</script>'
+        self.job_button_1.validated_save()
         response = self.client.get(self.location_type.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
         self.assertNotIn("<script>alert", content, content)
         self.assertIn("&lt;script&gt;alert", content, content)
+
+    def test_render_constrained_run_permissions(self):
+        obj_perm = ObjectPermission(
+            name="Test permission",
+            constraints={"pk": self.job_button_1.job.pk},
+            actions=["run"],
+        )
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ContentType.objects.get_for_model(Job))
+
+        with self.subTest("Ungrouped buttons"):
+            response = self.client.get(self.location_type.get_absolute_url(), follow=True)
+            self.assertEqual(response.status_code, 200)
+            content = extract_page_body(response.content.decode(response.charset))
+            self.assertInHTML(
+                NO_CONFIRM_BUTTON.format(
+                    button_id=self.job_button_1.pk,
+                    button_text=f"JobButton {self.location_type.name}",
+                    button_class=self.job_button_1.button_class,
+                    disabled="",
+                ),
+                content,
+            )
+            self.assertInHTML(
+                NO_CONFIRM_BUTTON.format(
+                    button_id=self.job_button_2.pk,
+                    button_text="Click me!",
+                    button_class=self.job_button_2.button_class,
+                    disabled="disabled",
+                ),
+                content,
+            )
+
+        with self.subTest("Grouped buttons"):
+            self.job_button_1.group_name = "Grouping"
+            self.job_button_1.validated_save()
+            self.job_button_2.group_name = "Grouping"
+            self.job_button_2.validated_save()
+
+            response = self.client.get(self.location_type.get_absolute_url(), follow=True)
+            self.assertEqual(response.status_code, 200)
+            content = extract_page_body(response.content.decode(response.charset))
+            self.assertInHTML(
+                "<li>"
+                + NO_CONFIRM_BUTTON.format(
+                    button_id=self.job_button_1.pk,
+                    button_text=f"JobButton {self.location_type.name}",
+                    button_class="link",
+                    disabled="",
+                )
+                + "</li>",
+                content,
+            )
+            self.assertInHTML(
+                "<li>"
+                + NO_CONFIRM_BUTTON.format(
+                    button_id=self.job_button_2.pk,
+                    button_text="Click me!",
+                    button_class="link",
+                    disabled="disabled",
+                )
+                + "</li>",
+                content,
+            )
 
 
 # TODO: Convert to StandardTestCases.Views

--- a/nautobot/extras/urls.py
+++ b/nautobot/extras/urls.py
@@ -485,8 +485,6 @@ urlpatterns = [
         views.JobResultDeleteView.as_view(),
         name="jobresult_delete",
     ),
-    # Job Button Run
-    path("job-button/<uuid:pk>/run/", views.JobButtonRunView.as_view(), name="jobbutton_run"),
     # Notes
     path("notes/add/", views.NoteEditView.as_view(), name="note_add"),
     path("notes/<slug:slug>/", views.NoteView.as_view(), name="note"),

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -13,8 +13,9 @@ from django.http import Http404, HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.encoding import iri_to_uri
 from django.utils.html import format_html
-from django.utils.http import is_safe_url
+from django.utils.http import is_safe_url, url_has_allowed_host_and_scheme
 from django.views.generic import View
 from django.template.loader import get_template, TemplateDoesNotExist
 from django_tables2 import RequestConfig

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1138,7 +1138,10 @@ class JobView(ObjectPermissionRequiredMixin, View):
             messages.error(request, "Unable to run or schedule job: Job is not presently installed.")
         elif not job_model.enabled:
             messages.error(request, "Unable to run or schedule job: Job is not enabled to be run.")
-        elif job_model.has_sensitive_variables and request.POST["_schedule_type"] != JobExecutionType.TYPE_IMMEDIATELY:
+        elif (
+            job_model.has_sensitive_variables
+            and request.POST.get("_schedule_type") != JobExecutionType.TYPE_IMMEDIATELY
+        ):
             messages.error(request, "Unable to schedule job: Job may have sensitive input variables.")
         elif job_model.has_sensitive_variables and job_model.approval_required:
             messages.error(
@@ -1229,6 +1232,19 @@ class JobView(ObjectPermissionRequiredMixin, View):
                     profile=profile,
                     task_queue=job_form.cleaned_data.get("_task_queue", None),
                 )
+
+                return_url = request.POST.get("_return_url")
+                if return_url is not None and url_has_allowed_host_and_scheme(
+                    url=return_url, allowed_hosts=request.get_host()
+                ):
+                    messages.info(
+                        request,
+                        format_html(
+                            'Job enqueued. <a href="{}">Click here for the results.</a>',
+                            job_result.get_absolute_url(),
+                        ),
+                    )
+                    return redirect(iri_to_uri(return_url))
 
                 return redirect("extras:jobresult", pk=job_result.pk)
 
@@ -1587,37 +1603,6 @@ class JobButtonUIViewSet(NautobotUIViewSet):
     queryset = JobButton.objects.all()
     serializer_class = serializers.JobButtonSerializer
     table_class = tables.JobButtonTable
-
-
-class JobButtonRunView(ObjectPermissionRequiredMixin, View):
-    """
-    View to run the Job linked to the Job Button.
-    """
-
-    queryset = JobButton.objects.all()
-
-    def get_required_permission(self):
-        return "extras.run_job"
-
-    def post(self, request, pk):
-        post_data = request.POST
-        job_button = JobButton.objects.get(pk=pk)
-        job_model = job_button.job
-        result = JobResult.enqueue_job(
-            func=run_job,
-            name=job_model.class_path,
-            obj_type=get_job_content_type(),
-            user=request.user,
-            data={
-                "object_pk": post_data["object_pk"],
-                "object_model_name": post_data["object_model_name"],
-            },
-            request=copy_safe_request(request),
-            commit=True,
-        )
-        msg = format_html('Job enqueued. <a href="{}">Click here for the results.</a>', result.get_absolute_url())
-        messages.info(request=request, message=msg)
-        return redirect(post_data["redirect_path"])
 
 
 #


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #4988
# What's Changed

Port of #4993 to ltm-1.6. A couple of merge conflicts to resolve, and the `job_run` URL is slug-based rather than pk-based in 1.6.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
