### PR TITLE
Fixed bug with invoke cli and invoke nbshell.

### DIFF
--- a/changes/5079.fixed
+++ b/changes/5079.fixed
@@ -1,1 +1,0 @@
-Fixed bug with invoke cli and invoke nbshell.

--- a/changes/5079.fixed
+++ b/changes/5079.fixed
@@ -1,0 +1,1 @@
+Fixed bug with invoke cli and invoke nbshell.

--- a/changes/5079.housekeeping
+++ b/changes/5079.housekeeping
@@ -1,0 +1,1 @@
+Increased overly-brief `start_period` for development `nautobot` container to allow sufficient time for initial migrations to run.

--- a/changes/5079.housekeeping
+++ b/changes/5079.housekeeping
@@ -1,1 +1,2 @@
 Increased overly-brief `start_period` for development `nautobot` container to allow sufficient time for initial migrations to run.
+Fixed bug with invoke cli and invoke nbshell.

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     healthcheck:
       interval: 5s
       timeout: 5s
-      start_period: 1m
+      start_period: 5m  # it takes a WHILE to run initial migrations with an empty DB
       retries: 3
       test:
         - "CMD"

--- a/tasks.py
+++ b/tasks.py
@@ -436,7 +436,7 @@ def nbshell(context):
     """Launch an interactive Nautobot shell."""
     command = "nautobot-server nbshell"
 
-    run_command(context, command, pty=True)
+    run_command(context, command)
 
 
 @task(
@@ -450,7 +450,7 @@ def cli(context, service="nautobot", root=False):
     context.nautobot.local = False
     command = "bash"
 
-    run_command(context, command, service=service, pty=True, root=root)
+    run_command(context, command, service=service, root=root)
 
 
 @task(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #DNE
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

After #5055 when running `invoke cli` or `invoke nbshell` you get this error:

`TypeError: tasks.docker_compose() got multiple values for keyword argument 'pty'`

This fixes that bug.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
