### PR TITLE
Fixes IntegrityError when setting DeviceType software images to null

### DIFF
--- a/changes/5708.fixed
+++ b/changes/5708.fixed
@@ -1,0 +1,1 @@
+Fixed integrity error when doing bulk edits that resulted from a delete operation on a related model.

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -91,9 +91,12 @@ class ChangeContext:
                 for entry in self.deferred_object_changes[key]:
                     objectchange = entry["instance"].to_objectchange(entry["action"])
                     objectchange.user = entry["user"]
+                    objectchange.user_name = objectchange.user.username
                     objectchange.request_id = self.change_id
                     objectchange.change_context = self.context
                     objectchange.change_context_detail = self.context_detail[:CHANGELOG_MAX_CHANGE_CONTEXT_DETAIL]
+                    if not objectchange.changed_object_id:
+                        objectchange.changed_object_id = entry.get("changed_object_id")
                     create_object_changes.append(objectchange)
                 self.deferred_object_changes.pop(key, None)
             ObjectChange.objects.bulk_create(create_object_changes, batch_size=batch_size)

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -246,7 +246,12 @@ def _handle_deleted_object(sender, instance, **kwargs):
 
         if save_new_objectchange:
             change_context.deferred_object_changes.setdefault(unique_object_change_id, []).append(
-                {"action": ObjectChangeActionChoices.ACTION_DELETE, "instance": instance, "user": user}
+                {
+                    "action": ObjectChangeActionChoices.ACTION_DELETE,
+                    "instance": instance,
+                    "user": user,
+                    "changed_object_id": instance.pk,
+                }
             )
             if not change_context.defer_object_changes:
                 objectchange = instance.to_objectchange(ObjectChangeActionChoices.ACTION_DELETE)

--- a/nautobot/extras/tests/test_context_managers.py
+++ b/nautobot/extras/tests/test_context_managers.py
@@ -312,9 +312,8 @@ class BulkEditDeleteChangeLogging(TestCase):
         software_image_file = SoftwareImageFile.objects.create(
             image_file_name="test.iso", software_version=software_version, status=software_status
         )
-        device_type = DeviceType(manufacturer=manufacturer, model="test123")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="test123")
         device_type.software_image_files.set([software_image_file])
-        DeviceType.objects.bulk_create([device_type])
         with web_request_context(self.user):
             with deferred_change_logging_for_bulk_operation():
                 device_type.software_image_files.set([])

--- a/nautobot/extras/tests/test_context_managers.py
+++ b/nautobot/extras/tests/test_context_managers.py
@@ -5,7 +5,16 @@ from django.test import TestCase
 from nautobot.core.celery import app
 from nautobot.core.testing import TransactionTestCase
 from nautobot.core.utils.lookup import get_changes_for_model
-from nautobot.dcim.models import Location, LocationType
+from nautobot.dcim.models import (
+    DeviceType,
+    DeviceTypeToSoftwareImageFile,
+    Location,
+    LocationType,
+    Manufacturer,
+    Platform,
+    SoftwareImageFile,
+    SoftwareVersion,
+)
 from nautobot.extras.choices import ObjectChangeActionChoices, ObjectChangeEventContextChoices
 from nautobot.extras.context_managers import (
     deferred_change_logging_for_bulk_operation,
@@ -293,6 +302,30 @@ class BulkEditDeleteChangeLogging(TestCase):
             self.assertIsNotNone(snapshots["postchange"])
             self.assertIsNone(snapshots["differences"]["removed"])
             self.assertEqual(snapshots["differences"]["added"]["description"], "changed")
+
+    def test_bulk_edit_device_type_software_image_file(self):
+        """Test that bulk edits to null does not cause integrity error"""
+        manufacturer = Manufacturer.objects.create(name="Test")
+        platform = Platform.objects.create(name="Test")
+        software_status = Status.objects.get_for_model(SoftwareVersion).first()
+        software_version = SoftwareVersion.objects.create(version="1.0.0", platform=platform, status=software_status)
+        software_image_file = SoftwareImageFile.objects.create(
+            image_file_name="test.iso", software_version=software_version, status=software_status
+        )
+        device_type = DeviceType(manufacturer=manufacturer, model="test123")
+        device_type.software_image_files.set([software_image_file])
+        DeviceType.objects.bulk_create([device_type])
+        with web_request_context(self.user):
+            with deferred_change_logging_for_bulk_operation():
+                device_type.software_image_files.set([])
+                device_type.save()
+
+        oc_list = get_changes_for_model(DeviceTypeToSoftwareImageFile)
+        self.assertEqual(len(oc_list), 1)
+        self.assertEqual(oc_list[0].action, ObjectChangeActionChoices.ACTION_DELETE)
+        self.assertIsNotNone(oc_list[0].changed_object_id)
+        self.assertEqual(oc_list[0].user, self.user)
+        self.assertEqual(oc_list[0].user_name, self.user.username)
 
     def test_change_log_context(self):
         location_type = LocationType.objects.get(name="Campus")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5708 
# What's Changed
- Captured `pk` of the changed_object in the signals before the delete operation removed it
- Added `user_name` to the change log record which was missing in this case.  (Similar to #5689)
# Screenshots
Bulk edit to null on `device_type.software_image_files` works correctly now.
![image](https://github.com/nautobot/nautobot/assets/141754521/0dde07e6-cf3d-4b05-89e0-4b8266e1774e)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests

