### PR TITLE
Properly encode URL query parameters when building a cloning URL

### DIFF
--- a/changes/5640.fixed
+++ b/changes/5640.fixed
@@ -1,0 +1,1 @@
+Fixed bug in generating the url parameters for cloning objects

--- a/changes/5640.fixed
+++ b/changes/5640.fixed
@@ -1,1 +1,1 @@
-Fixed bug in generating the url parameters for cloning objects
+Fixed bug in generating the URL parameters for cloning objects.

--- a/nautobot/core/views/utils.py
+++ b/nautobot/core/views/utils.py
@@ -1,5 +1,6 @@
 import datetime
 from io import BytesIO
+import urllib.parse
 
 from django.contrib import messages
 from django.core.exceptions import FieldError, ValidationError
@@ -269,7 +270,7 @@ def prepare_cloned_fields(instance):
         for tag in instance.tags.all():
             params.append(("tags", tag.pk))
 
-    # Concatenate parameters into a URL query string
-    param_string = "&".join([f"{k}={v}" for k, v in params])
+    # Encode the parameters into a URL query string
+    param_string = urllib.parse.urlencode(params)
 
     return param_string


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5640
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Switch to utilize urllib.parse.urlencode to generate the query parameter string when cloning an object.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
## Before
Before this patch a location with the description "9th & Vine" (well anything with a special character in it) would not populate the dialog properly when cloning.
![NautobotCloneIssue-0000](https://github.com/nautobot/nautobot/assets/635290/6ab4808d-ce0f-4a29-9a7b-a4413ead35b8)

## After
Now the clone dialog shows the description as expected.
![NautobotCloneIssue-0002](https://github.com/nautobot/nautobot/assets/635290/ae19b45b-50d5-4843-a5e4-17ab0cda6bc3)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
