### PR TITLE
Fix secret display in secretsgroup edit form

### DIFF
--- a/changes/5020.fixed
+++ b/changes/5020.fixed
@@ -1,0 +1,1 @@
+Fixed display of secrets when editing a SecretsGroup.

--- a/nautobot/extras/templates/extras/secretsgroup_edit.html
+++ b/nautobot/extras/templates/extras/secretsgroup_edit.html
@@ -14,57 +14,52 @@
         <div class="panel-heading"><strong>Secret Assignment</strong></div>
         <div class="panel-body">
             {% if secrets.errors %}
-                <div class="panel panel-danger">
-                    <div class="panel-heading"><strong>Errors</strong></div>
-                    <div class="panel-body">
-                        Please correct the error(s) below:
+                <div class="text-danger">
+                    Please correct the error(s) below:
 
-                        {% for secret in secrets.forms %}
-                            {% if secret.errors %}
-                                {% for error in secret.errors.values %}{{ error }}{% endfor %}
-                            {% endif %}
-                        {% endfor %}
-                    </div>
+                    {% for secret in secrets.forms %}
+                        {% if secret.errors %}
+                            {% for error in secret.errors.values %}{{ error }}{% endfor %}
+                        {% endif %}
+                    {% endfor %}
                 </div>
             {% endif %}
             {{ secrets.non_field_errors }}
-            <div class="form-group{% if secrets.errors %} has-error{% endif %}">
-                <table class="table" id="secrets">
-                    {{ secrets.management_form }}
-                    {% for secret_form in secrets.forms %}
-                        {% if forloop.first %}
-                            <thead>
-                                <tr>
-                                    {% for field in secret_form.visible_fields %}
-                                        <th>{{ field.label|capfirst }}</th>
+            <table class="table" id="secrets">
+                {{ secrets.management_form }}
+                {% for secret_form in secrets.forms %}
+                    {% if forloop.first %}
+                        <thead>
+                            <tr>
+                                {% for field in secret_form.visible_fields %}
+                                    <th>{{ field.label|capfirst }}</th>
+                                {% endfor %}
+                            </tr>
+                        </thead>
+                    {% endif %}
+                    <tr class="formset_row-{{ secrets.prefix }}">
+                        {% for field in secret_form.visible_fields %}
+                            <td>
+                                {% if forloop.first %}
+                                    {% for hidden in secret_form.hidden_fields %}
+                                        {{ hidden }}
                                     {% endfor %}
-                                </tr>
-                            </thead>
-                        {% endif %}
-                        <tr class="formset_row-{{ secrets.prefix }}">
-                            {% for field in secret_form.visible_fields %}
-                                <td>
-                                    {% if forloop.first %}
-                                        {% for hidden in secret_form.hidden_fields %}
-                                            {{ hidden }}
+                                {% endif %}
+                                {{ field }}
+                                {% if field.errors %}
+                                    <ul>
+                                        {% for error in field.errors %}
+                                            {# Embed an HTML comment indicating the error for extraction by tests #}
+                                            <!-- FORM-ERROR {{ field.name }}: {{ error }} -->
+                                            <li clas="text-danger">{{ error }}</li>
                                         {% endfor %}
-                                    {% endif %}
-                                    {{ field }}
-                                    {% if field.errors %}
-                                        <ul>
-                                            {% for error in field.errors %}
-                                                {# Embed an HTML comment indicating the error for extraction by tests #}
-                                                <!-- FORM-ERROR {{ field.name }}: {{ error }} -->
-                                                <li clas="text-danger">{{ error }}</li>
-                                            {% endfor %}
-                                        </ul>
-                                    {% endif %}
-                                </td>
-                            {% endfor %}
-                        </tr>
-                    {% endfor %}
-                </table>
-            </div>
+                                    </ul>
+                                {% endif %}
+                            </td>
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+            </table>
         </div>
     </div>
     {% include "inc/extras_features_edit_form_fields.html" %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #N/A
# What's Changed

Same kind of fix as in #4934, this time for secrets-group edit form. Based on a quick grep, this *should* be the last such case in core.

Before:

![image](https://github.com/nautobot/nautobot/assets/5603551/87605c71-444b-4914-9b51-434b1160fc11)

After:

![image](https://github.com/nautobot/nautobot/assets/5603551/9a50b070-75fb-4b2c-bf1c-3e047cedb911)



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
