### PR TITLE
Updates incorrect updated import path for "ordering" in the v1 to v2 docs

### DIFF
--- a/changes/5752.documentation
+++ b/changes/5752.documentation
@@ -1,0 +1,1 @@
+Corrected incorrect entry for `nautobot.utilities.ordering` in `v2-code-location-changes` table.

--- a/nautobot/docs/user-guide/administration/upgrading/from-v1/tables/v2-code-location-changes.yaml
+++ b/nautobot/docs/user-guide/administration/upgrading/from-v1/tables/v2-code-location-changes.yaml
@@ -85,7 +85,7 @@
   New Module: "nautobot.core.management"
 - Old Module: "nautobot.utilities.ordering"
   Class/Function(s): "(all)"
-  New Module: "nautobot.core.utils.ordering"
+  New Module: "nautobot.core.models.ordering"
 - Old Module: "nautobot.utilities.paginator"
   Class/Function(s): "(all)"
   New Module: "nautobot.core.views.paginator"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
- Incorrect import path change going from v1 to v2 in upgrade docs
The `ordering` module actually lives under `nautobot.core.models.ordering` and not `nautobot.core.utils.ordering`

