### PR TITLE
Add contacts and teams filters to BaseFilterSet and filter forms

### DIFF
--- a/changes/5212.added
+++ b/changes/5212.added
@@ -1,0 +1,1 @@
+Added `contacts` and `teams` filters to appropriate FilterSets and filter forms.

--- a/changes/5212.housekeeping
+++ b/changes/5212.housekeeping
@@ -1,0 +1,1 @@
+Enhanced `nautobot.core.testing.filters.FilterTestCases.BaseFilterTestCase.test_filters_generic()` test case to test for the presence and proper functioning of the `contacts` and `teams` filters on any appropriate model FilterSet.

--- a/nautobot/apps/forms.py
+++ b/nautobot/apps/forms.py
@@ -88,6 +88,7 @@ from nautobot.extras.forms.forms import (
     provider_choices_with_blank,
 )
 from nautobot.extras.forms.mixins import (
+    ContactTeamModelFilterFormMixin,
     CustomFieldModelFilterFormMixin,
     NoteFormBase,
     RelationshipModelFilterFormMixin,
@@ -110,6 +111,7 @@ __all__ = (
     "ColorSelect",
     "CommentField",
     "ConfirmationForm",
+    "ContactTeamModelFilterFormMixin",
     "ContentTypeSelect",
     "CSVChoiceField",
     "CSVContentTypeField",

--- a/nautobot/core/filters.py
+++ b/nautobot/core/filters.py
@@ -760,6 +760,26 @@ class BaseFilterSet(django_filters.FilterSet):
             if filter_name.startswith("_"):
                 del filters[filter_name]
 
+        if getattr(cls._meta.model, "is_contact_associable_model", False):
+            # Add "contacts" and "teams" filters
+            from nautobot.extras.models import Contact, Team
+
+            if "contacts" not in filters:
+                filters["contacts"] = NaturalKeyOrPKMultipleChoiceFilter(
+                    queryset=Contact.objects.all(),
+                    field_name="associated_contacts__contact",
+                    to_field_name="name",
+                    label="Contacts (name or ID)",
+                )
+
+            if "teams" not in filters:
+                filters["teams"] = NaturalKeyOrPKMultipleChoiceFilter(
+                    queryset=Team.objects.all(),
+                    field_name="associated_contacts__team",
+                    to_field_name="name",
+                    label="Teams (name or ID)",
+                )
+
         if "static_groups" not in filters and getattr(cls._meta.model, "is_static_group_associable_model", False):
             # Add "static_groups" field as the last key
             from nautobot.extras.models import StaticGroup

--- a/nautobot/core/tests/test_forms.py
+++ b/nautobot/core/tests/test_forms.py
@@ -637,12 +637,14 @@ class DynamicFilterFormTest(TestCase):
                 form._get_lookup_field_choices(),
                 [
                     ("color", "Color"),
+                    ("contacts", "Contacts (name or ID)"),
                     ("content_types", "Content type(s)"),
                     ("created", "Created"),
                     ("id", "Id"),
                     ("last_updated", "Last updated"),
                     ("name", "Name"),
                     ("static_groups", "Static groups (name or ID)"),
+                    ("teams", "Teams (name or ID)"),
                 ],
             )
             self.assertEqual(
@@ -656,6 +658,7 @@ class DynamicFilterFormTest(TestCase):
                     ("contact_email", "Contact E-mail"),
                     ("contact_name", "Contact name"),
                     ("contact_phone", "Contact phone"),
+                    ("contacts", "Contacts (name or ID)"),
                     ("created", "Created"),
                     ("description", "Description"),
                     ("devices", "Devices (name or ID)"),
@@ -689,6 +692,7 @@ class DynamicFilterFormTest(TestCase):
                     ("status", "Status (name or ID)"),
                     ("vlans", "Tagged VLANs (VID or ID)"),
                     ("tags", "Tags"),
+                    ("teams", "Teams (name or ID)"),
                     ("tenant_id", 'Tenant (ID) (deprecated, use "tenant" filter instead)'),
                     ("tenant", "Tenant (name or ID)"),
                     ("tenant_group", "Tenant Group (name or ID)"),
@@ -725,12 +729,14 @@ class DynamicFilterFormTest(TestCase):
                 [
                     (None, "---------"),
                     ("color", "Color"),
+                    ("contacts", "Contacts (name or ID)"),
                     ("content_types", "Content type(s)"),
                     ("created", "Created"),
                     ("id", "Id"),
                     ("last_updated", "Last updated"),
                     ("name", "Name"),
                     ("static_groups", "Static groups (name or ID)"),
+                    ("teams", "Teams (name or ID)"),
                 ],
             )
             self.assertEqual(

--- a/nautobot/docs/development/core/style-guide.md
+++ b/nautobot/docs/development/core/style-guide.md
@@ -63,7 +63,7 @@ New dependencies can be added to the project via the `poetry add` command. This 
 
 +++ 1.4.0
 
-    * Similarly, for filter forms, `nautobot.extras.forms.NautobotFilterForm` combines `nautobot.core.forms.BootstrapMixin`, `nautobot.extras.forms.CustomFieldModelFilterFormMixin`, and `nautobot.extras.forms.RelationshipModelFilterFormMixin`, and should be used where appropriate.
+    * Similarly, for filter forms, `nautobot.extras.forms.NautobotFilterForm` combines `nautobot.core.forms.BootstrapMixin`, `nautobot.extras.forms.ContactTeamModelFilterFormMixin`, `nautobot.extras.forms.CustomFieldModelFilterFormMixin`, and `nautobot.extras.forms.RelationshipModelFilterFormMixin`, and should be used where appropriate.
 
     * Similarly, for bulk-edit forms, `nautobot.extras.forms.NautobotBulkEditForm` combines `nautobot.core.forms.BulkEditForm` and `nautobot.core.forms.BootstrapMixin` with `nautobot.extras.forms.CustomFieldModelBulkEditFormMixin`, `nautobot.extras.forms.RelationshipModelBulkEditFormMixin` and `nautobot.extras.forms.NoteModelBulkEditFormMixin`, and should be used where appropriate.
 

--- a/nautobot/extras/forms/base.py
+++ b/nautobot/extras/forms/base.py
@@ -1,6 +1,7 @@
 from nautobot.core.forms import BootstrapMixin
 
 from .mixins import (
+    ContactTeamModelFilterFormMixin,
     CustomFieldModelBulkEditFormMixin,
     CustomFieldModelFilterFormMixin,
     CustomFieldModelFormMixin,
@@ -38,11 +39,16 @@ class NautobotModelForm(
     """
 
 
-class NautobotFilterForm(BootstrapMixin, CustomFieldModelFilterFormMixin, RelationshipModelFilterFormMixin):
+class NautobotFilterForm(
+    ContactTeamModelFilterFormMixin,
+    BootstrapMixin,
+    CustomFieldModelFilterFormMixin,  # currently must come *after* BootstrapMixin to get proper CSS classes applied
+    RelationshipModelFilterFormMixin,
+):
     """
     This class exists to combine common functionality and is used to inherit from throughout the
-    codebase where all three of BootstrapMixin, CustomFieldModelFilterFormMixin and RelationshipModelFilterFormMixin are
-    needed.
+    codebase where all of ContactTeamModelFilterFormMixin, CustomFieldModelFilterFormMixin, and
+    RelationshipModelFilterFormMixin are needed.
     """
 
 

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -17,6 +17,7 @@ from nautobot.extras.choices import (
     RelationshipTypeChoices,
 )
 from nautobot.extras.models import (
+    Contact,
     CustomField,
     Note,
     Relationship,
@@ -25,6 +26,7 @@ from nautobot.extras.models import (
     StaticGroup,
     Status,
     Tag,
+    Team,
 )
 from nautobot.extras.utils import remove_prefix_from_cf_key
 
@@ -32,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 __all__ = (
+    "ContactTeamModelFilterFormMixin",
     "CustomFieldModelBulkEditFormMixin",
     "CustomFieldModelFilterFormMixin",
     "CustomFieldModelFormMixin",
@@ -61,6 +64,30 @@ __all__ = (
 #
 # Form mixins
 #
+
+
+class ContactTeamModelFilterFormMixin(forms.Form):
+    """Adds the `contacts` and `teams` form fields to a filter form."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if getattr(self.model, "is_contact_associable_model", False):
+            if "contacts" not in self.fields:
+                self.fields["contacts"] = DynamicModelMultipleChoiceField(
+                    required=False,
+                    queryset=Contact.objects.all(),
+                    to_field_name="name",
+                )
+
+            if "teams" not in self.fields:
+                self.fields["teams"] = DynamicModelMultipleChoiceField(
+                    required=False,
+                    queryset=Team.objects.all(),
+                    to_field_name="name",
+                )
+
+            self.order_fields(self.field_order)
 
 
 class CustomFieldModelFilterFormMixin(forms.Form):


### PR DESCRIPTION
# Closes #5212
# What's Changed

- Added `contacts` and `teams` filters to appropriate FilterSets and filter forms.
- Enhanced `nautobot.core.testing.filters.FilterTestCases.BaseFilterTestCase.test_filters_generic()` test case to test for the presence and proper functioning of the `contacts` and `teams` filters on any appropriate model FilterSet.

# Screenshots

![image](https://github.com/nautobot/nautobot/assets/5603551/5a321c34-147f-4f4c-87e7-0c01f537cf66)

![image](https://github.com/nautobot/nautobot/assets/5603551/c3689d18-5aa9-477e-99eb-7a07d005041a)

![image](https://github.com/nautobot/nautobot/assets/5603551/3e71ab95-1ac8-4929-bcf2-f5bfb1eee987)



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
