### PR TITLE
Fix #5123 - unhandled ValueError under Django 4

### DIFF
--- a/changes/5123.fixed
+++ b/changes/5123.fixed
@@ -1,0 +1,1 @@
+Fixed an unhandled `ValueError` when filtering on `vlans` by their UUID rather than their VLAN ID.

--- a/nautobot/core/forms/fields.py
+++ b/nautobot/core/forms/fields.py
@@ -546,7 +546,7 @@ class DynamicModelChoiceMixin:
             filter_ = self.filter(field_name=field_name)
             try:
                 self.data_queryset = filter_.filter(self.queryset, data)
-            except (TypeError, ValidationError):
+            except (TypeError, ValueError, ValidationError):
                 # Catch any error caused by invalid initial data passed from the user
                 self.data_queryset = self.queryset.none()
         else:

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -93,15 +93,13 @@ User = get_user_model()
 
 
 class GraphQLTestCaseBase(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        # TODO: the below *shouldn't* be needed, but without it, when run with --parallel test flag,
-        # these tests consistently fail with schema construction errors
-        cls.SCHEMA = graphene_settings.SCHEMA  # not a no-op; this causes the schema to be built
+    def setUp(self):
+        self.SCHEMA = graphene_settings.SCHEMA  # not a no-op; this causes the schema to be built when first called
 
 
 class GraphQLTestCase(GraphQLTestCaseBase):
     def setUp(self):
+        super().setUp()
         self.user = create_test_user("graphql_testuser")
         GraphQLQuery.objects.create(name="GQL 1", query="{ query: locations {name} }")
         GraphQLQuery.objects.create(name="GQL 2", query="query ($name: [String!]) { locations(name:$name) {name} }")
@@ -238,6 +236,7 @@ class GraphQLGenerateSchemaTypeTestCase(GraphQLTestCaseBase):
 
 class GraphQLExtendSchemaType(GraphQLTestCaseBase):
     def setUp(self):
+        super().setUp()
         self.datas = (
             {"field_name": "my_text", "field_type": CustomFieldTypeChoices.TYPE_TEXT},
             {
@@ -329,6 +328,7 @@ class GraphQLExtendSchemaType(GraphQLTestCaseBase):
 
 class GraphQLExtendSchemaRelationship(GraphQLTestCaseBase):
     def setUp(self):
+        super().setUp()
         location_ct = ContentType.objects.get_for_model(Location)
         rack_ct = ContentType.objects.get_for_model(Rack)
         vlan_ct = ContentType.objects.get_for_model(VLAN)
@@ -455,6 +455,7 @@ class GraphQLExtendSchemaRelationship(GraphQLTestCaseBase):
 
 class GraphQLSearchParameters(GraphQLTestCaseBase):
     def setUp(self):
+        super().setUp()
         self.schema = generate_schema_type(app_name="dcim", model=Location)
 
     def test_search_parameters(self):
@@ -476,8 +477,6 @@ class GraphQLAPIPermissionTest(GraphQLTestCaseBase):
     @classmethod
     def setUpTestData(cls):
         """Initialize the Database with some datas and multiple users associated with different permissions."""
-        super().setUpTestData()
-
         cls.groups = (
             Group.objects.create(name="Group 1"),
             Group.objects.create(name="Group 2"),
@@ -705,7 +704,6 @@ class GraphQLQueryTest(GraphQLTestCaseBase):
     @classmethod
     def setUpTestData(cls):
         """Initialize the Database with some datas."""
-        super().setUpTestData()
         cls.user = User.objects.create(username="Super User", is_active=True, is_superuser=True)
 
         # Remove random IPAddress and Device fixtures for this custom test

--- a/nautobot/dcim/migrations/0060_alter_cable_status_alter_consoleport__path_and_more.py
+++ b/nautobot/dcim/migrations/0060_alter_cable_status_alter_consoleport__path_and_more.py
@@ -164,7 +164,7 @@ class Migration(migrations.Migration):
             model_name="interface",
             name="role",
             field=nautobot.extras.models.roles.RoleField(
-                blank=True, null=True,on_delete=django.db.models.deletion.PROTECT, to="extras.role"
+                blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to="extras.role"
             ),
         ),
         migrations.AlterField(


### PR DESCRIPTION
# Closes #5123 
# What's Changed

Turned out to be a much simpler solution than we'd feared. Just adding handling of the `ValueError` now raised instead of a `TypeError` or `ValidationError` sufficed to get this set of test cases passing.

Also an unrelated Ruff format fix for some formatting I inadvertently introduced when updating the prototype branch to latest `next`.

Also fixed an apparently new set of failures in the core graphql tests apparently due to graphene v2 not fully supporting `deepcopy` which Django 4.2 uses with any class attributes defined in `setUpTestData`. Changing it to instance-level `setUp` fixed the issue for now.

# Screenshots

Successful filtering by VLAN PK:

![image](https://github.com/nautobot/nautobot/assets/5603551/5a34c45a-f77f-49c4-a782-7af0da48d383)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
