### PR TITLE
Add DeviceFamily column to DeviceTypeTable

### DIFF
--- a/changes/5655.added
+++ b/changes/5655.added
@@ -1,0 +1,1 @@
+Added "Device Family" as a configurable column in the Device Types table view.

--- a/nautobot/dcim/tables/devicetypes.py
+++ b/nautobot/dcim/tables/devicetypes.py
@@ -103,6 +103,8 @@ class DeviceFamilyTable(BaseTable):
 class DeviceTypeTable(BaseTable):
     pk = ToggleColumn()
     model = tables.Column(linkify=True, verbose_name="Device Type")
+    manufacturer = tables.Column(linkify=True)
+    device_family = tables.Column(linkify=True)
     is_full_depth = BooleanColumn(verbose_name="Full Depth")
     device_count = LinkedCountColumn(
         viewname="dcim:device_list",
@@ -117,6 +119,7 @@ class DeviceTypeTable(BaseTable):
             "pk",
             "model",
             "manufacturer",
+            "device_family",
             "part_number",
             "u_height",
             "is_full_depth",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5655
# What's Changed

- Add "device family" column to DeviceTypeTable (not shown by default)
- Linkify existing "manufacturer" column as well.

# Screenshots

![image](https://github.com/nautobot/nautobot/assets/5603551/b2d7ef02-f67d-4913-ac44-9ef0057182a1)

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
