### PR TITLE
Resolve two issues with Job Buttons.

### DIFF
--- a/changes/5253.fixed
+++ b/changes/5253.fixed
@@ -1,0 +1,1 @@
+Fixed issue with Job Button Groups displaying when Conditional Rendering should remove the button.

--- a/changes/5261.fixed
+++ b/changes/5261.fixed
@@ -1,0 +1,1 @@
+Fixed Job Button using running jobs without Commit.

--- a/changes/5261.fixed
+++ b/changes/5261.fixed
@@ -1,1 +1,1 @@
-Fixed Job Button using running jobs without Commit.
+Fixed a regression introduced in v1.6.8 where Job Buttons would always run with `commit=False`.

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -29,6 +29,7 @@ HIDDEN_INPUTS = """
 <input type="hidden" name="object_model_name" value="{object_model_name}">
 <input type="hidden" name="_schedule_type" value="immediately">
 <input type="hidden" name="_return_url" value="{redirect_path}">
+<input type="hidden" name="_commit" value="on">
 """
 
 NO_CONFIRM_BUTTON = """
@@ -170,8 +171,10 @@ def job_buttons(context, obj):
         for jb in buttons:
             # Render grouped buttons as list items
             button_html, form_html = _render_job_button_for_obj(jb, obj, context, content_type)
-            buttons_rendered += format_html("<li>{}</li>", button_html)
-            forms_html += form_html
+            if button_html:
+                buttons_rendered += format_html("<li>{}</li>", button_html)
+            if form_html:
+                forms_html += form_html
 
         if buttons_rendered:
             buttons_html += format_html(

--- a/nautobot/extras/tests/test_templatetags.py
+++ b/nautobot/extras/tests/test_templatetags.py
@@ -13,7 +13,7 @@ class JobButtonsTest(TestCase):
     """Test Rendering of Job Buttons."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUp(cls):
         cls.site = Site.objects.create(name="Test", slug="test")
         cls.job = Job.objects.get(job_class_name="TestJobButtonReceiverSimple")
 

--- a/nautobot/extras/tests/test_templatetags.py
+++ b/nautobot/extras/tests/test_templatetags.py
@@ -1,0 +1,197 @@
+"""Test Templatetags provided by Extras."""
+
+from django.contrib.contenttypes.models import ContentType
+from django.test.client import RequestFactory
+from django.urls import reverse
+from nautobot.dcim.models import Site
+from nautobot.extras.models import Job, JobButton
+from nautobot.extras.templatetags.job_buttons import job_buttons
+from nautobot.utilities.testing import TestCase
+
+
+class JobButtonsTest(TestCase):
+    """Test Rendering of Job Buttons."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.site = Site.objects.create(name="Test", slug="test")
+        cls.job = Job.objects.get(job_class_name="TestJobButtonReceiverSimple")
+
+        cls.site_type = ContentType.objects.get_for_model(Site)
+
+        job_button_config = {
+            "name": "Job Button Site",
+            "job": cls.job,
+            "defaults": {
+                "text": "Job Button Site",
+                "button_class": "primary",
+            },
+        }
+        cls.jobbutton, _ = JobButton.objects.get_or_create(**job_button_config)
+        cls.jobbutton.content_types.set(
+            [
+                cls.site_type,
+            ]
+        )
+
+    def test_job_buttons_non_grouped(self):
+        """Job Button without a group and missing permissions renders disabled with a confirmation."""
+
+        result = self._build_request()
+        self.assertIn(
+            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn(
+            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn("disabled", result)
+
+    def test_job_buttons_non_grouped_no_confirm(self):
+        """Job Button without a group and missing permissions renders disabled without a confirmation."""
+
+        result = self._build_request()
+        self.assertNotIn(
+            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn(
+            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn("disabled", result)
+
+    def test_job_buttons_non_grouped_perms(self):
+        """Job Button without a group renders with a confirmation."""
+
+        self.add_permissions("extras.run_jobbutton", "extras.run_job")
+
+        result = self._build_request()
+        self.assertIn(
+            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn(
+            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertNotIn("disabled", result)
+
+    def test_job_buttons_non_grouped_conditional_rendering(self):
+        """Job Button Conditional Rendering Success Path renders."""
+
+        self.add_permissions("extras.run_jobbutton", "extras.run_job")
+        self.jobbutton.text = "{% if obj.slug == 'test' %}Job Button Site{% endif %}"
+        self.jobbutton.save()
+
+        result = self._build_request()
+        self.assertIn(
+            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn(
+            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertNotIn("disabled", result)
+
+    def test_job_buttons_non_grouped_conditional_rendering_false(self):
+        """Job Button Conditional Rendering Failure Path does not render."""
+
+        self.add_permissions("extras.run_jobbutton", "extras.run_job")
+        self.jobbutton.text = "{% if obj.slug == 'nope' %}Job Button Site{% endif %}"
+        self.jobbutton.save()
+
+        result = self._build_request()
+        self.assertEqual(
+            "",
+            result,
+        )
+
+    def test_job_buttons_non_grouped_conditional_rendering_exception(self):
+        """Job Button Conditional Rendering Exception Path renders."""
+
+        self.add_permissions("extras.run_jobbutton", "extras.run_job")
+        self.jobbutton.text = "{% if obj.slug == 'nope' %}Job Button Site"
+        self.jobbutton.save()
+
+        result = self._build_request()
+        self.assertNotIn(
+            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertNotIn(
+            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn("disabled", result)
+
+    def test_job_buttons_grouped(self):
+        """Job Button with a group and missing permissions renders disabled with a confirmation."""
+
+        self.jobbutton.group_name = "Site Buttons"
+
+        result = self._build_request()
+        self.assertIn(
+            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn(
+            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn("Site Buttons", result)
+        self.assertIn("disabled", result)
+
+    def test_job_buttons_grouped_perms(self):
+        """Job Button with a group and renders with a confirmation."""
+
+        self.add_permissions("extras.run_jobbutton", "extras.run_job")
+        self.jobbutton.group_name = "Site Buttons"
+
+        result = self._build_request()
+        self.assertIn(
+            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn(
+            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            result,
+        )
+        self.assertIn("Site Buttons", result)
+        self.assertNotIn("disabled", result)
+
+    def test_job_buttons_grouped_conditional_rendering_false(self):
+        """Job Button with a group does not render if Conditional Rendering False."""
+
+        self.add_permissions("extras.run_jobbutton", "extras.run_job")
+        self.jobbutton.group_name = "Site Buttons"
+        self.jobbutton.text = "{% if obj.slug == 'nope' %}Job Site Button{% endif %}"
+        self.jobbutton.save()
+
+        result = self._build_request()
+        self.assertEqual("", result)
+
+    def test_job_buttons_no_buttons(self):
+        self.jobbutton.delete()
+        self.assertEqual(
+            "",
+            self._build_request(),
+        )
+
+    def _build_request(self):
+        request = RequestFactory().get(
+            reverse(
+                "dcim:site",
+                kwargs={"slug": self.site.slug},
+            )
+        )
+        context = {
+            "request": request,
+            "user": self.user,
+            "perms": {},
+            "csrf_token": "",
+            "settings": {},
+        }
+        return job_buttons(context=context, obj=self.site)

--- a/nautobot/extras/tests/test_templatetags.py
+++ b/nautobot/extras/tests/test_templatetags.py
@@ -47,8 +47,8 @@ class JobButtonsTest(TestCase):
     def test_job_buttons_non_grouped_no_confirm(self):
         """Job Button without a group and missing permissions renders disabled without a confirmation."""
 
-self.jobbutton.confirmation = False
-self.jobbutton.save()
+        self.jobbutton.confirmation = False
+        self.jobbutton.save()
 
         result = self._build_request()
         self.assertNotIn(

--- a/nautobot/extras/tests/test_templatetags.py
+++ b/nautobot/extras/tests/test_templatetags.py
@@ -13,6 +13,7 @@ class JobButtonsTest(TestCase):
     """Test Rendering of Job Buttons."""
 
     def setUp(self):
+        super().setUp()
         self.site = Site.objects.create(name="Test", slug="test")
         self.job = Job.objects.get(job_class_name="TestJobButtonReceiverSimple")
 

--- a/nautobot/extras/tests/test_templatetags.py
+++ b/nautobot/extras/tests/test_templatetags.py
@@ -28,11 +28,7 @@ class JobButtonsTest(TestCase):
             },
         }
         cls.jobbutton, _ = JobButton.objects.get_or_create(**job_button_config)
-        cls.jobbutton.content_types.set(
-            [
-                cls.site_type,
-            ]
-        )
+        cls.jobbutton.content_types.set([cls.site_type])
 
     def test_job_buttons_non_grouped(self):
         """Job Button without a group and missing permissions renders disabled with a confirmation."""
@@ -131,6 +127,7 @@ class JobButtonsTest(TestCase):
         """Job Button with a group and missing permissions renders disabled with a confirmation."""
 
         self.jobbutton.group_name = "Site Buttons"
+        self.jobbutton.save()
 
         result = self._build_request()
         self.assertIn(
@@ -149,6 +146,7 @@ class JobButtonsTest(TestCase):
 
         self.add_permissions("extras.run_jobbutton", "extras.run_job")
         self.jobbutton.group_name = "Site Buttons"
+        self.jobbutton.save()
 
         result = self._build_request()
         self.assertIn(

--- a/nautobot/extras/tests/test_templatetags.py
+++ b/nautobot/extras/tests/test_templatetags.py
@@ -47,6 +47,9 @@ class JobButtonsTest(TestCase):
     def test_job_buttons_non_grouped_no_confirm(self):
         """Job Button without a group and missing permissions renders disabled without a confirmation."""
 
+self.jobbutton.confirmation = False
+self.jobbutton.save()
+
         result = self._build_request()
         self.assertNotIn(
             f'id="confirm_modal_id_{self.jobbutton.pk}"',

--- a/nautobot/extras/tests/test_templatetags.py
+++ b/nautobot/extras/tests/test_templatetags.py
@@ -12,23 +12,22 @@ from nautobot.utilities.testing import TestCase
 class JobButtonsTest(TestCase):
     """Test Rendering of Job Buttons."""
 
-    @classmethod
-    def setUp(cls):
-        cls.site = Site.objects.create(name="Test", slug="test")
-        cls.job = Job.objects.get(job_class_name="TestJobButtonReceiverSimple")
+    def setUp(self):
+        self.site = Site.objects.create(name="Test", slug="test")
+        self.job = Job.objects.get(job_class_name="TestJobButtonReceiverSimple")
 
-        cls.site_type = ContentType.objects.get_for_model(Site)
+        self.site_type = ContentType.objects.get_for_model(Site)
 
         job_button_config = {
             "name": "Job Button Site",
-            "job": cls.job,
+            "job": self.job,
             "defaults": {
                 "text": "Job Button Site",
                 "button_class": "primary",
             },
         }
-        cls.jobbutton, _ = JobButton.objects.get_or_create(**job_button_config)
-        cls.jobbutton.content_types.set([cls.site_type])
+        self.jobbutton, _ = JobButton.objects.get_or_create(**job_button_config)
+        self.jobbutton.content_types.set([self.site_type])
 
     def test_job_buttons_non_grouped(self):
         """Job Button without a group and missing permissions renders disabled with a confirmation."""

--- a/nautobot/extras/tests/test_templatetags.py
+++ b/nautobot/extras/tests/test_templatetags.py
@@ -39,11 +39,11 @@ class JobButtonsTest(TestCase):
 
         result = self._build_request()
         self.assertIn(
-            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="confirm_modal_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn(
-            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="form_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn("disabled", result)
@@ -53,11 +53,11 @@ class JobButtonsTest(TestCase):
 
         result = self._build_request()
         self.assertNotIn(
-            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="confirm_modal_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn(
-            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="form_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn("disabled", result)
@@ -69,11 +69,11 @@ class JobButtonsTest(TestCase):
 
         result = self._build_request()
         self.assertIn(
-            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="confirm_modal_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn(
-            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="form_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertNotIn("disabled", result)
@@ -87,11 +87,11 @@ class JobButtonsTest(TestCase):
 
         result = self._build_request()
         self.assertIn(
-            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="confirm_modal_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn(
-            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="form_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertNotIn("disabled", result)
@@ -118,11 +118,11 @@ class JobButtonsTest(TestCase):
 
         result = self._build_request()
         self.assertNotIn(
-            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="confirm_modal_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertNotIn(
-            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="form_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn("disabled", result)
@@ -134,11 +134,11 @@ class JobButtonsTest(TestCase):
 
         result = self._build_request()
         self.assertIn(
-            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="confirm_modal_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn(
-            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="form_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn("Site Buttons", result)
@@ -152,11 +152,11 @@ class JobButtonsTest(TestCase):
 
         result = self._build_request()
         self.assertIn(
-            f'id="confirm_modal_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="confirm_modal_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn(
-            f'id="form_id_{self.jobbutton.pk}_{self.site.pk}"',
+            f'id="form_id_{self.jobbutton.pk}"',
             result,
         )
         self.assertIn("Site Buttons", result)

--- a/nautobot/ipam/tests/test_filters.py
+++ b/nautobot/ipam/tests/test_filters.py
@@ -895,12 +895,16 @@ class VLANTestCase(FilterTestCases.FilterTestCase, FilterTestCases.TenancyFilter
     def test_region(self):
         regions = list(self.regions[:2])
         params = {"region_id": [regions[0].pk, regions[1].pk]}
+        # For some reason, our Factory classes are now generating two VLANs with the same VID and site and a null group,
+        # and since VLAN.meta.ordering == ["site", "group", "vid"] the sort order of these two VLANs is indeterminate.
+        # This was causing this test to consistently fail on postgres (but not mysql), so we're working around it
+        # by adding the "ordered=False" parameter to both of the below assertions.
         self.assertQuerysetEqual(
-            self.filterset(params, self.queryset).qs, self.queryset.filter(site__region__in=regions)
+            self.filterset(params, self.queryset).qs, self.queryset.filter(site__region__in=regions), ordered=False
         )
         params = {"region": [regions[0].slug, regions[1].slug]}
         self.assertQuerysetEqual(
-            self.filterset(params, self.queryset).qs, self.queryset.filter(site__region__in=regions)
+            self.filterset(params, self.queryset).qs, self.queryset.filter(site__region__in=regions), ordered=False
         )
 
     def test_site(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5261 #5253 
# What's Changed
Resolved regression where Job Buttons would not run with `commit=True`
Resolved regression with Grouped Job Buttons displaying the Group even if no buttons were rendered.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
![dummy](https://github.com/nautobot/nautobot/assets/17092348/9825478c-99cd-428a-917c-f27279bcb1c1)
![image](https://github.com/nautobot/nautobot/assets/17092348/c1a4a5ee-d926-45ac-bfad-dd122902185a)
![image](https://github.com/nautobot/nautobot/assets/17092348/46121157-e21d-4be0-b66d-eeb6f8403639)
![image](https://github.com/nautobot/nautobot/assets/17092348/415be4f7-e814-4804-ac9c-e86c744da314)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
