### PR TITLE
feat: Add search and sort to ipam.IPAddress.nat_inside

### DIFF
--- a/changes/5807.changed
+++ b/changes/5807.changed
@@ -1,0 +1,1 @@
+Updated the `IPAddressFilterSet`, `IPAddressDetailTable` and `IPAddressFilterForm` in the ipam application in order to make the nat_inside field sortable and searchable.

--- a/changes/5807.changed
+++ b/changes/5807.changed
@@ -1,1 +1,1 @@
-Updated the `IPAddressFilterSet`, `IPAddressDetailTable` and `IPAddressFilterForm` in the ipam application in order to make the nat_inside field sortable and searchable.
+Added the ability to sort and filter the `IPAddress` list view by the `nat_inside` field.

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -433,11 +433,15 @@ class IPAddressFilterSet(
         method="_has_interface_assignments",
         label="Has Interface Assignments",
     )
+    has_nat_inside = RelatedMembershipBooleanFilter(
+        field_name="nat_inside",
+        label="Has NAT Inside",
+    )
     ip_version = django_filters.NumberFilter()
 
     class Meta:
         model = IPAddress
-        fields = ["id", "dns_name", "type", "tags", "mask_length"]
+        fields = ["id", "dns_name", "type", "tags", "mask_length", "nat_inside"]
 
     def generate_query__has_interface_assignments(self, value):
         """Helper method used by DynamicGroups and by _assigned_to_interface method."""

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -433,6 +433,10 @@ class IPAddressFilterSet(
         method="_has_interface_assignments",
         label="Has Interface Assignments",
     )
+    nat_inside = django_filters.ModelMultipleChoiceFilter(
+        queryset=IPAddress.objects.all(),
+        label="NAT (Inside)",
+    )
     has_nat_inside = RelatedMembershipBooleanFilter(
         field_name="nat_inside",
         label="Has NAT Inside",

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -708,6 +708,8 @@ class IPAddressFilterForm(NautobotFilterForm, TenancyFilterForm, StatusModelFilt
         label="Has NAT Inside",
         widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
+
+
 #
 # VLAN groups
 #

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -664,6 +664,8 @@ class IPAddressFilterForm(NautobotFilterForm, TenancyFilterForm, StatusModelFilt
         "role",
         "tenant_group",
         "tenant",
+        "nat_inside",
+        "has_nat_inside",
     ]
     q = forms.CharField(required=False, label="Search")
     parent = forms.CharField(
@@ -700,8 +702,12 @@ class IPAddressFilterForm(NautobotFilterForm, TenancyFilterForm, StatusModelFilt
         widget=StaticSelect2(),
     )
     tags = TagFilterField(model)
-
-
+    nat_inside = DynamicModelChoiceField(queryset=IPAddress.objects.all(), required=False, label="NAT Inside Address")
+    has_nat_inside = forms.NullBooleanField(
+        required=False,
+        label="Has NAT Inside",
+        widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
+    )
 #
 # VLAN groups
 #

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -473,7 +473,7 @@ class IPAddressTable(StatusTableMixin, RoleTableMixin, BaseTable):
 
 
 class IPAddressDetailTable(IPAddressTable):
-    nat_inside = tables.Column(linkify=True, orderable=False, verbose_name="NAT (Inside)")
+    nat_inside = tables.Column(linkify=True, verbose_name="NAT (Inside)")
     tenant = TenantColumn()
     tags = TagColumn(url_name="ipam:ipaddress_list")
     assigned = BooleanColumn(accessor="assigned_count")

--- a/nautobot/ipam/tests/test_filters.py
+++ b/nautobot/ipam/tests/test_filters.py
@@ -462,6 +462,7 @@ class IPAddressTestCase(FilterTestCases.FilterTestCase, FilterTestCases.TenancyF
     queryset = IPAddress.objects.all()
     filterset = IPAddressFilterSet
     tenancy_related_name = "ip_addresses"
+    generic_filter_tests = (["nat_inside", "nat_inside__id"],)
 
     @classmethod
     def setUpTestData(cls):
@@ -644,6 +645,13 @@ class IPAddressTestCase(FilterTestCases.FilterTestCase, FilterTestCases.TenancyF
             status=statuses[0],
             namespace=cls.namespace,
             nat_inside=ip0,
+        )
+        IPAddress.objects.create(
+            address="10.2.2.2/32",
+            tenant=None,
+            status=statuses[0],
+            namespace=cls.namespace,
+            nat_inside=ip1,
         )
 
     def test_search(self):

--- a/nautobot/ipam/tests/test_filters.py
+++ b/nautobot/ipam/tests/test_filters.py
@@ -638,6 +638,13 @@ class IPAddressTestCase(FilterTestCases.FilterTestCase, FilterTestCases.TenancyF
             status=statuses[0],
             namespace=cls.namespace,
         )
+        IPAddress.objects.create(
+            address="10.1.1.1/32",
+            tenant=None,
+            status=statuses[0],
+            namespace=cls.namespace,
+            nat_inside=ip0,
+        )
 
     def test_search(self):
         ipv4_octets = self.ipv4_address.host.split(".")


### PR DESCRIPTION
# Closes N/A
# What's Changed

This change updates the filterset, table and search form for `ipam.IPAddress` to make the nat_inside field sortable and searchable.

# Screenshots
![Screenshot 2024-06-12 at 12 41 59 PM](https://github.com/nautobot/nautobot/assets/358901/91421ad0-82c7-4221-a951-1ccbf4627f3f)
![Screenshot 2024-06-12 at 12 42 13 PM](https://github.com/nautobot/nautobot/assets/358901/1ed02987-bd4e-4011-9772-736d52bd13b9)

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] ~Documentation Updates (when adding/changing features)~
- [ ] ~Example App Updates (when adding/changing features)~
- [ ] ~Outline Remaining Work, Constraints from Design~
