### PR TITLE
Switch from curl-based default Docker healthcheck to a CLI-based one

### DIFF
--- a/changes/5342.added
+++ b/changes/5342.added
@@ -1,0 +1,1 @@
+Added `MigrationsBackend` to health-check, which will fail if any unapplied database migrations are present.

--- a/changes/5342.changed
+++ b/changes/5342.changed
@@ -1,0 +1,1 @@
+Changed default Docker HEALTHCHECK to use `nautobot-server health_check` CLI command.

--- a/development/docker-compose.final.yml
+++ b/development/docker-compose.final.yml
@@ -8,12 +8,6 @@ services:
     image: "local/nautobot-final:local-py${PYTHON_VER}"
     ports:
       - 8443:8443
-    healthcheck:
-      test:
-        - "CMD"
-        - "curl"
-        - "-fk"
-        - "https://localhost:8443/health/"
   celery_worker:
     image: "local/nautobot-final:local-py${PYTHON_VER}"
     entrypoint: "nautobot-server celery worker -l INFO --events"

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -25,16 +25,6 @@ services:
     env_file:
       - dev.env
     tty: true
-    healthcheck:
-      interval: 5s
-      timeout: 5s
-      start_period: 5m  # it takes a WHILE to run initial migrations with an empty DB
-      retries: 3
-      test:
-        - "CMD"
-        - "curl"
-        - "-f"
-        - "http://localhost:8080/health/"
   celery_worker:
     image: "local/nautobot-dev:local-py${PYTHON_VER}"
     ports:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,7 +58,9 @@ RUN --mount=type=cache,target="/root/.cache/pip",sharing=locked \
     --mount=type=cache,target="/tmp",sharing=locked \
     pip install --upgrade pip wheel
 
-HEALTHCHECK --interval=5s --timeout=5s --start-period=5s --retries=1 CMD curl --fail http://localhost:8080/health/ || exit 1
+# timeout/interval=10s because `nautobot-server` can be slow to start - https://github.com/nautobot/nautobot/issues/4292
+# start-period=5m because initial migrations can take several minutes to run on a fresh DB
+HEALTHCHECK --interval=10s --timeout=10s --start-period=5m --retries=3 CMD nautobot-server health_check
 
 # Generate nautobot user and its required dirs for later consumption
 RUN mkdir /opt/nautobot /opt/nautobot/.cache /prom_cache /source && \

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -425,6 +425,10 @@ INSTALLED_APPS = [
     "graphene_django",
     "health_check",
     "health_check.storage",
+    # We have custom implementations of these in nautobot.extras.health_checks:
+    # "health_check.db",
+    # "health_check.contrib.migrations",
+    # "health_check.contrib.redis",
     "django_extensions",
     "constance.backends.database",
     "django_ajax_tables",

--- a/nautobot/extras/apps.py
+++ b/nautobot/extras/apps.py
@@ -43,7 +43,7 @@ class ExtrasConfig(NautobotConfig):
                 "during the execution of the migration command for the first time."
             )
 
-        # Register the DatabaseBackend health check
+        # Register the DatabaseBackend, MigrationsBackend, and RedisBackend health checks
         from nautobot.extras.health_checks import DatabaseBackend, MigrationsBackend, RedisBackend
 
         plugin_dir.register(DatabaseBackend)

--- a/nautobot/extras/apps.py
+++ b/nautobot/extras/apps.py
@@ -44,9 +44,10 @@ class ExtrasConfig(NautobotConfig):
             )
 
         # Register the DatabaseBackend health check
-        from nautobot.extras.health_checks import DatabaseBackend, RedisBackend
+        from nautobot.extras.health_checks import DatabaseBackend, MigrationsBackend, RedisBackend
 
         plugin_dir.register(DatabaseBackend)
+        plugin_dir.register(MigrationsBackend)
         plugin_dir.register(RedisBackend)
 
         # Register built-in SecretsProvider classes

--- a/nautobot/extras/health_checks.py
+++ b/nautobot/extras/health_checks.py
@@ -3,7 +3,8 @@ from typing import Optional
 from urllib.parse import urlparse
 
 from django.conf import settings
-from django.db import connection, DatabaseError, IntegrityError
+from django.db import connection, connections, DatabaseError, DEFAULT_DB_ALIAS, IntegrityError
+from django.db.migrations.executor import MigrationExecutor
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceReturnedUnexpectedResult, ServiceUnavailable
 from prometheus_client import Gauge
@@ -65,10 +66,32 @@ class DatabaseBackend(NautobotHealthCheckBackend):
                 obj.title = "newtest"
                 obj.save()
                 obj.delete()
-        except IntegrityError:
-            raise ServiceReturnedUnexpectedResult("Integrity Error")
-        except DatabaseError:
-            raise ServiceUnavailable("Database error")
+        except IntegrityError as e:
+            self.add_error(ServiceReturnedUnexpectedResult("Integrity Error"), e)
+        except DatabaseError as e:
+            self.add_error(ServiceUnavailable("Database error"), e)
+
+
+class MigrationsBackend(NautobotHealthCheckBackend):
+    """Check whether all migrations have been applied."""
+
+    metric = Gauge(
+        "health_check_migrations_info",
+        "State of migrations backend",
+        multiprocess_mode=NautobotHealthCheckBackend.MULTIPROCESS_MODE,
+    )
+
+    def check_status(self):
+        db_alias = getattr(settings, "HEALTHCHECK_MIGRATIONS_DB", DEFAULT_DB_ALIAS)
+        try:
+            executor = MigrationExecutor(connections[db_alias])
+            plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+            if plan:
+                self.add_error(ServiceUnavailable("There are migrations not yet applied"))
+        except DatabaseError as e:
+            self.add_error(ServiceUnavailable("Database is not ready"), e)
+        except Exception as e:
+            self.add_error(ServiceUnavailable("Unknown error"), e)
 
 
 class RedisHealthCheck(NautobotHealthCheckBackend):


### PR DESCRIPTION
# Closes N/A (but relates to #5340)
# What's Changed

- Switch default Docker healthcheck from a `curl` based one (which can fail if all request-processing workers/processes/threads are busy with other requests) to a CLI based one calling `nautobot-server health_check`.
   - Because of #4292 and related startup code, the `nautobot-server health_check` takes about 6 seconds to execute, so I increased the default `interval` and `timeout` for the healthcheck from 5s to 10s. We should be able to bring this back down once we improve the performance of `nautobot-server` startup time.
   - I changed the default `start-period` from 5s to 5m since we know that initial migrations may take several minutes to complete.
   - With the changes to the default health-check, we no longer need to override it with a custom health-check in `docker-compose.yml` and `docker-compose.final.yml`.
- Add a new healthcheck backend based on `health_check.contrib.migrations` implementation. This fails if there are any un-applied migrations detected and passes if all migrations are in effect. This is needed because while the `/health/` URL endpoint won't start responding until the nautobot-server process is serving responses, and therefore implicitly will fail while migrations are in process, the `nautobot-server health_check` CLI spins up its own process to report back ASAP. We don't want the container to report as healthy before migrations are completed, as dependent containers/processes (celery worker, celery beat) are likely to encounter errors if they try to start up while migrations are in-flight.

### QUESTION: should this go into `develop` as a bug fix or `next` as a feature/behavior-change?

# Screenshots

```
# nautobot-server health_check
DatabaseBackend          ... working
DefaultFileStorageHealthCheck ... working
MigrationsBackend        ... unavailable: There are migrations not yet applied
RedisBackend             ... working
```

```
# nautobot-server health_check
DatabaseBackend          ... working
DefaultFileStorageHealthCheck ... working
MigrationsBackend        ... working
RedisBackend             ... working
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
