### PR TITLE
Remove `files/get` endpoint which is not used from Nautobot 2.0

### DIFF
--- a/changes/5109.security
+++ b/changes/5109.security
@@ -1,0 +1,1 @@
+Removed `/files/get/` URL endpoint (for viewing FileAttachment files in the browser), as it was unused and could potentially pose security issues.

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -420,30 +420,24 @@ class DBFileStorageViewTestCase(TestCase):
         self.file_proxy_1 = FileProxy.objects.create(name=self.test_file_1.name, file=self.test_file_1)
         self.test_file_2 = SimpleUploadedFile(name="test_file_2.txt", content=b"I am content.\n")
         self.file_proxy_2 = FileProxy.objects.create(name=self.test_file_2.name, file=self.test_file_2)
-        self.urls = [
-            f"{reverse('db_file_storage.download_file')}?name={self.file_proxy_1.file.name}",
-            f"{reverse('db_file_storage.get_file')}?name={self.file_proxy_1.file.name}",
-        ]
+        self.url = f"{reverse('db_file_storage.download_file')}?name={self.file_proxy_1.file.name}"
 
     def test_get_file_anonymous(self):
         self.client.logout()
-        for url in self.urls:
-            with self.subTest(url):
-                response = self.client.get(url)
-                self.assertHttpStatus(response, 403)
+        with self.subTest(self.url):
+            response = self.client.get(self.url)
+            self.assertHttpStatus(response, 403)
 
     def test_get_file_without_permission(self):
-        for url in self.urls:
-            with self.subTest(url):
-                response = self.client.get(url)
-                self.assertHttpStatus(response, 403)
+        with self.subTest(self.url):
+            response = self.client.get(self.url)
+            self.assertHttpStatus(response, 403)
 
     def test_get_object_with_permission(self):
         self.add_permissions(get_permission_for_model(FileProxy, "view"))
-        for url in self.urls:
-            with self.subTest(url):
-                response = self.client.get(url)
-                self.assertHttpStatus(response, 200)
+        with self.subTest(self.url):
+            response = self.client.get(self.url)
+            self.assertHttpStatus(response, 200)
 
     def test_get_object_with_constrained_permission(self):
         obj_perm = ObjectPermission(
@@ -454,14 +448,10 @@ class DBFileStorageViewTestCase(TestCase):
         obj_perm.save()
         obj_perm.users.add(self.user)
         obj_perm.object_types.add(ContentType.objects.get_for_model(FileProxy))
-        for url in self.urls:
-            with self.subTest(url):
-                response = self.client.get(url)
-                self.assertHttpStatus(response, 200)
-        for url in [
-            f"{reverse('db_file_storage.download_file')}?name={self.file_proxy_2.file.name}",
-            f"{reverse('db_file_storage.get_file')}?name={self.file_proxy_2.file.name}",
-        ]:
-            with self.subTest(url):
-                response = self.client.get(url)
-                self.assertHttpStatus(response, 404)
+        with self.subTest(self.url):
+            response = self.client.get(self.url)
+            self.assertHttpStatus(response, 200)
+        url = f"{reverse('db_file_storage.download_file')}?name={self.file_proxy_2.file.name}"
+        with self.subTest(url):
+            response = self.client.get(url)
+            self.assertHttpStatus(response, 404)

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -424,20 +424,17 @@ class DBFileStorageViewTestCase(TestCase):
 
     def test_get_file_anonymous(self):
         self.client.logout()
-        with self.subTest(self.url):
-            response = self.client.get(self.url)
-            self.assertHttpStatus(response, 403)
+        response = self.client.get(self.url)
+        self.assertHttpStatus(response, 403)
 
     def test_get_file_without_permission(self):
-        with self.subTest(self.url):
-            response = self.client.get(self.url)
-            self.assertHttpStatus(response, 403)
+        response = self.client.get(self.url)
+        self.assertHttpStatus(response, 403)
 
     def test_get_object_with_permission(self):
         self.add_permissions(get_permission_for_model(FileProxy, "view"))
-        with self.subTest(self.url):
-            response = self.client.get(self.url)
-            self.assertHttpStatus(response, 200)
+        response = self.client.get(self.url)
+        self.assertHttpStatus(response, 200)
 
     def test_get_object_with_constrained_permission(self):
         obj_perm = ObjectPermission(

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -448,10 +448,8 @@ class DBFileStorageViewTestCase(TestCase):
         obj_perm.save()
         obj_perm.users.add(self.user)
         obj_perm.object_types.add(ContentType.objects.get_for_model(FileProxy))
-        with self.subTest(self.url):
-            response = self.client.get(self.url)
-            self.assertHttpStatus(response, 200)
+        response = self.client.get(self.url)
+        self.assertHttpStatus(response, 200)
         url = f"{reverse('db_file_storage.download_file')}?name={self.file_proxy_2.file.name}"
-        with self.subTest(url):
-            response = self.client.get(url)
-            self.assertHttpStatus(response, 404)
+        response = self.client.get(url)
+        self.assertHttpStatus(response, 404)

--- a/nautobot/core/urls.py
+++ b/nautobot/core/urls.py
@@ -60,12 +60,6 @@ urlpatterns = [
         {"add_attachment_headers": True},
         name="db_file_storage.download_file",
     ),
-    url(
-        "files/get/",
-        get_file_with_authorization,
-        {"add_attachment_headers": False},
-        name="db_file_storage.get_file",
-    ),
     # Templated css file
     path(
         "template.css", TemplateView.as_view(template_name="template.css", content_type="text/css"), name="template_css"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #N/A
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Removes the files/get URL endpoint which is not used. Also, the way it was configured without "add_attachment_headers": True it was missing the Content-Disposition: attachment HTTP header which causes a security vulnerability.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
