### PR TITLE
Add Device Redundancy Groups to Config Contexts

### DIFF
--- a/changes/5603.fixed
+++ b/changes/5603.fixed
@@ -1,1 +1,1 @@
-Corrected config context metadata filters to include device_redundancy_groups key.
+Fixed config contexts loaded from Git repositories not populating Device Redundancy Group information.

--- a/changes/5603.fixed
+++ b/changes/5603.fixed
@@ -1,0 +1,1 @@
+Corrected config context metadata filters to include device_redundancy_groups key.

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -19,7 +19,7 @@ import yaml
 
 from nautobot.core.celery import app as celery_app
 from nautobot.core.utils.git import GitRepo
-from nautobot.dcim.models import Device, DeviceType, Location, Platform
+from nautobot.dcim.models import Device, DeviceRedundancyGroup, DeviceType, Location, Platform
 from nautobot.extras.choices import (
     LogLevelChoices,
     SecretsGroupAccessTypeChoices,
@@ -272,6 +272,7 @@ def update_git_config_contexts(repository_record, job_result):
         "tenants",
         "tags",
         "dynamic_groups",
+        "device_redundancy_groups",
     ):
         if os.path.isdir(os.path.join(repository_record.filesystem_path, filter_type)):
             msg = (
@@ -402,6 +403,7 @@ def import_config_context(context_data, repository_record, job_result):
         ("tenants", Tenant),
         ("tags", Tag),
         ("dynamic_groups", DynamicGroup),
+        ("device_redundancy_groups", DeviceRedundancyGroup),
     ]:
         relations[key] = []
         for object_data in context_metadata.get(key, ()):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5603
# What's Changed
This corrects the bug detailed in #5603 where the device_redundancy_groups key is missing from the config context metadata filters.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
