### PR TITLE
Fixed some recurring scheduled jobs not using configured time zone

### DIFF
--- a/changes/3349.fixed
+++ b/changes/3349.fixed
@@ -1,0 +1,1 @@
+Fixed some recurring scheduled jobs not using configured time zone.

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -1018,16 +1018,17 @@ class ScheduledJob(BaseModel):
             day_of_month=day_of_month,
             month_of_year=month_of_year,
             day_of_week=day_of_week,
+            nowfun=timezone.now,
         )
 
     def to_cron(self):
         t = self.start_time
         if self.interval == JobExecutionType.TYPE_HOURLY:
-            return schedules.crontab(minute=t.minute)
+            return schedules.crontab(minute=t.minute, nowfun=timezone.now)
         elif self.interval == JobExecutionType.TYPE_DAILY:
-            return schedules.crontab(minute=t.minute, hour=t.hour)
+            return schedules.crontab(minute=t.minute, hour=t.hour, nowfun=timezone.now)
         elif self.interval == JobExecutionType.TYPE_WEEKLY:
-            return schedules.crontab(minute=t.minute, hour=t.hour, day_of_week=t.strftime("%w"))
+            return schedules.crontab(minute=t.minute, hour=t.hour, day_of_week=t.strftime("%w"), nowfun=timezone.now)
         elif self.interval == JobExecutionType.TYPE_CUSTOM:
             return self.get_crontab(self.crontab)
         raise ValueError(f"I do not know to convert {self.interval} to a Cronjob!")

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -1055,8 +1055,11 @@ class ScheduledJobIntervalTestCase(TestCase):
         with mock.patch("django.utils.timezone.now") as mock_now:
             mock_now.return_value = self._strptime("2 Jan 2024 8:00AM")
             is_due, _ = scheduled_job.schedule.is_due(scheduled_job.last_run_at)
+            mock_now.assert_called()
             self.assertFalse(is_due)
 
+            mock_now.reset_mock()
             mock_now.return_value = self._strptime("2 Jan 2024 10:00AM")
             is_due, _ = scheduled_job.schedule.is_due(scheduled_job.last_run_at)
+            mock_now.assert_called()
             self.assertTrue(is_due)

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -1036,10 +1036,7 @@ class ScheduledJobIntervalTestCase(TestCase):
         scheduled_job_weekday = self.cron_days[schedule_day_of_week]
         self.assertEqual(scheduled_job_weekday, requested_weekday)
 
-
-@override_settings(USE_TZ=True, TIME_ZONE="America/New_York")
-class ScheduledJobCronTestCase(TestCase):
-    @timezone.override("America/New_York")
+    @override_settings(USE_TZ=True, TIME_ZONE="America/New_York")
     def test_cron_time_zone(self):
         self.assertEqual(app.timezone.key, "America/New_York")
         tz_new_york = pytz.timezone("America/New_York")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes: #3349
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

The root cause of this issue is `celery.schedulers.crontab` is trying to compare the `.hour` of two datetime objects:
- `nautobot.core.celery.app.now()` which is in the current tz
- `ScheduledJob.last_run_at` which is stored in the database as utc
 
`.hour` is going to be different for objects in different timezones even when the normalized time is the same. This is actually fixed in [django-celery-beat](https://github.com/celery/django-celery-beat/blob/00f0a5c5b2ea4cff100e3c0c9013f4dc891db3e7/django_celery_beat/schedulers.py#L132C1-L136C55) but we didn't bring this logic over when we created `ScheduledJob`.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Unit, Integration Tests
