### PR TITLE
Fixed AssertionError when querying Date type custom fields in GraphQL.

### DIFF
--- a/changes/3664.fixed
+++ b/changes/3664.fixed
@@ -1,0 +1,1 @@
+Fixed AssertionError when querying Date type custom fields in GraphQL.

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -21,7 +21,7 @@ from nautobot.core.graphql.generators import (
     generate_restricted_queryset,
     generate_schema_type,
 )
-from nautobot.core.graphql.types import ContentTypeType, Date, JSON
+from nautobot.core.graphql.types import ContentTypeType, JSON, NautobotDate
 from nautobot.core.graphql.utils import str_to_var_name
 from nautobot.dcim.graphql.types import (
     CablePathType,
@@ -80,7 +80,7 @@ CUSTOM_FIELD_MAPPING = {
     CustomFieldTypeChoices.TYPE_INTEGER: graphene.Int(),
     CustomFieldTypeChoices.TYPE_TEXT: graphene.String(),
     CustomFieldTypeChoices.TYPE_BOOLEAN: graphene.Boolean(),
-    CustomFieldTypeChoices.TYPE_DATE: Date(),
+    CustomFieldTypeChoices.TYPE_DATE: NautobotDate(),
     CustomFieldTypeChoices.TYPE_URL: graphene.String(),
     CustomFieldTypeChoices.TYPE_SELECT: graphene.String(),
     CustomFieldTypeChoices.TYPE_JSON: JSON(),

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -21,7 +21,7 @@ from nautobot.core.graphql.generators import (
     generate_restricted_queryset,
     generate_schema_type,
 )
-from nautobot.core.graphql.types import ContentTypeType, JSON, NautobotDate
+from nautobot.core.graphql.types import ContentTypeType, DateType, JSON
 from nautobot.core.graphql.utils import str_to_var_name
 from nautobot.dcim.graphql.types import (
     CablePathType,
@@ -80,7 +80,7 @@ CUSTOM_FIELD_MAPPING = {
     CustomFieldTypeChoices.TYPE_INTEGER: graphene.Int(),
     CustomFieldTypeChoices.TYPE_TEXT: graphene.String(),
     CustomFieldTypeChoices.TYPE_BOOLEAN: graphene.Boolean(),
-    CustomFieldTypeChoices.TYPE_DATE: NautobotDate(),
+    CustomFieldTypeChoices.TYPE_DATE: DateType(),
     CustomFieldTypeChoices.TYPE_URL: graphene.String(),
     CustomFieldTypeChoices.TYPE_SELECT: graphene.String(),
     CustomFieldTypeChoices.TYPE_JSON: JSON(),

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -21,7 +21,7 @@ from nautobot.core.graphql.generators import (
     generate_restricted_queryset,
     generate_schema_type,
 )
-from nautobot.core.graphql.types import ContentTypeType, JSON
+from nautobot.core.graphql.types import ContentTypeType, Date, JSON
 from nautobot.core.graphql.utils import str_to_var_name
 from nautobot.dcim.graphql.types import (
     CablePathType,
@@ -80,7 +80,7 @@ CUSTOM_FIELD_MAPPING = {
     CustomFieldTypeChoices.TYPE_INTEGER: graphene.Int(),
     CustomFieldTypeChoices.TYPE_TEXT: graphene.String(),
     CustomFieldTypeChoices.TYPE_BOOLEAN: graphene.Boolean(),
-    CustomFieldTypeChoices.TYPE_DATE: graphene.Date(),
+    CustomFieldTypeChoices.TYPE_DATE: Date(),
     CustomFieldTypeChoices.TYPE_URL: graphene.String(),
     CustomFieldTypeChoices.TYPE_SELECT: graphene.String(),
     CustomFieldTypeChoices.TYPE_JSON: JSON(),

--- a/nautobot/core/graphql/types.py
+++ b/nautobot/core/graphql/types.py
@@ -26,7 +26,7 @@ class ContentTypeType(OptimizedNautobotObjectType):
         model = ContentType
 
 
-class NautobotDate(graphene.Date):
+class DateType(graphene.Date):
     """
     Overriding the default serialize method from https://github.com/graphql-python/graphene/blob/master/graphene/types/datetime.py
     to handle the case where the date object is passed as a str object.

--- a/nautobot/core/graphql/types.py
+++ b/nautobot/core/graphql/types.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.contrib.contenttypes.models import ContentType
 import graphene
 import graphene_django_optimizer as gql_optimizer
@@ -22,6 +24,23 @@ class ContentTypeType(OptimizedNautobotObjectType):
 
     class Meta:
         model = ContentType
+
+
+class Date(graphene.Date):
+    """
+    Overriding the default serialize method from https://github.com/graphql-python/graphene/blob/master/graphene/types/datetime.py
+    to handle the case where the date object is passed as a str object.
+    """
+
+    @staticmethod
+    def serialize(date):
+        if isinstance(date, datetime.datetime):
+            date = date.date()
+        if not isinstance(date, datetime.date) and isinstance(date, str):
+            date = datetime.datetime.strptime(date, "%Y-%m-%d").date()
+        if not isinstance(date, datetime.date):
+            raise AssertionError('Received not compatible date "{}"'.format(repr(date)))
+        return date.isoformat()
 
 
 class JSON(graphene.Scalar):

--- a/nautobot/core/graphql/types.py
+++ b/nautobot/core/graphql/types.py
@@ -26,7 +26,7 @@ class ContentTypeType(OptimizedNautobotObjectType):
         model = ContentType
 
 
-class Date(graphene.Date):
+class NautobotDate(graphene.Date):
     """
     Overriding the default serialize method from https://github.com/graphql-python/graphene/blob/master/graphene/types/datetime.py
     to handle the case where the date object is passed as a str object.
@@ -36,11 +36,11 @@ class Date(graphene.Date):
     def serialize(date):
         if isinstance(date, datetime.datetime):
             date = date.date()
-        if not isinstance(date, datetime.date) and isinstance(date, str):
-            date = datetime.datetime.strptime(date, "%Y-%m-%d").date()
-        if not isinstance(date, datetime.date):
-            raise AssertionError('Received not compatible date "{}"'.format(repr(date)))
-        return date.isoformat()
+            return date.isoformat()
+        elif isinstance(date, str):
+            return date
+        else:
+            raise AssertionError(f'Received not compatible date "{date!r}"')
 
 
 class JSON(graphene.Scalar):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #3664 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Fixed AssertionError when querying Date type custom fields in GraphQL.
Will backport this to LTM after it is approved.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
![Screen Shot 2024-01-30 at 12 17 08 PM](https://github.com/nautobot/nautobot/assets/46973263/d0723219-549b-481e-b22f-58565d4c2d6c)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
