### PR TITLE
Fix navbar graphql

### DIFF
--- a/nautobot/core/templates/graphene/graphiql.html
+++ b/nautobot/core/templates/graphene/graphiql.html
@@ -10,53 +10,34 @@ add "&raw" to the end of the URL within a browser.
 <!DOCTYPE html>
 <html>
 <head>
+  {% include 'inc/media.html' %}
+  {% block extra_styles %}{% endblock %}
   <!-- Nautobot template requirements -->
   <title>{% block title %}GraphiQL{% endblock %} - {{ settings.BRANDING_TITLE }}</title>
-  <link rel="stylesheet"
-        href="{% static 'bootstrap-3.4.1-dist/css/bootstrap.min.css' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=bootstrap-3.4.1-dist/css/bootstrap.min.css'">
-  <link rel="stylesheet"
-        href="{% static 'materialdesignicons-6.5.95/css/materialdesignicons.min.css' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=materialdesignicons-6.5.95/css/materialdesignicons.min.css'">
-  <link rel="stylesheet"
-        href="{% static 'jquery-ui-1.13.1/jquery-ui.min.css' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=jquery-ui-1.13.1/jquery-ui.min.css'">
-  <link rel="stylesheet"
-        href="{% static 'select2-4.0.13/select2.min.css' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=select2-4.0.13/select2.min.css'">
-  <link rel="stylesheet"
-        href="{% static 'select2-bootstrap-0.1.0-beta.10/select2-bootstrap.min.css' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=select2-bootstrap-0.1.0-beta.10/select2-bootstrap.min.css'">
-  <link rel="stylesheet"
-        href="{% static 'flatpickr-4.6.9/themes/light.min.css' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=flatpickr-4.6.9/themes/light.min.css'">
-  <link rel="stylesheet" id="dark-theme"
-        href="{% versioned_static 'css/dark.css' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=css/dark.css'" disabled="disabled" />
-  <link rel="stylesheet"
-        href="{% versioned_static 'css/base.css' %}"
-        onerror="window.location='{% url 'media_failure' %}?filename=css/base.css'">
-  <link rel="apple-touch-icon" sizes="180x180" href="{% custom_branding_or_static 'icon_180' 'img/nautobot_icon_180x180.png' %}">
-  <link rel="icon" type="image/png" sizes="32x32" href="{% custom_branding_or_static 'icon_32' 'img/nautobot_icon_32x32.png' %}">
-  <link rel="icon" type="image/png" sizes="16x16" href="{% custom_branding_or_static 'icon_16' 'img/nautobot_icon_16x16.png' %}">
-  <link rel="icon" type="image/png" sizes="192x192" href="{% custom_branding_or_static 'icon_192' 'img/nautobot_icon_192x192.png' %}">
-  <link rel="mask-icon" type="image/png" color="#0097ff" href="{% custom_branding_or_static 'icon_mask' 'img/nautobot_icon_monochrome.png' %}">
-  <link rel="shortcut icon" href="{% custom_branding_or_static 'favicon' 'img/favicon.ico' %}">
-  <meta name="msapplication-TileColor" content="#2d89ef">
-  <meta name="theme-color" content="#ffffff">
-  <meta charset="UTF-8">
-  <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width">
+
   <!-- GraphiQL template requirements -->
   <style>
-    html, body, #editor {
-      height: 100%;
+    #editor {
       margin: 0;
       width: 100%;
+      height: calc(100vh - 95px - 3rem);
     }
     .toolbar .dropdown-menu > li > a {
         clear: left;
         margin-right: 120px;  /* leave room for the "Save Changes" button if present */
     }
+    body {
+      padding-top: 56px;
+    }
+    .graphiql-container .doc-explorer-title-bar {
+      box-sizing: content-box;
+  }
+    .graphiql-container .history-title-bar {
+      box-sizing: content-box;
+  }
+  .graphiql-container .docExplorerShow {
+    white-space: nowrap;
+  }
   </style>
   <!-- As Nautobot may be run without internet access, we source these files locally rather than from an online CDN -->
   <link rel="stylesheet"
@@ -72,23 +53,16 @@ add "&raw" to the end of the URL within a browser.
           onerror="window.location='{% url 'media_failure' %}?filename=graphiql-1.5.16/graphiql.min.js'"></script>
   <script src="{% static 'subscriptions-transport-ws-0.9.18/client.min.js' %}"
       onerror="window.location='{% url 'media_failure' %}?filename=subscriptions-transport-ws-0.9.18/client.min.js'"></script>
-  <!-- Custom CSS to address some conflicts between the two -->
-  <style>
-    body {
-      padding-top: 54px;
-    }
-    .graphiql-container .doc-explorer-title-bar {
-        box-sizing: content-box;
-    }
-  </style>
 </head>
 <body>
   <!-- Nautobot page contents -->
   {% include 'inc/nav_menu.html' %}
   {% include 'modals/modal_theme.html' with name='theme'%}
   {% include 'inc/javascript.html' %}
-  <!-- GraphiQL page contents -->
-  <div id="editor"></div>
+  <div class="container-fluid wrapper banner-alert-area" id="main-content">
+    <!-- GraphiQL page contents -->
+    <div id="editor"></div>
+  </div>
   {% include 'inc/footer.html' %}
   {% csrf_token %}
   <script type="application/javascript">

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -42,7 +42,7 @@ body {
     transition-duration: var(--navbar-transition-duration);
     transition-timing-function: ease-in-out;
     transition-property: margin-left, width;
-    overflow: visible;
+    overflow: hidden;
     margin: 0;
 }
 .footer .row {


### PR DESCRIPTION
# Closes #5422
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
* main-content area for the graphql editor is made collapse capable and expandable depending on the side navbar
# Screenshots
Before:
<img width="1059" alt="image" src="https://github.com/nautobot/nautobot/assets/18483910/06ac094a-f131-48e2-9ca4-c337739815ca">


After:
<img width="811" alt="image" src="https://github.com/nautobot/nautobot/assets/18483910/bd148ac4-fea9-4edb-8f40-3c56466f2b49">

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
