### PR TITLE
Apply 'latest' and 'latest-py' Docker tags to stable releases rather than `develop`

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -246,15 +246,8 @@ jobs:
           export TAG_LATEST_FOR_BRANCH="false"
           export TAG_LATEST_FOR_PY="false"
 
-          if [[ $BRANCH == "develop" ]]; then
-            export TAG_LATEST_FOR_PY="true"
-          fi
-
           if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
             export TAG_LATEST_FOR_BRANCH="true"
-            if [[ $TAG_LATEST_FOR_PY == "true" ]]; then
-              export TAG_LATEST="true"
-            fi
           fi
 
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
   publish_containers:
     name: "Build & Publish Container Images"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs:
       - "ci"
     strategy:
@@ -59,36 +59,37 @@ jobs:
       INVOKE_NAUTOBOT_PYTHON_VER: "${{ matrix.python-version }}"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: "gitbranch"
       - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@v1"
+        uses: "docker/setup-qemu-action@v2"
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@v1"
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: "docker/setup-buildx-action@v2"
+      - name: "Login to GitHub Container Registry"
+        uses: "docker/login-action@v2"
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login to Docker
-        uses: docker/login-action@v1
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+      - name: "Login to Docker"
+        uses: "docker/login-action@v2"
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: "${{ secrets.DOCKERHUB_USERNAME }}"
+          password: "${{ secrets.DOCKERHUB_TOKEN }}"
       - name: "Docker Metadata"
         id: "dockermeta"
-        uses: "docker/metadata-action@v3"
+        uses: "docker/metadata-action@v4"
         with:
           images: "networktocode/nautobot,ghcr.io/nautobot/nautobot"
           flavor: |
-            latest=false
+            latest=true
           tags: |
             type=semver,pattern={{version}}-py${{ matrix.python-version }}
             type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.11 }}
             type=semver,pattern={{major}}.{{minor}}-py${{ matrix.python-version }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.python-version == 3.11 }}
+            type=raw,value=latest-py${{ matrix.python-version }}
             type=raw,value=stable,enable=${{ matrix.python-version == 3.11 }}
             type=raw,value=stable-py${{ matrix.python-version }}
           labels: |
@@ -114,12 +115,13 @@ jobs:
         with:
           images: "networktocode/nautobot-dev,ghcr.io/nautobot/nautobot-dev"
           flavor: |
-            latest=false
+            latest=true
           tags: |
             type=semver,pattern={{version}}-py${{ matrix.python-version }}
             type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.11 }}
             type=semver,pattern={{major}}.{{minor}}-py${{ matrix.python-version }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.python-version == 3.11 }}
+            type=raw,value=latest-py${{ matrix.python-version }}
             type=raw,value=stable,enable=${{ matrix.python-version == 3.11 }}
             type=raw,value=stable-py${{ matrix.python-version }}
           labels: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           images: "networktocode/nautobot,ghcr.io/nautobot/nautobot"
           flavor: |
-            latest=true
+            latest=${{ matrix.python-version == 3.11 }}
           tags: |
             type=semver,pattern={{version}}-py${{ matrix.python-version }}
             type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.11 }}
@@ -115,7 +115,7 @@ jobs:
         with:
           images: "networktocode/nautobot-dev,ghcr.io/nautobot/nautobot-dev"
           flavor: |
-            latest=true
+            latest=${{ matrix.python-version == 3.11 }}
           tags: |
             type=semver,pattern={{version}}-py${{ matrix.python-version }}
             type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.11 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=Nautobot
       - name: "Build"
-        uses: "docker/build-push-action@v2"
+        uses: "docker/build-push-action@v4"
         with:
           push: true
           target: final
@@ -111,7 +111,7 @@ jobs:
             POETRY_INSTALLER_PARALLEL=true
       - name: "Docker Dev Metadata"
         id: "dockerdevmeta"
-        uses: "docker/metadata-action@v3"
+        uses: "docker/metadata-action@v4"
         with:
           images: "networktocode/nautobot-dev,ghcr.io/nautobot/nautobot-dev"
           flavor: |
@@ -127,7 +127,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=Nautobot
       - name: "Build Dev Containers"
-        uses: "docker/build-push-action@v2"
+        uses: "docker/build-push-action@v4"
         with:
           push: true
           target: final-dev

--- a/changes/5171.added
+++ b/changes/5171.added
@@ -1,0 +1,1 @@
+Added `latest` and `latest-py<version>` tags to the `nautobot` Docker images published for the latest stable release of Nautobot.

--- a/changes/5171.changed
+++ b/changes/5171.changed
@@ -1,1 +1,1 @@
-Changed the `latest` and `latest-py<version>` Docker tags to point to the latest stable release of Nautobot, rather than the latest build from the `develop` branch.
+Changed the tagging of `nautobot-dev` Docker images to reserve the `latest` and `latest-py<version>` tags for the latest stable release of Nautobot, rather than the latest build from the `develop` branch.

--- a/changes/5171.changed
+++ b/changes/5171.changed
@@ -1,0 +1,1 @@
+Changed the `latest` and `latest-py<version>` Docker tags to point to the latest stable release of Nautobot, rather than the latest build from the `develop` branch.

--- a/nautobot/docs/user-guide/administration/installation/docker.md
+++ b/nautobot/docs/user-guide/administration/installation/docker.md
@@ -48,6 +48,8 @@ The following tags are available on both Docker Hub and the GitHub Container Reg
 
 | Tag                                                           | Nautobot Version      | Python Version | Example        |
 | ------------------------------------------------------------- | --------------------- | -------------- | -------------- |
+| `latest`                                                      | Latest stable release | 3.11           | `latest`       |
+| `latest-py${PYTHON_VER}`                                      | Latest stable release | As specified   | `latest-py3.8` |
 | `${NAUTOBOT_VER}`                                             | As specified          | 3.11           | `2.0.0`        |
 | `${NAUTOBOT_VER}-py${PYTHON_VER}`                             | As specified          | As specified   | `2.0.0-py3.8`  |
 | `${NAUTOBOT_MAJOR_VER}.${NAUTOBOT_MINOR_VER}`                 | As specified          | 3.11           | `2.0`          |
@@ -63,8 +65,6 @@ In addition to all tags described in the previous section, the following additio
 
 | Tag                                                  | Nautobot Branch              | Python Version |
 | ---------------------------------------------------- | ---------------------------- | -------------- |
-| `latest`                                             | `develop`, the latest commit | 3.11           |
-| `latest-py${PYTHON_VER}`                             | `develop`, the latest commit | As specified   |
 | `develop`                                            | `develop`, the latest commit | 3.11           |
 | `develop-py${PYTHON_VER}`                            | `develop`, the latest commit | As specified   |
 | `ltm-1.6`                                            | `ltm-1.6`, the latest commit | 3.11           |


### PR DESCRIPTION
# Closes #5171 
# What's Changed

Some history:

- Until #4167, we were publishing `nautobot` Docker images from every commit to `develop` with tags including `latest` and `latest-py<version>`.
   - #4167 changed this so that `nautobot` images are no longer published at all for `develop` or `next`, but did not add a new source of the `latest` and `latest-py` tags.
   - Even after #4167, the `nautobot-dev` images from `develop` were still receiving `latest` and `latest-py` tags.
- When we published v1.6.3, it clobbered the v2.0.0 `stable` tags for the `final` images, so we manually re-tagged the v2.0.0 `nautobot` images with `stable` as well as with `latest`. This was the last time we published a `latest` tag for any `nautobot` image until now.

This PR (hopefully!):

- stops tagging `develop` `nautobot-dev` images with `latest` or `latest-py` tags.
- adds `latest` and `latest-py<version>` tags to release images only for both `nautobot` and `nautobot-dev` images.
- Updates the docker-related actions used in `release.yml` to the same (newer) versions used currently in our `build-nautobot-image` custom action.
   - I didn't attempt to make `release.yml` use the `build-nautobot-image` action, as it has some assumptions that don't 100% align. Would be nice as future work though.

Of course, we won't fully be able to know if it's correct until we release v2.1.4... 😬 

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
