### PR TITLE
[ltm-1.6] Improve location detail view performance

### DIFF
--- a/changes/5254.changed
+++ b/changes/5254.changed
@@ -1,0 +1,2 @@
+Changed `TreeQuerySet.ancestors` implementation to a more efficient approach for shallow trees.
+Changed the location detail view not to annotate tree fields on its queries.

--- a/nautobot/core/tests/test_tree_queries.py
+++ b/nautobot/core/tests/test_tree_queries.py
@@ -1,0 +1,44 @@
+from nautobot.core.testing import TestCase
+from nautobot.dcim.models import Location
+
+
+class QuerySetAncestorTests(TestCase):
+    """Tests for custom `TreeQuerySet.ancestors` method."""
+
+    def test_empty_ancestors(self):
+        """Test that `TreeQuerySet.ancestors` works even when there are no ancestors."""
+        base_location_with_tree_fields = (
+            Location.objects.with_tree_fields().filter(location_type__name="Campus").first()
+        )
+        base_location_without_tree_fields = (
+            Location.objects.without_tree_fields().filter(location_type__name="Campus").first()
+        )
+
+        self.assertQuerysetEqual(
+            base_location_with_tree_fields.ancestors(),
+            base_location_without_tree_fields.ancestors(),
+            msg="`TreeQuerySet.ancestors()` output doesn't match between custom and original implementation for empty ancestors list",
+        )
+
+    def test_basic_path_comparison(self):
+        """Test that the custom `TreeQuerySet.ancestors` implementation matches the behaviour of the original one."""
+        base_location_with_tree_fields = Location.objects.with_tree_fields().filter(location_type__name="Aisle").first()
+        base_location_without_tree_fields = (
+            Location.objects.without_tree_fields().filter(location_type__name="Aisle").first()
+        )
+
+        self.assertQuerysetEqualAndNotEmpty(
+            base_location_with_tree_fields.ancestors(),
+            base_location_without_tree_fields.ancestors(),
+            msg="`TreeQuerySet.ancestors()` output doesn't match between custom and original implementation",
+        )
+
+    def test_tree_annotations_not_present(self):
+        """Test that using the custom `TreeQuerySet.ancestors` implementation the tree annotations aren't present."""
+        base_location_without_tree_fields = (
+            Location.objects.without_tree_fields().filter(location_type__name="Aisle").first()
+        )
+        ancestors_without_tree_fields = base_location_without_tree_fields.ancestors()
+        self.assertFalse(
+            hasattr(ancestors_without_tree_fields.first(), "tree_depth"), "Tree annotations should not be present."
+        )

--- a/nautobot/core/tests/test_tree_queries.py
+++ b/nautobot/core/tests/test_tree_queries.py
@@ -1,4 +1,4 @@
-from nautobot.core.testing import TestCase
+from nautobot.utilities.testing import TestCase
 from nautobot.dcim.models import Location
 
 

--- a/nautobot/utilities/tree_queries.py
+++ b/nautobot/utilities/tree_queries.py
@@ -1,5 +1,5 @@
 from django.core.cache import cache
-from django.db.models import Manager
+from django.db.models import Manager, Case, When
 from tree_queries.models import TreeNode
 from tree_queries.query import TreeManager as TreeManager_, TreeQuerySet as TreeQuerySet_
 
@@ -10,6 +10,33 @@ class TreeQuerySet(TreeQuerySet_, RestrictedQuerySet):
     """
     Combine django-tree-queries' TreeQuerySet with our RestrictedQuerySet for permissions enforcement.
     """
+
+    def ancestors(self, of, *, include_self=False):
+        """Custom ancestors method for optimization purposes.
+
+        Dynamically computes ancestors either through the tree or through the `parent` foreign key depending on whether
+        tree fields are present on `of`.
+        """
+        # If `of` has `tree_depth` defined, i.e. if it was retrieved from the database on a queryset where tree fields
+        # were enabled (see `TreeQuerySet.with_tree_fields` and `TreeQuerySet.without_tree_fields`), use the default
+        # implementation from `tree_queries.query.TreeQuerySet`.
+        # Furthermore, if `of` doesn't have a parent field we also have to defer to the tree-based implementation which
+        # will then annotate the tree fields and proceed as usual.
+        if hasattr(of, "tree_depth") or not hasattr(of, "parent"):
+            return super().ancestors(of, include_self=include_self)
+        # In the other case, traverse the `parent` foreign key until the root.
+        model_class = of._meta.concrete_model
+        ancestor_pks = []
+        if include_self:
+            ancestor_pks.append(of.pk)
+        while of := of.parent:
+            # Insert in reverse order so that the root is the first element
+            ancestor_pks.insert(0, of.pk)
+        # Maintain API compatibility by returning a queryset instead of a list directly.
+        # Reference:
+        # https://stackoverflow.com/questions/4916851/django-get-a-queryset-from-array-of-ids-in-specific-order
+        preserve_order = Case(*[When(pk=pk, then=position) for position, pk in enumerate(ancestor_pks)])
+        return model_class.objects.without_tree_fields().filter(pk__in=ancestor_pks).order_by(preserve_order)
 
 
 class TreeManager(Manager.from_queryset(TreeQuerySet), TreeManager_):


### PR DESCRIPTION
# Closes #DNE
# What's Changed

This should significantly speed up

- the location detail view
- any views utilizing `dcim/inc/location_hierarchy.html`

by doing a couple of things:

- Using `without_tree_fields` on the queryset for the view to ensure that `get_object_or_404` in the `get` method of the view doesn't have to calculate the location tree (it doesn't use any of the fields the calculation adds
- Using `without_tree_fields` on the query for the children of the location for the same reasons
- Implement a `LocationQuerySet.ancestors_without_cte` that provides a more optimized implementation of `TreeQuerySet.ancestors` in cases where the tree is shallow but wide
- Use this method in a couple of places

# Screenshots

_With ~40k locations_

ltm-1.6 @ d024edb7060ad665baf62e7aec9dbf66ecb6bdd3:
![Screenshot 2024-02-08 at 09 52 33](https://github.com/nautobot/nautobot/assets/12400533/13e7fd6b-cf21-43c9-8d92-895f3a8be01c)

this branch:
![Screenshot 2024-02-08 at 09 51 50](https://github.com/nautobot/nautobot/assets/12400533/d6e47ec8-7c20-4b20-af66-5e2f3b474a9d)

These numbers are pretty consistent when reloading the page. Note that these are number reproduced in a simple dev environment, the view in the actual deployment currently takes ~6-7s.

# TODO
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
- Further things to explore:
- [x] Pre-computing `ancestors` for `dcim/inc/location_hierarchy.html` because this still triggers a full tree query whenever used - we can optimize this if we assume our trees are shallow
- [ ] Applicability to 2.0
- [ ] Usage of `ancestors_without_cte` in other places
