### PR TITLE
Add more cases where it may be necessary to refresh Job class code on the fly

### DIFF
--- a/changes/5642.fixed
+++ b/changes/5642.fixed
@@ -1,0 +1,1 @@
+Fixed some cases where stale Job code might be present when Jobs are sourced from `JOBS_ROOT` or a Git repository.

--- a/changes/5642.fixed
+++ b/changes/5642.fixed
@@ -1,1 +1,2 @@
 Fixed some cases where stale Job code might be present when Jobs are sourced from `JOBS_ROOT` or a Git repository.
+Fixed incorrect handling of Job `kwargs` when dry-running a job approval request via the REST API.

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -971,7 +971,7 @@ class ScheduledJobViewSet(ReadOnlyModelViewSet):
 
         # Immediately enqueue the job
         job_class = get_job(job_model.class_path, reload=True)
-        job_kwargs = job_class.prepare_job_kwargs(scheduled_job.kwargs.get("data", {}))
+        job_kwargs = job_class.prepare_job_kwargs(scheduled_job.kwargs or {})
         job_kwargs["dryrun"] = True
         job_result = JobResult.enqueue_job(
             job_model,

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -33,6 +33,7 @@ from nautobot.core.models.querysets import count_related
 from nautobot.extras import filters
 from nautobot.extras.choices import JobExecutionType
 from nautobot.extras.filters import RoleFilterSet
+from nautobot.extras.jobs import get_job
 from nautobot.extras.models import (
     ComputedField,
     ConfigContext,
@@ -520,7 +521,7 @@ class JobViewSetBase(
     def variables(self, request, *args, **kwargs):
         """Get details of the input variables that may/must be specified to run a particular Job."""
         job_model = self.get_object()
-        job_class = job_model.job_class
+        job_class = get_job(job_model.class_path, reload=True)
         if job_class is None:
             raise Http404
         variables_dict = job_class._get_vars()
@@ -602,7 +603,7 @@ class JobViewSetBase(
                     "One of these two flags must be removed before this job can be scheduled or run."
                 )
 
-        job_class = job_model.job_class
+        job_class = get_job(job_model.class_path, reload=True)
         if job_class is None:
             raise MethodNotAllowed(
                 request.method, detail="This job's source code could not be located and cannot be run"
@@ -669,7 +670,7 @@ class JobViewSetBase(
         cleaned_data = None
         try:
             cleaned_data = job_class.validate_data(data, files=files)
-            cleaned_data = job_model.job_class.prepare_job_kwargs(cleaned_data)
+            cleaned_data = job_class.prepare_job_kwargs(cleaned_data)
 
         except FormsValidationError as e:
             # message_dict can only be accessed if ValidationError got a dict
@@ -969,13 +970,14 @@ class ScheduledJobViewSet(ReadOnlyModelViewSet):
             raise PermissionDenied("You do not have permission to run this job.")
 
         # Immediately enqueue the job
-        job_kwargs = job_model.job_class.prepare_job_kwargs(scheduled_job.kwargs.get("data", {}))
+        job_class = get_job(job_model.class_path, reload=True)
+        job_kwargs = job_class.prepare_job_kwargs(scheduled_job.kwargs.get("data", {}))
         job_kwargs["dryrun"] = True
         job_result = JobResult.enqueue_job(
             job_model,
             request.user,
             celery_kwargs=scheduled_job.celery_kwargs or {},
-            **job_model.job_class.serialize_data(job_kwargs),
+            **job_class.serialize_data(job_kwargs),
         )
         serializer = serializers.JobResultSerializer(job_result, context={"request": request})
 

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -844,8 +844,10 @@ class JobEditForm(NautobotModelForm):
         """
         For all overridable fields, if they aren't marked as overridden, revert them to the underlying value if known.
         """
+        from nautobot.extras.jobs import get_job  # avoid circular import
+
         cleaned_data = super().clean() or self.cleaned_data
-        job_class = self.instance.job_class
+        job_class = get_job(self.instance.class_path, reload=True)
         if job_class is not None:
             for field_name in JOB_OVERRIDABLE_FIELDS:
                 if not cleaned_data.get(f"{field_name}_override", False):

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1093,7 +1093,18 @@ def get_job(class_path, reload=False):
     Retrieve a specific job class by its class_path (`<module_name>.<JobClassName>`).
 
     May return None if the job can't be imported.
+
+    Args:
+        reload (bool): If True, **and** the given class_path describes a JOBS_ROOT or GitRepository Job,
+            then refresh **all** such Jobs before retrieving the job class.
     """
+    if reload:
+        if class_path.startswith("nautobot."):
+            # System job - not reloadable
+            reload = False
+        if any(class_path.startswith(f"{app_name}.") for app_name in settings.PLUGINS):
+            # App provided job - not reloadable
+            reload = False
     jobs = get_jobs(reload=reload)
     return jobs.get(class_path, None)
 

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -627,7 +627,7 @@ class JobResult(BaseModel, CustomFieldModel):
             schedule (ScheduledJob, optional): ScheduledJob instance to link to the JobResult. Cannot be used with synchronous=True.
             task_queue (str, optional): The celery queue to send the job to. If not set, use the default celery queue.
             synchronous (bool, optional): If True, run the job in the current process, blocking until the job completes.
-            *job_args: positional args passed to the job task
+            *job_args: positional args passed to the job task (UNUSED)
             **job_kwargs: keyword args passed to the job task
 
         Returns:

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -233,9 +233,14 @@ class Job(PrimaryModel):
     def __str__(self):
         return self.name
 
-    @cached_property
+    @property
     def job_class(self):
-        """Get the Job class (source code) associated with this Job model."""
+        """
+        Get the Job class (source code) associated with this Job model.
+
+        CAUTION: if the Job is provided by a Git Repository or is installed in JOBS_ROOT, you may need or wish to
+        call `get_job(self.class_path, reload=True)` to ensure that you have the latest Job code...
+        """
         from nautobot.extras.jobs import get_job
 
         if not self.installed:
@@ -290,10 +295,13 @@ class Job(PrimaryModel):
 
     def clean(self):
         """For any non-overridden fields, make sure they get reset to the actual underlying class value if known."""
-        if self.job_class is not None:
+        from nautobot.extras.jobs import get_job
+
+        job_class = get_job(self.class_path, reload=True)
+        if job_class is not None:
             for field_name in JOB_OVERRIDABLE_FIELDS:
                 if not getattr(self, f"{field_name}_override", False):
-                    setattr(self, field_name, getattr(self.job_class, field_name))
+                    setattr(self, field_name, getattr(job_class, field_name))
 
         # Protect against invalid input when auto-creating Job records
         if len(self.module_name) > JOB_MAX_NAME_LENGTH:

--- a/nautobot/extras/test_jobs/dry_run.py
+++ b/nautobot/extras/test_jobs/dry_run.py
@@ -1,5 +1,5 @@
 from nautobot.core.celery import register_jobs
-from nautobot.extras.jobs import DryRunVar, get_task_logger, Job
+from nautobot.extras.jobs import DryRunVar, get_task_logger, IntegerVar, Job
 from nautobot.extras.models import Status
 
 logger = get_task_logger(__name__)
@@ -11,8 +11,9 @@ class TestDryRun(Job):
     """
 
     dryrun = DryRunVar()
+    value = IntegerVar(required=False)
 
-    def run(self, dryrun):
+    def run(self, dryrun, value=None):
         """
         Job function.
         """

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -2303,6 +2303,7 @@ class JobApprovalTest(APITestCase):
             name="test dryrun",
             task="dry_run.TestDryRun",
             job_model=cls.dryrun_job_model,
+            kwargs={"value": 1},
             interval=JobExecutionType.TYPE_IMMEDIATELY,
             user=cls.additional_user,
             approval_required=True,
@@ -2442,6 +2443,8 @@ class JobApprovalTest(APITestCase):
         url = reverse("extras-api:scheduledjob-dry-run", kwargs={"pk": self.dryrun_scheduled_job.pk})
         response = self.client.post(url, **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
+        # The below fails because JobResult.task_kwargs doesn't get set until *after* the task begins executing.
+        # self.assertEqual(response.data["task_kwargs"], {"dryrun": True, "value": 1}, response.data)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_dry_run_not_supported(self):

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -1765,10 +1765,8 @@ class JobTestCase(
     model = Job
 
     def _get_queryset(self):
-        """Don't include hidden Jobs, non-installed Jobs, JobHookReceivers or JobButtonReceivers as they won't appear in the UI by default."""
-        return self.model.objects.filter(
-            installed=True, hidden=False, is_job_hook_receiver=False, is_job_button_receiver=False
-        )
+        """Don't include hidden Jobs or non-installed Jobs, as they won't appear in the UI by default."""
+        return self.model.objects.filter(installed=True, hidden=False)
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
# Closes #5537 (a followup to #5586)

The implementation of `JobModel.job_class` as a `cached_property` was problematic for long running (i.e. production, not runserver) server processes so I've changed it to just a regular `property`. Since its underlying implementation uses `get_job(class_path)` which just pulls directly from the registry, this is effectively removing a layer of no-longer-needed caching that was causing problems.

Secondarily, there are a number of cases where pulling from the registry might still not be up-to-date, again especially in the long-running server process case. I've replaced a number of cases where we were using `job_model.job_class` with `get_job(job_model.class_path, reload=True)` where it's critical to ensure that we have the latest job class code in memory.

Thirdarily, I've made `get_job(class_path, reload=True)` smarter so that it only actually reimports jobs if the specified class_path is not a system or App job (as those aren't actually reloadable).

Some testing in a user environment appears to show that this resolves some pesky issues with Job class loading from Git.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
