### PR TITLE
Changed device template to use correct rack group variable

### DIFF
--- a/changes/5162.fixed
+++ b/changes/5162.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect rack group variable in device template.

--- a/nautobot/dcim/templates/dcim/device.html
+++ b/nautobot/dcim/templates/dcim/device.html
@@ -35,7 +35,7 @@
                                     <tr>
                                         <td>Rack</td>
                                         <td>
-                                            {% if object.rack and object.rack_group %}
+                                            {% if object.rack and object.rack.group %}
                                                 {{ object.rack.group|hyperlinked_object }} /
                                             {% endif %}
                                             {{ object.rack|hyperlinked_object }}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes 5162
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Updated `{% if object.rack and object.rack_group %}` to `{% if object.rack and object.rack.group %}`
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Before Bugfix:
![Screenshot 2024-01-24 at 9 40 45 AM](https://github.com/nautobot/nautobot/assets/38091261/3bb885ae-dcd0-48e0-b419-8eb661671872)

After Bugfix:
![Screenshot 2024-01-23 at 12 36 01 PM](https://github.com/nautobot/nautobot/assets/38091261/c19570dd-f18e-42e8-873a-1ee9e0327eb5)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [X] Example Plugin Updates (when adding/changing features)
- [] Outline Remaining Work, Constraints from Design
