### PR TITLE
Revert unintended behavior change in Job class API

### DIFF
--- a/changes/5691.fixed
+++ b/changes/5691.fixed
@@ -1,0 +1,1 @@
+Restored pre-2.2.3 behavior of `Job().name` attribute (as distinct from `Job.name` classproperty) to fix unintended breakage of the `nautobot-golden-config` App.

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -330,7 +330,7 @@ class BaseJob:
         return result
 
     @classproperty
-    def name(cls) -> str:  # pylint: disable=no-self-argument
+    def name(cls) -> str:  # pylint: disable=no-self-argument, method-hidden
         """
         `Job.name` is the `Meta.name` if any, else the class name; however, `Job().name` is the `class_path` value.
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -109,6 +109,8 @@ class BaseJob:
 
     def __init__(self):
         self.logger = get_task_logger(self.__module__)
+        # Override the `name` classproperty on the instance; see the classproperty docstring for details and history.
+        self.name = self.class_path
 
     def __call__(self, *args, **kwargs):
         # Attempt to resolve serialized data back into original form by creating querysets or model instances
@@ -327,9 +329,14 @@ class BaseJob:
             raise TypeError(f"Meta.{attr_name} should be {expected_type}, not {type(result)}")
         return result
 
-    @final
     @classproperty
     def name(cls) -> str:  # pylint: disable=no-self-argument
+        """
+        `Job.name` is the `Meta.name` if any, else the class name; however, `Job().name` is the `class_path` value.
+
+        This discrepancy was introduced in the 2.0 Jobs refactoring, and by the time we noticed it,
+        there were already Apps relying on this behavior. :-(
+        """
         return cls._get_meta_attr_and_assert_type("name", cls.__name__, expected_type=str)
 
     @final

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -43,6 +43,15 @@ class JobTest(TestCase):
     Test job features that don't require a transaction test case.
     """
 
+    def test_name_inconsistency(self):
+        """
+        Test that `Job.name` != `Job().name`, an inconsistency we introduced in 2.0 but which Apps are relying on.
+        """
+        job_class = get_job("nautobot.core.jobs.ExportObjectList")
+        self.assertEqual(job_class.name, "Export Object List")
+        job_instance = job_class()
+        self.assertEqual(job_instance.name, "nautobot.core.jobs.ExportObjectList")
+
     def test_field_default(self):
         """
         Job test with field that is a default value that is falsey.


### PR DESCRIPTION
# Closes #5691
# What's Changed

In the conversion of Jobs to Celery tasks in 2.0, we added [code](https://github.com/nautobot/nautobot/compare/v2.2.2...v2.2.3#diff-e4b3fe39da892dc97291f6a19ae5449758cd5a1353cb61a19cbc6bffe41ade4eL32-L41) that, when instantiating a Job class, overrode its `name` classproperty with the `registered_name` (i.e. the `class_path`) of the Job. I'm not sure why we needed to do this, but current versions of `nautobot-golden-config` were relying on this behavior when introspecting which of their Jobs were being run. I removed this code as a part of the changes in #5586, not realizing that golden-config was relying on this, which resulted in #5691. As it's possible that there are other apps that are also relying on the previous behavior, I've taken the approach here of restoring the previous behavior rather than asking golden-config to update its code. Therefore, this PR reintroduces the 2.0-2.2.2 behavior wherein `JobClass.name` is the `Meta.name` value, but `JobClass().name` is the `class_path` value, and adds a test case verifying this behavior.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots

```python
>>> from nautobot.extras.jobs import get_jobs
>>> get_jobs()["nautobot.core.jobs.ExportObjectList"].name
'Export Object List'
>>> get_jobs()["nautobot.core.jobs.ExportObjectList"]().name
'nautobot.core.jobs.ExportObjectList'
```


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
