### PR TITLE
Make 'saved_view=...' query param imply the correct filtering, sorting, config, and pagination values

### DIFF
--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -35,7 +35,14 @@ class BaseTable(django_tables2.Table):
         }
 
     def __init__(
-        self, *args, table_changes_pending=False, saved_view=None, user=None, hide_hierarchy_ui=False, **kwargs
+        self,
+        *args,
+        table_changes_pending=False,
+        saved_view=None,
+        user=None,
+        hide_hierarchy_ui=False,
+        order_by=None,
+        **kwargs,
     ):
         # Add custom field columns
         model = self._meta.model
@@ -64,8 +71,11 @@ class BaseTable(django_tables2.Table):
                 )
             # symmetric relationships are already handled above in the source_type case
 
+        if order_by is None and saved_view is not None:
+            order_by = saved_view.config.get("sort_order", None)
+
         # Init table
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, order_by=order_by, **kwargs)
         self.hide_hierarchy_ui = hide_hierarchy_ui
 
         # Set default empty_text if none was provided

--- a/nautobot/core/utils/requests.py
+++ b/nautobot/core/utils/requests.py
@@ -65,7 +65,10 @@ def convert_querydict_to_factory_formset_acceptable_querydict(request_querydict,
                     # the filterset can handle the QueryDict conversion and we can just pass the QueryDict to the filterset
                     # then use the FilterSet to de-dupe the field names
                     lookup_field = re.sub(r"__\w+", "", filter_field_name)
-                lookup_value = request_querydict.getlist(filter_field_name)
+                if isinstance(request_querydict, QueryDict):
+                    lookup_value = request_querydict.getlist(filter_field_name)
+                else:
+                    lookup_value = request_querydict.get(filter_field_name)
 
                 query_dict.setlistdefault(lookup_field_placeholder % num, [lookup_field])
                 query_dict.setlistdefault(lookup_type_placeholder % num, [filter_field_name])

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -232,6 +232,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
         model = self.queryset.model
         content_type = ContentType.objects.get_for_model(model)
 
+        filter_params = request.GET
         display_filter_params = []
         dynamic_filter_form = None
         filter_form = None
@@ -261,7 +262,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
 
             if request.GET:
                 factory_formset_params = convert_querydict_to_factory_formset_acceptable_querydict(
-                    request.GET, filterset
+                    filter_params, filterset
                 )
                 dynamic_filter_form = DynamicFilterFormSet(filterset=filterset, data=factory_formset_params)
             else:
@@ -311,9 +312,6 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
         )
         if self.table:
             # Construct the objects table
-            if self.request.GET.getlist("sort"):
-                hide_hierarchy_ui = True  # hide tree hierarchy if custom sort is used
-            table_changes_pending = self.request.GET.get("table_changes_pending", False)
             if current_saved_view_pk:
                 try:
                     current_saved_view = SavedView.objects.restrict(request.user, "view").get(
@@ -321,6 +319,11 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
                     )
                 except ObjectDoesNotExist:
                     messages.error(request, f"Saved view {current_saved_view_pk} not found")
+            if self.request.GET.getlist("sort") or (
+                current_saved_view is not None and current_saved_view.config.get("sort_order")
+            ):
+                hide_hierarchy_ui = True  # hide tree hierarchy if custom sort is used
+            table_changes_pending = self.request.GET.get("table_changes_pending", False)
 
             table = self.table(
                 self.queryset,
@@ -348,7 +351,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
 
         # For the search form field, use a custom placeholder.
         q_placeholder = "Search " + bettertitle(model._meta.verbose_name_plural)
-        search_form = SearchForm(data=request.GET, q_placeholder=q_placeholder)
+        search_form = SearchForm(data=filter_params, q_placeholder=q_placeholder)
 
         valid_actions = self.validate_action_buttons(request)
 

--- a/nautobot/core/views/paginator.py
+++ b/nautobot/core/views/paginator.py
@@ -41,13 +41,14 @@ class EnhancedPage(Page):
         return page_list
 
 
-def get_paginate_count(request):
+def get_paginate_count(request, saved_view=None):
     """
     Determine the length of a page, using the following in order:
 
         1. per_page URL query parameter
-        2. Saved user preference
-        3. PAGINATE_COUNT global setting.
+        2. Saved view config
+        3. Saved user preference
+        4. PAGINATE_COUNT global setting.
     """
     if "per_page" in request.GET:
         try:
@@ -57,6 +58,11 @@ def get_paginate_count(request):
             return per_page
         except ValueError:
             pass
+
+    if saved_view is not None:
+        per_page = saved_view.config.get("pagination_count", None)
+        if per_page:
+            return per_page
 
     if request.user.is_authenticated:
         return request.user.get_config("pagination.per_page", config.get_settings_or_config("PAGINATE_COUNT"))

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -114,7 +114,7 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
             # Apply the request context
             paginate = {
                 "paginator_class": EnhancedPaginator,
-                "per_page": get_paginate_count(request),
+                "per_page": get_paginate_count(request, self.saved_view),
             }
             max_page_size = get_settings_or_config("MAX_PAGE_SIZE")
             if max_page_size and paginate["per_page"] > max_page_size:

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -52,7 +52,7 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
         if filterset_class:
             filterset = filterset_class()
             factory_formset_params = convert_querydict_to_factory_formset_acceptable_querydict(
-                view.filter_params, filterset
+                view.filter_params if view.filter_params is not None else request.GET, filterset
             )
         return DynamicFilterFormSet(filterset=filterset, data=factory_formset_params)
 

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -51,7 +51,9 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
         filterset = None
         if filterset_class:
             filterset = filterset_class()
-            factory_formset_params = convert_querydict_to_factory_formset_acceptable_querydict(request.GET, filterset)
+            factory_formset_params = convert_querydict_to_factory_formset_acceptable_querydict(
+                view.filter_params, filterset
+            )
         return DynamicFilterFormSet(filterset=filterset, data=factory_formset_params)
 
     def construct_user_permissions(self, request, model):
@@ -78,14 +80,16 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
         if view.action in ["list", "notes", "changelog"]:
             if view.action == "list":
                 permissions = kwargs.get("permissions", {})
-                if view.request.GET.getlist("sort"):
-                    view.hide_hierarchy_ui = True  # hide tree hierarchy if custom sort is used
                 self.saved_view = None
                 if saved_view_pk is not None:
                     try:
                         self.saved_view = SavedView.objects.restrict(request.user, "view").get(pk=saved_view_pk)
                     except ObjectDoesNotExist:
                         pass
+                if view.request.GET.getlist("sort") or (
+                    self.saved_view is not None and self.saved_view.config.get("sort_order")
+                ):
+                    view.hide_hierarchy_ui = True  # hide tree hierarchy if custom sort is used
                 table = table_class(
                     queryset,
                     table_changes_pending=table_changes_pending,
@@ -200,9 +204,9 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
                         for field_name, values in view.filter_params.items()
                     ]
                     if view.filterset_form_class is not None:
-                        filter_form = view.filterset_form_class(request.GET, label_suffix="")
+                        filter_form = view.filterset_form_class(view.filter_params, label_suffix="")
                 table = self.construct_table(view, request=request, permissions=permissions)
-                search_form = SearchForm(data=request.GET)
+                search_form = SearchForm(data=view.filter_params)
             elif view.action == "destroy":
                 form = form_class(initial=request.GET)
             elif view.action in ["create", "update"]:

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -633,6 +633,16 @@ function initializeDynamicFilterForm(context){
     // Remove applied filters
     this_context.find(".remove-filter-param").on("click", function(){
         let query_params = new URLSearchParams(location.search);
+        if (query_params.has("saved_view")) {
+            // Need to reverse-engineer the "real" query params from the rendered page
+            for (let element of document.getElementsByClassName("filter-selection-choice-remove")) {
+                let key = element.getAttribute("data-field-parent");
+                let value = element.getAttribute("data-field-value");
+                if (!query_params.has(key, value)) {
+                    query_params.append(key, value);
+                }
+            }
+        }
         let type = $(this).attr("data-field-type");
         let field_value = $(this).attr("data-field-value");
 

--- a/nautobot/users/models.py
+++ b/nautobot/users/models.py
@@ -1,7 +1,5 @@
 import binascii
 import os
-import urllib
-import urllib.parse
 
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser, Group, UserManager as UserManager_
@@ -15,7 +13,6 @@ from django.utils import timezone
 from nautobot.core.constants import CHARFIELD_MAX_LENGTH
 from nautobot.core.models import BaseManager, BaseModel, CompositeKeyQuerySetMixin
 from nautobot.core.models.fields import JSONArrayField
-from nautobot.core.utils.config import get_settings_or_config
 from nautobot.core.utils.data import flatten_dict
 from nautobot.extras.models.change_logging import ChangeLoggedModel
 from nautobot.extras.utils import extras_features
@@ -329,20 +326,3 @@ class SavedView(BaseModel, ChangeLoggedModel):
 
     def __str__(self):
         return f"{self.owner.username} - {self.view} - {self.name}"
-
-    @property
-    def view_config(self):
-        """Return a combined query strings of the config e.g. table_config, pagination_count, filter_params, sort_order stored on this SavedView"""
-        query_string = "?"
-        params = []
-        for key, value in self.config.get("filter_params", {}).items():
-            for item in value:
-                params.append((key, item))
-
-        params.append(("per_page", self.config.get("pagination_count", get_settings_or_config("PAGINATE_COUNT"))))
-
-        for value in self.config.get("sort", []):
-            params.append(("sort", value))
-
-        query_string += urllib.parse.urlencode(params)
-        return query_string

--- a/nautobot/users/views.py
+++ b/nautobot/users/views.py
@@ -268,8 +268,7 @@ class SavedViewUIViewSet(
         The detail view for a saved view should the related ObjectListView with saved configurations applied
         """
         instance = self.get_object()
-        query_string = instance.view_config
-        list_view_url = reverse(instance.view) + query_string + f"&saved_view={instance.pk}"
+        list_view_url = reverse(instance.view) + f"?saved_view={instance.pk}"
         return redirect(list_view_url)
 
     def update(self, request, *args, **kwargs):


### PR DESCRIPTION
# What's Changed

Adjustment to the work being done in #5639.

Make it so that we don't need `?saved_view=...&filter=...&sort=...&per_page=...` when using a Saved View - just specifying `?saved_view=...` implies the correct filter, sort, per_page, and table config values if not explicitly overridden by query params.

Doesn't manage to get rid of the need for `?table_changes_pending` parameter, maybe in the future we can tackle that too.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots

`saved_view` alone implies other parameters:

![image](https://github.com/nautobot/nautobot/assets/5603551/c98a28ad-bd54-4480-9902-43a8a22e78cf)

Removing a query parameter by clicking the "x" works and is detected as a change to the saved view:

![image](https://github.com/nautobot/nautobot/assets/5603551/736c47d6-42ef-43ea-a543-2b45f8ff59ab)

Returning to the saved view, can see that the filter forms are also correctly populated:

![image](https://github.com/nautobot/nautobot/assets/5603551/c11bef46-02d1-4b7a-aeb9-8360f8474cc1)
![image](https://github.com/nautobot/nautobot/assets/5603551/00890c00-3361-4fd8-b388-417b903f5a47)

Adding a new filter param gets correctly merged with the saved view params and is detected as a change:

![image](https://github.com/nautobot/nautobot/assets/5603551/55a7104f-52a2-4661-985b-3ee2e1458c2d)



<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- n/a Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
