### PR TITLE
Fix dev environment behavior under newer Docker versions

### DIFF
--- a/changes/5637.housekeeping
+++ b/changes/5637.housekeeping
@@ -1,0 +1,2 @@
+Removed "version" from development `docker-compose.yml` files as newer versions of Docker complain about it being obsolete.
+Fixed behavior of `invoke stop` so that it also stops the optional `mkdocs` container if present.

--- a/development/docker-compose.debug.yml
+++ b/development/docker-compose.debug.yml
@@ -1,6 +1,5 @@
 # Used to integrate with Microsoft VS Code dev containers feature.
 ---
-version: "3.4"
 services:
   nautobot:
     command: "sleep infinity"

--- a/development/docker-compose.dev.yml
+++ b/development/docker-compose.dev.yml
@@ -3,7 +3,6 @@
 # any override will need to include these volumes to use them.
 # see:  https://github.com/docker/compose/issues/3729
 ---
-version: "3.4"
 services:
   nautobot:
     volumes:

--- a/development/docker-compose.final-dev.yml
+++ b/development/docker-compose.final-dev.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.4"
 services:
   nautobot:
     build:

--- a/development/docker-compose.final.yml
+++ b/development/docker-compose.final.yml
@@ -1,6 +1,5 @@
 # Used to run the final container images vs the dev containers
 ---
-version: "3.4"
 services:
   nautobot:
     build:

--- a/development/docker-compose.keycloak.yml
+++ b/development/docker-compose.keycloak.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.4"
 services:
   nautobot:
     environment:

--- a/development/docker-compose.mysql.yml
+++ b/development/docker-compose.mysql.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.4"
 services:
   nautobot:
     environment:

--- a/development/docker-compose.postgres.yml
+++ b/development/docker-compose.postgres.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.4"
 services:
   db:
     image: postgres:13

--- a/development/docker-compose.vscode-rdb.yml
+++ b/development/docker-compose.vscode-rdb.yml
@@ -1,6 +1,5 @@
 # Used to integrate with Microsoft VS Code remote debug feature.
 ---
-version: "3.4"
 services:
   nautobot:
     ports:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.9"
 volumes:
   media_root:
 services:

--- a/tasks.py
+++ b/tasks.py
@@ -408,7 +408,7 @@ def stop(context, service=None):
     """Stop Nautobot and its dependencies."""
     print("Stopping Nautobot...")
     if not service:
-        docker_compose(context, "down")
+        docker_compose(context, "--profile '*' down")
     else:
         docker_compose(context, "stop", service=service)
 


### PR DESCRIPTION
# Closes #5637 
# What's Changed

Under newer versions of Docker/docker-compose:

- the `version` parameter in docker-compose.yml is considered obsolete and causes noisy warnings to be logged:

```
time="2024-05-01T08:59:53-04:00" level=warning msg="nautobot/development/docker-compose.yml: `version` is obsolete"
time="2024-05-01T08:59:53-04:00" level=warning msg="nautobot/development/docker-compose.postgres.yml: `version` is obsolete"
time="2024-05-01T08:59:53-04:00" level=warning msg="nautobot/development/docker-compose.dev.yml: `version` is obsolete"
```

- `docker compose down` only stops containers running without a profile, and fails to stop containers that belong to a profile (such as our optional `mkdocs` container).

This PR addresses both issues, by:
- removing the now-obsolete `version` from all of our docker-compose files
- changing the `invoke stop` command to run `docker compose --profile '*' down` instead of just `docker compose down`.

I validated these changes both before updating my local Docker install (Docker Desktop 4.15) and after updating it (Docker Desktop 4.29).

# Screenshots

No warnings now when starting containers:

```
❯ invoke serve-docs
Starting Nautobot in detached mode...
Running docker compose command "up --detach"
PYTHON_VER=3.8 \
docker compose \
    --project-name "nautobot" \
    --project-directory "nautobot/development/" \
    -f "nautobot/development/docker-compose.yml" \
    -f "nautobot/development/docker-compose.postgres.yml" \
    -f "nautobot/development/docker-compose.dev.yml" up \
    --detach mkdocs
 Container nautobot-mkdocs-1  Creating
 Container nautobot-mkdocs-1  Created
 Container nautobot-mkdocs-1  Starting
 Container nautobot-mkdocs-1  Started
```

All nautobot containers are now stopped by `invoke stop`, including the `mkdocs` container:

```
❯ invoke stop            
Stopping Nautobot...
Running docker compose command "--profile '*' down"
PYTHON_VER=3.8 \
docker compose \
    --project-name "nautobot" \
    --project-directory "nautobot/development/" \
    -f "nautobot/development/docker-compose.yml" \
    -f "nautobot/development/docker-compose.postgres.yml" \
    -f "nautobot/development/docker-compose.dev.yml" \
    --profile '*' down
 Container nautobot-mkdocs-1  Stopping
 Container nautobot-celery_worker-1  Stopping
 Container nautobot-celery_beat-1  Stopping
 Container nautobot-celery_beat-1  Stopped
 Container nautobot-celery_beat-1  Removing
 Container nautobot-celery_beat-1  Removed
 Container nautobot-celery_worker-1  Stopped
 Container nautobot-celery_worker-1  Removing
 Container nautobot-celery_worker-1  Removed
 Container nautobot-nautobot-1  Stopping
 Container nautobot-mkdocs-1  Stopped
 Container nautobot-mkdocs-1  Removing
 Container nautobot-mkdocs-1  Removed
 Container nautobot-nautobot-1  Stopped
 Container nautobot-nautobot-1  Removing
 Container nautobot-nautobot-1  Removed
 Container nautobot-selenium-1  Stopping
 Container nautobot-db-1  Stopping
 Container nautobot-redis-1  Stopping
 Container nautobot-selenium-1  Stopped
 Container nautobot-selenium-1  Removing
 Container nautobot-selenium-1  Removed
 Container nautobot-db-1  Stopped
 Container nautobot-db-1  Removing
 Container nautobot-db-1  Removed
 Container nautobot-redis-1  Stopped
 Container nautobot-redis-1  Removing
 Container nautobot-redis-1  Removed
 Network nautobot_default  Removing
 Network nautobot_default  Removed
```


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
