### PR TITLE
Add celery beat health check

### DIFF
--- a/changes/1102.added
+++ b/changes/1102.added
@@ -1,0 +1,2 @@
+Added health check for Celery Beat based on it touching a file (by default `/tmp/nautobot_celery_beat_heartbeat`) each time its scheduler wakes up.
+Added `CELERY_BEAT_HEARTBEAT_FILE` settings variable.

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -64,12 +64,16 @@ services:
     image: "local/nautobot-dev:local-py${PYTHON_VER}"
     entrypoint: "nautobot-server celery beat -l INFO"
     healthcheck:
-      disable: true
-    #   interval: 5s
-    #   timeout: 5s
-    #   start_period: 5s
-    #   retries: 3
-    #   test: ["CMD", "nautobot-server", "health_check"]
+      interval: 5s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+      test:
+        - "CMD"
+        - "/bin/sh"
+        - "-c"
+        # find the heartbeat file and report success if it was modified less than 0.1 minutes (6 seconds) ago, else fail
+        - '[ $(find /tmp/nautobot_celery_beat_heartbeat -mmin -0.1 | wc -l) -eq 1 ] || false'
     depends_on:
       nautobot:
         condition: service_healthy

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -3,8 +3,8 @@ import logging
 from pathlib import Path
 
 from celery import current_app
-from django_celery_beat.schedulers import DatabaseScheduler, ModelEntry
 from django.conf import settings
+from django_celery_beat.schedulers import DatabaseScheduler, ModelEntry
 from kombu.utils.json import loads
 
 from nautobot.extras.models import ScheduledJob, ScheduledJobs

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -1,7 +1,9 @@
 import os
+import os.path
 import platform
 import re
 import sys
+import tempfile
 
 from django.contrib.messages import constants as messages
 import django.forms
@@ -766,6 +768,12 @@ CONTENT_TYPE_CACHE_TIMEOUT = int(os.getenv("NAUTOBOT_CONTENT_TYPE_CACHE_TIMEOUT"
 #
 # Celery (used for background processing)
 #
+
+# Celery Beat heartbeat file path - will be touched by Beat each time it wakes up as a proof-of-health.
+CELERY_BEAT_HEARTBEAT_FILE = os.getenv(
+    "NAUTOBOT_CELERY_BEAT_HEARTBEAT_FILE",
+    os.path.join(tempfile.gettempdir(), "nautobot_celery_beat_heartbeat"),
+)
 
 # Celery broker URL used to tell workers where queues are located
 CELERY_BROKER_URL = os.getenv("NAUTOBOT_CELERY_BROKER_URL", parse_redis_connection(redis_database=0))

--- a/nautobot/core/templates/nautobot_config.py.j2
+++ b/nautobot/core/templates/nautobot_config.py.j2
@@ -37,6 +37,12 @@ from nautobot.core.settings_funcs import is_truthy, parse_redis_connection
 # Number of seconds to cache ContentType lookups. Set to 0 to disable caching.
 # CONTENT_TYPE_CACHE_TIMEOUT = int(os.getenv("NAUTOBOT_CONTENT_TYPE_CACHE_TIMEOUT", "0"))
 
+# Celery Beat heartbeat file path - will be touched by Beat each time it wakes up as a proof-of-health.
+# CELERY_BEAT_HEARTBEAT_FILE = os.getenv(
+#     "NAUTOBOT_CELERY_BEAT_HEARTBEAT_FILE",
+#     os.path.join(tempfile.gettempdir(), "nautobot_celery_beat_heartbeat"),
+# )
+
 # Celery broker URL used to tell workers where queues are located
 #
 # CELERY_BROKER_URL = os.getenv("NAUTOBOT_CELERY_BROKER_URL", parse_redis_connection(redis_database=0))

--- a/nautobot/docs/user-guide/administration/configuration/optional-settings.md
+++ b/nautobot/docs/user-guide/administration/configuration/optional-settings.md
@@ -183,6 +183,16 @@ If a custom URL is not provided for any of the links, the default link within th
 
 ---
 
+## CELERY_BEAT_HEARTBEAT_FILE
+
+Default: `/tmp/nautobot_celery_beat_heartbeat`
+
+Environment Variable: `NAUTOBOT_CELERY_BEAT_HEARTBEAT_FILE`
+
+Path to a file that will be `touch`ed each time the Celery Beat task scheduler wakes up. Suitable for use as a health check on the Celery Beat process. Set to an empty string `""` to disable this feature.
+
+---
+
 ## CELERY_BROKER_TRANSPORT_OPTIONS
 
 Default: `{}`


### PR DESCRIPTION
# Closes #1102
# What's Changed

- Add logic to our existing custom Celery Beat scheduler subclass such that each time it wakes up (every 5 seconds or less) it will touch a file (configurable via `settings.CELERY_BEAT_HEARTBEAT_FILE` or environment `NAUTOBOT_CELERY_BEAT_HEARTBEAT_FILE`, defaulting to `/tmp/nautobot_celery_beat_heartbeat`) as a proof of life.
- Add a custom healthcheck in `docker-compose.yml` that checks this file's last-modified time.
- Documentation, template config updates, etc.

# Screenshots

Health check successful:

```
❯ docker ps
CONTAINER ID   IMAGE                               COMMAND                  CREATED         STATUS                    PORTS                                             NAMES
c05da4131ed5   local/nautobot-dev:local-py3.8      "nautobot-server cel…"   About a minute ago   Up 59 seconds (healthy)            8080/tcp                                          nautobot-celery_beat-1
```

After patching the `tick()` method so that it hangs and does not return as it should, and restarting the container (since celery beat container doesn't auto-restart on code changes) we can see that the health check begins to fail:

```
❯ docker ps
CONTAINER ID   IMAGE                               COMMAND                  CREATED         STATUS                      PORTS                                             NAMES
b8ac67ab615d   local/nautobot-dev:local-py3.8      "nautobot-server cel…"   6 minutes ago   Up 25 seconds (unhealthy)   8080/tcp                                          nautobot-celery_beat-1
```


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
