### PR TITLE
bugfix: removing object.slug as this does not exist any longer, and g…

### DIFF
--- a/nautobot/core/templates/inc/object_details_advanced_panel.html
+++ b/nautobot/core/templates/inc/object_details_advanced_panel.html
@@ -31,19 +31,6 @@
                         </td>
                     </tr>
                 {% endif %}
-                {% if object.slug %}
-                    <tr>
-                        <td>Slug</td>
-                        <td>
-                            <span class="hover_copy">
-                                <span id="slug_copy">{{ object.slug }}</span>
-                                <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#slug_copy">
-                                    <span class="mdi mdi-content-copy"></span>
-                                </button>
-                            </span>
-                        </td>
-                    </tr>
-                {% endif %}
             </tbody>
         </table>
     </div>


### PR DESCRIPTION
When showing platforms, the console throws an error because of a reference to "object.slug" but no models in nautobot uses slug anymore, so it has been removed

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes NTC-1734 #<ISSUE NUMBER GOES HERE>
# What's Changed
- Removed an if statement that fails due to missing object, and all the contents within the if
