### PR TITLE
Fixed "Cannot resolve keyword 'task_id' into field" when calling celery result

### DIFF
--- a/changes/5440.fixed
+++ b/changes/5440.fixed
@@ -1,0 +1,1 @@
+Fixed "Cannot resolve keyword 'task_id' into field" when calling `nautobot-server celery result <task_id>`.

--- a/nautobot/extras/managers.py
+++ b/nautobot/extras/managers.py
@@ -9,16 +9,7 @@ from nautobot.core.models.querysets import RestrictedQuerySet
 
 class JobResultManager(BaseManager.from_queryset(RestrictedQuerySet), TaskResultManager):
     def get_task(self, task_id):
-        """Get result for task by ``task_id``.
-
-        Keyword Arguments:
-        -----------------
-            exception_retry_count (int): How many times to retry by
-                transaction rollback on exception.  This could
-                happen in a race condition if another worker is trying to
-                create the same task.  The default is to retry once.
-
-        """
+        """Get result for task by ``task_id``."""
         try:
             return self.get(id=task_id)
         except self.model.DoesNotExist:

--- a/nautobot/extras/managers.py
+++ b/nautobot/extras/managers.py
@@ -9,7 +9,11 @@ from nautobot.core.models.querysets import RestrictedQuerySet
 
 class JobResultManager(BaseManager.from_queryset(RestrictedQuerySet), TaskResultManager):
     def get_task(self, task_id):
-        """Get result for task by ``task_id``."""
+        """Get result for task by ``task_id``.
+
+        This overloads `TaskResultManager.get_task` provided by `django-celery-results` to manage custom
+        behaviors for integration with Nautobot.
+        """
         try:
             return self.get(id=task_id)
         except self.model.DoesNotExist:

--- a/nautobot/extras/managers.py
+++ b/nautobot/extras/managers.py
@@ -8,6 +8,25 @@ from nautobot.core.models.querysets import RestrictedQuerySet
 
 
 class JobResultManager(BaseManager.from_queryset(RestrictedQuerySet), TaskResultManager):
+    def get_task(self, task_id):
+        """Get result for task by ``task_id``.
+
+        Keyword Arguments:
+        -----------------
+            exception_retry_count (int): How many times to retry by
+                transaction rollback on exception.  This could
+                happen in a race condition if another worker is trying to
+                create the same task.  The default is to retry once.
+
+        """
+        try:
+            return self.get(id=task_id)
+        except self.model.DoesNotExist:
+            if self._last_id == task_id:
+                self.warn_if_repeatable_read()
+            self._last_id = task_id
+            return self.model(id=task_id)
+
     @transaction_retry(max_retries=2)
     def store_result(
         self,

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -1811,6 +1811,15 @@ class JobResultTestCase(TestCase):
                 JobResult.objects.create(name="ExampleJob2", user=None, result=lambda: 1)
             self.assertEqual(str(err.exception), "Object of type function is not JSON serializable")
 
+    def test_get_task(self):
+        """Assert bug fix for `Cannot resolve keyword 'task_id' into field` #5440"""
+        data = {
+            "output": "valid data",
+        }
+        job_result = JobResult.objects.create(name="ExampleJob1", user=None, result=data)
+
+        self.assertEqual(JobResult.objects.get_task(job_result.pk), job_result)
+
 
 class WebhookTest(ModelTestCases.BaseModelTestCase):
     model = Webhook


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5440 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

Update the `TaskResultManager.get_task` method to utilize the `id` field instead of `task_id`, aligning it with our `JobResult` model's primary identifier.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
