### PR TITLE
release/1.6.11

### DIFF
--- a/changes/3664.fixed
+++ b/changes/3664.fixed
@@ -1,1 +1,0 @@
-Fixed AssertionError when querying Date type custom fields in GraphQL.

--- a/changes/5151.security
+++ b/changes/5151.security
@@ -1,1 +1,0 @@
-Updated `pillow` dependency to 10.2.0 due to CVE-2023-50447.

--- a/changes/5162.fixed
+++ b/changes/5162.fixed
@@ -1,1 +1,0 @@
-Fixed incorrect rack group variable in device template.

--- a/changes/5169.added
+++ b/changes/5169.added
@@ -1,1 +1,0 @@
-Added support for user session profiling via django-silk.

--- a/nautobot/docs/release-notes/version-1.6.md
+++ b/nautobot/docs/release-notes/version-1.6.md
@@ -72,6 +72,21 @@ The default Python version for Nautobot Docker images has been changed from 3.7 
 As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support installation or operation under Python 3.7.
 
 <!-- towncrier release notes start -->
+## v1.6.11 (2024-02-05)
+
+### Security
+
+- [#5151](https://github.com/nautobot/nautobot/issues/5151) - Updated `pillow` dependency to 10.2.0 due to CVE-2023-50447.
+
+### Added
+
+- [#5169](https://github.com/nautobot/nautobot/issues/5169) - Added support for user session profiling via django-silk.
+
+### Fixed
+
+- [#3664](https://github.com/nautobot/nautobot/issues/3664) - Fixed AssertionError when querying Date type custom fields in GraphQL.
+- [#5162](https://github.com/nautobot/nautobot/issues/5162) - Fixed incorrect rack group variable in device template.
+
 ## v1.6.10 (2024-01-22)
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "1.6.10"
+version = "1.6.11"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## v1.6.11 (2024-02-05)

### Security

- [#5151](https://github.com/nautobot/nautobot/issues/5151) - Updated `pillow` dependency to 10.2.0 due to CVE-2023-50447.

### Added

- [#5169](https://github.com/nautobot/nautobot/issues/5169) - Added support for user session profiling via django-silk.

### Fixed

- [#3664](https://github.com/nautobot/nautobot/issues/3664) - Fixed AssertionError when querying Date type custom fields in GraphQL.
- [#5162](https://github.com/nautobot/nautobot/issues/5162) - Fixed incorrect rack group variable in device template.

