### PR TITLE
Fixed health check for beat container in `docker-compose.yml`.

### DIFF
--- a/changes/5434.fixed
+++ b/changes/5434.fixed
@@ -1,0 +1,1 @@
+Fixed health check for beat container in `docker-compose.yml`.

--- a/changes/5434.fixed
+++ b/changes/5434.fixed
@@ -1,1 +1,1 @@
-Fixed health check for beat container in `docker-compose.yml`.
+Fixed health check for beat container in `docker-compose.yml` under `docker-compose` v1.x.

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -73,7 +73,7 @@ services:
         - "/bin/sh"
         - "-c"
         # find the heartbeat file and report success if it was modified less than 0.1 minutes (6 seconds) ago, else fail
-        - '[ $(find /tmp/nautobot_celery_beat_heartbeat -mmin -0.1 | wc -l) -eq 1 ] || false'
+        - '[ $$(find /tmp/nautobot_celery_beat_heartbeat -mmin -0.1 | wc -l) -eq 1 ] || false'
     depends_on:
       nautobot:
         condition: service_healthy


### PR DESCRIPTION
This gets rid of the error message
`invalid interpolation format for services.celery_beat.healthcheck.test.[]: "[ $(find /tmp/nautobot_celery_beat_heartbeat -mmin -0.1 | wc -l) -eq 1 ] || false". You may need to escape any $ with another $` introduced by f9d84decdaf9c96140a2742082ddee6fc0474691.