### PR TITLE
Add documentation note to `FileVar` to the DJANGO setting reference

### DIFF
--- a/changes/5185.added
+++ b/changes/5185.added
@@ -1,0 +1,1 @@
+Add documentation note to `FileVar` to the DJANGO setting reference

--- a/nautobot/docs/development/jobs/index.md
+++ b/nautobot/docs/development/jobs/index.md
@@ -440,6 +440,9 @@ Similar to `ObjectVar`, but allows for the selection of multiple objects.
 
 An uploaded file. Note that uploaded files are present in memory only for the duration of the job's execution: They will not be automatically saved for future use. The job is responsible for writing file contents to disk where necessary.
 
+!!! note
+    Keep in mind that the maximum size is defined by the FILE_UPLOAD_MAX_MEMORY_SIZE from Django settings. By default, it uses 2621440 (i.e. 2.5 MB).
+
 #### `IPAddressVar`
 
 An IPv4 or IPv6 address, without a mask. Returns a `netaddr.IPAddress` object.

--- a/nautobot/docs/user-guide/administration/configuration/optional-settings.md
+++ b/nautobot/docs/user-guide/administration/configuration/optional-settings.md
@@ -487,6 +487,14 @@ Please see [the object permissions page](../guides/permissions.md) for more info
 
 ---
 
+## FILE_UPLOAD_MAX_MEMORY_SIZE
+
+Default:  2621440 (i.e. 2.5 MB).
+
+The maximum size (in bytes) that an upload will be before it gets streamed to the file system.
+
+---
+
 ## GIT_ROOT
 
 Default: `os.path.join(NAUTOBOT_ROOT, "git")`


### PR DESCRIPTION
# Closes: no issue created
# What's Changed

Added a note in the `FILEVAR` docs to highlight the dependency with the Django FILE_UPLOAD_MAX_MEMORY_SIZE

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
