### PR TITLE
Fix errors in app list views

### DIFF
--- a/changes/5254.fixed
+++ b/changes/5254.fixed
@@ -1,0 +1,1 @@
+Fixed `TypeError` and similar exceptions thrown when rendering certain App data tables in v2.1.3.

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -3,6 +3,7 @@ import logging
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.core.exceptions import FieldDoesNotExist
+from django.db import NotSupportedError
 from django.db.models.fields.related import ForeignKey, RelatedField
 from django.db.models.fields.reverse_related import ManyToOneRel
 from django.urls import reverse
@@ -61,7 +62,6 @@ class BaseTable(django_tables2.Table):
                 )
             # symmetric relationships are already handled above in the source_type case
 
-        model = getattr(self.Meta, "model", None)
         # Disable ordering on these TreeNode Models Table because TreeNode do not support sorting
         if model and issubclass(model, TreeNode):
             kwargs["orderable"] = False
@@ -106,27 +106,28 @@ class BaseTable(django_tables2.Table):
 
         # Dynamically update the table's QuerySet to ensure related fields are pre-fetched
         if isinstance(self.data, TableQuerysetData):
+            queryset = self.data.data
             select_fields = []
             prefetch_fields = []
             for column in self.columns:
                 if column.visible:
-                    model = getattr(self.Meta, "model")
+                    column_model = model
                     accessor = column.accessor
                     select_path = []
                     prefetch_path = []
                     for field_name in accessor.split(accessor.SEPARATOR):
                         try:
-                            field = model._meta.get_field(field_name)
+                            field = column_model._meta.get_field(field_name)
                         except FieldDoesNotExist:
                             break
                         if isinstance(field, ForeignKey) and not prefetch_path:
                             # Follow ForeignKeys to the related model via select_related
                             select_path.append(field_name)
-                            model = field.remote_field.model
+                            column_model = field.remote_field.model
                         elif isinstance(field, (RelatedField, ManyToOneRel)) and not select_path:
                             # Follow O2M and M2M relations to the related model via prefetch_related
                             prefetch_path.append(field_name)
-                            model = field.remote_field.model
+                            column_model = field.remote_field.model
                         elif isinstance(field, GenericForeignKey) and not select_path:
                             # Can't prefetch beyond a GenericForeignKey
                             prefetch_path.append(field_name)
@@ -140,13 +141,55 @@ class BaseTable(django_tables2.Table):
                         select_fields.append("__".join(select_path))
                     elif prefetch_path:
                         prefetch_fields.append("__".join(prefetch_path))
-            logger.debug(
-                "Applying .select_related(%s).prefetch_related(%s) to %s QuerySet",
-                select_fields,
-                prefetch_fields,
-                self.data.data.model.__name__,
-            )
-            self.data.data = self.data.data.select_related(*select_fields).prefetch_related(*prefetch_fields)
+
+            if select_fields:
+                # Django doesn't allow .select_related() on a QuerySet that had .values()/.values_list() applied, or
+                # one that has had union()/intersection()/difference() applied.
+                # We can detect and avoid these cases the same way that Django itself does.
+                if queryset._fields is not None:
+                    logger.debug(
+                        "NOT applying select_related(%s) to %s QuerySet as it includes .values()/.values_list()",
+                        select_fields,
+                        model.__name__,
+                    )
+                elif queryset.query.combinator:
+                    logger.debug(
+                        "NOT applying select_related(%s) to %s QuerySet as it is a combinator query",
+                        select_fields,
+                        model.__name__,
+                    )
+                else:
+                    logger.debug("Applying .select_related(%s) to %s QuerySet", select_fields, model.__name__)
+                    # Belt and suspenders - we should have avoided any error cases above, but be safe anyway:
+                    try:
+                        queryset = queryset.select_related(*select_fields)
+                    except (TypeError, ValueError, NotSupportedError) as exc:
+                        logger.warning(
+                            "Unexpected error when trying to .select_related() on %s QuerySet: %s",
+                            model.__name__,
+                            exc,
+                        )
+
+            if prefetch_fields:
+                if queryset.query.combinator:
+                    logger.debug(
+                        "NOT applying prefetch_related(%s) to %s QuerySet as it is a combinator query",
+                        prefetch_fields,
+                        model.__name__,
+                    )
+                else:
+                    logger.debug("Applying .prefetch_related(%s) to %s QuerySet", prefetch_fields, model.__name__)
+                    # Belt and suspenders - we should have avoided any error cases above, but be safe anyway:
+                    try:
+                        queryset = queryset.prefetch_related(*prefetch_fields)
+                    except (TypeError, ValueError, NotSupportedError) as exc:
+                        logger.warning(
+                            "Unexpected error when trying to .prefetch_related() on %s QuerySet: %s",
+                            model.__name__,
+                            exc,
+                        )
+
+            self.data.data = queryset
 
     @property
     def configurable_columns(self):


### PR DESCRIPTION
# Closes #5254 
# What's Changed

#5215 added automatic `select_related()` calls to the queryset provided for any BaseTable subclass. While this was unproblematic for all core tables, some apps use querysets that include a `.values()` or `.values_list()` method call, and Django throws an exception if you try to call `.select_related()` after calling `.values()` or `.values_list()`.

This PR adds logic to duplicate the known exception cases in Django and avoid calling `select_related()` or `prefetch_related()` in cases where we can detect that Django would reject these calls; as additional protection I've also added a `try...except` around these calls as well.

Interestingly, this issue was *not* caught by upstream testing for the apps; looks like we have some test gaps in both golden-config and device-lifecycle-mgmt for tests that would have caught this before the release. I'll follow up by opening issues against both of those repos to add test coverage.

# Screenshots

Locally installed golden-config and verified that without this fix, several of its views throw a TypeError, but with this fix, they all render successfully:

![image](https://github.com/nautobot/nautobot/assets/5603551/9d254284-f2d9-48c3-b053-c8a02a212789)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
