### PR TITLE
Use constance MemoryBackend to avoid spurious failures in parallel tests

### DIFF
--- a/changes/5240.housekeeping
+++ b/changes/5240.housekeeping
@@ -1,0 +1,1 @@
+Changed test config to use `constance.backends.memory.MemoryBackend` to avoid intermittent failures in parallel tests.

--- a/nautobot/core/tests/nautobot_config.py
+++ b/nautobot/core/tests/nautobot_config.py
@@ -37,6 +37,8 @@ STORAGE_CONFIG = {
     "AWS_S3_REGION_NAME": "us-west-1",
 }
 
+# Use in-memory Constance backend instead of database backend so that settings don't leak between parallel tests.
+CONSTANCE_BACKEND = "constance.backends.memory.MemoryBackend"
 
 # Enable test data factories, as they're a pre-requisite for Nautobot core tests.
 TEST_USE_FACTORIES = True


### PR DESCRIPTION
# Closes DNE
# What's Changed

We are seeing intermittent failures in unittest and CI when testing Constance settings, for example https://github.com/nautobot/nautobot/actions/runs/7805193476/job/21288932658?pr=5239. Appears possibly due to information leakage between tests of Constance settings in the database. Recommended solution (https://github.com/jazzband/django-constance/issues/343#issuecomment-616200747) is to use MemoryBackend instead of DatabaseBackend for parallel testing, so this PR does just that.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
