### PR TITLE
Filter objects with select/multiselect custom fields by choice PK

### DIFF
--- a/changes/5009.added
+++ b/changes/5009.added
@@ -1,0 +1,1 @@
+Added the option to filter objects with select/multi-select custom fields based on the UUID of the defined custom field choice(s), for example `/api/dcim/locations/?cf_multiselect=1ea9237c-3ba7-4985-ba7e-6fd9e9bff813` as an alternative to `/api/dcim/locations/?cf_multiselect=some-choice-value`.

--- a/nautobot/core/constants.py
+++ b/nautobot/core/constants.py
@@ -26,10 +26,6 @@ FILTER_CHAR_BASED_LOOKUP_MAP = {
     "nire": "iregex",
 }
 
-FILTER_LIST_BASED_LOOKUP_MAP = {
-    "nic": "icontains",
-}
-
 FILTER_NUMERIC_BASED_LOOKUP_MAP = {
     "n": "exact",
     "lte": "lte",

--- a/nautobot/core/constants.py
+++ b/nautobot/core/constants.py
@@ -26,6 +26,10 @@ FILTER_CHAR_BASED_LOOKUP_MAP = {
     "nire": "iregex",
 }
 
+FILTER_LIST_BASED_LOOKUP_MAP = {
+    "nic": "icontains",
+}
+
 FILTER_NUMERIC_BASED_LOOKUP_MAP = {
     "n": "exact",
     "lte": "lte",

--- a/nautobot/extras/filters/mixins.py
+++ b/nautobot/extras/filters/mixins.py
@@ -5,7 +5,7 @@ from django_filters.utils import verbose_lookup_expr
 
 from nautobot.core.constants import (
     FILTER_CHAR_BASED_LOOKUP_MAP,
-    FILTER_LIST_BASED_LOOKUP_MAP,
+    FILTER_NEGATION_LOOKUP_MAP,
     FILTER_NUMERIC_BASED_LOOKUP_MAP,
 )
 from nautobot.core.filters import (
@@ -95,7 +95,7 @@ class CustomFieldModelFilterSetMixin(django_filters.FilterSet):
         if issubclass(filter_type, (CustomFieldMultiValueNumberFilter, CustomFieldMultiValueDateFilter)):
             return FILTER_NUMERIC_BASED_LOOKUP_MAP
         elif issubclass(filter_type, CustomFieldMultiSelectFilter):
-            return FILTER_LIST_BASED_LOOKUP_MAP
+            return FILTER_NEGATION_LOOKUP_MAP
         else:
             return FILTER_CHAR_BASED_LOOKUP_MAP
 


### PR DESCRIPTION
# Closes #5009 
# What's Changed

Added the option to filter objects with select/multi-select custom fields based on the UUID of the defined custom field choice(s), for example `/api/dcim/locations/?cf_multiselect=1ea9237c-3ba7-4985-ba7e-6fd9e9bff813` as an alternative to `/api/dcim/locations/?cf_multiselect=some-choice-value`.

- Added `CustomFieldSelectFilter` class with custom `get_filter_predicate()` implementation
- Changed `CustomFieldMultiSelectFilter` to be a subclass of `CustomFieldSelectFilter`
- Removed `CustomFieldMultiValueSelectFilter` as it's confusing, totally unused, and not part of the apps namespace.
- ~Changed extended filter for multi-select custom fields from `__n` to `__nic` to match the fact that the base filter here is `icontains`, not `exact`.  (**I'm second-guessing this now, but it "feels" like a bug fix - thoughts??**)~ reverted this out of caution
- Add unit tests covering the new functionality.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots

<img width="1319" alt="image" src="https://github.com/nautobot/nautobot/assets/5603551/64347639-b256-4551-a6df-3b476cd4812b">


<img width="1324" alt="image" src="https://github.com/nautobot/nautobot/assets/5603551/54719aad-60bd-4e7a-a87d-8748ccc12b26">



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
