### PR TITLE
[LTM] Fixed Job buttons do not respect the `task_queues` of the job class.

### DIFF
--- a/changes/5247.fixed
+++ b/changes/5247.fixed
@@ -1,0 +1,1 @@
+Fixed Job buttons do not respect the `task_queues` of the job class.

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from django import template
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils.html import format_html
@@ -111,7 +112,7 @@ def _render_job_button_for_obj(job_button, obj, context, content_type):
     try:
         _task_queue = job_button.job.task_queues[0]
     except IndexError:
-        _task_queue = "default"
+        _task_queue = settings.CELERY_TASK_DEFAULT_QUEUE
     hidden_inputs = format_html(
         HIDDEN_INPUTS,
         csrf_token=context["csrf_token"],

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -28,6 +28,7 @@ HIDDEN_INPUTS = """
 <input type="hidden" name="object_pk" value="{object_pk}">
 <input type="hidden" name="object_model_name" value="{object_model_name}">
 <input type="hidden" name="_schedule_type" value="immediately">
+<input type="hidden" name="_task_queue" value="{task_queue}">
 <input type="hidden" name="_return_url" value="{redirect_path}">
 <input type="hidden" name="_commit" value="on">
 """
@@ -107,12 +108,17 @@ def _render_job_button_for_obj(job_button, obj, context, content_type):
 
     # Disable buttons if the user doesn't have permission to run the underlying Job.
     has_run_perm = Job.objects.check_perms(context["user"], instance=job_button.job, action="run")
+    try:
+        _task_queue = job_button.job.task_queues[0]
+    except IndexError:
+        _task_queue = "default"
     hidden_inputs = format_html(
         HIDDEN_INPUTS,
         csrf_token=context["csrf_token"],
         object_pk=obj.pk,
         object_model_name=f"{content_type.app_label}.{content_type.model}",
         redirect_path=context["request"].path,
+        task_queue=_task_queue,
     )
     template_args = {
         "button_id": job_button.pk,

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import urllib.parse
 import uuid
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
@@ -2058,7 +2059,9 @@ class JobButtonRenderingTestCase(TestCase):
         response = self.client.get(self.location_type.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
-        self.assertIn('<input type="hidden" name="_task_queue" value="default">', content, content)
+        self.assertIn(
+            f'<input type="hidden" name="_task_queue" value="{settings.CELERY_TASK_DEFAULT_QUEUE,}">', content, content
+        )
 
     def test_view_object_with_unsafe_text(self):
         """Ensure that JobButton text can't be used as a vector for XSS."""

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2013,10 +2013,11 @@ class JobButtonRenderingTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
+        self.job = Job.objects.get(job_class_name="TestJobButtonReceiverSimple")
         self.job_button_1 = JobButton(
             name="JobButton 1",
             text="JobButton {{ obj.name }}",
-            job=Job.objects.get(job_class_name="TestJobButtonReceiverSimple"),
+            job=self.job,
             confirmation=False,
         )
         self.job_button_1.validated_save()
@@ -2040,6 +2041,24 @@ class JobButtonRenderingTestCase(TestCase):
         content = extract_page_body(response.content.decode(response.charset))
         self.assertIn(f"JobButton {self.location_type.name}", content, content)
         self.assertIn("Click me!", content, content)
+
+    def test_task_queue_hidden_input_is_present(self):
+        """
+        Ensure that the job button respects the job class' task_queues and the job class task_queues[0]/default is passed as a hidden form input.
+        """
+        self.job.task_queues_override = True
+        self.job.task_queues = ["overriden_queue", "default", "priority"]
+        self.job.save()
+        response = self.client.get(self.location_type.get_absolute_url(), follow=True)
+        self.assertEqual(response.status_code, 200)
+        content = extract_page_body(response.content.decode(response.charset))
+        self.assertIn(f'<input type="hidden" name="_task_queue" value="{self.job.task_queues[0]}">', content, content)
+        self.job.task_queues_override = False
+        self.job.save()
+        response = self.client.get(self.location_type.get_absolute_url(), follow=True)
+        self.assertEqual(response.status_code, 200)
+        content = extract_page_body(response.content.decode(response.charset))
+        self.assertIn('<input type="hidden" name="_task_queue" value="default">', content, content)
 
     def test_view_object_with_unsafe_text(self):
         """Ensure that JobButton text can't be used as a vector for XSS."""

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2060,7 +2060,7 @@ class JobButtonRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
         self.assertIn(
-            f'<input type="hidden" name="_task_queue" value="{settings.CELERY_TASK_DEFAULT_QUEUE,}">', content, content
+            f'<input type="hidden" name="_task_queue" value="{settings.CELERY_TASK_DEFAULT_QUEUE}">', content, content
         )
 
     def test_view_object_with_unsafe_text(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5247 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Passed in `job_class.task_queues[0]` or `default` as `_task_queue` form input when running a job from a job button
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
