### PR TITLE
Backport 5828: Fixed an issue with Job code not being fully reloaded after syncing a git repo

### DIFF
--- a/changes/5816.fixed
+++ b/changes/5816.fixed
@@ -1,0 +1,1 @@
+Fixed an issue with Job code not being fully reloaded after syncing a Git repository.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5816
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
- [ ] Include in the job logs that the repo is being synced to a specific commit
