### PR TITLE
Fix #4075 - sortability of Device Bays list view by installed device status

### DIFF
--- a/changes/4075.fixed
+++ b/changes/4075.fixed
@@ -1,0 +1,1 @@
+Fixed sorting of Device Bays list view by installed device status.

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -37,15 +37,12 @@ from .template_code import (
     CONSOLESERVERPORT_BUTTONS,
     DEVICE_LINK,
     DEVICEBAY_BUTTONS,
-    DEVICEBAY_STATUS,
     FRONTPORT_BUTTONS,
     INTERFACE_BUTTONS,
     INTERFACE_IPADDRESSES,
     INTERFACE_REDUNDANCY_GROUP_INTERFACES,
     INTERFACE_REDUNDANCY_GROUP_INTERFACES_IPADDRESSES,
-    INTERFACE_REDUNDANCY_GROUP_STATUS,
     INTERFACE_REDUNDANCY_INTERFACE_PRIORITY,
-    INTERFACE_REDUNDANCY_INTERFACE_STATUS,
     INTERFACE_TAGGED_VLANS,
     LINKED_RECORD_COUNT,
     PATHENDPOINT,
@@ -772,7 +769,7 @@ class DeviceRearPortTable(RearPortTable):
 
 
 class DeviceBayTable(DeviceComponentTable):
-    status = tables.TemplateColumn(template_code=DEVICEBAY_STATUS)
+    installed_device__status = ColoredLabelColumn()
     installed_device = tables.Column(linkify=True)
     tags = TagColumn(url_name="dcim:devicebay_list")
 
@@ -783,7 +780,7 @@ class DeviceBayTable(DeviceComponentTable):
             "device",
             "name",
             "label",
-            "status",
+            "installed_device__status",
             "installed_device",
             "description",
             "tags",
@@ -793,7 +790,7 @@ class DeviceBayTable(DeviceComponentTable):
             "device",
             "name",
             "label",
-            "status",
+            "installed_device__status",
             "installed_device",
             "description",
         )
@@ -813,7 +810,7 @@ class DeviceDeviceBayTable(DeviceBayTable):
             "pk",
             "name",
             "label",
-            "status",
+            "installed_device__status",
             "installed_device",
             "description",
             "tags",
@@ -823,7 +820,7 @@ class DeviceDeviceBayTable(DeviceBayTable):
             "pk",
             "name",
             "label",
-            "status",
+            "installed_device__status",
             "installed_device",
             "description",
             "actions",
@@ -984,11 +981,8 @@ class InterfaceRedundancyGroupAssociationTable(BaseTable):
     priority = tables.TemplateColumn(template_code=INTERFACE_REDUNDANCY_INTERFACE_PRIORITY)
     interface__device = tables.Column(linkify=True)
     interface = tables.Column(linkify=True)
-    interface__status = tables.TemplateColumn(template_code=INTERFACE_REDUNDANCY_INTERFACE_STATUS)
-    interface_redundancy_group__status = tables.TemplateColumn(
-        template_code=INTERFACE_REDUNDANCY_GROUP_STATUS,
-        verbose_name="Group Status",
-    )
+    interface__status = ColoredLabelColumn()
+    interface_redundancy_group__status = ColoredLabelColumn(verbose_name="Group Status")
     interface__ip_addresses = tables.TemplateColumn(
         template_code=INTERFACE_REDUNDANCY_GROUP_INTERFACES_IPADDRESSES,
         orderable=False,

--- a/nautobot/dcim/tables/template_code.py
+++ b/nautobot/dcim/tables/template_code.py
@@ -50,17 +50,6 @@ DEVICE_LINK = """
 </a>
 """
 
-DEVICEBAY_STATUS = """
-{% if record.installed_device_id %}
-    {% load helpers %}
-    <span class="label" style="color: {{ record.installed_device.status.color|fgcolor }}; background-color: #{{ record.installed_device.status.color }}">
-        {{ record.installed_device.get_status_display }}
-    </span>
-{% else %}
-    <span class="label label-default">Vacant</span>
-{% endif %}
-"""
-
 INTERFACE_IPADDRESSES = """
 {% for ip in record.ip_addresses.all %}
     <a href="{{ ip.get_absolute_url }}">{{ ip }}</a> (<a href="{{ ip.parent.namespace.get_absolute_url }}">{{ ip.parent.namespace }}</a>)<br />
@@ -77,26 +66,10 @@ INTERFACE_REDUNDANCY_GROUP_INTERFACES_IPADDRESSES = """
 {% endfor %}
 """
 
-INTERFACE_REDUNDANCY_GROUP_STATUS = """
-{% load helpers %}
-<span class="label"
-    style="color: {{ record.interface_redundancy_group.status.color|fgcolor }};
-    background-color: #{{ record.interface_redundancy_group.status.color }}">
-    {{ record.interface_redundancy_group.get_status_display }}
-</span>
-"""
-
 INTERFACE_REDUNDANCY_INTERFACE_PRIORITY = """
 {% load helpers %}
 <span class="badge badge-default">
     {{ record.priority|placeholder }}
-</span>
-"""
-
-INTERFACE_REDUNDANCY_INTERFACE_STATUS = """
-{% load helpers %}
-<span class="label" style="color: {{ record.interface.status.color|fgcolor }}; background-color: #{{ record.interface.status.color }}">
-    {{ record.interface.get_status_display }}
 </span>
 """
 


### PR DESCRIPTION

# Closes #4075 
# What's Changed

- Replace bespoke template code for rendering statuses in the `DeviceBayTable`, `DeviceDeviceBayTable`, and `InterfaceRedundancyGroupAssociationTable` with our general-purpose `ColoredLabelColumn` class.
  - This does have the minor behavior change that the Device Bay tables now show our standard — marker instead of the special-purpose text "Vacant" in the Status column, but IMHO that's an improvement.
- Rename `status` column to `installed_device__status` in the Device Bay tables, which has no effect on the column header (it remains simply `Status`) but allows for correct lookup and sortability.

![image](https://github.com/nautobot/nautobot/assets/5603551/11147135-a603-494f-929a-b6aa4945eb9b)

Sorting by reverse status:

![image](https://github.com/nautobot/nautobot/assets/5603551/fae43651-e477-4b23-a809-688a079ed9fe)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
