### PR TITLE
Add static_groups and associated_contacts fields to GraphQL types

### DIFF
--- a/changes/5472.added
+++ b/changes/5472.added
@@ -3,4 +3,5 @@ Added `feature` filter to `/api/extras/content-types/`.
 Added `static_groups` filter to all applicable models via the `BaseFilterSet` class.
 Added `static_groups` field to applicable model create/edit forms via the `StaticGroupModelFormMixin` class (included in `NautobotModelForm` class automatically).
 Added `Static Groups` column to applicable model tables.
+Added `static_groups` and `associated_contacts` to applicable GraphQL types.
 Enhanced `BaseTable` class to automatically apply appropriate `count_related` annotations for any `LinkedCountColumn`.

--- a/nautobot/extras/apps.py
+++ b/nautobot/extras/apps.py
@@ -31,12 +31,11 @@ class ExtrasConfig(NautobotConfig):
         from graphene_django.converter import convert_django_field
 
         from nautobot.core.models.fields import TagsField
-        from nautobot.extras.graphql.types import TagType
 
         @convert_django_field.register(TagsField)
         def convert_field_to_list_tags(field, registry=None):
             """Convert TagsField to List of Tags."""
-            return graphene.List(TagType)
+            return graphene.List("nautobot.extras.graphql.types.TagType")
 
         from nautobot.extras.plugins.validators import wrap_model_clean_methods
 

--- a/nautobot/extras/graphql/types.py
+++ b/nautobot/extras/graphql/types.py
@@ -1,4 +1,3 @@
-
 from nautobot.core.graphql.types import OptimizedNautobotObjectType
 from nautobot.extras.filters import (
     ContactAssociationFilterSet,

--- a/nautobot/extras/graphql/types.py
+++ b/nautobot/extras/graphql/types.py
@@ -1,14 +1,37 @@
+
 from nautobot.core.graphql.types import OptimizedNautobotObjectType
-from nautobot.extras.filters import DynamicGroupFilterSet, StatusFilterSet, TagFilterSet
-from nautobot.extras.models import DynamicGroup, Status, Tag
+from nautobot.extras.filters import (
+    ContactAssociationFilterSet,
+    DynamicGroupFilterSet,
+    StaticGroupFilterSet,
+    StatusFilterSet,
+    TagFilterSet,
+)
+from nautobot.extras.models import ContactAssociation, DynamicGroup, StaticGroup, Status, Tag
 
 
-class TagType(OptimizedNautobotObjectType):
-    """Graphql Type Object for Tag model."""
+class ContactAssociationType(OptimizedNautobotObjectType):
+    """GraphQL Type object for `ContactAssociation` model."""
 
     class Meta:
-        model = Tag
-        filterset_class = TagFilterSet
+        model = ContactAssociation
+        filterset_class = ContactAssociationFilterSet
+
+
+class DynamicGroupType(OptimizedNautobotObjectType):
+    """Graphql Type object for `DynamicGroup` model."""
+
+    class Meta:
+        model = DynamicGroup
+        filterset_class = DynamicGroupFilterSet
+
+
+class StaticGroupType(OptimizedNautobotObjectType):
+    """GraphQL Type object for `StaticGroup` model."""
+
+    class Meta:
+        model = StaticGroup
+        filterset_class = StaticGroupFilterSet
 
 
 class StatusType(OptimizedNautobotObjectType):
@@ -19,9 +42,9 @@ class StatusType(OptimizedNautobotObjectType):
         filterset_class = StatusFilterSet
 
 
-class DynamicGroupType(OptimizedNautobotObjectType):
-    """Graphql Type object for `DynamicGroup` model."""
+class TagType(OptimizedNautobotObjectType):
+    """Graphql Type Object for Tag model."""
 
     class Meta:
-        model = DynamicGroup
-        filterset_class = DynamicGroupFilterSet
+        model = Tag
+        filterset_class = TagFilterSet


### PR DESCRIPTION
# Closes #5472 
# What's Changed

- Extend GraphQL schema generation to automatically add `static_groups` and `associated_contacts` fields to applicable models.
  - In support of this, add explicitly defined `StaticGroupType` and `ContactAssociationType` type declarations.

# Screenshots


```graphql
query { 
  locations (limit: 1, static_groups:["alpha"]){
    name
    static_groups {
      name
    }
    associated_contacts {
      contact {
        name
      }
      team {
        name
      }
      role { name }
      status {name}
    }
  }
}
```

response:

```json
{
  "data": {
    "locations": [
      {
        "name": "Campus-01",
        "static_groups": [
          {
            "name": "alpha"
          },
          {
            "name": "Cooler locations"
          },
          {
            "name": "Delta"
          }
        ],
        "associated_contacts": [
          {
            "contact": {
              "name": "Nathan Bonilla"
            },
            "team": null,
            "role": {
              "name": "CreativeAutomatic"
            },
            "status": {
              "name": "Active"
            }
          }
        ]
      }
    ]
  }
}
```


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
