### PR TITLE
fix dependency on social-auth-core

### DIFF
--- a/changes/5565.fixed
+++ b/changes/5565.fixed
@@ -1,0 +1,1 @@
+Fixes optional dependency on `social-auth-core` by removing an extras related to openidconnect that no longer exists.

--- a/poetry.lock
+++ b/poetry.lock
@@ -4023,4 +4023,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "696a1070c64d48e829d98c3fcf7bbc9c7f3ceb83f1a69ecfb9e8258c47495cd8"
+content-hash = "598fd7b79a8cde691fb4952cf652fb7447144e48f9f496d0c16823f5ef0d410f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ pyuwsgi = "~2.0.23"
 # YAML parsing and rendering
 PyYAML = "~6.0"
 # Social authentication core
-social-auth-core = {version = "~4.5.3", optional = true, extras = ["openidconnect", "saml"]}
+social-auth-core = {version = "~4.5.3", optional = true, extras = ["saml"]}
 # Social authentication/registration with support for many auth providers
 social-auth-app-django = "~5.4.0"
 # Rendering of SVG images (for rack elevations, etc.)


### PR DESCRIPTION
Since 4.5.0 of social-auth-core it has not had an extras of 'openidconnect' so drop it from the dependencies.
see https://github.com/python-social-auth/social-core/issues/895 fixes #5565

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
