### PR TITLE
Ensure IPAddress.ip_version gets set on save()

### DIFF
--- a/changes/5186.fixed
+++ b/changes/5186.fixed
@@ -1,0 +1,1 @@
+Fixed a case where an IPAddress created with a `host` and `mask_length` would default to a null `ip_version`.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -617,6 +617,8 @@ class Prefix(PrimaryModel):
     def save(self, *args, **kwargs):
         if isinstance(self.prefix, netaddr.IPNetwork):
             # Clear host bits from prefix
+            # This also has the subtle side effect of calling self._deconstruct_prefix(),
+            # which will (re)set the broadcast and ip_version values of this instance to their correct values.
             self.prefix = self.prefix.cidr
 
         # Determine if a parent exists and set it to the closest ancestor by `prefix_length`.
@@ -1116,6 +1118,8 @@ class IPAddress(PrimaryModel):
         # if self.parent.type != choices.PrefixTypeChoices.TYPE_NETWORK:
         #     err_msg = f"IP addresses cannot be created in {self.parent.type} prefixes. You must create a network prefix first."
         #     raise ValidationError({"address": err_msg})
+
+        self.address = self.address  # not a no-op - forces re-calling of self._deconstruct_address()
 
         # Force dns_name to lowercase
         if not self.dns_name.islower:

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -303,6 +303,56 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
             prefix.validated_save()
         self.assertIn(f'Prefixes may not associate to locations of type "{location_type.name}"', str(cm.exception))
 
+    def test_create_field_population(self):
+        """Test the various ways of creating a Prefix all result in correctly populated fields."""
+        with self.subTest("Creation with a prefix and status"):
+            prefix = Prefix(prefix="192.0.3.0/24", status=self.status)
+            prefix.save()
+            self.assertEqual(prefix.network, "192.0.3.0")
+            self.assertEqual(prefix.broadcast, "192.0.3.255")
+            self.assertEqual(prefix.prefix_length, 24)
+            self.assertEqual(prefix.type, PrefixTypeChoices.TYPE_NETWORK)  # default value
+            # parent field is tested exhaustively below
+            self.assertEqual(prefix.ip_version, 4)
+            self.assertEqual(prefix.namespace, get_default_namespace())  # default value
+
+        with self.subTest("Creation with a network, broadcast, and prefix_length"):
+            prefix = Prefix(network="192.0.4.0", broadcast="192.0.4.255", prefix_length=24, status=self.status)
+            prefix.save()
+            self.assertEqual(prefix.network, "192.0.4.0")
+            self.assertEqual(prefix.broadcast, "192.0.4.255")
+            self.assertEqual(prefix.prefix_length, 24)
+            self.assertEqual(prefix.type, PrefixTypeChoices.TYPE_NETWORK)  # default value
+            # parent field is tested exhaustively below
+            self.assertEqual(prefix.ip_version, 4)
+            self.assertEqual(prefix.namespace, get_default_namespace())  # default value
+            self.assertEqual(prefix.prefix, netaddr.IPNetwork("192.0.4.0/24"))
+
+        with self.subTest("Creation with conflicting values - prefix takes precedence"):
+            prefix = Prefix(
+                prefix="192.0.5.0/24",
+                status=self.status,
+                network="1.1.1.1",
+                broadcast="2.2.2.2",
+                prefix_length=27,
+                ip_version=6,
+            )
+            prefix.save()
+            self.assertEqual(prefix.network, "192.0.5.0")
+            self.assertEqual(prefix.broadcast, "192.0.5.255")
+            self.assertEqual(prefix.prefix_length, 24)
+            self.assertEqual(prefix.ip_version, 4)
+
+        with self.subTest("Creation with conflicting values - network and prefix_length take precedence"):
+            prefix = Prefix(
+                status=self.status, network="192.0.6.0", prefix_length=24, broadcast="192.0.6.127", ip_version=6
+            )
+            prefix.save()
+            self.assertEqual(prefix.network, "192.0.6.0")
+            self.assertEqual(prefix.broadcast, "192.0.6.255")
+            self.assertEqual(prefix.prefix_length, 24)
+            self.assertEqual(prefix.ip_version, 4)
+
     def test_tree_methods(self):
         """Test the various tree methods work as expected."""
 
@@ -854,6 +904,40 @@ class TestIPAddress(ModelTestCases.BaseModelTestCase):
         self.namespace = Namespace.objects.first()
         self.status = Status.objects.get(name="Active")
         self.prefix = Prefix.objects.create(prefix="192.0.2.0/24", status=self.status, namespace=self.namespace)
+
+    def test_create_field_population(self):
+        """Test that the various ways of creating an IPAddress result in correctly populated fields."""
+        if self.namespace != get_default_namespace():
+            prefix = Prefix.objects.create(prefix="192.0.2.0/24", status=self.status, namespace=get_default_namespace())
+        else:
+            prefix = self.prefix
+
+        with self.subTest("Creation with an address"):
+            ip = IPAddress(address="192.0.2.1/24", status=self.status)
+            ip.save()
+            self.assertEqual(ip.host, "192.0.2.1")
+            self.assertEqual(ip.mask_length, 24)
+            self.assertEqual(ip.type, IPAddressTypeChoices.TYPE_HOST)  # default value
+            self.assertEqual(ip.parent, prefix)
+            self.assertEqual(ip.ip_version, 4)
+
+        with self.subTest("Creation with a host and mask_length"):
+            ip = IPAddress(host="192.0.2.2", mask_length=24, status=self.status)
+            ip.save()
+            self.assertEqual(ip.host, "192.0.2.2")
+            self.assertEqual(ip.mask_length, 24)
+            self.assertEqual(ip.type, IPAddressTypeChoices.TYPE_HOST)  # default value
+            self.assertEqual(ip.parent, prefix)
+            self.assertEqual(ip.ip_version, 4)
+
+        with self.subTest("Creation with conflicting values - address takes precedence"):
+            ip = IPAddress(address="192.0.2.3/24", host="1.1.1.1", mask_length=32, ip_version=6, status=self.status)
+            ip.save()
+            self.assertEqual(ip.host, "192.0.2.3")
+            self.assertEqual(ip.mask_length, 24)
+            self.assertEqual(ip.type, IPAddressTypeChoices.TYPE_HOST)  # default value
+            self.assertEqual(ip.parent, prefix)
+            self.assertEqual(ip.ip_version, 4)
 
     #
     # Uniqueness enforcement tests


### PR DESCRIPTION
# Closes #5186 - partially!
# What's Changed

- In `IPAddress.save()`, ensure that `ip_version` gets correctly set or reset by doing `self.address = self.address`, which invokes `self._deconstruct_address()` to (re)populate the `host`, `mask_length`, and `ip_version` fields.
- I was going to add similar logic to `Prefix`, but it actually already has equivalent logic in its `save()` - so I've just added a comment documenting this non-obvious side effect.
- Add tests for various creation paths for both `IPAddress` and `Prefix` objects.

As future (i.e. 2.2/`next`) work, I'll update the `Prefix` and `IPAddress` models so that their `ip_version` fields are explicitly non-nullable. Since this will involve a (potentially long-running) data migration, I'm not doing so in this PR.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
