### PR TITLE
Fix Docker dependency issues #5332 and #5345

### DIFF
--- a/changes/5332.fixed
+++ b/changes/5332.fixed
@@ -1,0 +1,1 @@
+Fixed Docker image missing OS-level dependencies for SSO (SAML) support.

--- a/changes/5345.documentation
+++ b/changes/5345.documentation
@@ -1,0 +1,2 @@
+Added a note to the Nautobot installation documentation about the need to do `pip3 install --no-binary=pyuwsgi` in order to have SSL support in `pyuwsgi`.
+Added a note to the SSO documentation about the need to do `pip3 install --no-binary=lxml` to avoid incompatibilities between `lxml` and `xmlsec` packages.

--- a/changes/5345.fixed
+++ b/changes/5345.fixed
@@ -1,0 +1,1 @@
+Fixed intermittent 405 errors when using the Docker image with SAML authentication.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ RUN --mount=type=cache,target="/var/cache/apt",sharing=locked \
     --mount=type=cache,target="/var/lib/apt/lists",sharing=locked \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y curl git mime-support libxml2 libmariadb3 openssl && \
+    apt-get install --no-install-recommends -y curl git mime-support libxml2 libxmlsec1-dev libxmlsec1-openssl libmariadb3 openssl && \
     apt-get autoremove -y
 
 # DL3013 - pin all Python package versions
@@ -77,7 +77,7 @@ FROM system-dependencies AS system-dev-dependencies
 # Install development/install-time OS dependencies
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y build-essential libssl-dev libxmlsec1-dev libxmlsec1-openssl pkg-config libldap-dev libsasl2-dev libmariadb-dev nodejs npm && \
+    apt-get install --no-install-recommends -y build-essential libssl-dev pkg-config libldap-dev libsasl2-dev libmariadb-dev nodejs npm && \
     apt-get autoremove -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
@@ -123,7 +123,8 @@ ENV PATH="${POETRY_HOME}/bin:${PATH}"
 
 RUN poetry config virtualenvs.create ${POETRY_VIRTUALENVS_CREATE} && \
     poetry config installer.parallel "${POETRY_INSTALLER_PARALLEL}" && \
-    poetry config installer.no-binary pyuwsgi
+    poetry config installer.no-binary pyuwsgi && \
+    poetry config installer.no-binary lxml
 
 ################################ Stage: python-dependencies (intermediate build target)
 

--- a/nautobot/docs/user-guide/administration/configuration/authentication/sso.md
+++ b/nautobot/docs/user-guide/administration/configuration/authentication/sso.md
@@ -17,38 +17,22 @@ This module supports several [authentication backends](https://python-social-aut
 
     Hint: Use `sudo -iu nautobot`
 
-### Install Dependencies
+### Install Dependencies for OIDC or SAML
 
-If you are using OpenID Connect or SAML you will also need to install the extra dependencies for those.
+If you are using OpenID Connect or SAML you will also need to install the extra dependencies for those. These are grouped together under the `sso` Python extra for Nautobot and so can be easily installed with a single `pip3` command.
 
-#### OpenID Connect Dependencies
+!!! tip
+    You may find that additional system-level dependencies must be installed first so that the specialized Python libraries for XML can be built and compiled for your system. Specifics will vary by your OS, but for example, on Ubuntu, you may need to run:
 
-For OpenID connect, you'll need to install the `sso` Python extra.
+    ```no-highlight
+    sudo apt install -y libxmlsec1-dev libxmlsec1-openssl pkg-config
+    ```
 
-```no-highlight
-pip3 install "nautobot[sso]"
-```
-
-#### SAML Dependencies
-
-For SAML, additional system-level dependencies are required so that the specialized XML libraries can be built and compiled for your system.
-
-!!! note
-    These instructions have only been certified on Ubuntu 20.04 at this time.
-
-Install the system dependencies as `root`:
+Furthermore, due to potential incompatibilities between the precompiled binaries for the `lxml` and `xmlsec` Python packages that this installation will bring in, you need to tell Pip to not install the precompiled binary for `lxml`. Run the following command as the `nautobot` user:
 
 ```no-highlight
-sudo apt install -y libxmlsec1-dev libxmlsec1-openssl pkg-config
+pip3 install --no-binary=lxml "nautobot[sso]"
 ```
-
-Install the `sso` Python extra as the `nautobot` user.
-
-```no-highlight
-pip3 install "nautobot[sso]"
-```
-
-Please see the SAML configuration guide below for an example of how to configure Nautobot to authenticate using SAML with Google as the identity provider.
 
 ## Configuration
 

--- a/nautobot/docs/user-guide/administration/installation/nautobot.md
+++ b/nautobot/docs/user-guide/administration/installation/nautobot.md
@@ -156,6 +156,8 @@ We also want to deliberately install the `wheel` library which will tell Pip to 
 pip3 install --upgrade pip wheel
 ```
 
+By default, Pip will now install Python packages as wheels. In most cases this is desirable, however in some cases the wheel versions of packages may have been compiled with options differing from what is needed for a specific scenario. One such case presents itself here - the wheel for `pyuwsgi`, a key web server component of Nautobot, is built without SSL (HTTPS) support. This may be fine for a non-production deployment of Nautobot, such as in your lab, but for production deployments, not supporting HTTPS will not do at all. Fortunately, you can tell Pip when you don't want to use wheels for a specific package by passing the `--no-binary=<package>` CLI parameter. We'll use that below.
+
 ## Install Nautobot
 
 === "PostgreSQL (Ubuntu and RHEL Flavors)"
@@ -163,7 +165,7 @@ pip3 install --upgrade pip wheel
     Use Pip to install Nautobot:
 
     ```no-highlight
-    pip3 install nautobot
+    pip3 install --no-binary=pyuwsgi nautobot
     ```
 
 === "MySQL (Ubuntu and RHEL Flavors)"
@@ -171,7 +173,7 @@ pip3 install --upgrade pip wheel
     Use Pip to install Nautobot with the MySQL client:
 
     ```no-highlight
-    pip3 install "nautobot[mysql]"
+    pip3 install --no-binary=pyuwsgi "nautobot[mysql]"
     ```
 
 Great! We have `NAUTOBOT_ROOT` ready for use by the `nautobot` user, so let's proceed to verifying the installation.


### PR DESCRIPTION
# Closes #5332
# Closes #5345, but fix should be backported to ltm-1.6 too.
# What's Changed

- In our Dockerfile, move the `libxmlsec1-dev` and `libxmlsec1-openssl` OS dependencies from the `system-dev-dependencies` stage to the `system-dependencies` stage so that they get included in the final Docker image to support SAML SSO integration. (This fixes #5332, which was a regression of #4282)
- In our Dockerfile, add `poetry config installer.no-binary lxml` to force `lxml` to be installed from source, fixing #5345 ([reference](https://github.com/lxml/lxml/blob/master/doc/FAQ.txt#L623-L631))
   - In the SSO setup documentation, add a note about using `pip3 install --no-binary=lxml`, similarly.
- In the Nautobot installation documentation, add a note about using `pip3 install --no-binary=pyuwsgi` since that was missing from the docs.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
