### PR TITLE
Avoid creating underscore-prefixed filters when FilterSet includes '__all__'

### DIFF
--- a/nautobot/core/filters.py
+++ b/nautobot/core/filters.py
@@ -716,6 +716,11 @@ class BaseFilterSet(django_filters.FilterSet):
         """
         filters = super().get_filters()
 
+        # Remove any filters that may have been auto-generated from private model attributes
+        for filter_name in list(filters.keys()):
+            if filter_name.startswith("_"):
+                del filters[filter_name]
+
         # django-filters has no concept of "abstract" filtersets, so we have to fake it
         if cls._meta.model is not None:
             new_filters = {}


### PR DESCRIPTION
# What's Changed

An unanticipated/unintended side effect of using `fields = "__all__"` in declaring a FilterSet was that django-filter really does interpret this as "all fields", including underscore-prefixed fields that would normally be considered private in a Pythonic sense. The most notable instance of this was on our newer custom-field-capable models that were using `fields = "__all__"`, as these unexpectedly developed a `_custom_field_data` filter in addition to the expected individual custom field filters. This in turn led to a series of noisy warnings when generating the GraphQL schema, as GraphQL filter names *cannot* start with an underscore:

```
19:03:50.398 INFO    nautobot.core.graphql.schema schema.py                 generate_query_mixin() :
  Beginning generation of Nautobot GraphQL schema
19:03:50.398 DEBUG   nautobot.core.graphql.schema schema.py                 generate_query_mixin() :
  Generating dynamic schemas for all models in the models_features graphql registry
19:03:50.704 DEBUG   nautobot.core.graphql.schema schema.py                 generate_query_mixin() :
  Adding plugins' statically defined graphql schema types
19:03:50.704 DEBUG   nautobot.core.graphql.schema schema.py                 generate_query_mixin() :
  Extending all registered schema types with dynamic attributes
19:03:51.748 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerFilterSet is not GraphQL safe, and will be omitted
19:03:52.170 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on SoftwareVersionFilterSet is not GraphQL safe, and will be omitted
19:03:52.197 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerFilterSet is not GraphQL safe, and will be omitted
19:03:52.832 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerFilterSet is not GraphQL safe, and will be omitted
19:03:53.073 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on NamespaceFilterSet is not GraphQL safe, and will be omitted
19:03:54.181 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerFilterSet is not GraphQL safe, and will be omitted
19:03:54.318 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ContactAssociationFilterSet is not GraphQL safe, and will be omitted
19:03:54.589 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on SoftwareImageFileFilterSet is not GraphQL safe, and will be omitted
19:03:54.614 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on SoftwareVersionFilterSet is not GraphQL safe, and will be omitted
19:03:54.638 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerFilterSet is not GraphQL safe, and will be omitted
19:03:54.847 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ContactAssociationFilterSet is not GraphQL safe, and will be omitted
19:03:54.959 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ContactAssociationFilterSet is not GraphQL safe, and will be omitted
19:03:54.993 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ContactFilterSet is not GraphQL safe, and will be omitted
19:03:55.033 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ContactAssociationFilterSet is not GraphQL safe, and will be omitted
19:03:55.066 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on TeamFilterSet is not GraphQL safe, and will be omitted
19:03:55.105 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ContactAssociationFilterSet is not GraphQL safe, and will be omitted
19:03:56.508 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerFilterSet is not GraphQL safe, and will be omitted
19:03:56.579 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on SoftwareImageFileFilterSet is not GraphQL safe, and will be omitted
19:03:56.682 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on SoftwareImageFileFilterSet is not GraphQL safe, and will be omitted
19:03:56.753 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on SoftwareVersionFilterSet is not GraphQL safe, and will be omitted
19:03:56.827 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerManagedDeviceGroupFilterSet is not GraphQL safe, and will be omitted
19:03:56.847 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerFilterSet is not GraphQL safe, and will be omitted
19:03:56.929 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerManagedDeviceGroupFilterSet is not GraphQL safe, and will be omitted
19:03:56.949 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerManagedDeviceGroupFilterSet is not GraphQL safe, and will be omitted
19:03:58.301 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on NamespaceFilterSet is not GraphQL safe, and will be omitted
19:03:59.140 WARNING nautobot.core.graphql.utils utils.py        get_filtering_args_from_filterset() :
  Filter "_custom_field_data" on ControllerFilterSet is not GraphQL safe, and will be omitted
19:03:59.542 INFO    nautobot.core.graphql.schema schema.py                 generate_query_mixin() :
  Generation of Nautobot GraphQL schema complete
```

Since we never intended `_custom_field_data` and similar fields like `_name` to be directly and automatically filterable, the simplest solution is to customize our `BaseFilterSet` class's `get_filters()` method to automatically remove and discard any `_`-prefixed filter names that were otherwise automatically added.

# Screenshots

After:

```
19:09:24.869 INFO    nautobot.core.graphql.schema schema.py                 generate_query_mixin() :
  Beginning generation of Nautobot GraphQL schema
19:09:24.869 DEBUG   nautobot.core.graphql.schema schema.py                 generate_query_mixin() :
  Generating dynamic schemas for all models in the models_features graphql registry
19:09:25.079 DEBUG   nautobot.core.graphql.schema schema.py                 generate_query_mixin() :
  Adding plugins' statically defined graphql schema types
19:09:25.080 DEBUG   nautobot.core.graphql.schema schema.py                 generate_query_mixin() :
  Extending all registered schema types with dynamic attributes
19:09:32.486 INFO    nautobot.core.graphql.schema schema.py                 generate_query_mixin() :
  Generation of Nautobot GraphQL schema complete
```

Also confirmed in the Swagger UI that the unintended `_custom_field_data` filter was present on various endpoints before this change, but is no longer present after this change.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
