### PR TITLE
feature: rearrange job list table row contents

### DIFF
--- a/changes/5126.changed
+++ b/changes/5126.changed
@@ -1,0 +1,1 @@
+Rearranged Job List table row contents.

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -97,7 +97,7 @@ GITREPOSITORY_BUTTONS = """
 """
 
 JOB_BUTTONS = """
-<a href="{% url 'extras:job_run' pk=record.pk %}" class="btn btn-primary btn-xs" title="Run/Schedule" {% if not perms.extras.run_job or not record.runnable %}disabled="disabled"{% endif %}><i class="mdi mdi-play" aria-hidden="true"></i></a>
+<a href="{% url 'extras:job' pk=record.pk %}" class="btn btn-primary btn-xs" title="Details"><i class="mdi mdi-information" aria-hidden="true"></i></a>
 """
 
 OBJECTCHANGE_OBJECT = """
@@ -600,7 +600,10 @@ class JobTable(BaseTable):
     # TODO(Glenn): pk = ToggleColumn()
     source = tables.Column()
     # grouping is used to, well, group the Jobs, so it isn't a column of its own.
-    name = tables.Column(linkify=True)
+    name = tables.Column(
+        attrs={"a": {"class": "job_run", "title": "Run/Schedule"}},
+        linkify=("extras:job_run", {"pk": tables.A("pk")}),
+    )
     installed = BooleanColumn()
     enabled = BooleanColumn()
     has_sensitive_variables = BooleanColumn()
@@ -633,6 +636,9 @@ class JobTable(BaseTable):
 
     def render_description(self, value):
         return render_markdown(value)
+
+    def render_name(self, value):
+        return format_html('<span class="btn btn-primary btn-xs"><i class="mdi mdi-play"></i></span>{}', value)
 
     class Meta(BaseTable.Meta):
         model = JobModel

--- a/nautobot/extras/templates/extras/inc/job_table.html
+++ b/nautobot/extras/templates/extras/inc/job_table.html
@@ -28,7 +28,7 @@
                 </th>
             </tr>
             {% endifchanged %}
-            <tr class="collapseme-{{ row.record.grouping|slugify }} collapse in" data-parent="#accordion" {{ row.attrs.as_html }}>
+            <tr class="collapseme-{{ row.record.grouping|slugify }}{% if not perms.extras.run_job or not row.record.runnable %} disabled{% endif %} collapse in" data-parent="#accordion" {{ row.attrs.as_html }}>
                 {% for column, cell in row.items %}
                     <td {{ column.attrs.td.as_html }}>{{ cell }}</td>
                 {% endfor %}

--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -1,6 +1,32 @@
 {% extends 'generic/object_list.html' %}
 {% load helpers %}
 
+{% block extra_styles %}
+<style>
+    .accordion-toggle {
+        font-size: 14px;
+        font-weight: 700;
+    }
+
+    tr a.job_run .btn {
+        margin: -4px 10px 0 0;
+    }
+
+    tr.disabled {
+        background-color: #f4f4f4;
+    }
+
+    tr.disabled a.job_run {
+        cursor: not-allowed;
+        opacity: 0.65;
+    }
+
+    tr.disabled a.job_run .btn {
+        cursor: not-allowed;
+    }
+</style>
+{% endblock %}
+
 {% block buttons %}
 <button type="button" class="btn btn-default" id="accordion-toggle-all">Collapse All</button>
 {% endblock %}

--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -13,7 +13,7 @@
     }
 
     tr.disabled {
-        background-color: #f4f4f4;
+        color: #7d7f7c;
     }
 
     tr.disabled a.job_run {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5126

# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
- Decrease job group accordion panel `font-size` to 14px and emphasise it with bold `font-weight` instead.
- Move play button to the left of job's name, make the anchor link to job run instead of job detail view.
- Replace play icon linking to job run with information icon linking to job detail view.
- Show disabled jobs with lower opacity on the link in the first column, `cursor: not-allowed;` and grayed out description.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
| Rearranged view | Explanation of changes |
| - | - |
| ![image](https://github.com/nautobot/nautobot/assets/117445994/2ddf1143-cba3-4653-ac36-3767f744e7aa) | ![image_explained](https://github.com/nautobot/nautobot/assets/117445994/e833edc1-9626-4258-894e-e5b4652c2b4b) |
