### PR TITLE
Fix Display Issue on Dynamic Groups tags field

### DIFF
--- a/changes/4237.fixed
+++ b/changes/4237.fixed
@@ -1,0 +1,1 @@
+Fixed display issue with multiple tags filter on dynamic groups. Multiple Tags are now displayed with an AND.

--- a/changes/4237.fixed
+++ b/changes/4237.fixed
@@ -1,1 +1,1 @@
-Fixed display issue with multiple tags filter on dynamic groups. Multiple Tags are now displayed with an AND.
+Fixed display issue with multiple tags filter on dynamic groups. Multiple Tags are now correctly displayed with an AND.

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -13,7 +13,6 @@ from django.utils.functional import cached_property
 import django_filters
 
 from nautobot.core.constants import CHARFIELD_MAX_LENGTH
-from nautobot.core.filters import TagFilter
 from nautobot.core.forms.constants import BOOLEAN_WITH_BLANK_CHOICES
 from nautobot.core.forms.fields import DynamicModelChoiceField
 from nautobot.core.forms.widgets import StaticSelect2
@@ -607,7 +606,7 @@ class DynamicGroup(OrganizationalModel):
             for v in value:
                 if filter_field.conjoined:
                     query &= models.Q(**filter_field.get_filter_predicate(v))
-                else: 
+                else:
                     query |= models.Q(**filter_field.get_filter_predicate(v))
 
         # The method `get_filter_predicate()` is only available on instances or subclasses


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #4237 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Correct the display on Dynamic Group Query to show that tags are AND instead of OR. As a followup, it could be nice to create a "Tags OR" filter and form field so that we can also do the OR for tags.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
BEFORE:
![image](https://github.com/nautobot/nautobot/assets/17092348/41207c8b-19e8-47e9-90b0-9897401fd5e3)

AFTER:
![image](https://github.com/nautobot/nautobot/assets/17092348/645b4f94-7a7c-4bcc-bd2a-b7bdbf3c2f93)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
