### PR TITLE
 fixes early return conditional in ensure_git_repository the second time [LTM]

### DIFF
--- a/changes/5042.fixed
+++ b/changes/5042.fixed
@@ -1,0 +1,1 @@
+Fixed early return conditional in ensure_git_repository.

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -293,10 +293,9 @@ def ensure_git_repository(
     if head is not None:
         # If the repo exists and has HEAD already checked out, the repo is present and has the correct branch selected.
         with suppress(InvalidGitRepositoryError):
-            if (
-                Path(repository_record.filesystem_path).exists()
-                and Repo(repository_record.filesystem_path).rev_parse("HEAD") == head
-            ):
+            if Path(repository_record.filesystem_path).exists() and str(
+                Repo(repository_record.filesystem_path).rev_parse("HEAD")
+            ) == str(head):
                 return
 
     from_url, to_path, from_branch = get_repo_from_url_to_path_and_from_branch(


### PR DESCRIPTION
# Closes: #4142 
# What's Changed
The type return by `git.Repo.rev_parse("HEAD")` was still off, i.e. not a string. This commit fixes this by converting it to a string.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
