### PR TITLE
Release 1.6.13

### DIFF
--- a/changes/4247.added
+++ b/changes/4247.added
@@ -1,1 +1,0 @@
-Added a check to the `nautobot-server pre_migrate` command to identify Interfaces and VMInterfaces with multiple VRFs through IPAddress relationships.

--- a/changes/5307.fixed
+++ b/changes/5307.fixed
@@ -1,1 +1,0 @@
-Fixed Custom Field form field(s) missing from git repository edit form.

--- a/changes/5336.fixed
+++ b/changes/5336.fixed
@@ -1,1 +1,0 @@
-Fixed 'docker-compose: command not found' error when running invoke commands.

--- a/changes/5345.documentation
+++ b/changes/5345.documentation
@@ -1,2 +1,0 @@
-Added a note to the Nautobot installation documentation about the need to do `pip3 install --no-binary=pyuwsgi` in order to have SSL support in `pyuwsgi`.
-Added a note to the SSO documentation about the need to do `pip3 install --no-binary=lxml` to avoid incompatibilities between `lxml` and `xmlsec` packages.

--- a/changes/5345.fixed
+++ b/changes/5345.fixed
@@ -1,1 +1,0 @@
-Fixed intermittent 405 errors when using the Docker image with SAML authentication.

--- a/nautobot/docs/release-notes/version-1.6.md
+++ b/nautobot/docs/release-notes/version-1.6.md
@@ -72,6 +72,23 @@ The default Python version for Nautobot Docker images has been changed from 3.7 
 As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support installation or operation under Python 3.7.
 
 <!-- towncrier release notes start -->
+## v1.6.13 (2024-03-04)
+
+### Added
+
+- [#4247](https://github.com/nautobot/nautobot/issues/4247) - Added a check to the `nautobot-server pre_migrate` command to identify Interfaces and VMInterfaces with multiple VRFs through IPAddress relationships.
+
+### Fixed
+
+- [#5307](https://github.com/nautobot/nautobot/issues/5307) - Fixed Custom Field form field(s) missing from git repository edit form.
+- [#5336](https://github.com/nautobot/nautobot/issues/5336) - Fixed 'docker-compose: command not found' error when running invoke commands.
+- [#5345](https://github.com/nautobot/nautobot/issues/5345) - Fixed intermittent 405 errors when using the Docker image with SAML authentication.
+
+### Documentation
+
+- [#5345](https://github.com/nautobot/nautobot/issues/5345) - Added a note to the Nautobot installation documentation about the need to do `pip3 install --no-binary=pyuwsgi` in order to have SSL support in `pyuwsgi`.
+- [#5345](https://github.com/nautobot/nautobot/issues/5345) - Added a note to the SSO documentation about the need to do `pip3 install --no-binary=lxml` to avoid incompatibilities between `lxml` and `xmlsec` packages.
+
 ## v1.6.12 (2024-02-20)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "1.6.12"
+version = "1.6.13"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## v1.6.13 (2024-03-04)

### Added

- [#4247](https://github.com/nautobot/nautobot/issues/4247) - Added a check to the `nautobot-server pre_migrate` command to identify Interfaces and VMInterfaces with multiple VRFs through IPAddress relationships.

### Fixed

- [#5307](https://github.com/nautobot/nautobot/issues/5307) - Fixed Custom Field form field(s) missing from git repository edit form.
- [#5336](https://github.com/nautobot/nautobot/issues/5336) - Fixed 'docker-compose: command not found' error when running invoke commands.
- [#5345](https://github.com/nautobot/nautobot/issues/5345) - Fixed intermittent 405 errors when using the Docker image with SAML authentication.

### Documentation

- [#5345](https://github.com/nautobot/nautobot/issues/5345) - Added a note to the Nautobot installation documentation about the need to do `pip3 install --no-binary=pyuwsgi` in order to have SSL support in `pyuwsgi`.
- [#5345](https://github.com/nautobot/nautobot/issues/5345) - Added a note to the SSO documentation about the need to do `pip3 install --no-binary=lxml` to avoid incompatibilities between `lxml` and `xmlsec` packages.