### PR TITLE
Fixed Roles API response containing duplicate entries when filtering …

### DIFF
--- a/changes/5431.fixed
+++ b/changes/5431.fixed
@@ -1,0 +1,1 @@
+Fixed Roles API response containing duplicate entries when filtering on more than on `content_types`.

--- a/changes/5431.fixed
+++ b/changes/5431.fixed
@@ -1,1 +1,2 @@
 Fixed Roles API response containing duplicate entries when filtering on more than one `content_types` value.
+Fixed Providers API response containing duplicate entries when filtering on more than one `location` value.

--- a/nautobot/circuits/tests/test_filters.py
+++ b/nautobot/circuits/tests/test_filters.py
@@ -57,7 +57,7 @@ class ProviderTestCase(FilterTestCases.NameOnlyFilterTestCase):
     def test_location(self):
         expected = self.queryset.filter(
             circuits__circuit_terminations__location__in=[self.locations[0].pk, self.locations[1].pk]
-        )
+        ).distinct()
         params = {"location": [self.locations[0].pk, self.locations[1].pk]}
         self.assertQuerysetEqualAndNotEmpty(self.filterset(params, self.queryset).qs, expected)
         params = {"location": [self.locations[0].name, self.locations[1].name]}

--- a/nautobot/core/filters.py
+++ b/nautobot/core/filters.py
@@ -260,6 +260,9 @@ class ContentTypeMultipleChoiceFilter(django_filters.MultipleChoiceFilter):
         if not self.conjoined:
             qs = qs.filter(q)
 
+        if self.distinct:
+            qs = qs.distinct()
+
         return qs
 
 
@@ -522,7 +525,10 @@ class TreeNodeMultipleChoiceFilter(NaturalKeyOrPKMultipleChoiceFilter):
 
         # Fetch the generated Q object and filter the incoming qs with it before passing it along.
         query = self.generate_query(value)
-        return self.get_method(qs)(query)
+        result = self.get_method(qs)(query)
+        if self.distinct:
+            result = result.distinct()
+        return result
 
 
 #

--- a/nautobot/extras/filters/__init__.py
+++ b/nautobot/extras/filters/__init__.py
@@ -387,6 +387,11 @@ class NautobotFilterSet(
     are needed.
     """
 
+    def filter_queryset(self, queryset):
+        # Ensure the filtered result is distinct, particularly when filtering on a
+        # many-to-many field with `conjoined` set to False to avoid duplicate entries.
+        return super().filter_queryset(queryset).distinct()
+
 
 #
 # Custom Links
@@ -1061,9 +1066,6 @@ class RoleFilterSet(NautobotFilterSet):
         # such as 'Device or VirtualMachine' but not 'Device and VirtualMachine'.
         conjoined=False,
     )
-
-    def filter_queryset(self, queryset):
-        return super().filter_queryset(queryset).distinct()
 
     class Meta:
         model = Role

--- a/nautobot/extras/filters/__init__.py
+++ b/nautobot/extras/filters/__init__.py
@@ -387,11 +387,6 @@ class NautobotFilterSet(
     are needed.
     """
 
-    def filter_queryset(self, queryset):
-        # Ensure the filtered result is distinct, particularly when filtering on a
-        # many-to-many field with `conjoined` set to False to avoid duplicate entries.
-        return super().filter_queryset(queryset).distinct()
-
 
 #
 # Custom Links

--- a/nautobot/extras/filters/__init__.py
+++ b/nautobot/extras/filters/__init__.py
@@ -1062,6 +1062,9 @@ class RoleFilterSet(NautobotFilterSet):
         conjoined=False,
     )
 
+    def filter_queryset(self, queryset):
+        return super().filter_queryset(queryset).distinct()
+
     class Meta:
         model = Role
         fields = [

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -1811,8 +1811,8 @@ class RoleTestCase(FilterTestCases.NameOnlyFilterTestCase):
     def test_content_types(self):
         device_ct = ContentType.objects.get_for_model(Device)
         rack_ct = ContentType.objects.get_for_model(Rack)
-        device_roles = self.queryset.filter(content_types=device_ct)
-        params = {"content_types": ["dcim.device"]}
+        device_roles = self.queryset.filter(content_types__in=[device_ct, rack_ct]).distinct()
+        params = {"content_types": ["dcim.device", "dcim.rack"]}
         self.assertQuerysetEqualAndNotEmpty(self.filterset(params, self.queryset).qs, device_roles)
 
         rack_roles = self.queryset.filter(content_types=rack_ct)


### PR DESCRIPTION
…on more than on `content_types`.

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5431 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example Plugin Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
