### PR TITLE
[LTM] allow a GitRepository to 'reclaim' Jobs from a previously deleted repository

### DIFF
--- a/changes/2974.fixed
+++ b/changes/2974.fixed
@@ -1,0 +1,1 @@
+Fixed an error when deleting and then recreating a GitRepository that provides Jobs.


### PR DESCRIPTION
# Closes #2974 
# What's Changed

When deleting a GitRepository, `on_delete=SET_NULL` causes all of its existing Job records to be updated with a null `git_repository` ForeignKey. When creating a new GitRepository record, we try to `get_or_create` Job records with the new GitRepository pk, and this fails since the pk doesn't match null but the other uniqueness constraints of the Job record still apply, resulting in an IntegrityError.

Solution: To handle this specific case, catch the IntegrityError and fall back to looking for an existing Job record that matches all other appropriate attributes but has a null `git_repository`, and update it to point to the new GitRepository.

This is an LTM-specific issue, as Jobs in 2.x do not have a `git_repository` FK but rather just a `@property` that dynamically looks up the appropriate GitRepository record based on the Job's `module_name`.

# Screenshots

Before:

![image](https://github.com/nautobot/nautobot/assets/5603551/20da5af7-b942-4f7b-a3f2-5fc8378674bd)

After:

![image](https://github.com/nautobot/nautobot/assets/5603551/197a030c-e979-4d63-bd74-df86f45c3d45)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
