### PR TITLE
Fix VLAN selection in VMInterface edit forms

### DIFF
--- a/changes/5738.fixed
+++ b/changes/5738.fixed
@@ -1,0 +1,2 @@
+Fixed incorrect API query parameters when selecting VLANs to apply to a VM Interface.
+Fixed incorrect query parameters when accessing or creating Clusters from a Cluster Type detail view.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -2586,14 +2586,14 @@ class InterfaceBulkEditForm(
         queryset=VLAN.objects.all(),
         required=False,
         query_params={
-            "location": "null",
+            "locations": "null",
         },
     )
     tagged_vlans = DynamicModelMultipleChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
         query_params={
-            "location": "null",
+            "locations": "null",
         },
     )
     vrf = DynamicModelChoiceField(
@@ -2637,8 +2637,8 @@ class InterfaceBulkEditForm(
             # Limit VLAN choices by Location
             if locations.count() == 1:
                 location = locations.first()
-                self.fields["untagged_vlan"].widget.add_query_param("location", location.pk)
-                self.fields["tagged_vlans"].widget.add_query_param("location", location.pk)
+                self.fields["untagged_vlan"].widget.add_query_param("locations", location.pk)
+                self.fields["tagged_vlans"].widget.add_query_param("locations", location.pk)
 
         # Restrict parent/bridge/LAG interface assignment by device (or VC master)
         if device_count == 1:

--- a/nautobot/virtualization/forms.py
+++ b/nautobot/virtualization/forms.py
@@ -497,8 +497,8 @@ class VMInterfaceForm(NautobotModelForm, InterfaceCommonForm):
         # Add current location to VLANs query params
         location = virtual_machine.location
         if location:
-            self.fields["untagged_vlan"].widget.add_query_param("location", location.pk)
-            self.fields["tagged_vlans"].widget.add_query_param("location", location.pk)
+            self.fields["untagged_vlan"].widget.add_query_param("locations", location.pk)
+            self.fields["tagged_vlans"].widget.add_query_param("locations", location.pk)
 
 
 class VMInterfaceCreateForm(BootstrapMixin, InterfaceCommonForm):
@@ -570,8 +570,8 @@ class VMInterfaceCreateForm(BootstrapMixin, InterfaceCommonForm):
         # Add current location to VLANs query params
         location = virtual_machine.location
         if location:
-            self.fields["untagged_vlan"].widget.add_query_param("location", location.pk)
-            self.fields["tagged_vlans"].widget.add_query_param("location", location.pk)
+            self.fields["untagged_vlan"].widget.add_query_param("locations", location.pk)
+            self.fields["tagged_vlans"].widget.add_query_param("locations", location.pk)
 
 
 class VMInterfaceBulkEditForm(TagsBulkEditFormMixin, StatusModelBulkEditFormMixin, NautobotBulkEditForm):
@@ -640,8 +640,8 @@ class VMInterfaceBulkEditForm(TagsBulkEditFormMixin, StatusModelBulkEditFormMixi
             location = getattr(parent_obj.cluster, "location", None)
             if location is not None:
                 # Add current location to VLANs query params
-                self.fields["untagged_vlan"].widget.add_query_param("location", location.pk)
-                self.fields["tagged_vlans"].widget.add_query_param("location", location.pk)
+                self.fields["untagged_vlan"].widget.add_query_param("locations", location.pk)
+                self.fields["tagged_vlans"].widget.add_query_param("locations", location.pk)
 
         self.fields["parent_interface"].choices = ()
         self.fields["parent_interface"].widget.attrs["disabled"] = True

--- a/nautobot/virtualization/templates/virtualization/clustertype.html
+++ b/nautobot/virtualization/templates/virtualization/clustertype.html
@@ -14,7 +14,7 @@
                 <tr>
                     <td>Clusters</td>
                     <td>
-                        <a href="{% url 'virtualization:cluster_list' %}?type={{ object.name }}">{{ cluster_table.rows|length }}</a>
+                        <a href="{% url 'virtualization:cluster_list' %}?cluster_type={{ object.name }}">{{ cluster_table.rows|length }}</a>
                     </td>
                 </tr>
             </table>
@@ -29,7 +29,7 @@
             {% include 'inc/table.html' with table=cluster_table %}
             {% if perms.virtualization.add_cluster %}
                 <div class="panel-footer text-right noprint">
-                    <a href="{% url 'virtualization:cluster_add' %}?type={{ object.pk }}" class="btn btn-xs btn-primary">
+                    <a href="{% url 'virtualization:cluster_add' %}?cluster_type={{ object.pk }}" class="btn btn-xs btn-primary">
                         <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add cluster
                     </a>
                 </div>


### PR DESCRIPTION
# Closes #5738 
# What's Changed

- Correct the invalid mixture of `location=` and `locations=` query parameters in VMInterface form VLAN selection.
- Fix a query params bug (`type` versus `cluster_type`) in the Cluster Type detail view that I stumbled across while testing this.
- Change Interface form VLAN query params to use `locations` for consistency and since `location` filter is documented to be deprecated.

# Screenshots

![image](https://github.com/nautobot/nautobot/assets/5603551/90d9d627-43a3-4caa-89e1-04bcfa83ee80)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
