### PR TITLE
Add ability to inject custom HTML head tags (closes #1858)

### DIFF
--- a/changes/1858.added
+++ b/changes/1858.added
@@ -1,0 +1,1 @@
+Added ability to inject custom HTML head tags.

--- a/nautobot/core/templates/admin/base.html
+++ b/nautobot/core/templates/admin/base.html
@@ -45,6 +45,7 @@
             width: 100%;
         }
     </style>
+    {% if settings.CUSTOM_HEAD %}{{ settings.CUSTOM_HEAD | safe }}{% endif %}
 </head>
 <body {% if is_popup %}style="padding-left: 0px;"{% endif %}>
 

--- a/nautobot/core/templates/base_django.html
+++ b/nautobot/core/templates/base_django.html
@@ -8,6 +8,7 @@
     <title>{% block title %}Home{% endblock %} - {{ settings.BRANDING_TITLE }}</title>
     {% include 'inc/media.html' %}
     {% block extra_styles %}{% endblock %}
+    {% if settings.CUSTOM_HEAD %}{{ settings.CUSTOM_HEAD | safe }}{% endif %}
 </head>
 <body>
     {% include 'inc/nav_menu.html' %}

--- a/nautobot/core/templates/graphene/graphiql.html
+++ b/nautobot/core/templates/graphene/graphiql.html
@@ -50,6 +50,7 @@ add "&raw" to the end of the URL within a browser.
           onerror="window.location='{% url 'media_failure' %}?filename=graphiql-1.5.16/graphiql.min.js'"></script>
   <script src="{% static 'subscriptions-transport-ws-0.9.18/client.min.js' %}"
       onerror="window.location='{% url 'media_failure' %}?filename=subscriptions-transport-ws-0.9.18/client.min.js'"></script>
+      {% if settings.CUSTOM_HEAD %}{{ settings.CUSTOM_HEAD | safe }}{% endif %}
 </head>
 <body>
   <!-- Nautobot page contents -->

--- a/nautobot/core/templates/media_failure.html
+++ b/nautobot/core/templates/media_failure.html
@@ -13,6 +13,7 @@
             margin-bottom: 30px;
         }
     </style>
+    {% if settings.CUSTOM_HEAD %}{{ settings.CUSTOM_HEAD | safe }}{% endif %}
 </head>
 <body>
     <div style="margin: auto; width: 800px">

--- a/nautobot/core/templates/rest_framework/api.html
+++ b/nautobot/core/templates/rest_framework/api.html
@@ -7,6 +7,11 @@
     {% include 'inc/media.html' %}
 {% endblock bootstrap_theme %}
 
+{% block head %}
+    {{ block.super }}
+    {% if settings.CUSTOM_HEAD %}{{ settings.CUSTOM_HEAD | safe }}{% endif %}
+{% endblock head %}
+
 {% block body %}
     {% include 'inc/nav_menu.html' %}
     <div class="container-fluid" id="main-content">


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #1858
# What's Changed

Add the ability to inject custom HTML head tags (to customize the CSS style for example).

Unless a default value must be set for this change, the variable definition is left to the instance admin.

# Config example

`settings.py`
```py
if os.getenv('NAUTOBOT_CUSTOM_HEAD'):
    CUSTOM_HEAD = os.getenv('NAUTOBOT_CUSTOM_HEAD').strip()
elif os.getenv('NAUTOBOT_CUSTOM_HEAD_FILE'):
    with open(
        os.getenv('NAUTOBOT_CUSTOM_HEAD_FILE'),
        mode='r',
        encoding='utf-8'
    ) as fh:
        CUSTOM_HEAD = fh.read()
```

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
