### PR TITLE
Adds location & rack group to device bulk edit query params

### DIFF
--- a/changes/5111.fixed
+++ b/changes/5111.fixed
@@ -1,0 +1,1 @@
+Fixed rack group and rack filtering by the location selected in the device bulk edit form.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -1645,14 +1645,20 @@ class DeviceBulkEditForm(
         required=False,
         query_params={"manufacturer": "$manufacturer"},
     )
-    rack = DynamicModelChoiceField(queryset=Rack.objects.all(), required=False)
+    rack = DynamicModelChoiceField(
+        queryset=Rack.objects.all(),
+        required=False,
+        query_params={"location": "$location", "rack_group": "$rack_group"},
+    )
     position = forms.IntegerField(required=False)
     face = forms.ChoiceField(
         required=False,
         choices=add_blank_choice(DeviceFaceChoices),
         widget=StaticSelect2(),
     )
-    rack_group = DynamicModelChoiceField(queryset=RackGroup.objects.all(), required=False)
+    rack_group = DynamicModelChoiceField(
+        queryset=RackGroup.objects.all(), required=False, query_params={"location": "$location"}
+    )
     tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
     platform = DynamicModelChoiceField(queryset=Platform.objects.all(), required=False)
     serial = forms.CharField(max_length=255, required=False, label="Serial Number")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #5111
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
This PR simply adds the missing query params for location and rack group to the device bulk edit form.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
