### PR TITLE
fix: Fixed `or` operator with Javascript `||`

### DIFF
--- a/changes/5589.changed
+++ b/changes/5589.changed
@@ -1,0 +1,1 @@
+Fixed an invalid Javascript operator in the LLDP neighbor view.

--- a/nautobot/dcim/templates/dcim/device/lldp_neighbors.html
+++ b/nautobot/dcim/templates/dcim/device/lldp_neighbors.html
@@ -65,7 +65,7 @@ var ready = (callback) => {
 };
 
 function getAttribute(node, querySelector, attribute) {
-    if (node === null or node.querySelector(querySelector) === null) {
+    if (node === null || node.querySelector(querySelector) === null) {
         return "";
     }
     return node.querySelector(querySelector).getAttribute(attribute) || "";


### PR DESCRIPTION
# What's Changed

Corrected invalid javascript operator `or` that was accidentally introduced in a previous fix for the Device LLDP neighbors view.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] ~Attached Screenshots, Payload Example~
- [ ] ~Unit, Integration Tests~
- [ ] ~Documentation Updates (when adding/changing features)~
- [ ] ~Example App Updates (when adding/changing features)~
- [ ] ~Outline Remaining Work, Constraints from Design~
