### PR TITLE
Add CircuitTermination list link to nav menu

### DIFF
--- a/changes/5747.added
+++ b/changes/5747.added
@@ -1,0 +1,1 @@
+Added "Circuit Terminations" menu item.

--- a/nautobot/circuits/navigation.py
+++ b/nautobot/circuits/navigation.py
@@ -34,9 +34,17 @@ menu_items = (
                         ),
                     ),
                     NavMenuItem(
+                        link="circuits:circuittermination_list",
+                        name="Circuit Terminations",
+                        weight=200,
+                        permissions=[
+                            "circuits.view_circuittermination",
+                        ],
+                    ),
+                    NavMenuItem(
                         link="circuits:circuittype_list",
                         name="Circuit Types",
-                        weight=200,
+                        weight=300,
                         permissions=[
                             "circuits.view_circuittype",
                         ],


### PR DESCRIPTION
# Closes #5747
# What's Changed

Add "Circuit Terminations" nav menu item, so that users can easily access the CircuitTermination list view and do import/export operations if desired.

# Screenshots

![image](https://github.com/nautobot/nautobot/assets/5603551/b6786cbc-3dcc-4c62-97b9-acb0fcb9e1cd)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
