### PR TITLE
Fix issue on virtual chassis table member count url linked correctly …

### DIFF
--- a/changes/5527.fixed
+++ b/changes/5527.fixed
@@ -1,1 +1,1 @@
-Fix issue on virtual chassis table member count url linked correctly to filtered device table.
+Fixed incorrect "members" links in Virtual Chassis list view.

--- a/changes/5527.fixed
+++ b/changes/5527.fixed
@@ -1,0 +1,1 @@
+Fix issue on virtual chassis table member count url linked correctly to filtered device table.

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -919,7 +919,7 @@ class VirtualChassisTable(BaseTable):
     master = tables.Column(linkify=True)
     member_count = LinkedCountColumn(
         viewname="dcim:device_list",
-        url_params={"virtual_chassis_id": "pk"},
+        url_params={"virtual_chassis": "pk"},
         verbose_name="Members",
     )
     tags = TagColumn(url_name="dcim:virtualchassis_list")


### PR DESCRIPTION

# Closes N/A
# What's Changed

Was reported on slack an issue with virtual chassis member count filter not working. I did not test this, but this seems correct based on the following code change https://github.com/nautobot/nautobot/commit/3c05ea997477db950f62b3ebb03b17415147611d#diff-7488d50989a94497b70a565bb61aed097a5504aea5815860690a8bab86941c5cL1037

I additionally looked for other similar patterns, and did not see any. 

# Screenshots

# TODO
