### PR TITLE
Static groups UI

### DIFF
--- a/changes/5472.added
+++ b/changes/5472.added
@@ -2,3 +2,5 @@ Added `StaticGroup` and `StaticGroupAssociation` data models, used for staticall
 Added `feature` filter to `/api/extras/content-types/`.
 Added `static_groups` filter to all applicable models via the `BaseFilterSet` class.
 Added `static_groups` field to applicable model create/edit forms via the `StaticGroupModelFormMixin` class (included in `NautobotModelForm` class automatically).
+Added `Static Groups` column to applicable model tables.
+Enhanced `BaseTable` class to automatically apply appropriate `count_related` annotations for any `LinkedCountColumn`.

--- a/changes/5472.added
+++ b/changes/5472.added
@@ -1,3 +1,4 @@
 Added `StaticGroup` and `StaticGroupAssociation` data models, used for statically defining groups of Nautobot objects.
 Added `feature` filter to `/api/extras/content-types/`.
-Added `static_group` filter to all applicable models via the `BaseFilterSet` class.
+Added `static_groups` filter to all applicable models via the `BaseFilterSet` class.
+Added `static_groups` field to applicable model create/edit forms via the `StaticGroupModelFormMixin` class (included in `NautobotModelForm` class automatically).

--- a/changes/5472.added
+++ b/changes/5472.added
@@ -1,1 +1,3 @@
 Added `StaticGroup` and `StaticGroupAssociation` data models, used for statically defining groups of Nautobot objects.
+Added `feature` filter to `/api/extras/content-types/`.
+Added `static_group` filter to all applicable models via the `BaseFilterSet` class.

--- a/nautobot/apps/forms.py
+++ b/nautobot/apps/forms.py
@@ -77,6 +77,7 @@ from nautobot.extras.forms import (
     NoteModelFormMixin,
     RelationshipModelBulkEditFormMixin,
     RelationshipModelFormMixin,
+    StaticGroupModelFormMixin,
     StatusModelBulkEditFormMixin,
     TagsBulkEditFormMixin,
 )
@@ -171,6 +172,7 @@ __all__ = (
     "SlugField",
     "SlugWidget",
     "SmallTextarea",
+    "StaticGroupModelFormMixin",
     "StaticSelect2",
     "StaticSelect2Multiple",
     "StatusModelBulkEditFormMixin",

--- a/nautobot/circuits/tables.py
+++ b/nautobot/circuits/tables.py
@@ -4,6 +4,7 @@ from django_tables2.utils import Accessor
 from nautobot.core.tables import (
     BaseTable,
     ButtonsColumn,
+    LinkedCountColumn,
     TagColumn,
     ToggleColumn,
 )
@@ -48,7 +49,11 @@ class ProviderNetworkTable(BaseTable):
 class ProviderTable(BaseTable):
     pk = ToggleColumn()
     name = tables.LinkColumn()
-    circuit_count = tables.Column(accessor=Accessor("count_circuits"), verbose_name="Circuits")
+    circuit_count = LinkedCountColumn(
+        viewname="circuits:circuit_list",
+        url_params={"provider": "pk"},
+        verbose_name="Circuits",
+    )
     tags = TagColumn(url_name="circuits:provider_list")
 
     class Meta(BaseTable.Meta):
@@ -75,7 +80,11 @@ class ProviderTable(BaseTable):
 class CircuitTypeTable(BaseTable):
     pk = ToggleColumn()
     name = tables.LinkColumn()
-    circuit_count = tables.Column(verbose_name="Circuits")
+    circuit_count = LinkedCountColumn(
+        viewname="circuits:circuit_list",
+        url_params={"circuit_type": "pk"},
+        verbose_name="Circuits",
+    )
     actions = ButtonsColumn(CircuitType)
 
     class Meta(BaseTable.Meta):

--- a/nautobot/circuits/views.py
+++ b/nautobot/circuits/views.py
@@ -5,7 +5,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django_tables2 import RequestConfig
 
 from nautobot.core.forms import ConfirmationForm
-from nautobot.core.models.querysets import count_related
 from nautobot.core.views import generic, mixins as view_mixins
 from nautobot.core.views.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.core.views.viewsets import NautobotUIViewSet
@@ -28,7 +27,7 @@ class CircuitTypeUIViewSet(
 ):
     filterset_class = filters.CircuitTypeFilterSet
     form_class = forms.CircuitTypeForm
-    queryset = CircuitType.objects.annotate(circuit_count=count_related(Circuit, "circuit_type"))
+    queryset = CircuitType.objects.all()
     serializer_class = serializers.CircuitTypeSerializer
     table_class = tables.CircuitTypeTable
 
@@ -90,7 +89,7 @@ class ProviderUIViewSet(NautobotUIViewSet):
     filterset_class = filters.ProviderFilterSet
     filterset_form_class = forms.ProviderFilterForm
     form_class = forms.ProviderForm
-    queryset = Provider.objects.annotate(count_circuits=count_related(Circuit, "provider"))
+    queryset = Provider.objects.all()
     serializer_class = serializers.ProviderSerializer
     table_class = tables.ProviderTable
 

--- a/nautobot/core/filters.py
+++ b/nautobot/core/filters.py
@@ -705,7 +705,7 @@ class BaseFilterSet(django_filters.FilterSet):
         fields = super().get_fields()
         if "id" not in fields and (cls._meta.exclude is None or "id" not in cls._meta.exclude):
             # Add "id" as the first key in the `fields` dict
-            fields = dict(id=[django_filters.conf.settings.DEFAULT_LOOKUP_EXPR], **fields)
+            fields = {"id": [django_filters.conf.settings.DEFAULT_LOOKUP_EXPR], **fields}
         return fields
 
     @classmethod
@@ -715,16 +715,16 @@ class BaseFilterSet(django_filters.FilterSet):
         """
         filters = super().get_filters()
 
-        if "static_group" not in filters and getattr(cls._meta.model, "is_static_group_associable_model", False):
-            # Add "static_group" field as the last key
+        if "static_groups" not in filters and getattr(cls._meta.model, "is_static_group_associable_model", False):
+            # Add "static_groups" field as the last key
             from nautobot.extras.models import StaticGroup
 
-            filters["static_group"] = NaturalKeyOrPKMultipleChoiceFilter(
+            filters["static_groups"] = NaturalKeyOrPKMultipleChoiceFilter(
                 queryset=StaticGroup.objects.all(),
                 field_name="associated_static_groups__static_group",
                 to_field_name="name",
                 query_params={"content_type": cls._meta.model._meta.label_lower},
-                label="Static group",
+                label="Static groups (name or ID)",
             )
 
         # django-filters has no concept of "abstract" filtersets, so we have to fake it

--- a/nautobot/core/filters.py
+++ b/nautobot/core/filters.py
@@ -715,11 +715,7 @@ class BaseFilterSet(django_filters.FilterSet):
         """
         filters = super().get_filters()
 
-        if (
-            "static_group" not in filters
-            and hasattr(cls._meta.model, "is_static_group_associable_model")
-            and cls._meta.model.is_static_group_associable_model
-        ):
+        if ("static_group" not in filters and getattr(cls._meta.model, "is_static_group_associable_model", False)):
             # Add "static_group" field as the last key
             from nautobot.extras.models import StaticGroup
 

--- a/nautobot/core/filters.py
+++ b/nautobot/core/filters.py
@@ -715,7 +715,7 @@ class BaseFilterSet(django_filters.FilterSet):
         """
         filters = super().get_filters()
 
-        if ("static_group" not in filters and getattr(cls._meta.model, "is_static_group_associable_model", False)):
+        if "static_group" not in filters and getattr(cls._meta.model, "is_static_group_associable_model", False):
             # Add "static_group" field as the last key
             from nautobot.extras.models import StaticGroup
 
@@ -723,11 +723,15 @@ class BaseFilterSet(django_filters.FilterSet):
                 queryset=StaticGroup.objects.all(),
                 field_name="associated_static_groups__static_group",
                 to_field_name="name",
+                query_params={"content_type": cls._meta.model._meta.label_lower},
                 label="Static group",
             )
 
         # django-filters has no concept of "abstract" filtersets, so we have to fake it
         if cls._meta.model is not None:
+            if "tags" in filters and isinstance(filters["tags"], TagFilter):
+                filters["tags"].extra["query_params"] = {"content_types": [cls._meta.model._meta.label_lower]}
+
             new_filters = {}
             for existing_filter_name, existing_filter in filters.items():
                 new_filters.update(

--- a/nautobot/core/forms/fields.py
+++ b/nautobot/core/forms/fields.py
@@ -228,6 +228,10 @@ class MultipleContentTypeField(django_forms.ModelMultipleChoiceField):
 
         if "queryset" not in kwargs:
             if feature is not None:
+                from nautobot.extras.registry import registry
+
+                if feature not in registry["model_features"]:
+                    raise KeyError
                 kwargs["queryset"] = ContentType.objects.filter(
                     extras_utils.FeatureQuery(feature).get_query()
                 ).order_by("app_label", "model")

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -1,8 +1,9 @@
+import contextlib
 import logging
 
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.fields import GenericForeignKey
-from django.core.exceptions import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import NotSupportedError
 from django.db.models.fields.related import ForeignKey, RelatedField
 from django.db.models.fields.reverse_related import ManyToOneRel
@@ -15,6 +16,7 @@ from django_tables2.data import TableQuerysetData
 from django_tables2.utils import Accessor, OrderBy, OrderByTuple
 from tree_queries.models import TreeNode
 
+from nautobot.core.models.querysets import count_related
 from nautobot.core.templatetags import helpers
 from nautobot.core.utils import lookup
 from nautobot.extras import choices, models
@@ -37,6 +39,14 @@ class BaseTable(django_tables2.Table):
     def __init__(self, *args, user=None, hide_hierarchy_ui=False, **kwargs):
         # Add custom field columns
         model = self._meta.model
+
+        if model.is_static_group_associable_model:
+            self.base_columns["static_group_count"] = LinkedCountColumn(
+                viewname="extras:staticgroup_list",
+                url_params={"member_id": "pk"},
+                verbose_name="Static Groups",
+                reverse_lookup="static_group_associations__associated_object_id",
+            )
 
         for cf in models.CustomField.objects.get_for_model(model):
             name = cf.add_prefix_to_cf_key()
@@ -80,12 +90,11 @@ class BaseTable(django_tables2.Table):
                     self.columns.hide(column.name)
 
         # Apply custom column ordering for user
+        pk = self.base_columns.pop("pk", None)
+        actions = self.base_columns.pop("actions", None)
         if user is not None and not isinstance(user, AnonymousUser):
             columns = user.get_config(f"tables.{self.__class__.__name__}.columns")
             if columns:
-                pk = self.base_columns.pop("pk", None)
-                actions = self.base_columns.pop("actions", None)
-
                 for name, column in self.base_columns.items():
                     if name in columns:
                         self.columns.show(name)
@@ -93,51 +102,63 @@ class BaseTable(django_tables2.Table):
                         self.columns.hide(name)
                 self.sequence = [c for c in columns if c in self.base_columns]
 
-                # Always include PK and actions column, if defined on the table
-                if pk:
-                    self.base_columns["pk"] = pk
-                    self.sequence.insert(0, "pk")
-                if actions:
-                    self.base_columns["actions"] = actions
-                    self.sequence.append("actions")
+        # Always include PK and actions columns, if defined on the table, as first and last columns respectively
+        if pk:
+            with contextlib.suppress(ValueError):
+                self.sequence.remove("pk")
+            self.base_columns["pk"] = pk
+            self.sequence.insert(0, "pk")
+        if actions:
+            with contextlib.suppress(ValueError):
+                self.sequence.remove("actions")
+            self.base_columns["actions"] = actions
+            self.sequence.append("actions")
 
         # Dynamically update the table's QuerySet to ensure related fields are pre-fetched
         if isinstance(self.data, TableQuerysetData):
             queryset = self.data.data
             select_fields = []
             prefetch_fields = []
+            count_fields = []
             for column in self.columns:
-                if column.visible:
-                    column_model = model
-                    accessor = column.accessor
-                    select_path = []
-                    prefetch_path = []
-                    for field_name in accessor.split(accessor.SEPARATOR):
-                        try:
-                            field = column_model._meta.get_field(field_name)
-                        except FieldDoesNotExist:
-                            break
-                        if isinstance(field, ForeignKey) and not prefetch_path:
-                            # Follow ForeignKeys to the related model via select_related
-                            select_path.append(field_name)
-                            column_model = field.remote_field.model
-                        elif isinstance(field, (RelatedField, ManyToOneRel)) and not select_path:
-                            # Follow O2M and M2M relations to the related model via prefetch_related
-                            prefetch_path.append(field_name)
-                            column_model = field.remote_field.model
-                        elif isinstance(field, GenericForeignKey) and not select_path:
-                            # Can't prefetch beyond a GenericForeignKey
-                            prefetch_path.append(field_name)
-                            break
-                        else:
-                            # Need to stop processing once field is not a RelatedField or GFK
-                            # Ex: ["_custom_field_data", "tenant_id"] needs to exit
-                            # the loop as "tenant_id" would be misidentified as a RelatedField.
-                            break
-                    if select_path:
-                        select_fields.append("__".join(select_path))
-                    elif prefetch_path:
-                        prefetch_fields.append("__".join(prefetch_path))
+                if not column.visible:
+                    continue
+                if isinstance(column.column, LinkedCountColumn):
+                    column_model = lookup.get_model_for_view_name(column.column.viewname)
+                    reverse_lookup = column.column.reverse_lookup or next(iter(column.column.url_params.keys()))
+                    count_fields.append((column.name, column_model, reverse_lookup))
+                    continue
+
+                column_model = model
+                accessor = column.accessor
+                select_path = []
+                prefetch_path = []
+                for field_name in accessor.split(accessor.SEPARATOR):
+                    try:
+                        field = column_model._meta.get_field(field_name)
+                    except FieldDoesNotExist:
+                        break
+                    if isinstance(field, ForeignKey) and not prefetch_path:
+                        # Follow ForeignKeys to the related model via select_related
+                        select_path.append(field_name)
+                        column_model = field.remote_field.model
+                    elif isinstance(field, (RelatedField, ManyToOneRel)) and not select_path:
+                        # Follow O2M and M2M relations to the related model via prefetch_related
+                        prefetch_path.append(field_name)
+                        column_model = field.remote_field.model
+                    elif isinstance(field, GenericForeignKey) and not select_path:
+                        # Can't prefetch beyond a GenericForeignKey
+                        prefetch_path.append(field_name)
+                        break
+                    else:
+                        # Need to stop processing once field is not a RelatedField or GFK
+                        # Ex: ["_custom_field_data", "tenant_id"] needs to exit
+                        # the loop as "tenant_id" would be misidentified as a RelatedField.
+                        break
+                if select_path:
+                    select_fields.append("__".join(select_path))
+                elif prefetch_path:
+                    prefetch_fields.append("__".join(prefetch_path))
 
             if select_fields:
                 # Django doesn't allow .select_related() on a QuerySet that had .values()/.values_list() applied, or
@@ -185,6 +206,23 @@ class BaseTable(django_tables2.Table):
                             model.__name__,
                             exc,
                         )
+
+            if count_fields:
+                for column_name, column_model, lookup_name in count_fields:
+                    if hasattr(queryset.first(), column_name):
+                        continue
+                    try:
+                        logger.debug(
+                            "Applying .annotate(%s=count_related(%s, %r) to %s QuerySet",
+                            column_name,
+                            column_model.__name__,
+                            lookup_name,
+                            model.__name__,
+                        )
+                        queryset = queryset.annotate(**{column_name: count_related(column_model, lookup_name)})
+                    except FieldError:
+                        # No error message logged here as the above is *very much* best-effort
+                        pass
 
             self.data.data = queryset
 
@@ -396,12 +434,15 @@ class LinkedCountColumn(django_tables2.Column):
     :param viewname: The view name to use for URL resolution
     :param view_kwargs: Additional kwargs to pass for URL resolution (optional)
     :param url_params: A dict of query parameters to append to the URL (e.g. ?foo=bar) (optional)
+    :param reverse_lookup: The reverse lookup parameter to use to derive the count. If not specified, the first key
+        in `url_params` will be implicitly used as the `reverse_lookup` value.
     """
 
-    def __init__(self, viewname, *args, view_kwargs=None, url_params=None, default=0, **kwargs):
+    def __init__(self, viewname, *args, view_kwargs=None, url_params=None, reverse_lookup=None, default=0, **kwargs):
         self.viewname = viewname
         self.view_kwargs = view_kwargs or {}
         self.url_params = url_params
+        self.reverse_lookup = reverse_lookup
         super().__init__(*args, default=default, **kwargs)
 
     def render(self, record, value):  # pylint: disable=arguments-differ

--- a/nautobot/core/templates/generic/object_bulk_update.html
+++ b/nautobot/core/templates/generic/object_bulk_update.html
@@ -29,7 +29,9 @@
     <div class="row">
         <div class="col-md-8">
             <div class="panel panel-default">
-                {% render_table table 'inc/table.html' %}
+                <div class="table-responsive">
+                    {% render_table table 'inc/table.html' %}
+                </div>
             </div>
         </div>
         <div class="col-md-4">

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -225,5 +225,17 @@
             }
         }
     });
+
+    document.getElementById("static_group_assignment_cancel").addEventListener("click", (e) => {
+        // Clear form data on cancel, but not on "close" "x" button
+        $("#static_group_assignment_modal").modal("hide");
+        document.getElementById("static_group_assignment_all").value = "";
+        document.getElementById("static_group_assignment_pks").replaceChildren();
+        document.getElementById("id_create_and_assign_to_new_group_name").value = "";
+        $("#id_add_to_groups").val(null).trigger("change");
+        $("#id_remove_from_groups").val(null).trigger("change");
+    });
+
+
 </script>
 {% endblock %}

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -107,7 +107,6 @@
             <form id="object_list_form" method="post" class="form form-horizontal">
                 {% csrf_token %}
                 <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
-                <input type="hidden" name="content_type" value="{{ content_type.pk }}">
                 {% if table.paginator.num_pages > 1 %}
                 <div class="table-responsive">
                     <div id="select_all_box" class="hidden panel panel-default noprint">
@@ -127,7 +126,8 @@
                                             data-objects="all"
                                             class="btn btn-primary btn-sm"
                                             disabled="disabled">
-                                        <span class="mdi mdi-group" aria-hidden="true"></span> Update Static Groups for All
+                                        <span class="mdi mdi-group" aria-hidden="true"></span>
+                                        Update Static Groups for All
                                     </button>
                                 {% endif %}
                                 {% if bulk_edit_url and permissions.change %}
@@ -205,6 +205,7 @@
         removed: (row) => { row.remove(); }
     });
 
+    // TODO: move this to a JS file that is auto-included by static_group_assignment_modal templatetag
     $("#static_group_assignment_modal").on("show.bs.modal", function (event) {
         console.log("Hello")
         const button = $(event.relatedTarget);

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load buttons %}
 {% load helpers %}
+{% load perms %}
 {% load plugins %}
 {% load static %}
 
@@ -106,6 +107,7 @@
             <form method="post" class="form form-horizontal">
                 {% csrf_token %}
                 <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
+                <input type="hidden" name="content_type" value="{{ content_type.pk }}">
                 {% if table.paginator.num_pages > 1 %}
                 <div class="table-responsive">
                     <div id="select_all_box" class="hidden panel panel-default noprint">
@@ -135,6 +137,11 @@
                 {% include table_template|default:'panel_table.html' %}
                 <div class="pull-left noprint">
                     {% block bulk_buttons %}{% endblock %}
+                    {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
+                        <button type="submit" name="_add_to_static_group" formaction="{% url 'extras:staticgroup_add' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-primary btn-sm">
+                            <span class="mdi mdi-group" aria-hidden="true"></span> Add Selected to Static Group
+                        </button>
+                    {% endif %}
                     {% if bulk_edit_url and permissions.change %}
                         <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm">
                             <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit Selected

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -207,15 +207,14 @@
 
     // TODO: move this to a JS file that is auto-included by static_group_assignment_modal templatetag
     $("#static_group_assignment_modal").on("show.bs.modal", function (event) {
-        console.log("Hello")
         const button = $(event.relatedTarget);
         const selected_or_all = button.data("objects");
         const pks_target = document.getElementById("static_group_assignment_pks");
         pks_target.replaceChildren();
         if (selected_or_all == "all") {
-            $("#static_group_assignment_all").val(true);
+            document.getElementById("static_group_assignment_all").value = true;
         } else {
-            $("#static_group_assignment_all").val();
+            document.getElementById("static_group_assignment_all").value = "";
             const formData = new FormData(document.getElementById("object_list_form"));
             for (let pk of formData.getAll("pk")) {
                 let input = document.createElement("input");

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -120,8 +120,12 @@
                             </div>
                             <div class="pull-right">
                                 {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
-                                    <button type="submit" name="_add_to_static_group" formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-primary btn-sm" disabled="disabled">
-                                        <span class="mdi mdi-group" aria-hidden="true"></span> Add All to Static Group
+                                    <button type="submit"
+                                            name="_add_to_static_group"
+                                            formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
+                                            class="btn btn-primary btn-sm"
+                                            disabled="disabled">
+                                        <span class="mdi mdi-group" aria-hidden="true"></span> Update Static Groups for All
                                     </button>
                                 {% endif %}
                                 {% if bulk_edit_url and permissions.change %}
@@ -143,8 +147,11 @@
                 <div class="pull-left noprint">
                     {% block bulk_buttons %}{% endblock %}
                     {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
-                        <button type="submit" name="_add_to_static_group" formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-primary btn-sm">
-                            <span class="mdi mdi-group" aria-hidden="true"></span> Add Selected to Static Group
+                        <button type="submit"
+                                name="_add_to_static_group"
+                                formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
+                                class="btn btn-primary btn-sm">
+                            <span class="mdi mdi-group" aria-hidden="true"></span> Update Static Groups
                         </button>
                     {% endif %}
                     {% if bulk_edit_url and permissions.change %}

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -119,6 +119,11 @@
                                 </label>
                             </div>
                             <div class="pull-right">
+                                {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
+                                    <button type="submit" name="_add_to_static_group" formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-primary btn-sm" disabled="disabled">
+                                        <span class="mdi mdi-group" aria-hidden="true"></span> Add All to Static Group
+                                    </button>
+                                {% endif %}
                                 {% if bulk_edit_url and permissions.change %}
                                     <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm" disabled="disabled">
                                         <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit All
@@ -138,7 +143,7 @@
                 <div class="pull-left noprint">
                     {% block bulk_buttons %}{% endblock %}
                     {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
-                        <button type="submit" name="_add_to_static_group" formaction="{% url 'extras:staticgroup_add' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-primary btn-sm">
+                        <button type="submit" name="_add_to_static_group" formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-primary btn-sm">
                             <span class="mdi mdi-group" aria-hidden="true"></span> Add Selected to Static Group
                         </button>
                     {% endif %}

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -104,7 +104,7 @@
     <div class="col-md-12">
         {% with bulk_edit_url=content_type.model_class|validated_viewname:"bulk_edit" bulk_delete_url=content_type.model_class|validated_viewname:"bulk_delete" %}
         {% if permissions.change or permissions.delete %}
-            <form method="post" class="form form-horizontal">
+            <form id="object_list_form" method="post" class="form form-horizontal">
                 {% csrf_token %}
                 <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
                 <input type="hidden" name="content_type" value="{{ content_type.pk }}">
@@ -120,9 +120,11 @@
                             </div>
                             <div class="pull-right">
                                 {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
-                                    <button type="submit"
-                                            name="_add_to_static_group"
-                                            formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
+                                    <button type="button"
+                                            id="update_static_groups_for_all"
+                                            data-toggle="modal"
+                                            data-target="#static_group_assignment_modal"
+                                            data-objects="all"
                                             class="btn btn-primary btn-sm"
                                             disabled="disabled">
                                         <span class="mdi mdi-group" aria-hidden="true"></span> Update Static Groups for All
@@ -147,9 +149,11 @@
                 <div class="pull-left noprint">
                     {% block bulk_buttons %}{% endblock %}
                     {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
-                        <button type="submit"
-                                name="_add_to_static_group"
-                                formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
+                        <button type="button"
+                                id="update_static_groups_for_selected"
+                                data-toggle="modal"
+                                data-target="#static_group_assignment_modal"
+                                data-objects="selected"
                                 class="btn btn-primary btn-sm">
                             <span class="mdi mdi-group" aria-hidden="true"></span> Update Static Groups
                         </button>
@@ -177,6 +181,7 @@
 </div>
 {% if table %}{% table_config_form table table_name="ObjectTable" %}{% endif %}
 {% filter_form_modal filter_form dynamic_filter_form model_plural_name=title %}
+{% static_group_assignment_modal request=request content_type=content_type %}
 {% endblock %}
 
 {% block javascript %}
@@ -198,6 +203,27 @@
         formCssClass: 'dynamic-filterform',
         added: jsify_form,
         removed: (row) => { row.remove(); }
+    });
+
+    $("#static_group_assignment_modal").on("show.bs.modal", function (event) {
+        console.log("Hello")
+        const button = $(event.relatedTarget);
+        const selected_or_all = button.data("objects");
+        const pks_target = document.getElementById("static_group_assignment_pks");
+        pks_target.replaceChildren();
+        if (selected_or_all == "all") {
+            $("#static_group_assignment_all").val(true);
+        } else {
+            $("#static_group_assignment_all").val();
+            const formData = new FormData(document.getElementById("object_list_form"));
+            for (let pk of formData.getAll("pk")) {
+                let input = document.createElement("input");
+                input.setAttribute("type", "hidden");
+                input.setAttribute("name", "pk");
+                input.setAttribute("value", pk);
+                pks_target.append(input);
+            }
+        }
     });
 </script>
 {% endblock %}

--- a/nautobot/core/templates/generic/object_retrieve.html
+++ b/nautobot/core/templates/generic/object_retrieve.html
@@ -109,6 +109,13 @@
                 </li>
             {% endif %}
         {% endif %}
+        {% if object.is_static_group_associable_model and perms.extras.view_staticgroup %}
+            <li role="presentation"{% if request.GET.tab == 'static_groups' %} class="active"{% endif %}>
+                <a href="{{ object.get_absolute_url }}#static_groups" onclick="switch_tab(this.href)" aria-controls="static_groups" role="tab" data-toggle="tab">
+                    Static Groups
+                </a>
+            </li>
+        {% endif %}
         {% if perms.extras.view_objectchange %}
             {% if active_tab != 'changelog' and object.get_changelog_url or active_tab == 'changelog' %}
                 <li role="presentation"{% if active_tab == 'changelog' %} class="active"{% endif %}>
@@ -197,6 +204,28 @@
                                         <div class="clearfix"></div>
                                     </div>
                                 {% endwith %}
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+        {% if object.is_static_group_associable_model and perms.extras.view_staticgroup %}
+            <div id="static_groups" role="tabpanel" class="tab-pane {% if request.GET.tab == 'static_groups' %}active{% else %}fade{% endif %}">
+                <div class="row">
+                    <div class="col-md-12">
+                        <form method="post">
+                            {% csrf_token %}
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <strong>Static Groups</strong>
+                                    <div class="pull-right noprint">
+                                        <!-- Insert table config button here -->
+                                    </div>
+                                </div>
+                                <div class="table-responsive">
+                                    {% render_table associated_static_groups_table 'inc/table.html' %}
+                                </div>
                             </div>
                         </form>
                     </div>

--- a/nautobot/core/templates/generic/object_retrieve.html
+++ b/nautobot/core/templates/generic/object_retrieve.html
@@ -112,7 +112,7 @@
         {% if object.is_static_group_associable_model and perms.extras.view_staticgroup %}
             <li role="presentation"{% if request.GET.tab == 'static_groups' %} class="active"{% endif %}>
                 <a href="{{ object.get_absolute_url }}#static_groups" onclick="switch_tab(this.href)" aria-controls="static_groups" role="tab" data-toggle="tab">
-                    Static Groups
+                    Static Groups {% badge object.static_groups.count %}
                 </a>
             </li>
         {% endif %}

--- a/nautobot/core/templates/inc/extras_features_edit_form_fields.html
+++ b/nautobot/core/templates/inc/extras_features_edit_form_fields.html
@@ -24,6 +24,14 @@
         </div>
     </div>
 {% endif %}
+{% if form.static_groups and perms.extras.add_staticgroupassociation %}
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Static Groups</strong></div>
+        <div class="panel-body">
+            {% render_field form.static_groups %}
+        </div>
+    </div>
+{% endif %}
 {% if form.tags %}
     <div class="panel panel-default">
         <div class="panel-heading"><strong>Tags</strong></div>

--- a/nautobot/core/templates/utilities/obj_table.html
+++ b/nautobot/core/templates/utilities/obj_table.html
@@ -1,9 +1,8 @@
 {% load helpers %}
-{% if permissions.change or permissions.delete or perms.extras.add_staticgroupassociation %}
+{% if permissions.change or permissions.delete %}
     <form method="post" class="form form-horizontal">
         {% csrf_token %}
         <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
-        {% if content_type %}<input type="hidden" name="content_type" value="{{ content_type.pk }}">{% endif %}
         {% if table.paginator.num_pages > 1 %}
             <div id="select_all_box" class="hidden panel panel-default noprint">
                 <div class="panel-body">
@@ -14,15 +13,6 @@
                         </label>
                     </div>
                     <div class="pull-right">
-                        {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
-                            <button type="submit"
-                                    name="_add_to_static_group"
-                                    formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
-                                    class="btn btn-primary btn-sm"
-                                    disabled="disabled">
-                                <span class="mdi mdi-group" aria-hidden="true"></span> Update Static Groups for All
-                            </button>
-                        {% endif %}
                         {% if bulk_edit_url and permissions.change %}
                             <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if bulk_querystring %}?{{ bulk_querystring }}{% elif request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm" disabled="disabled">
                                 <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit All
@@ -40,14 +30,6 @@
         {% include table_template|default:'responsive_table.html' %}
         <div class="pull-left noprint">
             {% block extra_actions %}{% endblock %}
-            {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
-                <button type="submit"
-                        name="_add_to_static_group"
-                        formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
-                        class="btn btn-primary btn-sm">
-                    <span class="mdi mdi-group" aria-hidden="true"></span> Update Static Groups
-                </button>
-            {% endif %}
             {% if bulk_edit_url and permissions.change %}
                 <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm">
                     <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit Selected

--- a/nautobot/core/templates/utilities/obj_table.html
+++ b/nautobot/core/templates/utilities/obj_table.html
@@ -1,8 +1,9 @@
 {% load helpers %}
-{% if permissions.change or permissions.delete %}
+{% if permissions.change or permissions.delete or perms.extras.add_staticgroupassociation %}
     <form method="post" class="form form-horizontal">
         {% csrf_token %}
         <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
+        {% if content_type %}<input type="hidden" name="content_type" value="{{ content_type.pk }}">{% endif %}
         {% if table.paginator.num_pages > 1 %}
             <div id="select_all_box" class="hidden panel panel-default noprint">
                 <div class="panel-body">
@@ -13,6 +14,15 @@
                         </label>
                     </div>
                     <div class="pull-right">
+                        {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
+                            <button type="submit"
+                                    name="_add_to_static_group"
+                                    formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
+                                    class="btn btn-primary btn-sm"
+                                    disabled="disabled">
+                                <span class="mdi mdi-group" aria-hidden="true"></span> Update Static Groups for All
+                            </button>
+                        {% endif %}
                         {% if bulk_edit_url and permissions.change %}
                             <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if bulk_querystring %}?{{ bulk_querystring }}{% elif request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm" disabled="disabled">
                                 <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit All
@@ -30,6 +40,14 @@
         {% include table_template|default:'responsive_table.html' %}
         <div class="pull-left noprint">
             {% block extra_actions %}{% endblock %}
+            {% if content_type.model_class.is_static_group_associable_model and perms.extras.add_staticgroupassociation %}
+                <button type="submit"
+                        name="_add_to_static_group"
+                        formaction="{% url 'extras:staticgroup_bulk_assign' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
+                        class="btn btn-primary btn-sm">
+                    <span class="mdi mdi-group" aria-hidden="true"></span> Update Static Groups
+                </button>
+            {% endif %}
             {% if bulk_edit_url and permissions.change %}
                 <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm">
                     <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit Selected

--- a/nautobot/core/templates/utilities/templatetags/static_group_assignment_modal.html
+++ b/nautobot/core/templates/utilities/templatetags/static_group_assignment_modal.html
@@ -27,7 +27,7 @@
                     <button type="submit" class="btn btn-primary">
                         <span class="mdi mdi-group" aria-hidden="true"></span> Apply
                     </button>
-                    <button class="btn btn-default" data-dismiss="modal">
+                    <button type="button" class="btn btn-default" id="static_group_assignment_cancel">
                         <span class="mdi mdi-close-thick" aria-hidden="true"></span> Cancel
                     </button>
                 </div>

--- a/nautobot/core/templates/utilities/templatetags/static_group_assignment_modal.html
+++ b/nautobot/core/templates/utilities/templatetags/static_group_assignment_modal.html
@@ -1,0 +1,37 @@
+{% load form_helpers %}
+
+<div class="modal fade" tabindex="-1" role="dialog" id="static_group_assignment_modal">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type-"button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h4 class="modal-title">Static Group Assignment</h4>
+            </div>
+            <form id="static_group_assignment_form" action="{% url 'extras:staticgroup_bulk_assign' %}?"
+                  method="post" class="form form-horizontal">
+                <div class="modal-body">
+                    {% csrf_token %}
+                    <input type="hidden" name="return_url" value="{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}">
+                    <input type="hidden" id="static_group_assignment_all" name="_all">
+                    <span id="static_group_assignment_pks"></span>
+                    {% for field in form.hidden_fields %}
+                        {{ field }}
+                    {% endfor %}
+                    {% render_field form.create_and_assign_to_new_group_name %}
+                    {% render_field form.add_to_groups %}
+                    {% render_field form.remove_from_groups %}
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary">
+                        <span class="mdi mdi-group" aria-hidden="true"></span> Apply
+                    </button>
+                    <button class="btn btn-default" data-dismiss="modal">
+                        <span class="mdi mdi-close-thick" aria-hidden="true"></span> Cancel
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/nautobot/core/templates/utilities/templatetags/static_group_assignment_modal.html
+++ b/nautobot/core/templates/utilities/templatetags/static_group_assignment_modal.html
@@ -19,8 +19,8 @@
                     {% for field in form.hidden_fields %}
                         {{ field }}
                     {% endfor %}
-                    {% render_field form.create_and_assign_to_new_group_name %}
                     {% render_field form.add_to_groups %}
+                    {% render_field form.create_and_assign_to_new_group_name %}
                     {% render_field form.remove_from_groups %}
                 </div>
                 <div class="modal-footer">

--- a/nautobot/core/templatetags/form_helpers.py
+++ b/nautobot/core/templatetags/form_helpers.py
@@ -45,7 +45,7 @@ def render_form(form, excluded_fields=None):
     https://github.com/nautobot/nautobot/issues/4503
     """
     if excluded_fields is None:
-        excluded_fields = ["tags", "object_note"]
+        excluded_fields = ["tags", "static_groups", "object_note"]
 
     return {
         "form": form,

--- a/nautobot/core/templatetags/helpers.py
+++ b/nautobot/core/templatetags/helpers.py
@@ -714,6 +714,16 @@ def filter_form_modal(
     }
 
 
+@register.inclusion_tag("utilities/templatetags/static_group_assignment_modal.html")
+def static_group_assignment_modal(request, content_type):
+    from nautobot.extras.forms import StaticGroupBulkAssignForm
+
+    return {
+        "request": request,
+        "form": StaticGroupBulkAssignForm(model=content_type.model_class()),
+    }
+
+
 @register.inclusion_tag("utilities/templatetags/modal_form_as_dialog.html")
 def modal_form_as_dialog(form, editing=False, form_name=None, obj=None, obj_type=None):
     """Generate a form in a modal view.

--- a/nautobot/core/tests/test_forms.py
+++ b/nautobot/core/tests/test_forms.py
@@ -642,6 +642,7 @@ class DynamicFilterFormTest(TestCase):
                     ("id", "Id"),
                     ("last_updated", "Last updated"),
                     ("name", "Name"),
+                    ("static_groups", "Static groups (name or ID)"),
                 ],
             )
             self.assertEqual(
@@ -684,6 +685,7 @@ class DynamicFilterFormTest(TestCase):
                     ("racks", "Rack (name or ID)"),
                     ("rack_groups", "Rack groups (name or ID)"),
                     ("shipping_address", "Shipping address"),
+                    ("static_groups", "Static groups (name or ID)"),
                     ("status", "Status (name or ID)"),
                     ("vlans", "Tagged VLANs (VID or ID)"),
                     ("tags", "Tags"),
@@ -728,6 +730,7 @@ class DynamicFilterFormTest(TestCase):
                     ("id", "Id"),
                     ("last_updated", "Last updated"),
                     ("name", "Name"),
+                    ("static_groups", "Static groups (name or ID)"),
                 ],
             )
             self.assertEqual(

--- a/nautobot/core/tests/test_utils.py
+++ b/nautobot/core/tests/test_utils.py
@@ -6,12 +6,12 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.http import QueryDict
-from django.test import TestCase
 
 from nautobot.circuits import models as circuits_models
 from nautobot.core import exceptions, forms, settings_funcs
 from nautobot.core.api import utils as api_utils
 from nautobot.core.models import fields as core_fields, utils as models_utils
+from nautobot.core.testing import TestCase
 from nautobot.core.utils import data as data_utils, filtering, lookup, requests
 from nautobot.core.utils.migrations import update_object_change_ct_for_replaced_models
 from nautobot.dcim import filters as dcim_filters, forms as dcim_forms, models as dcim_models, tables
@@ -438,61 +438,61 @@ class LookupRelatedFunctionTest(TestCase):
             location_fields = ["comments", "name", "contact_email", "physical_address", "shipping_address"]
             for field_name in location_fields:
                 form_field = filtering.get_filterset_parameter_form_field(dcim_models.Location, field_name)
-                self.assertIs(type(form_field), forms.MultiValueCharField)
+                self.assertIsInstance(form_field, forms.MultiValueCharField)
 
             device_fields = ["serial", "name"]
             for field_name in device_fields:
                 form_field = filtering.get_filterset_parameter_form_field(dcim_models.Device, field_name)
-                self.assertIs(type(form_field), forms.MultiValueCharField)
+                self.assertIsInstance(form_field, forms.MultiValueCharField)
 
         with self.subTest("Test IntegerField"):
             form_field = filtering.get_filterset_parameter_form_field(dcim_models.Location, "asn")
-            self.assertIs(type(form_field), django_forms.IntegerField)
+            self.assertIsInstance(form_field, django_forms.IntegerField)
 
             device_fields = ["vc_position", "vc_priority"]
             for field_name in device_fields:
                 form_field = filtering.get_filterset_parameter_form_field(dcim_models.Device, field_name)
-                self.assertIs(type(form_field), django_forms.IntegerField)
+                self.assertIsInstance(form_field, django_forms.IntegerField)
 
         with self.subTest("Test DynamicModelMultipleChoiceField"):
             location_fields = ["tenant", "status"]
             for field_name in location_fields:
                 form_field = filtering.get_filterset_parameter_form_field(dcim_models.Location, field_name)
-                self.assertIs(type(form_field), forms.DynamicModelMultipleChoiceField)
+                self.assertIsInstance(form_field, forms.DynamicModelMultipleChoiceField)
 
             device_fields = ["cluster", "device_type", "location"]
             for field_name in device_fields:
                 form_field = filtering.get_filterset_parameter_form_field(dcim_models.Device, field_name)
-                self.assertIs(type(form_field), forms.DynamicModelMultipleChoiceField)
+                self.assertIsInstance(form_field, forms.DynamicModelMultipleChoiceField)
 
             location_fields = ["has_circuit_terminations", "has_devices"]
             for field_name in location_fields:
                 with self.subTest("Test ChoiceField", model=dcim_models.Location, field_name=field_name):
                     form_field = filtering.get_filterset_parameter_form_field(dcim_models.Location, field_name)
-                    self.assertIs(type(form_field), django_forms.ChoiceField)
-                    self.assertIs(type(form_field.widget), forms.StaticSelect2)
+                    self.assertIsInstance(form_field, django_forms.ChoiceField)
+                    self.assertIsInstance(form_field.widget, forms.StaticSelect2)
 
             device_fields = ["has_console_ports", "has_interfaces", "local_config_context_data"]
             for field_name in device_fields:
                 with self.subTest("Test ChoiceField", model=dcim_models.Device, field_name=field_name):
                     form_field = filtering.get_filterset_parameter_form_field(dcim_models.Device, field_name)
-                    self.assertIs(type(form_field), django_forms.ChoiceField)
-                    self.assertIs(type(form_field.widget), forms.StaticSelect2)
+                    self.assertIsInstance(form_field, django_forms.ChoiceField)
+                    self.assertIsInstance(form_field.widget, forms.StaticSelect2)
 
         with self.subTest("Test MultipleChoiceField"):
             form_field = filtering.get_filterset_parameter_form_field(dcim_models.Device, "face")
-            self.assertIs(type(form_field), django_forms.MultipleChoiceField)
+            self.assertIsInstance(form_field, django_forms.MultipleChoiceField)
 
         with self.subTest("Test DateTimePicker"):
             form_field = filtering.get_filterset_parameter_form_field(dcim_models.Location, "last_updated")
-            self.assertIs(type(form_field.widget), forms.DateTimePicker)
+            self.assertIsInstance(form_field.widget, forms.DateTimePicker)
 
             form_field = filtering.get_filterset_parameter_form_field(dcim_models.Device, "last_updated")
-            self.assertIs(type(form_field.widget), forms.DateTimePicker)
+            self.assertIsInstance(form_field.widget, forms.DateTimePicker)
 
         with self.subTest("Test DatePicker"):
             form_field = filtering.get_filterset_parameter_form_field(circuits_models.Circuit, "install_date")
-            self.assertIs(type(form_field.widget), forms.DatePicker)
+            self.assertIsInstance(form_field.widget, forms.DatePicker)
 
         with self.subTest("Test Invalid parameter"):
             with self.assertRaises(exceptions.FilterSetFieldNotFound) as err:
@@ -501,16 +501,18 @@ class LookupRelatedFunctionTest(TestCase):
 
         with self.subTest("Test Content types"):
             form_field = filtering.get_filterset_parameter_form_field(extras_models.Status, "content_types")
-            self.assertIs(type(form_field), forms.MultipleContentTypeField)
+            self.assertIsInstance(form_field, forms.MultipleContentTypeField)
 
             # Assert total ContentTypes generated by form_field is == total `content_types` generated by TaggableClassesQuery
             form_field = filtering.get_filterset_parameter_form_field(extras_models.Tag, "content_types")
-            self.assertIs(type(form_field), forms.MultipleContentTypeField)
-            self.assertEqual(form_field.queryset.count(), extras_utils.TaggableClassesQuery().as_queryset().count())
+            self.assertIsInstance(form_field, forms.MultipleContentTypeField)
+            self.assertQuerysetEqualAndNotEmpty(form_field.queryset, extras_utils.TaggableClassesQuery().as_queryset())
 
             form_field = filtering.get_filterset_parameter_form_field(extras_models.JobHook, "content_types")
-            self.assertIs(type(form_field), forms.MultipleContentTypeField)
-            self.assertEqual(form_field.queryset.count(), extras_utils.ChangeLoggedModelsQuery().as_queryset().count())
+            self.assertIsInstance(form_field, forms.MultipleContentTypeField)
+            self.assertQuerysetEqualAndNotEmpty(
+                form_field.queryset, extras_utils.ChangeLoggedModelsQuery().as_queryset()
+            )
 
     def test_convert_querydict_to_factory_formset_dict(self):
         location_filter_set = dcim_filters.LocationFilterSet()

--- a/nautobot/core/utils/lookup.py
+++ b/nautobot/core/utils/lookup.py
@@ -208,6 +208,21 @@ def get_view_for_model(model, view_type=""):
     return result
 
 
+def get_model_for_view_name(view_name):
+    """
+    Return the model class associated with the given view_name e.g. "circuits:circuit_detail", "dcim:device_list" and etc.
+    If the app_label or model_name contained by the given view_name is invalid, this will return `None`.
+    """
+    app_label, model_name = view_name.split(":")  # dcim, device_list
+    model_name = model_name.split("_")[0]  # device
+
+    try:
+        model = apps.get_model(app_label=app_label, model_name=model_name)
+        return model
+    except LookupError:
+        return None
+
+
 def get_created_and_last_updated_usernames_for_model(instance):
     """
     Args:

--- a/nautobot/core/utils/lookup.py
+++ b/nautobot/core/utils/lookup.py
@@ -224,8 +224,9 @@ def get_created_and_last_updated_usernames_for_model(instance):
     created_by = None
     last_updated_by = None
     try:
-        created_by_record = object_change_records.get(action=ObjectChangeActionChoices.ACTION_CREATE)
-        created_by = created_by_record.user_name
+        created_by_record = object_change_records.filter(action=ObjectChangeActionChoices.ACTION_CREATE).first()
+        if created_by_record is not None:
+            created_by = created_by_record.user_name
     except ObjectChange.DoesNotExist:
         pass
 

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -14,7 +14,7 @@ from django.core.exceptions import (
 from django.db import IntegrityError, transaction
 from django.db.models import ManyToManyField, ProtectedError
 from django.forms import Form, ModelMultipleChoiceField, MultipleHiddenInput
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.encoding import iri_to_uri
 from django.utils.html import format_html
@@ -38,7 +38,6 @@ from nautobot.core.forms import (
 from nautobot.core.forms.forms import DynamicFilterFormSet
 from nautobot.core.templatetags.helpers import bettertitle, validated_viewname
 from nautobot.core.utils.config import get_settings_or_config
-from nautobot.core.utils.lookup import get_created_and_last_updated_usernames_for_model
 from nautobot.core.utils.permissions import get_permission_for_model
 from nautobot.core.utils.requests import (
     convert_querydict_to_factory_formset_acceptable_querydict,
@@ -49,14 +48,14 @@ from nautobot.core.views.mixins import GetReturnURLMixin, ObjectPermissionRequir
 from nautobot.core.views.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.core.views.utils import (
     check_filter_for_display,
+    common_detail_view_context,
     get_csv_form_fields_from_serializer_class,
     handle_protectederror,
     import_csv_helper,
     prepare_cloned_fields,
 )
 from nautobot.extras.context_managers import deferred_change_logging_for_bulk_operation
-from nautobot.extras.models import ContactAssociation, ExportTemplate
-from nautobot.extras.tables import AssociatedContactsTable, StaticGroupTable
+from nautobot.extras.models import ExportTemplate
 from nautobot.extras.utils import bulk_delete_with_bulk_change_logging, remove_prefix_from_cf_key
 
 
@@ -111,61 +110,17 @@ class ObjectView(ObjectPermissionRequiredMixin, View):
         Generic GET handler for accessing an object.
         """
         instance = get_object_or_404(self.queryset, **kwargs)
-        # Get the ObjectChange records to populate the advanced tab information
-        created_by, last_updated_by = get_created_and_last_updated_usernames_for_model(instance)
+        content_type = ContentType.objects.get_for_model(self.queryset.model)
+        context = {
+            "object": instance,
+            "content_type": content_type,
+            "verbose_name": self.queryset.model._meta.verbose_name,
+            "verbose_name_plural": self.queryset.model._meta.verbose_name_plural,
+            **common_detail_view_context(request, instance),
+            **self.get_extra_context(request, instance),
+        }
 
-        # TODO: this feels inelegant - should the tabs lookup be a dedicated endpoint rather than piggybacking
-        # on the object-retrieve endpoint?
-        # TODO: similar functionality probably needed in NautobotUIViewSet as well, not currently present
-        if request.GET.get("viewconfig", None) == "true":
-            # TODO: we shouldn't be importing a private-named function from another module. Should it be renamed?
-            from nautobot.extras.templatetags.plugins import _get_registered_content
-
-            temp_fake_context = {
-                "object": instance,
-                "request": request,
-                "settings": {},
-                "csrf_token": "",
-                "perms": {},
-            }
-
-            plugin_tabs = _get_registered_content(instance, "detail_tabs", temp_fake_context, return_html=False)
-            resp = {"tabs": plugin_tabs}
-            return JsonResponse(resp)
-        else:
-            content_type = ContentType.objects.get_for_model(self.queryset.model)
-            context = {
-                "object": instance,
-                "content_type": content_type,
-                "verbose_name": self.queryset.model._meta.verbose_name,
-                "verbose_name_plural": self.queryset.model._meta.verbose_name_plural,
-                "created_by": created_by,
-                "last_updated_by": last_updated_by,
-                **self.get_extra_context(request, instance),
-            }
-            if instance.is_contact_associable_model:
-                paginate = {"paginator_class": EnhancedPaginator, "per_page": get_paginate_count(request)}
-                associations = (
-                    ContactAssociation.objects.filter(
-                        associated_object_id=instance.id,
-                        associated_object_type=content_type,
-                    )
-                    .restrict(request.user, "view")
-                    .order_by("role__name")
-                )
-                associations_table = AssociatedContactsTable(associations, orderable=False)
-                RequestConfig(request, paginate).configure(associations_table)
-                associations_table.columns.show("pk")
-                context["associated_contacts_table"] = associations_table
-            if instance.is_static_group_associable_model:
-                paginate = {"paginator_class": EnhancedPaginator, "per_page": get_paginate_count(request)}
-                static_groups = instance.static_groups.restrict(request.user, "view")
-                static_groups_table = StaticGroupTable(static_groups, orderable=False)
-                RequestConfig(request, paginate).configure(static_groups_table)
-                static_groups_table.columns.show("pk")
-                context["associated_static_groups_table"] = static_groups_table
-
-            return render(request, self.get_template_name(), context)
+        return render(request, self.get_template_name(), context)
 
 
 class ObjectListView(ObjectPermissionRequiredMixin, View):

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -56,7 +56,7 @@ from nautobot.core.views.utils import (
 )
 from nautobot.extras.context_managers import deferred_change_logging_for_bulk_operation
 from nautobot.extras.models import ContactAssociation, ExportTemplate
-from nautobot.extras.tables import AssociatedContactsTable
+from nautobot.extras.tables import AssociatedContactsTable, StaticGroupTable
 from nautobot.extras.utils import bulk_delete_with_bulk_change_logging, remove_prefix_from_cf_key
 
 
@@ -157,6 +157,14 @@ class ObjectView(ObjectPermissionRequiredMixin, View):
                 RequestConfig(request, paginate).configure(associations_table)
                 associations_table.columns.show("pk")
                 context["associated_contacts_table"] = associations_table
+            if instance.is_static_group_associable_model:
+                paginate = {"paginator_class": EnhancedPaginator, "per_page": get_paginate_count(request)}
+                static_groups = instance.static_groups.restrict(request.user, "view")
+                static_groups_table = StaticGroupTable(static_groups, orderable=False)
+                RequestConfig(request, paginate).configure(static_groups_table)
+                static_groups_table.columns.show("pk")
+                context["associated_static_groups_table"] = static_groups_table
+
             return render(request, self.get_template_name(), context)
 
 

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -23,7 +23,7 @@ from nautobot.core.utils.requests import (
 from nautobot.core.views.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.core.views.utils import check_filter_for_display, get_csv_form_fields_from_serializer_class
 from nautobot.extras.models.change_logging import ObjectChange
-from nautobot.extras.tables import AssociatedContactsTable
+from nautobot.extras.tables import AssociatedContactsTable, StaticGroupTable
 from nautobot.extras.utils import get_base_template
 
 
@@ -251,6 +251,13 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
                 context["associated_contacts_table"] = associations_table
             else:
                 context["associated_contacts_table"] = None
+            if instance.is_static_group_associable_model:
+                paginate = {"paginator_class": EnhancedPaginator, "per_page": get_paginate_count(request)}
+                static_groups = instance.static_groups.restrict(request.user, "view")
+                static_groups_table = StaticGroupTable(static_groups, orderable=False)
+                RequestConfig(request, paginate).configure(static_groups_table)
+                static_groups_table.columns.show("pk")
+                context["associated_static_groups_table"] = static_groups_table
             context.update(view.get_extra_context(request, instance))
         else:
             if view.action == "list":

--- a/nautobot/dcim/homepage.py
+++ b/nautobot/dcim/homepage.py
@@ -39,7 +39,7 @@ layout = (
                 model=models.Location,
                 description="Hierarchical geographic locations",
                 permissions=["dcim.view_location"],
-                weight=200,
+                weight=100,
             ),
         ),
     ),

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -48,7 +48,6 @@ from .template_code import (
     INTERFACE_REDUNDANCY_GROUP_INTERFACES_IPADDRESSES,
     INTERFACE_REDUNDANCY_INTERFACE_PRIORITY,
     INTERFACE_TAGGED_VLANS,
-    LINKED_RECORD_COUNT,
     PATHENDPOINT,
     POWEROUTLET_BUTTONS,
     POWERPORT_BUTTONS,
@@ -940,8 +939,9 @@ class VirtualChassisTable(BaseTable):
 class DeviceRedundancyGroupTable(BaseTable):
     pk = ToggleColumn()
     name = tables.Column(linkify=True)
-    device_count = tables.TemplateColumn(
-        template_code=LINKED_RECORD_COUNT,
+    device_count = LinkedCountColumn(
+        viewname="dcim:device_list",
+        url_params={"device_redundancy_group": "pk"},
         verbose_name="Devices",
     )
     secrets_group = tables.Column(linkify=True)
@@ -1188,7 +1188,11 @@ class ControllerManagedDeviceGroupTable(BaseTable):
     controller = tables.Column(linkify=True)
     tags = TagColumn(url_name="dcim:controllermanageddevicegroup_list")
     actions = ButtonsColumn(ControllerManagedDeviceGroup)
-    device_count = tables.TemplateColumn(template_code=LINKED_RECORD_COUNT, verbose_name="Devices")
+    device_count = LinkedCountColumn(
+        viewname="dcim:device_list",
+        url_params={"controller_managed_device_group": "pk"},
+        verbose_name="Devices",
+    )
 
     class Meta(BaseTable.Meta):
         """Meta attributes."""

--- a/nautobot/dcim/tables/devicetypes.py
+++ b/nautobot/dcim/tables/devicetypes.py
@@ -45,9 +45,21 @@ __all__ = (
 class ManufacturerTable(BaseTable):
     pk = ToggleColumn()
     name = tables.LinkColumn()
-    device_type_count = tables.Column(verbose_name="Device Types")
-    inventory_item_count = tables.Column(verbose_name="Inventory Items")
-    platform_count = tables.Column(verbose_name="Platforms")
+    device_type_count = LinkedCountColumn(
+        viewname="dcim:devicetype_list",
+        url_params={"manufacturer": "pk"},
+        verbose_name="Device Types",
+    )
+    inventory_item_count = LinkedCountColumn(
+        viewname="dcim:inventoryitem_list",
+        url_params={"manufacturer": "pk"},
+        verbose_name="Inventory Items",
+    )
+    platform_count = LinkedCountColumn(
+        viewname="dcim:platform_list",
+        url_params={"manufacturer": "pk"},
+        verbose_name="Platforms",
+    )
     actions = ButtonsColumn(Manufacturer)
 
     class Meta(BaseTable.Meta):
@@ -71,7 +83,11 @@ class ManufacturerTable(BaseTable):
 class DeviceFamilyTable(BaseTable):
     pk = ToggleColumn()
     name = tables.Column(linkify=True)
-    device_type_count = tables.Column(verbose_name="Device Types")
+    device_type_count = LinkedCountColumn(
+        viewname="dcim:devicetype_list",
+        url_params={"device_family": "pk"},
+        verbose_name="Device Types",
+    )
     actions = ButtonsColumn(DeviceFamily)
     tags = TagColumn(url_name="dcim:devicefamily_list")
 

--- a/nautobot/dcim/tables/racks.py
+++ b/nautobot/dcim/tables/racks.py
@@ -31,7 +31,11 @@ class RackGroupTable(BaseTable):
     pk = ToggleColumn()
     name = tables.TemplateColumn(template_code=TREE_LINK, attrs={"td": {"class": "text-nowrap"}})
     location = tables.Column(linkify=True)
-    rack_count = tables.Column(verbose_name="Racks")
+    rack_count = LinkedCountColumn(
+        viewname="dcim:rack_list",
+        url_params={"rack_group": "pk"},
+        verbose_name="Racks",
+    )
     actions = ButtonsColumn(model=RackGroup, prepend_template=RACKGROUP_ELEVATIONS)
 
     class Meta(BaseTable.Meta):

--- a/nautobot/dcim/templates/dcim/device.html
+++ b/nautobot/dcim/templates/dcim/device.html
@@ -403,6 +403,28 @@
             </div>
         </div>
     </div>
-</div>
 {% endif %}
+{% if object.is_static_group_associable_model and perms.extras.view_staticgroup %}
+    <div id="static_groups" role="tabpanel" class="tab-pane {% if request.GET.tab == 'static_groups' %}active{% else %}fade{% endif %}">
+        <div class="row">
+            <div class="col-md-12">
+                <form method="post">
+                    {% csrf_token %}
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <strong>Static Groups</strong>
+                            <div class="pull-right noprint">
+                                <!-- Insert table config button here -->
+                            </div>
+                        </div>
+                        <div class="table-responsive">
+                            {% render_table associated_static_groups_table 'inc/table.html' %}
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endif %}
+</div>
 {% endblock content %}

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -468,7 +468,7 @@ class MigrateLocationDataToContactView(generic.ObjectEditView):
 
 
 class RackGroupListView(generic.ObjectListView):
-    queryset = RackGroup.objects.annotate(rack_count=count_related(Rack, "rack_group"))
+    queryset = RackGroup.objects.all()
     filterset = filters.RackGroupFilterSet
     filterset_form = forms.RackGroupFilterForm
     table = tables.RackGroupTable
@@ -514,7 +514,7 @@ class RackGroupBulkImportView(generic.BulkImportView):  # 3.0 TODO: remove, unus
 
 
 class RackGroupBulkDeleteView(generic.BulkDeleteView):
-    queryset = RackGroup.objects.annotate(rack_count=count_related(Rack, "rack_group")).select_related("location")
+    queryset = RackGroup.objects.all()
     filterset = filters.RackGroupFilterSet
     table = tables.RackGroupTable
 
@@ -525,7 +525,7 @@ class RackGroupBulkDeleteView(generic.BulkDeleteView):
 
 
 class RackListView(generic.ObjectListView):
-    queryset = Rack.objects.annotate(device_count=count_related(Device, "rack"))
+    queryset = Rack.objects.all()
     filterset = filters.RackFilterSet
     filterset_form = forms.RackFilterForm
     table = tables.RackDetailTable
@@ -634,14 +634,14 @@ class RackBulkImportView(generic.BulkImportView):  # 3.0 TODO: remove, unused
 
 
 class RackBulkEditView(generic.BulkEditView):
-    queryset = Rack.objects.select_related("location", "rack_group", "tenant", "role")
+    queryset = Rack.objects.all()
     filterset = filters.RackFilterSet
     table = tables.RackTable
     form = forms.RackBulkEditForm
 
 
 class RackBulkDeleteView(generic.BulkDeleteView):
-    queryset = Rack.objects.select_related("location", "rack_group", "tenant", "role")
+    queryset = Rack.objects.all()
     filterset = filters.RackFilterSet
     table = tables.RackTable
 
@@ -703,11 +703,7 @@ class RackReservationBulkDeleteView(generic.BulkDeleteView):
 
 
 class ManufacturerListView(generic.ObjectListView):
-    queryset = Manufacturer.objects.annotate(
-        device_type_count=count_related(DeviceType, "manufacturer"),
-        inventory_item_count=count_related(InventoryItem, "manufacturer"),
-        platform_count=count_related(Platform, "manufacturer"),
-    )
+    queryset = Manufacturer.objects.all()
     filterset = filters.ManufacturerFilterSet
     table = tables.ManufacturerTable
 
@@ -751,7 +747,7 @@ class ManufacturerBulkImportView(generic.BulkImportView):  # 3.0 TODO: remove, u
 
 
 class ManufacturerBulkDeleteView(generic.BulkDeleteView):
-    queryset = Manufacturer.objects.annotate(device_type_count=count_related(DeviceType, "manufacturer"))
+    queryset = Manufacturer.objects.all()
     table = tables.ManufacturerTable
     filterset = filters.ManufacturerFilterSet
 
@@ -762,7 +758,7 @@ class ManufacturerBulkDeleteView(generic.BulkDeleteView):
 
 
 class DeviceTypeListView(generic.ObjectListView):
-    queryset = DeviceType.objects.annotate(device_count=count_related(Device, "device_type"))
+    queryset = DeviceType.objects.all()
     filterset = filters.DeviceTypeFilterSet
     filterset_form = forms.DeviceTypeFilterForm
     table = tables.DeviceTypeTable
@@ -881,22 +877,14 @@ class DeviceTypeImportView(generic.ObjectImportView):
 
 
 class DeviceTypeBulkEditView(generic.BulkEditView):
-    queryset = (
-        DeviceType.objects.select_related("manufacturer")
-        .prefetch_related("software_image_files")
-        .annotate(device_count=count_related(Device, "device_type"))
-    )
+    queryset = DeviceType.objects.all()
     filterset = filters.DeviceTypeFilterSet
     table = tables.DeviceTypeTable
     form = forms.DeviceTypeBulkEditForm
 
 
 class DeviceTypeBulkDeleteView(generic.BulkDeleteView):
-    queryset = (
-        DeviceType.objects.select_related("manufacturer")
-        .prefetch_related("software_image_files")
-        .annotate(device_count=count_related(Device, "device_type"))
-    )
+    queryset = DeviceType.objects.all()
     filterset = filters.DeviceTypeFilterSet
     table = tables.DeviceTypeTable
 
@@ -1207,10 +1195,7 @@ class DeviceBayTemplateBulkDeleteView(generic.BulkDeleteView):
 
 
 class PlatformListView(generic.ObjectListView):
-    queryset = Platform.objects.annotate(
-        device_count=count_related(Device, "platform"),
-        virtual_machine_count=count_related(VirtualMachine, "platform"),
-    )
+    queryset = Platform.objects.all()
     filterset = filters.PlatformFilterSet
     table = tables.PlatformTable
 
@@ -2686,7 +2671,7 @@ class InterfaceConnectionsListView(ConnectionsListView):
 
 
 class VirtualChassisListView(generic.ObjectListView):
-    queryset = VirtualChassis.objects.annotate(member_count=count_related(Device, "virtual_chassis"))
+    queryset = VirtualChassis.objects.all()
     table = tables.VirtualChassisTable
     filterset = filters.VirtualChassisFilterSet
     filterset_form = forms.VirtualChassisFilterForm
@@ -2924,7 +2909,7 @@ class VirtualChassisBulkDeleteView(generic.BulkDeleteView):
 
 
 class PowerPanelListView(generic.ObjectListView):
-    queryset = PowerPanel.objects.annotate(power_feed_count=count_related(PowerFeed, "power_panel"))
+    queryset = PowerPanel.objects.all()
     filterset = filters.PowerPanelFilterSet
     filterset_form = forms.PowerPanelFilterForm
     table = tables.PowerPanelTable
@@ -2966,9 +2951,7 @@ class PowerPanelBulkEditView(generic.BulkEditView):
 
 
 class PowerPanelBulkDeleteView(generic.BulkDeleteView):
-    queryset = PowerPanel.objects.select_related("location", "rack_group").annotate(
-        power_feed_count=count_related(PowerFeed, "power_panel")
-    )
+    queryset = PowerPanel.objects.all()
     filterset = filters.PowerPanelFilterSet
     table = tables.PowerPanelTable
 
@@ -3022,11 +3005,7 @@ class DeviceRedundancyGroupUIViewSet(NautobotUIViewSet):
     filterset_class = filters.DeviceRedundancyGroupFilterSet
     filterset_form_class = forms.DeviceRedundancyGroupFilterForm
     form_class = forms.DeviceRedundancyGroupForm
-    queryset = (
-        DeviceRedundancyGroup.objects.select_related("status")
-        .prefetch_related("devices")
-        .annotate(device_count=count_related(Device, "device_redundancy_group"))
-    )
+    queryset = DeviceRedundancyGroup.objects.all()
     serializer_class = serializers.DeviceRedundancyGroupSerializer
     table_class = tables.DeviceRedundancyGroupTable
 
@@ -3048,11 +3027,7 @@ class InterfaceRedundancyGroupUIViewSet(NautobotUIViewSet):
     filterset_class = filters.InterfaceRedundancyGroupFilterSet
     filterset_form_class = forms.InterfaceRedundancyGroupFilterForm
     form_class = forms.InterfaceRedundancyGroupForm
-    queryset = InterfaceRedundancyGroup.objects.select_related("status")
-    queryset = queryset.prefetch_related("interfaces")
-    queryset = queryset.annotate(
-        interface_count=count_related(Interface, "interface_redundancy_groups"),
-    )
+    queryset = InterfaceRedundancyGroup.objects.all()
     serializer_class = serializers.InterfaceRedundancyGroupSerializer
     table_class = tables.InterfaceRedundancyGroupTable
     lookup_field = "pk"
@@ -3102,7 +3077,7 @@ class DeviceFamilyUIViewSet(NautobotUIViewSet):
     filterset_class = filters.DeviceFamilyFilterSet
     form_class = forms.DeviceFamilyForm
     bulk_update_form_class = forms.DeviceFamilyBulkEditForm
-    queryset = DeviceFamily.objects.annotate(device_type_count=count_related(DeviceType, "device_family"))
+    queryset = DeviceFamily.objects.all()
     serializer_class = serializers.DeviceFamilySerializer
     table_class = tables.DeviceFamilyTable
     lookup_field = "pk"
@@ -3145,7 +3120,7 @@ class SoftwareImageFileUIViewSet(NautobotUIViewSet):
     filterset_form_class = forms.SoftwareImageFileFilterForm
     form_class = forms.SoftwareImageFileForm
     bulk_update_form_class = forms.SoftwareImageFileBulkEditForm
-    queryset = SoftwareImageFile.objects.annotate(device_type_count=count_related(DeviceType, "software_image_files"))
+    queryset = SoftwareImageFile.objects.all()
 
     serializer_class = serializers.SoftwareImageFileSerializer
     table_class = tables.SoftwareImageFileTable
@@ -3156,11 +3131,7 @@ class SoftwareVersionUIViewSet(NautobotUIViewSet):
     filterset_form_class = forms.SoftwareVersionFilterForm
     form_class = forms.SoftwareVersionForm
     bulk_update_form_class = forms.SoftwareVersionBulkEditForm
-    queryset = SoftwareVersion.objects.annotate(
-        software_image_file_count=count_related(SoftwareImageFile, "software_version"),
-        device_count=count_related(Device, "software_version"),
-        inventory_item_count=count_related(InventoryItem, "software_version"),
-    )
+    queryset = SoftwareVersion.objects.all()
     serializer_class = serializers.SoftwareVersionSerializer
     table_class = tables.SoftwareVersionTable
 
@@ -3203,11 +3174,7 @@ class ControllerManagedDeviceGroupUIViewSet(NautobotUIViewSet):
     filterset_form_class = forms.ControllerManagedDeviceGroupFilterForm
     form_class = forms.ControllerManagedDeviceGroupForm
     bulk_update_form_class = forms.ControllerManagedDeviceGroupBulkEditForm
-    queryset = (
-        ControllerManagedDeviceGroup.objects.all()
-        .prefetch_related("devices")
-        .annotate(device_count=count_related(Device, "controller_managed_device_group"))
-    )
+    queryset = ControllerManagedDeviceGroup.objects.all()
     serializer_class = serializers.ControllerManagedDeviceGroupSerializer
     table_class = tables.ControllerManagedDeviceGroupTable
     template_name = "dcim/controllermanageddevicegroup_create.html"

--- a/nautobot/docs/user-guide/core-data-model/tenancy/tenant.md
+++ b/nautobot/docs/user-guide/core-data-model/tenancy/tenant.md
@@ -1,18 +1,19 @@
 # Tenants
 
-A tenant represents a discrete grouping of resources used for administrative purposes. Typically, tenants are used to represent individual customers or internal departments within an organization. The following objects can be assigned to tenants:
+A tenant represents a discrete grouping of resources used for administrative purposes. Typically, tenants are used to represent individual customers or internal departments within an organization. Many object types can be assigned to tenants, including:
 
-* Locations
-* Racks
-* Rack reservations
-* Devices
-* VRFs
-* Prefixes
-* IP addresses
-* VLANs
 * Circuits
 * Clusters
+* Devices
+* IP addresses
+* Locations
+* Prefixes
+* Racks
+* Rack reservations
+* Static groups
 * Virtual machines
+* VLANs
+* VRFs
 
 Tenant assignment is used to signify the ownership of an object in Nautobot. As such, each object may only be owned by a single tenant. For example, if you have a firewall dedicated to a particular customer, you would assign it to the tenant which represents that customer. However, if the firewall serves multiple customers, it doesn't *belong* to any particular customer, so tenant assignment would not be appropriate.
 

--- a/nautobot/docs/user-guide/platform-functionality/staticgroup.md
+++ b/nautobot/docs/user-guide/platform-functionality/staticgroup.md
@@ -6,9 +6,9 @@ Static Groups provide a way to organize objects (of a single Content Type). They
 
 A given Static Group may contain any number of objects of the appropriate type as members, and an object may belong to any number of Static Groups of the appropriate content-type as a member of each.
 
-When creating a Static Group, you must provide a unique name for the group and define the Content Type of objects that it contains, for example `dcim.device`. You can also optionally provide a description for the group and apply [Tags](tag.md) to it.
+When creating a Static Group, you must provide a unique name for the group and define the Content Type of objects that it contains, for example `dcim.device`. You can also optionally provide a description for the group, assign it to a [Tenant](../core-data-model/tenancy/tenant.md) and/or apply [Tags](tag.md) to it.
 
-Once created, the Content Type for a Static Group may not be changed, as doing so would invalidate any existing members of this group. The name, description, and tags may be updated if desired.
+Once created, the Content Type for a Static Group may not be changed, as doing so would invalidate any existing members of this group. The name, description, tenant, and tags may be updated if desired.
 
 Each association of a given object into a given Static Group is recorded by a [Static Group Association](staticgroupassociation.md) database record.
 

--- a/nautobot/docs/user-guide/platform-functionality/staticgroup.md
+++ b/nautobot/docs/user-guide/platform-functionality/staticgroup.md
@@ -10,7 +10,7 @@ When creating a Static Group, you must provide a unique name for the group and d
 
 Once created, the Content Type for a Static Group may not be changed, as doing so would invalidate any existing members of this group. The name, description, tenant, and tags may be updated if desired.
 
-Each association of a given object into a given Static Group is recorded by a [Static Group Association](staticgroupassociation.md) database record.
+Each association of a given object into a given Static Group is recorded by a [Static Group Association](staticgroupassociation.md) database record. Individual objects can be associated to Static Groups in their create/edit form, but in most cases it's easier and quicker to bulk-update a set of objects from their appropriate list/table view via the "Update Static Groups" button.
 
 ## REST API
 
@@ -22,15 +22,15 @@ As in the database itself, in the REST API, assignment of individual objects to 
 
 From a given `StaticGroup` record, the following Python APIs are available:
 
-* `group.members` - returns a `QuerySet` directly representing the objects (for example, a `QuerySet` of `Prefix` records for a Static Group of Prefixes) that are members of this group
-* `group.static_group_associations` - returns a `QuerySet` of `StaticGroupAssociation` records representing the assignment of objects to this group
-* `group.add_members(list_or_queryset)` - associate the given objects to this group as members by creating the appropriate `StaticGroupAssociation` database records
-* `group.remove_members(list_or_queryset)` - disassociate the given objects from this group by deleting any appropriate `StaticGroupAssociation` database records
+* `group.members` - returns a `QuerySet` directly representing the objects (for example, a `QuerySet` of `Prefix` records for a Static Group of Prefixes) that are members of this group. Can also be set by providing either a list or `QuerySet` of appropriate objects -- doing so will replace all assigned group members with the provided objects, so in many cases you may prefer to use the `add_members` and `remove_members` APIs below instead.
+* `group.static_group_associations` - returns a `QuerySet` of `StaticGroupAssociation` records representing the assignment of objects to this group.
+* `group.add_members(list_or_queryset)` - associate the given objects to this group as members by creating the appropriate `StaticGroupAssociation` database records.
+* `group.remove_members(list_or_queryset)` - disassociate the given objects from this group by deleting any appropriate `StaticGroupAssociation` database records.
 
 From a given record of any object type that can be a member of a Static Group, the following Python APIs are available:
 
-* `object.static_groups` - returns a `QuerySet` directly representing the `StaticGroup` records that contain this object as a member
-* `object.associated_static_groups` - returns a `QuerySet` of `StaticGroupAssociation` records representing the assignment of this object to static groups
+* `object.static_groups` - returns a `QuerySet` directly representing the `StaticGroup` records that contain this object as a member.
+* `object.associated_static_groups` - returns a `QuerySet` of `StaticGroupAssociation` records representing the assignment of this object to static groups.
 
 !!! tip
-    By default, all models inheriting from Nautobot's `OrganizationalModel` or `PrimaryModel` classes are assumed to be a viable object type for Static Groups to contain. Individual models that do not wish to be assignable to Static Groups can declare the flag `is_static_group_associable_model = False` on their model definition.
+    By default, all models inheriting from Nautobot's `OrganizationalModel` or `PrimaryModel` classes are assumed to be a viable object type for Static Groups to contain. Individual models that do not wish to be assignable to Static Groups can declare the flag `is_static_group_associable_model = False` on their model definition. Conversely, models that inherit directly from Nautobot's `BaseModel` default to *not* supporting Static Groups, but can include the `nautobot.apps.models.StaticGroupMixin` class as a part of their class definition in order to enable Static Group support.

--- a/nautobot/extras/factory.py
+++ b/nautobot/extras/factory.py
@@ -45,6 +45,7 @@ from nautobot.extras.utils import (
     RoleModelsQuery,
     TaggableClassesQuery,
 )
+from nautobot.tenancy.models import Tenant
 
 
 class ContactFactory(PrimaryModelFactory):
@@ -311,7 +312,7 @@ class StaticGroupFactory(PrimaryModelFactory):
 
     class Meta:
         model = StaticGroup
-        exclude = ("color", "has_description")
+        exclude = ("color", "has_description", "has_tenant")
 
     color = factory.Faker("safe_color_name")
     content_type = random_instance(
@@ -322,6 +323,8 @@ class StaticGroupFactory(PrimaryModelFactory):
     )
     has_description = NautobotBoolIterator()
     description = factory.Maybe("has_description", factory.Faker("text", max_nb_chars=CHARFIELD_MAX_LENGTH), "")
+    has_tenant = NautobotBoolIterator()
+    tenant = factory.Maybe("has_tenant", random_instance(Tenant))
 
     @factory.post_generation
     def members(self, created, extracted, **kwargs):

--- a/nautobot/extras/factory.py
+++ b/nautobot/extras/factory.py
@@ -314,12 +314,12 @@ class StaticGroupFactory(PrimaryModelFactory):
         model = StaticGroup
         exclude = ("color", "has_description", "has_tenant")
 
-    color = factory.Faker("safe_color_name")
+    color = UniqueFaker("color_name")
     content_type = random_instance(
         lambda: ContentType.objects.filter(FeatureQuery("static_groups").get_query()), allow_null=False
     )
     name = factory.LazyAttribute(
-        lambda o: f"{o.color.title()} {bettertitle(o.content_type.model_class()._meta.verbose_name_plural)}"
+        lambda o: f"{o.color} {bettertitle(o.content_type.model_class()._meta.verbose_name_plural)}"
     )
     has_description = NautobotBoolIterator()
     description = factory.Maybe("has_description", factory.Faker("text", max_nb_chars=CHARFIELD_MAX_LENGTH), "")

--- a/nautobot/extras/filters/__init__.py
+++ b/nautobot/extras/filters/__init__.py
@@ -355,6 +355,7 @@ class ContentTypeFilterSet(BaseFilterSet):
     has_serializer = django_filters.BooleanFilter(
         method="_has_serializer", label="A REST API serializer exists for this type"
     )
+    feature = django_filters.CharFilter(method="_feature", label="Objects of this type support the named feature")
 
     class Meta:
         model = ContentType
@@ -398,6 +399,9 @@ class ContentTypeFilterSet(BaseFilterSet):
             return queryset.filter(pk__in=ct_pks)
         else:
             return queryset.exclude(pk__in=ct_pks)
+
+    def _feature(self, queryset, name, value):
+        return queryset.filter(FeatureQuery(value).get_query())
 
 
 # TODO: remove in 2.2

--- a/nautobot/extras/filters/__init__.py
+++ b/nautobot/extras/filters/__init__.py
@@ -1119,8 +1119,11 @@ class SecretsGroupAssociationFilterSet(BaseFilterSet):
 # StaticGroups
 #
 
+# Must be imported **after* NautobotFilterSet class is defined to avoid a circular import loop.
+from nautobot.tenancy.filters.mixins import TenancyModelFilterSetMixin  # noqa: E402
 
-class StaticGroupFilterSet(NautobotFilterSet):
+
+class StaticGroupFilterSet(TenancyModelFilterSetMixin, NautobotFilterSet):
     q = SearchFilter(
         filter_predicates={
             "name": "icontains",
@@ -1133,12 +1136,6 @@ class StaticGroupFilterSet(NautobotFilterSet):
     member_id = MultiValueUUIDFilter(
         field_name="static_group_associations__associated_object_id",
         label="Group member ID",
-    )
-    tenant = NaturalKeyOrPKMultipleChoiceFilter(
-        field_name="tenant",
-        queryset=Tenant.objects.all(),
-        label="Tenant (ID or name)",
-        to_field_name="name",
     )
 
     class Meta:

--- a/nautobot/extras/filters/__init__.py
+++ b/nautobot/extras/filters/__init__.py
@@ -1130,6 +1130,10 @@ class StaticGroupFilterSet(NautobotFilterSet):
         },
     )
     content_type = ContentTypeMultipleChoiceFilter(choices=FeatureQuery("static_groups").get_choices, conjoined=False)
+    member_id = MultiValueUUIDFilter(
+        field_name="static_group_associations__associated_object_id",
+        label="Group member ID",
+    )
     tenant = NaturalKeyOrPKMultipleChoiceFilter(
         field_name="tenant",
         queryset=Tenant.objects.all(),

--- a/nautobot/extras/filters/__init__.py
+++ b/nautobot/extras/filters/__init__.py
@@ -1130,6 +1130,12 @@ class StaticGroupFilterSet(NautobotFilterSet):
         },
     )
     content_type = ContentTypeMultipleChoiceFilter(choices=FeatureQuery("static_groups").get_choices, conjoined=False)
+    tenant = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="tenant",
+        queryset=Tenant.objects.all(),
+        label="Tenant (ID or name)",
+        to_field_name="name",
+    )
 
     class Meta:
         model = StaticGroup

--- a/nautobot/extras/filters/mixins.py
+++ b/nautobot/extras/filters/mixins.py
@@ -303,7 +303,17 @@ class RoleModelFilterSetMixin(django_filters.FilterSet):
     Mixin to add a `role` filter field to a FilterSet.
     """
 
-    role = RoleFilter()
+    @classmethod
+    def get_filters(cls):
+        filters = super().get_filters()
+
+        if cls._meta.model is not None:
+            filters["role"] = RoleFilter(
+                field_name="role",
+                query_params={"content_types": [cls._meta.model._meta.label_lower]},
+            )
+
+        return filters
 
 
 class StatusFilter(NaturalKeyOrPKMultipleChoiceFilter):
@@ -322,4 +332,14 @@ class StatusModelFilterSetMixin(django_filters.FilterSet):
     Mixin to add a `status` filter field to a FilterSet.
     """
 
-    status = StatusFilter()
+    @classmethod
+    def get_filters(cls):
+        filters = super().get_filters()
+
+        if cls._meta.model is not None:
+            filters["status"] = StatusFilter(
+                field_name="status",
+                query_params={"content_types": [cls._meta.model._meta.label_lower]},
+            )
+
+        return filters

--- a/nautobot/extras/forms/base.py
+++ b/nautobot/extras/forms/base.py
@@ -9,6 +9,7 @@ from .mixins import (
     RelationshipModelBulkEditFormMixin,
     RelationshipModelFilterFormMixin,
     RelationshipModelFormMixin,
+    StaticGroupModelFormMixin,
 )
 
 __all__ = (
@@ -23,7 +24,13 @@ __all__ = (
 #
 
 
-class NautobotModelForm(BootstrapMixin, CustomFieldModelFormMixin, RelationshipModelFormMixin, NoteModelFormMixin):
+class NautobotModelForm(
+    CustomFieldModelFormMixin,
+    NoteModelFormMixin,
+    RelationshipModelFormMixin,
+    StaticGroupModelFormMixin,
+    BootstrapMixin,
+):
     """
     This class exists to combine common functionality and is used to inherit from throughout the
     codebase where all of BootstrapMixin, CustomFieldModelFormMixin, RelationshipModelFormMixin, and

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -1559,7 +1559,7 @@ class StaticGroupBulkEditForm(NautobotBulkEditForm):
         nullable_fields = ["tenant"]
 
 
-class StaticGroupBulkAssignForm(BulkEditForm):
+class StaticGroupBulkAssignForm(BootstrapMixin, BulkEditForm):
     content_type = forms.ModelChoiceField(
         queryset=ContentType.objects.filter(FeatureQuery("static_groups").get_query()).order_by("app_label", "model"),
         widget=forms.HiddenInput(),

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -1557,7 +1557,11 @@ class StaticGroupBulkAssignForm(BulkEditForm):
         queryset=ContentType.objects.filter(FeatureQuery("static_groups").get_query()).order_by("app_label", "model"),
         widget=forms.HiddenInput(),
     )
-    create_and_assign_to_new_group_name = forms.CharField(required=False, label="Add to new group", help_text="Create a new group with this name and assign the selected objects to it.")
+    create_and_assign_to_new_group_name = forms.CharField(
+        required=False,
+        label="Add to new group",
+        help_text="Create a new group with this name and assign the selected objects to it.",
+    )
 
     def __init__(self, model, *args, **kwargs):
         super().__init__(model, *args, **kwargs)
@@ -1568,10 +1572,16 @@ class StaticGroupBulkAssignForm(BulkEditForm):
             required=False,
         )
         self.fields["add_to_groups"] = DynamicModelMultipleChoiceField(
-            queryset=StaticGroup.objects.all(), required=False, query_params={"content_type": model._meta.label_lower}, label="Add to existing group(s)",
+            queryset=StaticGroup.objects.all(),
+            required=False,
+            query_params={"content_type": model._meta.label_lower},
+            label="Add to existing group(s)",
         )
         self.fields["remove_from_groups"] = DynamicModelMultipleChoiceField(
-                queryset=StaticGroup.objects.all(), required=False, query_params={"content_type": model._meta.label_lower}, label="Remove from group(s)",
+            queryset=StaticGroup.objects.all(),
+            required=False,
+            query_params={"content_type": model._meta.label_lower},
+            label="Remove from group(s)",
         )
 
     class Meta:

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -1557,16 +1557,21 @@ class StaticGroupBulkAssignForm(BulkEditForm):
         queryset=ContentType.objects.filter(FeatureQuery("static_groups").get_query()).order_by("app_label", "model"),
         widget=forms.HiddenInput(),
     )
-    new_static_group_name = forms.CharField(max_length=CHARFIELD_MAX_LENGTH, required=False)
+    create_and_assign_to_new_group_name = forms.CharField(required=False, label="Add to new group", help_text="Create a new group with this name and assign the selected objects to it.")
 
     def __init__(self, model, *args, **kwargs):
         super().__init__(model, *args, **kwargs)
-        self.fields["pk"] = ModelMultipleChoiceField(
+        self.fields["content_type"].initial = ContentType.objects.get_for_model(model)
+        self.fields["pk"] = forms.ModelMultipleChoiceField(
             queryset=model.objects.all(),
             widget=forms.MultipleHiddenInput(),
+            required=False,
         )
-        self.fields["static_groups"] = DynamicModelMultipleChoiceField(
-            queryset=StaticGroup.objects.all(), required=False, query_params={"content_type": model._meta.label_lower}
+        self.fields["add_to_groups"] = DynamicModelMultipleChoiceField(
+            queryset=StaticGroup.objects.all(), required=False, query_params={"content_type": model._meta.label_lower}, label="Add to existing group(s)",
+        )
+        self.fields["remove_from_groups"] = DynamicModelMultipleChoiceField(
+                queryset=StaticGroup.objects.all(), required=False, query_params={"content_type": model._meta.label_lower}, label="Remove from group(s)",
         )
 
     class Meta:

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -162,9 +162,7 @@ __all__ = (
     "StaticGroupBulkEditForm",
     "StaticGroupFilterForm",
     "StaticGroupForm",
-    "StaticGroupAssociationBulkEditForm",
     "StaticGroupAssociationFilterForm",
-    "StaticGroupAssociationForm",
     "StatusForm",
     "StatusFilterForm",
     "StatusBulkEditForm",
@@ -1521,9 +1519,9 @@ class SecretsGroupFilterForm(NautobotFilterForm):
 class StaticGroupForm(NautobotModelForm):
     """Generic create/update form for `StaticGroup` objects."""
 
-    # TODO: we should use a DynamicModelChoiceField here but then need the ability to filter ContentType API by feature
-    content_type = forms.ModelChoiceField(
-        queryset=ContentType.objects.filter(FeatureQuery("static_groups").get_query()).order_by("app_label", "model"),
+    content_type = DynamicModelChoiceField(
+        queryset=ContentType.objects.all(),
+        query_params={"feature": "static_groups"},
     )
 
     class Meta:
@@ -1567,19 +1565,12 @@ class StaticGroupBulkAssignForm(BulkEditForm):
             queryset=model.objects.all(),
             widget=forms.MultipleHiddenInput(),
         )
-        self.fields["static_groups"] = DynamicModelMultipleChoiceField(queryset=StaticGroup.objects.all(), required=False, query_params={"content_type": model._meta.label_lower})
+        self.fields["static_groups"] = DynamicModelMultipleChoiceField(
+            queryset=StaticGroup.objects.all(), required=False, query_params={"content_type": model._meta.label_lower}
+        )
 
     class Meta:
         nullable_fields = []
-
-
-class StaticGroupAssociationForm(NautobotModelForm):
-    static_group = DynamicModelChoiceField(queryset=StaticGroup.objects.all())
-    # TODO how to handle GenericForeignKey population via form? Do we even need/want this?
-
-    class Meta:
-        model = StaticGroupAssociation
-        fields = ("static_group",)
 
 
 class StaticGroupAssociationFilterForm(NautobotFilterForm):
@@ -1590,11 +1581,6 @@ class StaticGroupAssociationFilterForm(NautobotFilterForm):
         queryset=ContentType.objects.filter(FeatureQuery("static_groups").get_query()).order_by("app_label", "model"),
         required=False,
     )
-
-
-# TODO do we need a StaticGroupAssociationBulkEditForm at all?
-class StaticGroupAssociationBulkEditForm(NautobotBulkEditForm):
-    pk = forms.ModelMultipleChoiceField(queryset=StaticGroupAssociation.objects.all(), widget=forms.MultipleHiddenInput)
 
 
 #

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -1566,7 +1566,7 @@ class StaticGroupBulkAssignForm(BootstrapMixin, BulkEditForm):
     )
     create_and_assign_to_new_group_name = forms.CharField(
         required=False,
-        label="Add to new group",
+        label="Create a new group",
         help_text="Create a new group with this name and assign the selected objects to it.",
     )
 

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -1523,7 +1523,7 @@ class StaticGroupForm(NautobotModelForm):
         queryset=ContentType.objects.all(),
         query_params={"feature": "static_groups"},
     )
-    tenant = DynamicModelChoiceField(queryset=Tenant.objects.all())
+    tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
 
     class Meta:
         model = StaticGroup

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -1594,6 +1594,12 @@ class StaticGroupBulkAssignForm(BootstrapMixin, BulkEditForm):
     class Meta:
         nullable_fields = []
 
+    def clean(self):
+        data = super().clean()
+
+        if data["add_to_groups"].filter(pk__in=data["remove_from_groups"].values_list("pk", flat=True)).exists():
+            raise ValidationError("Same group specified for both addition and removal")
+
 
 class StaticGroupAssociationFilterForm(NautobotFilterForm):
     model = StaticGroupAssociation

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -1523,6 +1523,7 @@ class StaticGroupForm(NautobotModelForm):
         queryset=ContentType.objects.all(),
         query_params={"feature": "static_groups"},
     )
+    tenant = DynamicModelChoiceField(queryset=Tenant.objects.all())
 
     class Meta:
         model = StaticGroup
@@ -1530,6 +1531,7 @@ class StaticGroupForm(NautobotModelForm):
             "name",
             "content_type",
             "description",
+            "tenant",
             "tags",
         )
 
@@ -1541,6 +1543,7 @@ class StaticGroupFilterForm(NautobotFilterForm):
         queryset=ContentType.objects.filter(FeatureQuery("static_groups").get_query()).order_by("app_label", "model"),
         required=False,
     )
+    tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
     tags = TagFilterField(model)
 
 
@@ -1550,6 +1553,10 @@ class StaticGroupBulkEditForm(NautobotBulkEditForm):
         widget=forms.MultipleHiddenInput(),
     )
     description = forms.CharField(max_length=CHARFIELD_MAX_LENGTH, required=False)
+    tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
+
+    class Meta:
+        nullable_fields = ["tenant"]
 
 
 class StaticGroupBulkAssignForm(BulkEditForm):

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -22,6 +22,7 @@ from nautobot.extras.models import (
     Relationship,
     RelationshipAssociation,
     Role,
+    StaticGroup,
     Status,
     Tag,
 )
@@ -39,6 +40,7 @@ __all__ = (
     "RelationshipModelBulkEditFormMixin",
     "RelationshipModelFilterFormMixin",
     "RelationshipModelFormMixin",
+    "StaticGroupModelFormMixin",
     "StatusModelBulkEditFormMixin",
     "StatusModelFilterFormMixin",
     "TagsBulkEditFormMixin",
@@ -742,6 +744,33 @@ class RoleModelFilterFormMixin(forms.Form):
             to_field_name="name",
         )
         self.order_fields(self.field_order)  # Reorder fields again
+
+
+class StaticGroupModelFormMixin(forms.ModelForm):
+    """
+    Mixin to add `static_groups` field to model create/edit forms where applicable.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self._meta.model.is_static_group_associable_model:
+            self.fields["static_groups"] = DynamicModelMultipleChoiceField(
+                required=False,
+                initial=self.instance.static_groups if self.instance else None,
+                queryset=StaticGroup.objects.get_for_model(self._meta.model),
+                query_params={"content_type": self._meta.model._meta.label_lower},
+                to_field_name="name",
+            )
+
+    def save(self, commit=True):
+        obj = super().save(commit=commit)
+        if commit and obj.is_static_group_associable_model:
+            current_groups = set(obj.static_groups)
+            for static_group in set(self.cleaned_data.get("static_groups")).difference(current_groups):
+                static_group.add_members([obj])
+            for static_group in current_groups.difference(self.cleaned_data.get("static_groups")):
+                static_group.remove_members([obj])
+        return obj
 
 
 class StatusModelBulkEditFormMixin(forms.Form):

--- a/nautobot/extras/homepage.py
+++ b/nautobot/extras/homepage.py
@@ -1,6 +1,6 @@
 from nautobot.core.apps import HomePageItem, HomePagePanel
 from nautobot.extras.choices import JobResultStatusChoices
-from nautobot.extras.models import GitRepository, JobResult, ObjectChange
+from nautobot.extras.models import GitRepository, JobResult, ObjectChange, StaticGroup
 
 
 def get_job_results(request):
@@ -18,6 +18,19 @@ def get_changelog(request):
 
 
 layout = (
+    HomePagePanel(
+        name="Organization",
+        items=(
+            HomePageItem(
+                name="Static Groups",
+                link="extras:staticgroup_list",
+                model=StaticGroup,
+                description="Statically defined groups of objects",
+                permissions=["extras.view_staticgroup"],
+                weight=300,
+            ),
+        ),
+    ),
     HomePagePanel(
         name="Data Sources",
         weight=700,

--- a/nautobot/extras/migrations/0107_staticgroup_staticgroupassociation.py
+++ b/nautobot/extras/migrations/0107_staticgroup_staticgroupassociation.py
@@ -52,7 +52,7 @@ class Migration(migrations.Migration):
                         blank=True,
                         null=True,
                         on_delete=django.db.models.deletion.PROTECT,
-                        related_name="static_groups_set",
+                        related_name="managed_static_groups",
                         to="tenancy.tenant",
                     ),
                 ),

--- a/nautobot/extras/migrations/0107_staticgroup_staticgroupassociation.py
+++ b/nautobot/extras/migrations/0107_staticgroup_staticgroupassociation.py
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
                     models.ForeignKey(
                         limit_choices_to=nautobot.extras.utils.FeatureQuery("static_groups"),
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="static_groups",
+                        related_name="static_groups_set",
                         to="contenttypes.contenttype",
                     ),
                 ),
@@ -52,7 +52,7 @@ class Migration(migrations.Migration):
                         blank=True,
                         null=True,
                         on_delete=django.db.models.deletion.PROTECT,
-                        related_name="static_groups",
+                        related_name="static_groups_set",
                         to="tenancy.tenant",
                     ),
                 ),

--- a/nautobot/extras/migrations/0107_staticgroup_staticgroupassociation.py
+++ b/nautobot/extras/migrations/0107_staticgroup_staticgroupassociation.py
@@ -7,6 +7,7 @@ from django.db import migrations, models
 import django.db.models.deletion
 
 import nautobot.core.models.fields
+import nautobot.extras.models.groups
 import nautobot.extras.models.mixins
 import nautobot.extras.utils
 
@@ -60,6 +61,9 @@ class Migration(migrations.Migration):
             options={
                 "ordering": ["name"],
             },
+            managers=[
+                ("objects", nautobot.extras.models.groups.StaticGroupManager()),
+            ],
             bases=(
                 models.Model,
                 nautobot.extras.models.mixins.DynamicGroupMixin,

--- a/nautobot/extras/migrations/0107_staticgroup_staticgroupassociation.py
+++ b/nautobot/extras/migrations/0107_staticgroup_staticgroupassociation.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ("contenttypes", "0002_remove_content_type_name"),
         ("extras", "0106_populate_default_statuses_and_roles_for_contact_associations"),
+        ("tenancy", "0001_initial"),
     ]
 
     operations = [
@@ -42,6 +43,16 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.CASCADE,
                         related_name="static_groups",
                         to="contenttypes.contenttype",
+                    ),
+                ),
+                (
+                    "tenant",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="static_groups",
+                        to="tenancy.tenant",
                     ),
                 ),
                 ("tags", nautobot.core.models.fields.TagsField(through="extras.TaggedItem", to="extras.Tag")),

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -47,8 +47,15 @@ class StaticGroup(PrimaryModel):
         limit_choices_to=FeatureQuery("static_groups"),
         help_text="The type of object contained in this Static Group.",
     )
+    tenant = models.ForeignKey(
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="static_groups",
+        blank=True,
+        null=True,
+    )
 
-    clone_fields = ["content_type"]
+    clone_fields = ["content_type", "tenant"]
     is_static_group_associable_model = False
 
     class Meta:

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -63,14 +63,14 @@ class StaticGroup(PrimaryModel):
     content_type = models.ForeignKey(
         to=ContentType,
         on_delete=models.CASCADE,
-        related_name="static_groups",
+        related_name="static_groups_set",
         limit_choices_to=FeatureQuery("static_groups"),
         help_text="The type of object contained in this Static Group.",
     )
     tenant = models.ForeignKey(
         to="tenancy.Tenant",
         on_delete=models.PROTECT,
-        related_name="static_groups",
+        related_name="static_groups_set",  # "static_groups" would clash with StaticGroupMixin.static_groups property
         blank=True,
         null=True,
     )

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -70,7 +70,7 @@ class StaticGroup(PrimaryModel):
     tenant = models.ForeignKey(
         to="tenancy.Tenant",
         on_delete=models.PROTECT,
-        related_name="static_groups_set",  # "static_groups" would clash with StaticGroupMixin.static_groups property
+        related_name="managed_static_groups",  # "static_groups" clash with StaticGroupMixin.static_groups property
         blank=True,
         null=True,
     )

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -80,6 +80,11 @@ class StaticGroup(PrimaryModel):
             pk__in=self.static_group_associations.values_list("associated_object_id", flat=True)
         )
 
+    @property
+    def count(self):
+        """Return the number of member objects in this group."""
+        return self.members.count()
+
     def clean(self):
         super().clean()
 

--- a/nautobot/extras/models/mixins.py
+++ b/nautobot/extras/models/mixins.py
@@ -180,6 +180,9 @@ class StaticGroupMixin(models.Model):
 
     @property
     def static_groups(self):
+        """
+        Returns a QuerySet of StaticGroups that have this object as a member.
+        """
         from nautobot.extras.models.groups import StaticGroup
 
         return StaticGroup.objects.filter(pk__in=self.associated_static_groups.values_list("static_group", flat=True))

--- a/nautobot/extras/navigation.py
+++ b/nautobot/extras/navigation.py
@@ -53,6 +53,18 @@ menu_items = (
                             ),
                         ),
                     ),
+                    NavMenuItem(
+                        link="extras:staticgroup_list",
+                        name="Static Groups",
+                        weight=200,
+                        permissions=["extras.view_staticgroup"],
+                        buttons=(
+                            NavMenuAddButton(
+                                link="extras:staticgroup_add",
+                                permissions=["extras.add_staticgroup"],
+                            ),
+                        ),
+                    ),
                 ),
             ),
             NavMenuGroup(

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -35,6 +35,7 @@ from nautobot.extras.models import (
     JobResult,
     ObjectChange,
     Relationship,
+    StaticGroup,
 )
 from nautobot.extras.querysets import NotesQuerySet
 from nautobot.extras.tasks import delete_custom_field_data, provision_field
@@ -67,12 +68,15 @@ def get_user_if_authenticated(user, instance):
 @receiver(post_save, sender=ComputedField)
 @receiver(post_save, sender=CustomField)
 @receiver(post_save, sender=CustomField.content_types.through)
+@receiver(post_save, sender=StaticGroup)
 @receiver(m2m_changed, sender=ComputedField)
 @receiver(m2m_changed, sender=CustomField)
 @receiver(m2m_changed, sender=CustomField.content_types.through)
+@receiver(m2m_changed, sender=StaticGroup)
 @receiver(post_delete, sender=ComputedField)
 @receiver(post_delete, sender=CustomField)
 @receiver(post_delete, sender=CustomField.content_types.through)
+@receiver(post_delete, sender=StaticGroup)
 def invalidate_models_cache(sender, **kwargs):
     """Invalidate the related-models cache for ComputedFields and CustomFields."""
     if sender is CustomField.content_types.through:

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -137,7 +137,10 @@ def _handle_changed_object(sender, instance, raw=False, **kwargs):
 
         # Generate a unique identifier for this change to stash in the change context
         # This is used for deferred change logging and for looking up related changes without querying the database
-        unique_object_change_id = f"{changed_object_type.pk}__{changed_object_id}__{user.pk}"
+        if user is not None:
+            unique_object_change_id = f"{changed_object_type.pk}__{changed_object_id}__{user.pk}"
+        else:
+            unique_object_change_id = f"{changed_object_type.pk}__{changed_object_id}"
 
         # If a change already exists for this change_id, user, and object, update it instead of creating a new one.
         # If the object was deleted then recreated with the same pk (don't do this), change the action to update.

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -44,6 +44,8 @@ from .models import (
     ScheduledJob,
     Secret,
     SecretsGroup,
+    StaticGroup,
+    StaticGroupAssociation,
     Status,
     Tag,
     TaggedItem,
@@ -1030,6 +1032,38 @@ class SecretsGroupTable(BaseTable):
             "name",
             "description",
         )
+
+
+#
+# Static Groups
+#
+
+
+class StaticGroupTable(BaseTable):
+    """Table for list view of `StaticGroup` objects."""
+
+    pk = ToggleColumn()
+    name = tables.Column(linkify=True)
+    # TODO members_count column
+    tags = TagColumn(url_name="extras:staticgroup_list")
+    actions = ButtonsColumn(StaticGroup)
+
+    class Meta(BaseTable.Meta):
+        model = StaticGroup
+        fields = ["pk", "name", "content_type", "description", "tags", "actions"]
+
+
+class StaticGroupAssociationTable(BaseTable):
+    """Table for list view of `StaticGroupAssociation` objects."""
+
+    pk = ToggleColumn()
+    static_group = tables.Column(linkify=True)
+    associated_object = tables.Column(linkify=True)
+    actions = ButtonsColumn(StaticGroupAssociation)
+
+    class Meta(BaseTable.Meta):
+        model = StaticGroupAssociation
+        fields = ["pk", "static_group", "associated_object", "tags", "actions"]
 
 
 #

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -1055,7 +1055,7 @@ class StaticGroupTable(BaseTable):
 
     pk = ToggleColumn()
     name = tables.Column(linkify=True)
-    count = tables.TemplateColumn(MEMBERS_COUNT, verbose_name="Group Members")
+    count = tables.TemplateColumn(MEMBERS_COUNT, verbose_name="Members")
     tenant = tables.Column(linkify=True)
     tags = TagColumn(url_name="extras:staticgroup_list")
     actions = ButtonsColumn(StaticGroup)
@@ -1070,7 +1070,7 @@ class StaticGroupAssociationTable(BaseTable):
 
     pk = ToggleColumn()
     static_group = tables.Column(linkify=True)
-    associated_object = tables.Column(linkify=True)
+    associated_object = tables.Column(linkify=True, verbose_name="Associated Object")
     actions = ButtonsColumn(StaticGroupAssociation, buttons=["changelog", "delete"])
 
     class Meta(BaseTable.Meta):

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -119,7 +119,7 @@ MEMBERS_COUNT = """
 {% load helpers %}
 {% with urlname=record.model|validated_viewname:"list" %}
 {% if urlname %}
-    <a href="{% url urlname %}?static_group={{ record.name }}">{{ record.count }}</a>
+    <a href="{% url urlname %}?static_groups={{ record.name }}">{{ record.count }}</a>
 {% else %}
     {{ record.count }}
 {% endif %}

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -1094,7 +1094,7 @@ class StatusTable(BaseTable):
 
     class Meta(BaseTable.Meta):
         model = Status
-        fields = ["pk", "name", "color", "content_types", "description"]
+        fields = ["pk", "name", "color", "content_types", "description", "actions"]
 
 
 class StatusTableMixin(BaseTable):

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -115,6 +115,17 @@ OBJECTCHANGE_REQUEST_ID = """
 <a href="{% url 'extras:objectchange_list' %}?request_id={{ value }}">{{ value }}</a>
 """
 
+MEMBERS_COUNT = """
+{% load helpers %}
+{% with urlname=record.model|validated_viewname:"list" %}
+{% if urlname %}
+    <a href="{% url urlname %}?static_group={{ record.name }}">{{ record.count }}</a>
+{% else %}
+    {{ record.count }}
+{% endif %}
+{% endwith %}
+"""
+
 # TODO: Webhook content_types in table order_by
 WEBHOOK_CONTENT_TYPES = """
 {{ value.all|join:", "|truncatewords:15 }}
@@ -1044,13 +1055,13 @@ class StaticGroupTable(BaseTable):
 
     pk = ToggleColumn()
     name = tables.Column(linkify=True)
-    # TODO members_count column
+    count = tables.TemplateColumn(MEMBERS_COUNT, verbose_name="Group Members")
     tags = TagColumn(url_name="extras:staticgroup_list")
     actions = ButtonsColumn(StaticGroup)
 
     class Meta(BaseTable.Meta):
         model = StaticGroup
-        fields = ["pk", "name", "content_type", "description", "tags", "actions"]
+        fields = ["pk", "name", "content_type", "count", "description", "tags", "actions"]
 
 
 class StaticGroupAssociationTable(BaseTable):

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -1056,12 +1056,13 @@ class StaticGroupTable(BaseTable):
     pk = ToggleColumn()
     name = tables.Column(linkify=True)
     count = tables.TemplateColumn(MEMBERS_COUNT, verbose_name="Group Members")
+    tenant = tables.Column(linkify=True)
     tags = TagColumn(url_name="extras:staticgroup_list")
     actions = ButtonsColumn(StaticGroup)
 
     class Meta(BaseTable.Meta):
         model = StaticGroup
-        fields = ["pk", "name", "content_type", "count", "description", "tags", "actions"]
+        fields = ["pk", "name", "content_type", "count", "description", "tenant", "tags", "actions"]
 
 
 class StaticGroupAssociationTable(BaseTable):

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -1071,11 +1071,11 @@ class StaticGroupAssociationTable(BaseTable):
     pk = ToggleColumn()
     static_group = tables.Column(linkify=True)
     associated_object = tables.Column(linkify=True)
-    actions = ButtonsColumn(StaticGroupAssociation)
+    actions = ButtonsColumn(StaticGroupAssociation, buttons=["changelog", "delete"])
 
     class Meta(BaseTable.Meta):
         model = StaticGroupAssociation
-        fields = ["pk", "static_group", "associated_object", "tags", "actions"]
+        fields = ["pk", "static_group", "associated_object", "actions"]
 
 
 #

--- a/nautobot/extras/templates/extras/staticgroup_bulk_assign.html
+++ b/nautobot/extras/templates/extras/staticgroup_bulk_assign.html
@@ -1,1 +1,4 @@
 {% extends 'generic/object_bulk_update.html' %}
+{% load helpers %}
+
+{% block title %}Updating Static Groups for {{ table.rows|length }} {{ obj_type_plural|bettertitle }}{% endblock %}

--- a/nautobot/extras/templates/extras/staticgroup_bulk_assign.html
+++ b/nautobot/extras/templates/extras/staticgroup_bulk_assign.html
@@ -1,0 +1,1 @@
+{% extends 'generic/object_bulk_update.html' %}

--- a/nautobot/extras/templates/extras/staticgroup_bulk_assign.html
+++ b/nautobot/extras/templates/extras/staticgroup_bulk_assign.html
@@ -1,4 +1,0 @@
-{% extends 'generic/object_bulk_update.html' %}
-{% load helpers %}
-
-{% block title %}Updating Static Groups for {{ table.rows|length }} {{ obj_type_plural|bettertitle }}{% endblock %}

--- a/nautobot/extras/templates/extras/staticgroup_retrieve.html
+++ b/nautobot/extras/templates/extras/staticgroup_retrieve.html
@@ -4,7 +4,7 @@
 {% block extra_nav_tabs %}
     <li role="presentation"{% if request.GET.tab == 'members' %} class="active"{% endif %}>
         <a href="{{ object.get_absolute_url }}#members" onclick="switch_tab(this.href, reload=true)" aria-controls="members" role="tab" data-toggle="tab">
-            Members {% badge object.count %}
+            Members {% badge object.count True%}
         </a>
     </li>
 {% endblock extra_nav_tabs %}
@@ -13,7 +13,7 @@
     <div id="members" role="tabpanel" class="tab-pane{% if request.GET.tab == 'members' %} active{% else %} fade{% endif %}">
         <div class="row">
             <div class="col-md-12">
-                {% include 'utilities/obj_table.html' with table=members_table table_template='panel_table.html' heading='Static Group members' content_type=object.content_type permissions=members_table_permissions %}
+                {% include 'utilities/obj_table.html' with table=members_table table_template='panel_table.html' heading='Static Group members' %}
             </div>
         </div>
     </div>
@@ -36,6 +36,10 @@
             <tr>
                 <td>Content Type</td>
                 <td>{{ object.content_type }}</td>
+            </tr>
+            <tr>
+                <td>Tenant</td>
+                <td>{{ object.tenant|hyperlinked_object }}</td>
             </tr>
         </table>
     </div>

--- a/nautobot/extras/templates/extras/staticgroup_retrieve.html
+++ b/nautobot/extras/templates/extras/staticgroup_retrieve.html
@@ -11,6 +11,15 @@
 
 {% block extra_tab_content %}
     <div id="members" role="tabpanel" class="tab-pane{% if request.GET.tab == 'members' %} active{% else %} fade{% endif %}">
+        {% if members_list_url %}
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="alert alert-success" role="alert">
+                        You can bulk-add and bulk-remove members of this group from the <a href="{{ members_list_url }}">{{ members_verbose_name_plural|bettertitle }} list view</a>.
+                    </div>
+                </div>
+            </div>
+        {% endif %}
         <div class="row">
             <div class="col-md-12">
                 {% include 'utilities/obj_table.html' with table=members_table table_template='panel_table.html' heading='Static Group members' %}

--- a/nautobot/extras/templates/extras/staticgroup_retrieve.html
+++ b/nautobot/extras/templates/extras/staticgroup_retrieve.html
@@ -4,7 +4,7 @@
 {% block extra_nav_tabs %}
     <li role="presentation"{% if request.GET.tab == 'members' %} class="active"{% endif %}>
         <a href="{{ object.get_absolute_url }}#members" onclick="switch_tab(this.href)" aria-controls="members" role="tab" data-toggle="tab">
-            Members {% badge object.count True%}
+            Members {% badge object.count True %}
         </a>
     </li>
 {% endblock extra_nav_tabs %}

--- a/nautobot/extras/templates/extras/staticgroup_retrieve.html
+++ b/nautobot/extras/templates/extras/staticgroup_retrieve.html
@@ -3,7 +3,7 @@
 
 {% block extra_nav_tabs %}
     <li role="presentation"{% if request.GET.tab == 'members' %} class="active"{% endif %}>
-        <a href="{{ object.get_absolute_url }}#members" onclick="switch_tab(this.href, reload=true)" aria-controls="members" role="tab" data-toggle="tab">
+        <a href="{{ object.get_absolute_url }}#members" onclick="switch_tab(this.href)" aria-controls="members" role="tab" data-toggle="tab">
             Members {% badge object.count True%}
         </a>
     </li>

--- a/nautobot/extras/templates/extras/staticgroup_retrieve.html
+++ b/nautobot/extras/templates/extras/staticgroup_retrieve.html
@@ -13,7 +13,7 @@
     <div id="members" role="tabpanel" class="tab-pane{% if request.GET.tab == 'members' %} active{% else %} fade{% endif %}">
         <div class="row">
             <div class="col-md-12">
-                {% include 'utilities/obj_table.html' with table=members_table table_template='panel_table.html' heading='Static Group members' %}
+                {% include 'utilities/obj_table.html' with table=members_table table_template='panel_table.html' heading='Static Group members' content_type=object.content_type permissions=members_table_permissions %}
             </div>
         </div>
     </div>

--- a/nautobot/extras/templates/extras/staticgroup_retrieve.html
+++ b/nautobot/extras/templates/extras/staticgroup_retrieve.html
@@ -1,0 +1,43 @@
+{% extends 'generic/object_retrieve.html' %}
+{% load helpers %}
+
+{% block extra_nav_tabs %}
+    <li role="presentation"{% if request.GET.tab == 'members' %} class="active"{% endif %}>
+        <a href="{{ object.get_absolute_url }}#members" onclick="switch_tab(this.href, reload=true)" aria-controls="members" role="tab" data-toggle="tab">
+            Members {% badge object.count %}
+        </a>
+    </li>
+{% endblock extra_nav_tabs %}
+
+{% block extra_tab_content %}
+    <div id="members" role="tabpanel" class="tab-pane{% if request.GET.tab == 'members' %} active{% else %} fade{% endif %}">
+        <div class="row">
+            <div class="col-md-12">
+                {% include 'utilities/obj_table.html' with table=members_table table_template='panel_table.html' heading='Static Group members' %}
+            </div>
+        </div>
+    </div>
+{% endblock extra_tab_content %}
+
+{% block content_left_page %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <strong>Static Group</strong>
+        </div>
+        <table class="table table-hover panel-body attr-table">
+            <tr>
+                <td>Name</td>
+                <td>{{ object.name }}</td>
+            </tr>
+            <tr>
+                <td>Description</td>
+                <td>{{ object.description }}</td>
+            </tr>
+            <tr>
+                <td>Content Type</td>
+                <td>{{ object.content_type }}</td>
+            </tr>
+        </table>
+    </div>
+{% endblock content_left_page %}
+

--- a/nautobot/extras/templates/extras/staticgroupassociation_retrieve.html
+++ b/nautobot/extras/templates/extras/staticgroupassociation_retrieve.html
@@ -1,0 +1,20 @@
+{% extends 'generic/object_retrieve.html' %}
+{% load helpers %}
+
+{% block content_left_page %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <strong>Static Group Association</strong>
+        </div>
+        <table class="table table-hover panel-body attr-table">
+            <tr>
+                <td>Static Group</td>
+                <td>{{ object.static_group|hyperlinked_object }}</td>
+            </tr>
+            <tr>
+                <td>Associated Object</td>
+                <td>{{ object.associated_object|hyperlinked_object }}</td>
+            </tr>
+        </table>
+    </div>
+{% endblock content_left_page %}

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -81,6 +81,7 @@ from nautobot.extras.tests.constants import BIG_GRAPHQL_DEVICE_QUERY
 from nautobot.extras.tests.test_relationships import RequiredRelationshipTestMixin
 from nautobot.extras.utils import TaggableClassesQuery
 from nautobot.ipam.models import IPAddress, Prefix, VLAN, VLANGroup
+from nautobot.tenancy.models import Tenant
 from nautobot.users.models import ObjectPermission
 from nautobot.virtualization.models import VirtualMachine
 
@@ -3508,6 +3509,7 @@ class StaticGroupTest(APIViewTestCases.APIViewTestCase):
                 "description": "A group containing dcim.location objects",
                 "content_type": "dcim.location",
                 "tags": [tag.pk for tag in Tag.objects.get_for_model(StaticGroup)],
+                "tenant": Tenant.objects.first().pk,
             },
             {
                 "name": "Group of Devices",
@@ -3525,6 +3527,7 @@ class StaticGroupTest(APIViewTestCases.APIViewTestCase):
         }
         cls.bulk_update_data = {
             "description": "New description",
+            "tenant": Tenant.objects.last().pk,
         }
 
     def test_changing_content_type_not_allowed(self):

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -1814,6 +1814,7 @@ class StaticGroupTestCase(FilterTestCases.NameOnlyFilterTestCase):
     generic_filter_tests = (
         ["description"],
         ["name"],
+        ["member_id", "static_group_associations__associated_object_id"],
         ["tenant", "tenant__id"],
         ["tenant", "tenant__name"],
     )

--- a/nautobot/extras/tests/test_filters.py
+++ b/nautobot/extras/tests/test_filters.py
@@ -1814,6 +1814,8 @@ class StaticGroupTestCase(FilterTestCases.NameOnlyFilterTestCase):
     generic_filter_tests = (
         ["description"],
         ["name"],
+        ["tenant", "tenant__id"],
+        ["tenant", "tenant__name"],
     )
 
     def test_content_type(self):

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -1696,23 +1696,30 @@ class StaticGroupTest(ModelTestCases.BaseModelTestCase):
         # test bulk addition
         sg.add_members(Prefix.objects.filter(ip_version=4))
         self.assertIsInstance(sg.members, PrefixQuerySet)
-        self.assertEqual(sg.members.count(), Prefix.objects.filter(ip_version=4).count())
+        self.assertQuerysetEqualAndNotEmpty(sg.members, Prefix.objects.filter(ip_version=4))
         # test duplicate objects aren't re-added
         sg.add_members(Prefix.objects.all())
-        self.assertEqual(sg.members.count(), Prefix.objects.all().count())
+        self.assertQuerysetEqualAndNotEmpty(sg.members, Prefix.objects.all())
         self.assertEqual(sg.static_group_associations.count(), Prefix.objects.all().count())
         # test idempotence and alternate code path
         sg.add_members(list(Prefix.objects.all()))
-        self.assertEqual(sg.members.count(), Prefix.objects.all().count())
+        self.assertQuerysetEqualAndNotEmpty(sg.members, Prefix.objects.all())
         self.assertEqual(sg.static_group_associations.count(), Prefix.objects.all().count())
+
         # test bulk removal
         sg.remove_members(Prefix.objects.filter(ip_version=4))
-        self.assertEqual(sg.members.count(), Prefix.objects.filter(ip_version=6).count())
+        self.assertQuerysetEqualAndNotEmpty(sg.members, Prefix.objects.filter(ip_version=6))
         self.assertEqual(sg.static_group_associations.count(), Prefix.objects.filter(ip_version=6).count())
         # test idempotence and alternate code path
         sg.remove_members(list(Prefix.objects.filter(ip_version=4)))
-        self.assertEqual(sg.members.count(), Prefix.objects.filter(ip_version=6).count())
+        self.assertQuerysetEqualAndNotEmpty(sg.members, Prefix.objects.filter(ip_version=6))
         self.assertEqual(sg.static_group_associations.count(), Prefix.objects.filter(ip_version=6).count())
+
+        # test property setter
+        sg.members = Prefix.objects.filter(ip_version=4)
+        self.assertQuerysetEqualAndNotEmpty(sg.members, Prefix.objects.filter(ip_version=4))
+        sg.members = list(Prefix.objects.filter(ip_version=6))
+        self.assertQuerysetEqualAndNotEmpty(sg.members, Prefix.objects.filter(ip_version=6))
 
         self.assertIsInstance(Prefix.objects.filter(ip_version=6).first().static_groups, QuerySet)
         self.assertIn(sg, list(Prefix.objects.filter(ip_version=6).first().static_groups))

--- a/nautobot/extras/urls.py
+++ b/nautobot/extras/urls.py
@@ -31,6 +31,8 @@ router.register("contact-associations", views.ContactAssociationUIViewSet)
 router.register("external-integrations", views.ExternalIntegrationUIViewSet)
 router.register("job-buttons", views.JobButtonUIViewSet)
 router.register("roles", views.RoleUIViewSet)
+router.register("static-groups", views.StaticGroupUIViewSet)
+router.register("static-group-associations", views.StaticGroupAssociationUIViewSet)
 router.register("teams", views.TeamUIViewSet)
 
 urlpatterns = [

--- a/nautobot/extras/urls.py
+++ b/nautobot/extras/urls.py
@@ -604,6 +604,8 @@ urlpatterns = [
         name="secretsgroup_notes",
         kwargs={"model": SecretsGroup},
     ),
+    # Static group custom views - the base StaticGroupUIViewSet is registered above
+    path("static-groups/assign-members/", views.StaticGroupBulkAssignView.as_view(), name="staticgroup_bulk_assign"),
     # Custom statuses
     path("statuses/", views.StatusListView.as_view(), name="status_list"),
     path("statuses/add/", views.StatusEditView.as_view(), name="status_add"),

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -144,12 +144,11 @@ class FeatureQuery:
         # `registry` record being used by `FeatureQuery`.
 
         populate_model_features_registry()
-        entries = self.as_dict()
-        if entries:
+        try:
             query = Q()
-            for app_label, models in entries:
+            for app_label, models in self.as_dict():
                 query |= Q(app_label=app_label, model__in=models)
-        else:
+        except KeyError:
             query = Q(pk__in=[])
 
         return query
@@ -159,8 +158,10 @@ class FeatureQuery:
         Given an extras feature, return a iterable of app_label: [models] for content type lookup.
 
         Mis-named, as it returns an iterable of (key, value) (i.e. dict.items()) rather than an actual dict.
+
+        Raises a KeyError if the given feature doesn't exist.
         """
-        return registry["model_features"].get(self.feature, {}).items()
+        return registry["model_features"][self.feature].items()
 
     def get_choices(self):
         """

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -144,17 +144,23 @@ class FeatureQuery:
         # `registry` record being used by `FeatureQuery`.
 
         populate_model_features_registry()
-        query = Q()
-        for app_label, models in self.as_dict():
-            query |= Q(app_label=app_label, model__in=models)
+        entries = self.as_dict()
+        if entries: 
+            query = Q()
+            for app_label, models in entries:
+                query |= Q(app_label=app_label, model__in=models)
+        else:
+            query = Q(pk__in=[])
 
         return query
 
     def as_dict(self):
         """
-        Given an extras feature, return a dict of app_label: [models] for content type lookup
+        Given an extras feature, return a iterable of app_label: [models] for content type lookup.
+
+        Mis-named, as it returns an iterable of (key, value) (i.e. dict.items()) rather than an actual dict.
         """
-        return registry["model_features"][self.feature].items()
+        return registry["model_features"].get(self.feature, {}).items()
 
     def get_choices(self):
         """

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -145,7 +145,7 @@ class FeatureQuery:
 
         populate_model_features_registry()
         entries = self.as_dict()
-        if entries: 
+        if entries:
             query = Q()
             for app_label, models in entries:
                 query |= Q(app_label=app_label, model__in=models)

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -12,6 +12,7 @@ from django.http import Http404, HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template, TemplateDoesNotExist
 from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 from django.utils import timezone
 from django.utils.encoding import iri_to_uri
 from django.utils.html import format_html
@@ -24,7 +25,7 @@ from nautobot.core.forms import restrict_form_fields
 from nautobot.core.models.querysets import count_related
 from nautobot.core.models.utils import pretty_print_query
 from nautobot.core.tables import ButtonsColumn
-from nautobot.core.utils.lookup import get_filterset_for_model, get_table_for_model
+from nautobot.core.utils.lookup import get_filterset_for_model, get_route_for_model, get_table_for_model
 from nautobot.core.utils.permissions import get_permission_for_model
 from nautobot.core.utils.requests import normalize_querydict
 from nautobot.core.views import generic, viewsets
@@ -2352,11 +2353,11 @@ class StaticGroupUIViewSet(NautobotUIViewSet):
             RequestConfig(request, paginate).configure(members_table)
             members_table.columns.show("pk")  # TODO why is this needed?
             context["members_table"] = members_table
-            context["members_table_permissions"] = {
-                "add": request.user.has_perm(get_permission_for_model(StaticGroupAssociation, "add")),
-                "change": request.user.has_perm(get_permission_for_model(StaticGroupAssociation, "change")),
-                "delete": request.user.has_perm(get_permission_for_model(StaticGroupAssociation, "delete")),
-            }
+            try:
+                context["members_list_url"] = reverse(get_route_for_model(instance.model, "list"))
+            except NoReverseMatch:
+                context["members_list_url"] = None
+            context["members_verbose_name_plural"] = instance.model._meta.verbose_name_plural
 
         return context
 

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -32,6 +32,7 @@ from nautobot.core.views.mixins import (
     GetReturnURLMixin,
     ObjectBulkDestroyViewMixin,
     ObjectBulkUpdateViewMixin,
+    ObjectChangeLogViewMixin,
     ObjectDestroyViewMixin,
     ObjectDetailViewMixin,
     ObjectEditViewMixin,
@@ -2416,15 +2417,18 @@ class StaticGroupUIViewSet(NautobotUIViewSet):
 
 class StaticGroupAssociationUIViewSet(
     ObjectBulkDestroyViewMixin,
+    ObjectChangeLogViewMixin,
     ObjectDestroyViewMixin,
     ObjectDetailViewMixin,
     ObjectListViewMixin,
     # TODO anything else?
 ):
     filterset_class = filters.StaticGroupAssociationFilterSet
+    filterset_form_class = forms.StaticGroupAssociationFilterForm
     queryset = StaticGroupAssociation.objects.all()
     serializer_class = serializers.StaticGroupAssociationSerializer
     table_class = tables.StaticGroupAssociationTable
+    action_buttons = ("export",)
 
 
 class StaticGroupBulkAssignView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2351,7 +2351,9 @@ class StaticGroupUIViewSet(NautobotUIViewSet):
                 "per_page": get_paginate_count(request),
             }
             RequestConfig(request, paginate).configure(members_table)
-            members_table.columns.show("pk")  # TODO why is this needed?
+            members_table.columns.hide("pk")
+            if "actions" in members_table.columns:
+                members_table.columns.hide("actions")
             context["members_table"] = members_table
             try:
                 context["members_list_url"] = reverse(get_route_for_model(instance.model, "list"))

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2403,7 +2403,13 @@ class StaticGroupUIViewSet(NautobotUIViewSet):
                 "per_page": get_paginate_count(request),
             }
             RequestConfig(request, paginate).configure(members_table)
+            members_table.columns.show("pk")  # TODO why is this needed?
             context["members_table"] = members_table
+            context["members_table_permissions"] = {
+                "add": request.user.has_perm(get_permission_for_model(StaticGroupAssociation, "add")),
+                "change": request.user.has_perm(get_permission_for_model(StaticGroupAssociation, "change")),
+                "delete": request.user.has_perm(get_permission_for_model(StaticGroupAssociation, "delete")),
+            }
 
         return context
 

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2476,10 +2476,11 @@ class StaticGroupBulkAssignView(GetReturnURLMixin, ObjectPermissionRequiredMixin
             except StaticGroupAssociation.DoesNotExist:
                 msg = "Static group association failed due to object-level permissions violation"
                 logger.warning(msg)
-                form.add_error(None, msg)
+                messages.error(self.request, msg)
 
         else:
             logger.debug("Form validation failed")
+            messages.error(self.request, form.errors)
 
         return redirect(self.get_return_url(request))
 

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -443,6 +443,7 @@ class IPAddressTable(StatusTableMixin, RoleTableMixin, BaseTable):
     )
     tenant = TenantColumn()
     parent__namespace = tables.Column(linkify=True)
+    # Interface, Device, and VirtualMachine tables aren't currently filterable by IP address (?) so no LinkedCountColumn
     interface_count = tables.Column(verbose_name="Interfaces")
     interface_parent_count = tables.Column(verbose_name="Devices")
     vm_interface_count = LinkedCountColumn(

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -368,7 +368,7 @@ class RouteTargetBulkDeleteView(generic.BulkDeleteView):
 
 
 class RIRListView(generic.ObjectListView):
-    queryset = RIR.objects.annotate(assigned_prefix_count=count_related(Prefix, "rir"))
+    queryset = RIR.objects.all()
     filterset = filters.RIRFilterSet
     filterset_form = forms.RIRFilterForm
     table = tables.RIRTable
@@ -409,7 +409,7 @@ class RIRBulkImportView(generic.BulkImportView):  # 3.0 TODO: remove, unused
 
 
 class RIRBulkDeleteView(generic.BulkDeleteView):
-    queryset = RIR.objects.annotate(assigned_prefix_count=count_related(Prefix, "rir"))
+    queryset = RIR.objects.all()
     filterset = filters.RIRFilterSet
     table = tables.RIRTable
 
@@ -424,7 +424,7 @@ class PrefixListView(generic.ObjectListView):
     filterset_form = forms.PrefixFilterForm
     table = tables.PrefixDetailTable
     template_name = "ipam/prefix_list.html"
-    queryset = Prefix.objects.annotate(location_count=count_related(Location, "prefixes"))
+    queryset = Prefix.objects.all()
     use_new_ui = True
 
 
@@ -442,13 +442,8 @@ class PrefixView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Parent prefixes table
-        parent_prefixes = (
-            instance.ancestors()
-            .restrict(request.user, "view")
-            .select_related("parent", "namespace", "status", "vlan", "role")
-            .annotate(location_count=count_related(Location, "prefixes"))
-        )
-        parent_prefix_table = tables.PrefixTable(list(parent_prefixes))
+        parent_prefixes = instance.ancestors().restrict(request.user, "view")
+        parent_prefix_table = tables.PrefixTable(parent_prefixes)
         parent_prefix_table.exclude = ("namespace",)
 
         vrfs = instance.vrf_assignments.restrict(request.user, "view")
@@ -701,9 +696,7 @@ class PrefixBulkImportView(generic.BulkImportView):  # 3.0 TODO: remove, unused
 
 
 class PrefixBulkEditView(generic.BulkEditView):
-    queryset = Prefix.objects.select_related("status", "namespace", "tenant", "vlan", "role").annotate(
-        location_count=count_related(Location, "prefixes")
-    )
+    queryset = Prefix.objects.all()
     filterset = filters.PrefixFilterSet
     table = tables.PrefixTable
     form = forms.PrefixBulkEditForm
@@ -716,9 +709,7 @@ class PrefixBulkEditView(generic.BulkEditView):
 
 
 class PrefixBulkDeleteView(generic.BulkDeleteView):
-    queryset = Prefix.objects.select_related("status", "namespace", "tenant", "vlan", "role").annotate(
-        location_count=count_related(Location, "prefixes")
-    )
+    queryset = Prefix.objects.all()
     filterset = filters.PrefixFilterSet
     table = tables.PrefixTable
 
@@ -749,13 +740,8 @@ class IPAddressView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Parent prefixes table
-        parent_prefixes = (
-            instance.ancestors()
-            .restrict(request.user, "view")
-            .select_related("status", "role", "tenant")
-            .annotate(location_count=count_related(Location, "prefixes"))
-        )
-        parent_prefixes_table = tables.PrefixTable(list(parent_prefixes), orderable=False)
+        parent_prefixes = instance.ancestors().restrict(request.user, "view")
+        parent_prefixes_table = tables.PrefixTable(parent_prefixes, orderable=False)
 
         # Related IP table
         related_ips = (
@@ -1218,7 +1204,7 @@ class IPAddressToInterfaceUIViewSet(view_mixins.ObjectBulkCreateViewMixin):  # 3
 
 
 class VLANGroupListView(generic.ObjectListView):
-    queryset = VLANGroup.objects.annotate(vlan_count=count_related(VLAN, "vlan_group"))
+    queryset = VLANGroup.objects.all()
     filterset = filters.VLANGroupFilterSet
     filterset_form = forms.VLANGroupFilterForm
     table = tables.VLANGroupTable
@@ -1279,7 +1265,7 @@ class VLANGroupBulkImportView(generic.BulkImportView):  # 3.0 TODO: remove, unus
 
 
 class VLANGroupBulkDeleteView(generic.BulkDeleteView):
-    queryset = VLANGroup.objects.select_related("location").annotate(vlan_count=count_related(VLAN, "vlan_group"))
+    queryset = VLANGroup.objects.all()
     filterset = filters.VLANGroupFilterSet
     table = tables.VLANGroupTable
 
@@ -1290,7 +1276,7 @@ class VLANGroupBulkDeleteView(generic.BulkDeleteView):
 
 
 class VLANListView(generic.ObjectListView):
-    queryset = VLAN.objects.annotate(location_count=count_related(Location, "vlans"))
+    queryset = VLAN.objects.all()
     filterset = filters.VLANFilterSet
     filterset_form = forms.VLANFilterForm
     table = tables.VLANDetailTable

--- a/nautobot/tenancy/templates/tenancy/tenant.html
+++ b/nautobot/tenancy/templates/tenancy/tenant.html
@@ -44,8 +44,28 @@
             </div>
             <div class="row panel-body">
                 <div class="col-md-4 text-center">
+                    <h2><a href="{% url 'circuits:circuit_list' %}?tenant={{ object.name }}" class="btn {% if stats.circuit_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.circuit_count }}</a></h2>
+                    <p>Circuits</p>
+                </div>
+                <div class="col-md-4 text-center">
+                    <h2><a href="{% url 'virtualization:cluster_list' %}?tenant={{ object.name }}" class="btn {% if stats.cluster_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.cluster_count }}</a></h2>
+                    <p>Clusters</p>
+                </div>
+                <div class="col-md-4 text-center">
+                    <h2><a href="{% url 'dcim:device_list' %}?tenant={{ object.name }}" class="btn {% if stats.device_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.device_count }}</a></h2>
+                    <p>Devices</p>
+                </div>
+                <div class="col-md-4 text-center">
+                    <h2><a href="{% url 'ipam:ipaddress_list' %}?tenant={{ object.name }}" class="btn {% if stats.ipaddress_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.ipaddress_count }}</a></h2>
+                    <p>IP addresses</p>
+                </div>
+                <div class="col-md-4 text-center">
                     <h2><a href="{% url 'dcim:location_list' %}?tenant={{ object.name }}" class="btn {% if stats.location_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.location_count }}</a></h2>
                     <p>Locations</p>
+                </div>
+                <div class="col-md-4 text-center">
+                    <h2><a href="{% url 'ipam:prefix_list' %}?tenant={{ object.name }}" class="btn {% if stats.prefix_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.prefix_count }}</a></h2>
+                    <p>Prefixes</p>
                 </div>
                 <div class="col-md-4 text-center">
                     <h2><a href="{% url 'dcim:rack_list' %}?tenant={{ object.name }}" class="btn {% if stats.rack_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.rack_count }}</a></h2>
@@ -56,36 +76,20 @@
                     <p>Rack reservations</p>
                 </div>
                 <div class="col-md-4 text-center">
-                    <h2><a href="{% url 'dcim:device_list' %}?tenant={{ object.name }}" class="btn {% if stats.device_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.device_count }}</a></h2>
-                    <p>Devices</p>
-                </div>
-                <div class="col-md-4 text-center">
-                    <h2><a href="{% url 'ipam:vrf_list' %}?tenant={{ object.name }}" class="btn {% if stats.vrf_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.vrf_count }}</a></h2>
-                    <p>VRFs</p>
-                </div>
-                <div class="col-md-4 text-center">
-                    <h2><a href="{% url 'ipam:prefix_list' %}?tenant={{ object.name }}" class="btn {% if stats.prefix_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.prefix_count }}</a></h2>
-                    <p>Prefixes</p>
-                </div>
-                <div class="col-md-4 text-center">
-                    <h2><a href="{% url 'ipam:ipaddress_list' %}?tenant={{ object.name }}" class="btn {% if stats.ipaddress_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.ipaddress_count }}</a></h2>
-                    <p>IP addresses</p>
-                </div>
-                <div class="col-md-4 text-center">
-                    <h2><a href="{% url 'ipam:vlan_list' %}?tenant={{ object.name }}" class="btn {% if stats.vlan_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.vlan_count }}</a></h2>
-                    <p>VLANs</p>
-                </div>
-                <div class="col-md-4 text-center">
-                    <h2><a href="{% url 'circuits:circuit_list' %}?tenant={{ object.name }}" class="btn {% if stats.circuit_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.circuit_count }}</a></h2>
-                    <p>Circuits</p>
+                    <h2><a href="{% url 'extras:staticgroup_list' %}?tenant={{ object.name }}" class="btn {% if stats.staticgroup_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.staticgroup_count }}</a></h2>
+                    <p>Static groups</p>
                 </div>
                 <div class="col-md-4 text-center">
                     <h2><a href="{% url 'virtualization:virtualmachine_list' %}?tenant={{ object.name }}" class="btn {% if stats.virtualmachine_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.virtualmachine_count }}</a></h2>
                     <p>Virtual machines</p>
                 </div>
                 <div class="col-md-4 text-center">
-                    <h2><a href="{% url 'virtualization:cluster_list' %}?tenant={{ object.name }}" class="btn {% if stats.cluster_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.cluster_count }}</a></h2>
-                    <p>Clusters</p>
+                    <h2><a href="{% url 'ipam:vlan_list' %}?tenant={{ object.name }}" class="btn {% if stats.vlan_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.vlan_count }}</a></h2>
+                    <p>VLANs</p>
+                </div>
+                <div class="col-md-4 text-center">
+                    <h2><a href="{% url 'ipam:vrf_list' %}?tenant={{ object.name }}" class="btn {% if stats.vrf_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.vrf_count }}</a></h2>
+                    <p>VRFs</p>
                 </div>
             </div>
         </div>

--- a/nautobot/tenancy/views.py
+++ b/nautobot/tenancy/views.py
@@ -1,7 +1,6 @@
 from django_tables2 import RequestConfig
 
 from nautobot.circuits.models import Circuit
-from nautobot.core.models.querysets import count_related
 from nautobot.core.views import generic
 from nautobot.core.views.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.dcim.models import Device, Location, Rack, RackReservation
@@ -18,7 +17,7 @@ from .models import Tenant, TenantGroup
 
 
 class TenantGroupListView(generic.ObjectListView):
-    queryset = TenantGroup.objects.annotate(tenant_count=count_related(Tenant, "tenant_group"))
+    queryset = TenantGroup.objects.all()
     filterset = filters.TenantGroupFilterSet
     table = tables.TenantGroupTable
 
@@ -61,7 +60,7 @@ class TenantGroupBulkImportView(generic.BulkImportView):  # 3.0 TODO: remove, un
 
 
 class TenantGroupBulkDeleteView(generic.BulkDeleteView):
-    queryset = TenantGroup.objects.annotate(tenant_count=count_related(Tenant, "tenant_group"))
+    queryset = TenantGroup.objects.all()
     table = tables.TenantGroupTable
     filterset = filters.TenantGroupFilterSet
 

--- a/nautobot/tenancy/views.py
+++ b/nautobot/tenancy/views.py
@@ -5,6 +5,7 @@ from nautobot.core.models.querysets import count_related
 from nautobot.core.views import generic
 from nautobot.core.views.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.dcim.models import Device, Location, Rack, RackReservation
+from nautobot.extras.models import StaticGroup
 from nautobot.ipam.models import IPAddress, Prefix, VLAN, VRF
 from nautobot.virtualization.models import Cluster, VirtualMachine
 
@@ -82,22 +83,23 @@ class TenantView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         stats = {
+            "circuit_count": Circuit.objects.restrict(request.user, "view").filter(tenant=instance).count(),
+            "cluster_count": Cluster.objects.restrict(request.user, "view").filter(tenant=instance).count(),
+            "device_count": Device.objects.restrict(request.user, "view").filter(tenant=instance).count(),
+            "ipaddress_count": IPAddress.objects.restrict(request.user, "view").filter(tenant=instance).count(),
             # TODO: Should we include child locations of the filtered locations in the location_count below?
             "location_count": Location.objects.restrict(request.user, "view").filter(tenant=instance).count(),
+            "prefix_count": Prefix.objects.restrict(request.user, "view").filter(tenant=instance).count(),
             "rack_count": Rack.objects.restrict(request.user, "view").filter(tenant=instance).count(),
             "rackreservation_count": RackReservation.objects.restrict(request.user, "view")
             .filter(tenant=instance)
             .count(),
-            "device_count": Device.objects.restrict(request.user, "view").filter(tenant=instance).count(),
-            "vrf_count": VRF.objects.restrict(request.user, "view").filter(tenant=instance).count(),
-            "prefix_count": Prefix.objects.restrict(request.user, "view").filter(tenant=instance).count(),
-            "ipaddress_count": IPAddress.objects.restrict(request.user, "view").filter(tenant=instance).count(),
-            "vlan_count": VLAN.objects.restrict(request.user, "view").filter(tenant=instance).count(),
-            "circuit_count": Circuit.objects.restrict(request.user, "view").filter(tenant=instance).count(),
+            "staticgroup_count": StaticGroup.objects.restrict(request.user, "view").filter(tenant=instance).count(),
             "virtualmachine_count": VirtualMachine.objects.restrict(request.user, "view")
             .filter(tenant=instance)
             .count(),
-            "cluster_count": Cluster.objects.restrict(request.user, "view").filter(tenant=instance).count(),
+            "vlan_count": VLAN.objects.restrict(request.user, "view").filter(tenant=instance).count(),
+            "vrf_count": VRF.objects.restrict(request.user, "view").filter(tenant=instance).count(),
         }
 
         return {

--- a/nautobot/virtualization/tables.py
+++ b/nautobot/virtualization/tables.py
@@ -43,7 +43,9 @@ VMINTERFACE_BUTTONS = """
 class ClusterTypeTable(BaseTable):
     pk = ToggleColumn()
     name = tables.LinkColumn()
-    cluster_count = tables.Column(verbose_name="Clusters")
+    cluster_count = LinkedCountColumn(
+        viewname="virtualization:cluster_list", url_params={"cluster_type": "pk"}, verbose_name="Clusters"
+    )
     actions = ButtonsColumn(ClusterType)
 
     class Meta(BaseTable.Meta):
@@ -60,7 +62,9 @@ class ClusterTypeTable(BaseTable):
 class ClusterGroupTable(BaseTable):
     pk = ToggleColumn()
     name = tables.LinkColumn()
-    cluster_count = tables.Column(verbose_name="Clusters")
+    cluster_count = LinkedCountColumn(
+        viewname="virtualization:cluster_list", url_params={"cluster_group": "pk"}, verbose_name="Clusters"
+    )
     actions = ButtonsColumn(ClusterGroup)
 
     class Meta(BaseTable.Meta):

--- a/nautobot/virtualization/views.py
+++ b/nautobot/virtualization/views.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django_tables2 import RequestConfig
 
-from nautobot.core.models.querysets import count_related
 from nautobot.core.utils.requests import normalize_querydict
 from nautobot.core.views import generic
 from nautobot.core.views.paginator import EnhancedPaginator, get_paginate_count
@@ -25,7 +24,7 @@ from .models import Cluster, ClusterGroup, ClusterType, VirtualMachine, VMInterf
 
 
 class ClusterTypeListView(generic.ObjectListView):
-    queryset = ClusterType.objects.annotate(cluster_count=count_related(Cluster, "cluster_type"))
+    queryset = ClusterType.objects.all()
     filterset = filters.ClusterTypeFilterSet
     table = tables.ClusterTypeTable
 
@@ -35,14 +34,7 @@ class ClusterTypeView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Clusters
-        clusters = (
-            Cluster.objects.restrict(request.user, "view")
-            .filter(cluster_type=instance)
-            .select_related("cluster_group", "location", "tenant")
-        ).annotate(
-            device_count=count_related(Device, "cluster"),
-            vm_count=count_related(VirtualMachine, "cluster"),
-        )
+        clusters = Cluster.objects.restrict(request.user, "view").filter(cluster_type=instance)
 
         cluster_table = tables.ClusterTable(clusters)
         cluster_table.columns.hide("cluster_type")
@@ -73,7 +65,7 @@ class ClusterTypeBulkImportView(generic.BulkImportView):  # 3.0 TODO: remove, un
 
 
 class ClusterTypeBulkDeleteView(generic.BulkDeleteView):
-    queryset = ClusterType.objects.annotate(cluster_count=count_related(Cluster, "cluster_type"))
+    queryset = ClusterType.objects.all()
     table = tables.ClusterTypeTable
     filterset = filters.ClusterTypeFilterSet
 
@@ -84,7 +76,7 @@ class ClusterTypeBulkDeleteView(generic.BulkDeleteView):
 
 
 class ClusterGroupListView(generic.ObjectListView):
-    queryset = ClusterGroup.objects.annotate(cluster_count=count_related(Cluster, "cluster_group"))
+    queryset = ClusterGroup.objects.all()
     filterset = filters.ClusterGroupFilterSet
     table = tables.ClusterGroupTable
 
@@ -94,14 +86,7 @@ class ClusterGroupView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Clusters
-        clusters = (
-            Cluster.objects.restrict(request.user, "view")
-            .filter(cluster_group=instance)
-            .select_related("cluster_type", "location", "tenant")
-        ).annotate(
-            device_count=count_related(Device, "cluster"),
-            vm_count=count_related(VirtualMachine, "cluster"),
-        )
+        clusters = Cluster.objects.restrict(request.user, "view").filter(cluster_group=instance)
 
         cluster_table = tables.ClusterTable(clusters)
         cluster_table.columns.hide("cluster_group")
@@ -132,7 +117,7 @@ class ClusterGroupBulkImportView(generic.BulkImportView):  # 3.0 TODO: remove, u
 
 
 class ClusterGroupBulkDeleteView(generic.BulkDeleteView):
-    queryset = ClusterGroup.objects.annotate(cluster_count=count_related(Cluster, "cluster_group"))
+    queryset = ClusterGroup.objects.all()
     table = tables.ClusterGroupTable
     filterset = filters.ClusterGroupFilterSet
 
@@ -144,10 +129,7 @@ class ClusterGroupBulkDeleteView(generic.BulkDeleteView):
 
 class ClusterListView(generic.ObjectListView):
     permission_required = "virtualization.view_cluster"
-    queryset = Cluster.objects.annotate(
-        device_count=count_related(Device, "cluster"),
-        vm_count=count_related(VirtualMachine, "cluster"),
-    )
+    queryset = Cluster.objects.all()
     table = tables.ClusterTable
     filterset = filters.ClusterFilterSet
     filterset_form = forms.ClusterFilterForm
@@ -157,11 +139,7 @@ class ClusterView(generic.ObjectView):
     queryset = Cluster.objects.all()
 
     def get_extra_context(self, request, instance):
-        devices = (
-            Device.objects.restrict(request.user, "view")
-            .filter(cluster=instance)
-            .select_related("location", "rack", "tenant", "device_type__manufacturer")
-        )
+        devices = Device.objects.restrict(request.user, "view").filter(cluster=instance)
         device_table = DeviceTable(list(devices), orderable=False)
         if request.user.has_perm("virtualization.change_cluster"):
             device_table.columns.show("pk")
@@ -187,14 +165,14 @@ class ClusterBulkImportView(generic.BulkImportView):  # 3.0 TODO: remove, unused
 
 
 class ClusterBulkEditView(generic.BulkEditView):
-    queryset = Cluster.objects.select_related("cluster_type", "cluster_group", "location")
+    queryset = Cluster.objects.all()
     filterset = filters.ClusterFilterSet
     table = tables.ClusterTable
     form = forms.ClusterBulkEditForm
 
 
 class ClusterBulkDeleteView(generic.BulkDeleteView):
-    queryset = Cluster.objects.select_related("cluster_type", "cluster_group", "location")
+    queryset = Cluster.objects.all()
     filterset = filters.ClusterFilterSet
     table = tables.ClusterTable
 


### PR DESCRIPTION
# Closes #5472
# What's Changed

Continuation of the work from #5631.

- Automatically add a `static_groups` filter to any subclass of BaseFilterSet that is static-group-associable
  - This ended up looking similar to the logic that we had in `get_filterset_parameter_form_field()` for tag, status, and role generic filters, but I liked my implementation better as it's on the filterset itself rather than a separate function. So I refactored how those three filters are set up to similarly move their logic to the filterset or mixin and out of the function.
- Add "Update Static Groups" button to object_list.html generic template
  - This opens a simple modal rather than sending the user to a separate view, similar to the Saved View modal in #5639.
  - Add custom form and custom view for bulk-assigning selected objects to static groups as backing for this modal.
- Add "Static Groups" tab to object_retrieve.html generic template (and device.html template since that overrides it)
  - Like the "Contacts" tab, this is implemented as part of the base view/template rather than a separate standalone view.
- Add `tenant` field to the StaticGroup model, and update factory, filterset, and tests accordingly
  - [x] TODO might need some model documentation update for this
- Add full UI for StaticGroups, including nav menu entry
- Add limited subset of UI for StaticGroupAssociations
- Add static groups count to Tenant detail view and re-sort its contents alphabetically.

# Screenshots

![image](https://github.com/nautobot/nautobot/assets/5603551/f487fdc7-a034-43ee-b78b-40bc291fd99b)
![image](https://github.com/nautobot/nautobot/assets/5603551/fea6b14c-2833-427a-85f3-140486709081)
![image](https://github.com/nautobot/nautobot/assets/5603551/79be6a73-2c91-418c-85f8-5cbcd1d3c0a7)
![image](https://github.com/nautobot/nautobot/assets/5603551/97e1acc4-d65a-4046-9732-27b40c0b3649)
![image](https://github.com/nautobot/nautobot/assets/5603551/71e4a396-9c97-43d5-975f-80462e8e1743)
![image](https://github.com/nautobot/nautobot/assets/5603551/d54df998-f7e0-4928-b9a4-98eea488b748)
![image](https://github.com/nautobot/nautobot/assets/5603551/0a2c20f5-8e7c-4ca3-8698-d5d632c3a669)
![image](https://github.com/nautobot/nautobot/assets/5603551/51bbfdf2-5733-48d5-94e3-b23dd93fa8ad)
![image](https://github.com/nautobot/nautobot/assets/5603551/6d514a47-0eb6-4161-9521-6f1d463ce84e)



<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
