### PR TITLE
Enforce user object permissions when viewing Static Group members

### DIFF
--- a/changes/5761.fixed
+++ b/changes/5761.fixed
@@ -1,0 +1,2 @@
+Added missing static-groups tab to SoftwareImageFile detail view.
+Fixed permissions enforcement on StaticGroup member object lists.

--- a/nautobot/core/testing/views.py
+++ b/nautobot/core/testing/views.py
@@ -213,6 +213,8 @@ class ViewTestCases:
                             escape(str(instance.cf.get(custom_field.key) or "")), response_body, msg=response_body
                         )
 
+            return response  # for consumption by child test cases if desired
+
         @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
         def test_get_object_with_constrained_permission(self):
             instance1, instance2 = self._get_queryset().all()[:2]
@@ -230,10 +232,13 @@ class ViewTestCases:
             obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
 
             # Try GET to permitted object
-            self.assertHttpStatus(self.client.get(instance1.get_absolute_url()), 200)
+            response = self.client.get(instance1.get_absolute_url())
+            self.assertHttpStatus(response, 200)
 
             # Try GET to non-permitted object
             self.assertHttpStatus(self.client.get(instance2.get_absolute_url()), 404)
+
+            return response  # for consumption by child test cases if desired
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
         def test_has_advanced_tab(self):

--- a/nautobot/dcim/templates/dcim/softwareimagefile_retrieve.html
+++ b/nautobot/dcim/templates/dcim/softwareimagefile_retrieve.html
@@ -185,25 +185,49 @@
                                 <div class="table-responsive">
                                     {% render_table associated_contacts_table 'inc/table.html' %}
                                 </div>
-                                <div class="panel-footer noprint">
-                                    {% if perms.extras.change_contactassociation %}
-                                        <button type="submit" name="_edit" formaction="{% url 'extras:contactassociation_bulk_edit' %}?return_url={{request.path}}" class="btn btn-warning btn-xs">
-                                            <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit
-                                        </button>
-                                    {% endif %}
-                                    {% if perms.extras.delete_contactassociation %}
-                                        <button type="submit" formaction="{% url 'extras:contactassociation_bulk_delete' %}?return_url={{request.path}}" class="btn btn-danger btn-xs">
-                                            <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
-                                        </button>
-                                    {% endif %}
-                                    {% if perms.extras.add_contactassociation %}
-                                        <div class="pull-right">
-                                            <a href="{% url 'extras:object_contact_team_assign' %}?return_url={{request.path}}&associated_object_id={{object.id}}&associated_object_type={{content_type.id}}" class="btn btn-primary btn-xs">
-                                                <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add Contact
-                                            </a>
-                                        </div>
-                                    {% endif %}
-                                    <div class="clearfix"></div>
+                                {% with request.path|add:"?tab=contacts"|urlencode as return_url %}
+                                    <div class="panel-footer noprint">
+                                        {% if perms.extras.change_contactassociation %}
+                                            <button type="submit" name="_edit" formaction="{% url 'extras:contactassociation_bulk_edit' %}?return_url={{request.path}}" class="btn btn-warning btn-xs">
+                                                <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit
+                                            </button>
+                                        {% endif %}
+                                        {% if perms.extras.delete_contactassociation %}
+                                            <button type="submit" formaction="{% url 'extras:contactassociation_bulk_delete' %}?return_url={{request.path}}" class="btn btn-danger btn-xs">
+                                                <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
+                                            </button>
+                                        {% endif %}
+                                        {% if perms.extras.add_contactassociation %}
+                                            <div class="pull-right">
+                                                <a href="{% url 'extras:object_contact_team_assign' %}?return_url={{request.path}}&associated_object_id={{object.id}}&associated_object_type={{content_type.id}}" class="btn btn-primary btn-xs">
+                                                    <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add Contact
+                                                </a>
+                                            </div>
+                                        {% endif %}
+                                        <div class="clearfix"></div>
+                                    </div>
+                                {% endwith %}
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+        {% if object.is_static_group_associable_model and perms.extras.view_staticgroup %}
+            <div id="static_groups" role="tabpanel" class="tab-pane {% if request.GET.tab == 'static_groups' %}active{% else %}fade{% endif %}">
+                <div class="row">
+                    <div class="col-md-12">
+                        <form method="post">
+                            {% csrf_token %}
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <strong>Static Groups</strong>
+                                    <div class="pull-right noprint">
+                                        <!-- Insert table config button here -->
+                                    </div>
+                                </div>
+                                <div class="table-responsive">
+                                    {% render_table associated_static_groups_table 'inc/table.html' %}
                                 </div>
                             </div>
                         </form>

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -1136,7 +1136,7 @@ class StaticGroupViewSet(NautobotModelViewSet):
         # Retrieve the serializer for the content_type and paginate the results
         member_model_class = instance.content_type.model_class()
         member_serializer_class = get_serializer_for_model(member_model_class)
-        members = self.paginate_queryset(instance.members)
+        members = self.paginate_queryset(instance.members.restrict(request.user, "view"))
         member_serializer = member_serializer_class(members, many=True, context={"request": request})
         return self.get_paginated_response(member_serializer.data)
 

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -17,6 +17,7 @@ from nautobot.core.models.fields import slugify_dashes_to_underscores
 from nautobot.core.testing import APITestCase, APIViewTestCases
 from nautobot.core.testing.utils import disable_warnings
 from nautobot.core.utils.lookup import get_route_for_model
+from nautobot.core.utils.permissions import get_permission_for_model
 from nautobot.dcim.models import (
     Controller,
     Device,
@@ -3542,6 +3543,7 @@ class StaticGroupTest(APIViewTestCases.APIViewTestCase):
         """Test that the `/members/` API endpoint returns what is expected."""
         self.add_permissions("extras.view_staticgroup")
         instance = StaticGroup.objects.filter(static_group_associations__isnull=False).distinct().first()
+        self.add_permissions(get_permission_for_model(instance.content_type.model_class(), "view"))
         self.assertIsNotNone(instance)
         member_count = instance.members.count()
         url = reverse("extras-api:staticgroup-members", kwargs={"pk": instance.pk})
@@ -3549,6 +3551,26 @@ class StaticGroupTest(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(member_count, response.json()["count"])
         # TODO: assert that members are serialized correctly?
+
+    def test_get_members_with_constrained_permission(self):
+        """Test that the `/members/` API endpoint enforces permissions on the member model."""
+        self.add_permissions("extras.view_staticgroup")
+        instance = StaticGroup.objects.filter(static_group_associations__isnull=False).distinct().first()
+        obj1 = instance.members.first()
+        obj_perm = ObjectPermission(
+            name="Test permission",
+            constraints={"pk__in": [obj1.pk]},
+            actions=["view"],
+        )
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(instance.content_type)
+
+        url = reverse("extras-api:staticgroup-members", kwargs={"pk": instance.pk})
+        response = self.client.get(url, **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["id"], str(obj1.pk))
 
     def test_list_omits_hidden_by_default(self):
         """Test that the list view defaults to omitting hidden groups."""

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2794,7 +2794,7 @@ class StaticGroupTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         queryset = super()._get_queryset()
         # We want .first() to pick groups with members
         return queryset.annotate(members_count=count_related(StaticGroupAssociation, "static_group")).order_by(
-            "-members_count"
+            "-members_count", "name"
         )
 
     def test_get_object_with_permission(self):

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -15,9 +15,11 @@ from django.utils.html import format_html
 from nautobot.circuits.models import Circuit
 from nautobot.core.choices import ColorChoices
 from nautobot.core.models.fields import slugify_dashes_to_underscores
+from nautobot.core.models.querysets import count_related
 from nautobot.core.templatetags.helpers import bettertitle
 from nautobot.core.testing import extract_form_failures, extract_page_body, TestCase, ViewTestCases
 from nautobot.core.testing.utils import disable_warnings, post_data
+from nautobot.core.utils.permissions import get_permission_for_model
 from nautobot.dcim.models import (
     ConsolePort,
     Controller,
@@ -2787,6 +2789,67 @@ class StaticGroupTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "description": "Is anyone there?",
             "tenant": Tenant.objects.last().pk,
         }
+
+    def _get_queryset(self):
+        queryset = super()._get_queryset()
+        # We want .first() to pick groups with members
+        return queryset.annotate(members_count=count_related(StaticGroupAssociation, "static_group")).order_by(
+            "-members_count"
+        )
+
+    def test_get_object_with_permission(self):
+        instance = self._get_queryset().first()
+        # Add view permissions for the group's members:
+        self.add_permissions(get_permission_for_model(instance.content_type.model_class(), "view"))
+
+        response = super().test_get_object_with_permission()
+
+        response_body = extract_page_body(response.content.decode(response.charset))
+        # Check that the "members" table in the detail view includes all appropriate member objects
+        for member in instance.members:
+            self.assertIn(str(member.pk), response_body)
+
+    def test_get_object_with_constrained_permission(self):
+        instance = self._get_queryset().first()
+        # Add permission for one of the group's members but not the others:
+        member1, member2 = instance.members[:2]
+        obj_perm = ObjectPermission(
+            name="Members permission",
+            constraints={"pk": member1.pk},
+            actions=["view"],
+        )
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(instance.content_type)
+
+        response = super().test_get_object_with_constrained_permission()
+
+        response_body = extract_page_body(response.content.decode(response.charset))
+        # Check that the "members" table in the detail view includes all permitted member objects
+        self.assertIn(str(member1.pk), response_body)
+        self.assertNotIn(str(member2.pk), response_body)
+
+    def test_get_object_static_groups_with_constrained_permission(self):
+        instance1 = self._get_queryset().first()
+        member = instance1.members.first()
+        self.add_permissions(get_permission_for_model(member, "view"))
+        instance2 = StaticGroup.objects.create(name="Forbidden group", content_type=instance1.content_type)
+        instance2.add_members([member])
+        obj_perm = ObjectPermission(
+            name="Groups permission",
+            constraints={"pk": instance1.pk},
+            actions=["view"],
+        )
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ContentType.objects.get_for_model(StaticGroup))
+
+        url = member.get_absolute_url()
+        response = self.client.get(url)
+        self.assertHttpStatus(response, 200)
+        response_body = response.content.decode(response.charset)
+        self.assertIn(str(instance1.pk), response_body)
+        self.assertNotIn(str(instance2.pk), response_body)
 
     def test_edit_object_with_permission(self):
         instance = self._get_queryset().first()

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2360,7 +2360,7 @@ class StaticGroupUIViewSet(NautobotUIViewSet):
         context = super().get_extra_context(request, instance)
         if self.action == "retrieve":
             members_table_class = get_table_for_model(instance.model)
-            members_table = members_table_class(instance.members, orderable=False)
+            members_table = members_table_class(instance.members.restrict(request.user, "view"), orderable=False)
             paginate = {
                 "paginator_class": EnhancedPaginator,
                 "per_page": get_paginate_count(request),


### PR DESCRIPTION
# Closes #n/a
# What's Changed

Similar to #5757, but for the new static-groups feature in `next`.

Also I discovered while testing this that the custom detail template for SoftwareImageFile hadn't been updated to include a static-groups tab, so this fixes that as well.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
