### PR TITLE
Fixed doc referece to job cprofile file location

### DIFF
--- a/changes/5526.fixed
+++ b/changes/5526.fixed
@@ -1,0 +1,1 @@
+Fixed doc referece to job cprofile file location.

--- a/changes/5526.fixed
+++ b/changes/5526.fixed
@@ -1,1 +1,1 @@
-Fixed doc referece to job cprofile file location.
+Fixed doc reference to job cprofile file location.

--- a/nautobot/docs/development/jobs/index.md
+++ b/nautobot/docs/development/jobs/index.md
@@ -673,7 +673,7 @@ A full description on how to deal with the output of `cProfile` can be found in 
 ```python
 import pstats
 job_result_uuid = "66b70231-002f-412b-8cc4-1cc9609c2c9b"
-stats = pstats.Stats(f"/tmp/job-result-{job_result_uuid}.pstats")
+stats = pstats.Stats(f"/tmp/nautobot-jobresult-{job_result_uuid}.pstats")
 stats.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(10)
 ```
 


### PR DESCRIPTION

# Closes N/A
# What's Changed

Reflected location of docs: https://github.com/nautobot/nautobot/blob/c6ce7dbd4b98aa776fbf630f733ce44f48f313f7/nautobot/extras/jobs.py#L138C60-L138C78

 
# Screenshots

# TODO
