### PR TITLE
Fix `annotate_config_context_data` and `pytz` usage under Django 4

### DIFF
--- a/changes/5159.fixed
+++ b/changes/5159.fixed
@@ -1,0 +1,1 @@
+Fixed a `ProgrammingError` raised when attempting to render a Device's or Virtual Machine's config context.

--- a/changes/5160.dependencies
+++ b/changes/5160.dependencies
@@ -1,0 +1,1 @@
+Updated `django-timezone-field` to version 6.1.0.

--- a/changes/5160.housekeeping
+++ b/changes/5160.housekeeping
@@ -1,0 +1,1 @@
+Replaced references to `pytz` with `zoneinfo` in keeping with Django 4.

--- a/nautobot/core/tests/runner.py
+++ b/nautobot/core/tests/runner.py
@@ -11,9 +11,9 @@ from nautobot.core.celery import app, setup_nautobot_job_logging
 from nautobot.core.settings_funcs import parse_redis_connection
 
 
-def init_worker_with_unique_cache(counter):
+def init_worker_with_unique_cache(*args, **kwargs):
     """Extend Django's default parallel unit test setup to also ensure distinct Redis caches."""
-    _init_worker(counter)  # call Django default to set _worker_id and set up parallel DB instances
+    _init_worker(*args, **kwargs)  # call Django default to set _worker_id and set up parallel DB instances
     # _worker_id is now 1, 2, 3, 4, etc.
 
     from django.test.runner import _worker_id

--- a/nautobot/dcim/factory.py
+++ b/nautobot/dcim/factory.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 import factory
 from faker import Faker
+
 try:
     import zoneinfo
 except ImportError:  # python 3.8

--- a/nautobot/dcim/factory.py
+++ b/nautobot/dcim/factory.py
@@ -5,7 +5,10 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 import factory
 from faker import Faker
-import pytz
+try:
+    import zoneinfo
+except ImportError:  # python 3.8
+    from backports import zoneinfo
 
 from nautobot.circuits.models import CircuitTermination
 from nautobot.core.factory import (
@@ -92,6 +95,8 @@ NETWORK_DRIVERS = {
     "Juniper": ["juniper_junos"],
     "Palo Alto": ["paloalto_panos"],
 }
+
+TIME_ZONES = zoneinfo.available_timezones()
 
 
 # Retrieve correct rack reservation units
@@ -478,7 +483,7 @@ class LocationFactory(PrimaryModelFactory):
     facility = factory.Maybe("has_facility", factory.Faker("building_number"), "")
 
     has_time_zone = NautobotBoolIterator()
-    time_zone = factory.Maybe("has_time_zone", factory.Faker("random_element", elements=pytz.common_timezones))
+    time_zone = factory.Maybe("has_time_zone", factory.Faker("random_element", elements=TIME_ZONES))
 
     has_physical_address = NautobotBoolIterator()
     physical_address = factory.Maybe("has_physical_address", factory.Faker("address"))

--- a/nautobot/dcim/migrations/0059_alter_cable_status_alter_consoleport__path_and_more.py
+++ b/nautobot/dcim/migrations/0059_alter_cable_status_alter_consoleport__path_and_more.py
@@ -67,6 +67,20 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.AlterField(
+            model_name="controller",
+            name="role",
+            field=nautobot.extras.models.roles.RoleField(
+                blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="extras.role"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="controller",
+            name="status",
+            field=nautobot.extras.models.statuses.StatusField(
+                on_delete=django.db.models.deletion.PROTECT, to="extras.status"
+            ),
+        ),
+        migrations.AlterField(
             model_name="device",
             name="local_config_context_data_owner_content_type",
             field=nautobot.core.models.fields.ForeignKeyWithAutoRelatedName(
@@ -263,6 +277,20 @@ class Migration(migrations.Migration):
             name="device_type",
             field=nautobot.core.models.fields.ForeignKeyWithAutoRelatedName(
                 on_delete=django.db.models.deletion.CASCADE, to="dcim.devicetype"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="softwareimagefile",
+            name="status",
+            field=nautobot.extras.models.statuses.StatusField(
+                on_delete=django.db.models.deletion.PROTECT, to="extras.status"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="softwareversion",
+            name="status",
+            field=nautobot.extras.models.statuses.StatusField(
+                on_delete=django.db.models.deletion.PROTECT, to="extras.status"
             ),
         ),
     ]

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timezone
 from decimal import Decimal
 import unittest
 
@@ -8,8 +9,12 @@ from django.db.models import Q
 from django.test import override_settings
 from django.urls import reverse
 from netaddr import EUI
-import pytz
 import yaml
+
+try:
+    import zoneinfo
+except ImportError:  # python 3.8
+    from backports import zoneinfo
 
 from nautobot.circuits.choices import CircuitTerminationSideChoices
 from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, Provider
@@ -197,7 +202,7 @@ class LocationTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "tenant": tenant.pk,
             "facility": "Facility X",
             "asn": 65001,
-            "time_zone": pytz.UTC,
+            "time_zone": zoneinfo.ZoneInfo("UTC"),
             "physical_address": "742 Evergreen Terrace, Springfield, USA",
             "shipping_address": "742 Evergreen Terrace, Springfield, USA",
             "latitude": Decimal("35.780000"),
@@ -217,7 +222,7 @@ class LocationTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "tenant": tenant.pk,
             "status": Status.objects.get_for_model(Location).last().pk,
             "asn": 65009,
-            "time_zone": pytz.timezone("US/Eastern"),
+            "time_zone": zoneinfo.ZoneInfo("US/Eastern"),
         }
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -1,5 +1,4 @@
 import datetime
-from datetime import timezone
 from decimal import Decimal
 import unittest
 

--- a/nautobot/extras/migrations/0107_alter_configcontext_cluster_groups_and_more.py
+++ b/nautobot/extras/migrations/0107_alter_configcontext_cluster_groups_and_more.py
@@ -81,9 +81,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="contactassociation",
             name="role",
-            field=nautobot.extras.models.roles.RoleField(
-                blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="extras.role"
-            ),
+            field=nautobot.extras.models.roles.RoleField(on_delete=django.db.models.deletion.PROTECT, to="extras.role"),
         ),
         migrations.AlterField(
             model_name="contactassociation",

--- a/nautobot/extras/querysets.py
+++ b/nautobot/extras/querysets.py
@@ -86,10 +86,10 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
         """
         Attach the subquery annotation to the base queryset.
 
-        Order By clause in Subquery is not guaranteed to be respected within the aggregated JSON array, which is why
-        we include "weight" and "name" into the result so that we can sort it within Python to ensure correctness.
+        Note that the underlying function of our JSONBAgg in MySQL, `JSONARRAY_AGG`, does not support an `ordering`,
+        unlike PostgreSQL's implementation. This is why we include "weight" and "name" into the result so that we can
+        sort it within Python to ensure correctness.
 
-        TODO This method does not accurately reflect location inheritance because of the reasons stated in _get_config_context_filters()
         Do not use this method by itself, use get_config_context() method directly on ConfigContextModel instead.
         """
         from nautobot.extras.models import ConfigContext
@@ -97,7 +97,6 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
         return self.annotate(
             config_context_data=Subquery(
                 ConfigContext.objects.filter(self._get_config_context_filters())
-                .order_by("weight", "name")
                 .annotate(
                     _data=EmptyGroupByJSONBAgg(
                         JSONObject(
@@ -108,15 +107,13 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
                     )
                 )
                 .values("_data")
+                .order_by()
             )
         ).distinct()
 
     def _get_config_context_filters(self):
         """
         This method is constructing the set of Q objects for the specific object types.
-        Note that locations filters are not included in the method because the filter needs the
-        ability to query the ancestors for a particular tree node for subquery and we lost it since
-        moving from mptt to django-tree-queries https://github.com/matthiask/django-tree-queries/issues/54.
         """
         tag_query_filters = {
             "object_id": OuterRef(OuterRef("pk")),

--- a/nautobot/ipam/signals.py
+++ b/nautobot/ipam/signals.py
@@ -109,7 +109,7 @@ def assert_locations_content_types(sender, instance, action, reverse, model, pk_
         # instance = the Prefix or VLAN
         # model = Location class
         instance_ct = ContentType.objects.get_for_model(instance)
-        invalid_locations = model.objects.select_related("location_type").filter(
+        invalid_locations = model.objects.without_tree_fields().select_related("location_type").filter(
             Q(pk__in=pk_set), ~Q(location_type__content_types__in=[instance_ct])
         )
         if invalid_locations.exists():

--- a/nautobot/ipam/signals.py
+++ b/nautobot/ipam/signals.py
@@ -109,8 +109,10 @@ def assert_locations_content_types(sender, instance, action, reverse, model, pk_
         # instance = the Prefix or VLAN
         # model = Location class
         instance_ct = ContentType.objects.get_for_model(instance)
-        invalid_locations = model.objects.without_tree_fields().select_related("location_type").filter(
-            Q(pk__in=pk_set), ~Q(location_type__content_types__in=[instance_ct])
+        invalid_locations = (
+            model.objects.without_tree_fields()
+            .select_related("location_type")
+            .filter(Q(pk__in=pk_set), ~Q(location_type__content_types__in=[instance_ct]))
         )
         if invalid_locations.exists():
             invalid_location_types = {location.location_type.name for location in invalid_locations}

--- a/poetry.lock
+++ b/poetry.lock
@@ -988,19 +988,18 @@ Django = ">=3.2"
 
 [[package]]
 name = "django-timezone-field"
-version = "5.1"
+version = "6.1.0"
 description = "A Django app providing DB, form, and REST framework fields for zoneinfo and pytz timezone objects."
 optional = false
-python-versions = ">=3.7,<4.0"
+python-versions = ">=3.8,<4.0"
 files = [
-    {file = "django_timezone_field-5.1-py3-none-any.whl", hash = "sha256:16ca9955a4e16064e32168b1a0d1cdb2839679c6cb56856c1f49f506e2ca4281"},
-    {file = "django_timezone_field-5.1.tar.gz", hash = "sha256:73fc49519273cd5da1c7f16abc04a4bcad87b00cc02968d0d384c0fecf9a8a86"},
+    {file = "django_timezone_field-6.1.0-py3-none-any.whl", hash = "sha256:0095f43da716552fcc606783cfb42cb025892514f1ec660ebfa96186eb83b74c"},
+    {file = "django_timezone_field-6.1.0.tar.gz", hash = "sha256:d40f7059d7bae4075725d04a9dae601af9fe3c7f0119a69b0e2c6194a782f797"},
 ]
 
 [package.dependencies]
 "backports.zoneinfo" = {version = ">=0.2.1,<0.3.0", markers = "python_version < \"3.9\""}
-Django = ">=2.2,<3.0.dev0 || >=3.2.dev0,<5.0"
-pytz = "*"
+Django = ">=3.2,<6.0"
 
 [[package]]
 name = "django-tree-queries"
@@ -4002,4 +4001,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "ecc4d94bd85d9199c7ebdd613fdd962ffabc1a78acbcfb3db7d450592c77505c"
+content-hash = "7a5094ad8e4fd49d5e97b3b23fbe5364368fe814a5da7deb4b75f754603e56ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,7 @@ django-tables2 = "~2.6.0"
 # Tags
 django-taggit = "~4.0.0"
 # Represent time zones in Django
-# NOTE: django-timezone-field 4.2.x is available but appears to break our initial migrations?
-django-timezone-field = "~5.1"
+django-timezone-field = "~6.1.0"
 # Tree database structures based on Common Table Expressions
 django-tree-queries = "~0.16.1"
 # Run production webservers such as uWSGI/gunicorn as a Django management command.


### PR DESCRIPTION
# Closes #5159, #5160
# What's Changed

## #5159
Under Django 4, the `annotate_config_context_data` would throw an exception due to the use of `order_by` on columns (`name`, `weight`) that aren't part of the returned subquery. I'm still not entirely clear why this was acceptable in Django 3 but not in Django 4, but in any case we don't actually need to try and have the DB order the subquery, because (due to lack of functionality in MySQL) we will need to sort the result in Python in any case.

I verified that this change fixes all of the test case failures reported in #5159, as well as a few quick manual tests of config context rendering for a Device.

### Screenshots

![image](https://github.com/nautobot/nautobot/assets/5603551/2167d93e-970b-4589-8e72-33452b7a559b)

## #5160 
Django switched from `pytz` to `zoneinfo` as the underlying time-zone library; we need to update to latest `django-timezone-field` version, plus replace any references in our code as well.

## Other fixes

- Work around an error in IPAM signals during factory data construction that looks similar to #5157; in this case just adding `.without_tree_fields()` appears to fix this issue, may be a similar tactic needed for #5157.
- A couple of migrations file updates that I missed when updating the parent prototype branch to latest `next` content.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example Plugin Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
