### PR TITLE
Fix xmlsec/lxml mismatch in Docker image

### DIFF
--- a/changes/5707.fixed
+++ b/changes/5707.fixed
@@ -1,0 +1,1 @@
+Fixed invalid installation of `xmlsec` library in the Docker images.

--- a/changes/5707.fixed
+++ b/changes/5707.fixed
@@ -1,1 +1,1 @@
-Fixed invalid installation of `xmlsec` library in the Docker images.
+Fixed invalid installation of `xmlsec` library in the Nautobot Docker images.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -125,7 +125,7 @@ ENV PATH="${POETRY_HOME}/bin:${PATH}"
 
 RUN poetry config virtualenvs.create ${POETRY_VIRTUALENVS_CREATE} && \
     poetry config installer.parallel "${POETRY_INSTALLER_PARALLEL}" && \
-    poetry config installer.no-binary lxml,pyuwsgi
+    poetry config installer.no-binary lxml,pyuwsgi,xmlsec
 
 ################################ Stage: python-dependencies (intermediate build target)
 

--- a/nautobot/docs/user-guide/administration/configuration/authentication/sso.md
+++ b/nautobot/docs/user-guide/administration/configuration/authentication/sso.md
@@ -28,10 +28,10 @@ If you are using OpenID Connect or SAML you will also need to install the extra 
     sudo apt install -y libxmlsec1-dev libxmlsec1-openssl pkg-config
     ```
 
-Furthermore, due to potential incompatibilities between the precompiled binaries for the `lxml` and `xmlsec` Python packages that this installation will bring in, you need to tell Pip to not install the precompiled binary for `lxml`. Run the following command as the `nautobot` user:
+Furthermore, due to potential incompatibilities between the precompiled binaries for the `lxml` and `xmlsec` Python packages that this installation will bring in, you need to tell Pip to not install the precompiled binary for either of these packages. Run the following command as the `nautobot` user:
 
 ```no-highlight
-pip3 install --no-binary=lxml "nautobot[sso]"
+pip3 install --no-binary=lxml,xmlsec "nautobot[sso]"
 ```
 
 ## Configuration


### PR DESCRIPTION
# Closes #N/A
# What's Changed

In order for both of the SSO dependencies `lxml` and `xmlsec` to be usable together, they *both* need to be installed from source rather than from wheels. We already were installing `lxml` from source but missed doing the same for `xmlsec`.

# Screenshots

Before:

```
❯ invoke cli        
root@1d381b1a39e4:/source# python
Python 3.8.19 (default, Apr 24 2024, 13:06:49) 
[GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import xmlsec
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
xmlsec.InternalError: (-1, 'lxml & xmlsec libxml2 library version mismatch')
>>> 
```

After:

```
❯ invoke cli        
root@915b74fb7e21:/source# python
Python 3.8.19 (default, Apr 24 2024, 13:06:49) 
[GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import xmlsec
>>> 
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
