### PR TITLE
Consolidate detail action buttons

### DIFF
--- a/changes/5871.changed
+++ b/changes/5871.changed
@@ -1,0 +1,1 @@
+Consolidated Detail View Action buttons into a single button with a dropdown menu.

--- a/nautobot/core/templates/buttons/consolidated_detail_view_action_buttons.html
+++ b/nautobot/core/templates/buttons/consolidated_detail_view_action_buttons.html
@@ -3,7 +3,7 @@
     {% for button in detail_view_action_buttons %}
         {{ button }}
         {% if forloop.first %}
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu pull-right" role="menu">
         {% endif %}
     {% endfor %}
     </ul>

--- a/nautobot/core/templates/buttons/consolidated_detail_view_action_buttons.html
+++ b/nautobot/core/templates/buttons/consolidated_detail_view_action_buttons.html
@@ -1,0 +1,13 @@
+{% if detail_view_action_buttons|length > 1 %}
+<div class="btn-group">
+    {% for button in detail_view_action_buttons %}
+        {{ button }}
+        {% if forloop.first %}
+    <ul class="dropdown-menu">
+        {% endif %}
+    {% endfor %}
+    </ul>
+</div>
+{% elif detail_view_action_buttons|length == 1 %}
+    {{ detail_view_action_buttons|first }}
+{% endif %}

--- a/nautobot/core/templates/generic/object_retrieve.html
+++ b/nautobot/core/templates/generic/object_retrieve.html
@@ -46,15 +46,7 @@
     {% block buttons %}
         {% plugin_buttons object %}
         {% block extra_buttons %}{% endblock extra_buttons %}
-        {% if object.clone_fields and user|can_add:object %}
-            {% clone_button object %}
-        {% endif %}
-        {% if user|can_change:object %}
-            {% edit_button object %}
-        {% endif %}
-        {% if user|can_delete:object %}
-            {% delete_button object %}
-        {% endif %}
+        {% consolidate_detail_view_action_buttons %}
     {% endblock buttons %}
     </div>
 

--- a/nautobot/core/templates/utilities/theme_preview.html
+++ b/nautobot/core/templates/utilities/theme_preview.html
@@ -134,9 +134,7 @@
 </div>
 
 <div class="pull-right noprint">
-    {% clone_button object %}
-    {% edit_button object %}
-    {% delete_button object %}
+    {% consolidate_detail_view_action_buttons %}
 </div>
 <h1>
     <span class="hover_copy">

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -352,7 +352,7 @@ def consolidate_detail_view_action_buttons(context):
                 """
             )
 
-    # Render a generic "Bulk Actions" dropdown button if the edit button is not present
+    # Render a generic "Actions" dropdown button if the edit button is not present
     elif detail_view_action_button_count >= 1:
         detail_view_action_buttons.append(
             format_html(

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -375,7 +375,7 @@ def consolidate_detail_view_action_buttons(context):
         detail_view_action_buttons.append(
             format_html(
                 child_button_fragment,
-                label=f"Clone {bettertitle(context["verbose_name"])}",
+                label=f"Clone {bettertitle(context['verbose_name'])}",
                 attrs=render_tag_attrs(
                     {
                         "class": clone_button_classes,

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -284,7 +284,7 @@ def consolidate_detail_view_action_buttons(context):
 
     Context must include the following keys:
         request (HttpRequest): The HTTP request object.
-        object (Model Instance): The object in the detail view.
+        object (Model): The object in the detail view.
         user (User): The current user.
     """
     instance = context["object"]
@@ -352,12 +352,12 @@ def consolidate_detail_view_action_buttons(context):
                 """
             )
 
-    # Render a generic "Bulk Actions" dropup button if the edit button is not present
+    # Render a generic "Bulk Actions" dropdown button if the edit button is not present
     elif detail_view_action_button_count >= 1:
         detail_view_action_buttons.append(
             format_html(
                 """
-                <button type="button" class="btn btn-warning dropdown-toggle" data-toggle="dropdown">
+                <button type="button" id="actions-dropdown" class="btn btn-warning dropdown-toggle" data-toggle="dropdown">
                     Actions <span class="caret"></span>
                 </button>
                 """

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -2,6 +2,8 @@ from django import template
 from django.urls import NoReverseMatch, reverse
 from django.utils.html import format_html, format_html_join
 
+from nautobot.core.templatetags.helpers import bettertitle
+from nautobot.core.templatetags.perms import can_add, can_change, can_delete
 from nautobot.core.utils import lookup
 from nautobot.core.views import utils as views_utils
 from nautobot.extras import models
@@ -14,11 +16,43 @@ register = template.Library()
 #
 
 
+@register.simple_tag()
+def action_url(instance, action):
+    """
+    URL to the <action> view for the instance.
+
+    Helper to `edit_button`, `delete_button` and `consolidated_detail_view_action_buttons` tags,
+    but can be used separately if needed.
+
+    Args:
+        instance (BaseModel): Model record.
+        action (str): Action (add/edit/delete) to link to.
+    """
+    viewname = lookup.get_route_for_model(instance, action)
+    if action == "add":
+        try:
+            return reverse(viewname)
+        except NoReverseMatch:
+            return None
+
+    # We try different lookups to get a valid reverse url
+    lookup_keys = ["pk", "slug", "key"]
+
+    for lookup_key in lookup_keys:
+        if hasattr(instance, lookup_key):
+            kwargs = {lookup_key: getattr(instance, lookup_key)}
+            try:
+                return reverse(viewname, kwargs=kwargs)
+            except NoReverseMatch:
+                continue
+
+    return None
+
+
 @register.inclusion_tag("buttons/clone.html")
 def clone_button(instance):
-    try:
-        url = reverse(lookup.get_route_for_model(instance, "add"))
-    except NoReverseMatch:
+    url = action_url(instance, "add")
+    if not url:
         return {"url": None}
 
     # Populate cloned field values
@@ -41,21 +75,7 @@ def edit_button(instance, use_pk=False, key="slug"):
         use_pk (bool): Used for backwards compatibility, no-op in this function.
         key (str): Used for backwards compatibility, no-op in this function.
     """
-    viewname = lookup.get_route_for_model(instance, "edit")
-
-    # We try different lookups to get a valid reverse url
-    lookup_keys = ["pk", "slug", "key"]
-
-    for lookup_key in lookup_keys:
-        if hasattr(instance, lookup_key):
-            kwargs = {lookup_key: getattr(instance, lookup_key)}
-            try:
-                url = reverse(viewname, kwargs=kwargs)
-                return {"url": url}
-            except NoReverseMatch:
-                continue
-
-    return {"url": None}
+    return {"url": action_url(instance, "edit")}
 
 
 @register.inclusion_tag("buttons/delete.html")
@@ -68,21 +88,7 @@ def delete_button(instance, use_pk=False, key="slug"):
         use_pk (bool): Used for backwards compatibility, no-op in this function.
         key (str): Used for backwards compatibility, no-op in this function.
     """
-    viewname = lookup.get_route_for_model(instance, "delete")
-
-    # We try different lookups to get a valid reverse url
-    lookup_keys = ["pk", "slug", "key"]
-
-    for lookup_key in lookup_keys:
-        if hasattr(instance, lookup_key):
-            kwargs = {lookup_key: getattr(instance, lookup_key)}
-            try:
-                url = reverse(viewname, kwargs=kwargs)
-                return {"url": url}
-            except NoReverseMatch:
-                continue
-
-    return {"url": None}
+    return {"url": action_url(instance, "delete")}
 
 
 #
@@ -267,6 +273,140 @@ def consolidate_bulk_action_buttons(context):
 
     return {
         "bulk_action_buttons": bulk_action_buttons,
+    }
+
+
+@register.inclusion_tag("buttons/consolidated_detail_view_action_buttons.html", takes_context=True)
+def consolidate_detail_view_action_buttons(context):
+    """
+    Generates a list of action buttons for detail view operations (edit, clone, delete) based on the
+    model capabilities and user permissions.
+
+    Context must include the following keys:
+        request (HttpRequest): The HTTP request object.
+        object (Model Instance): The object in the detail view.
+        user (User): The current user.
+    """
+    instance = context["object"]
+    detail_view_action_buttons = []
+    object_edit_url = action_url(instance, "edit")
+    object_delete_url = action_url(instance, "delete")
+    object_clone_url = action_url(instance, "add")
+    render_edit_button = bool(object_edit_url and can_change(context["user"], instance))
+    render_delete_button = bool(object_delete_url and can_delete(context["user"], instance))
+    render_clone_button = bool(
+        hasattr(instance, "clone_fields") and object_clone_url and can_add(context["user"], instance)
+    )
+
+    detail_view_action_button_count = sum([render_edit_button, render_delete_button, render_clone_button])
+
+    if detail_view_action_button_count == 0:
+        return {
+            "detail_view_action_buttons": detail_view_action_buttons,
+        }
+
+    child_button_fragment = primary_button_fragment = """
+        <a {attrs}>
+            <span class="{icon}" aria-hidden="true"></span> {label}
+        </a>
+    """
+
+    delete_button_fragment = """
+        <button class="{button_class}">
+            <a {attrs}>
+                <span class="{icon}" aria-hidden="true"></span> {label}
+            </a>
+        </button>
+    """
+
+    edit_button_classes = "btn btn-warning"
+    delete_button_classes = "btn btn-danger"
+    clone_button_classes = "btn btn-primary"
+    clone_icon = "mdi mdi-plus-thick"
+
+    if detail_view_action_button_count > 1:
+        child_button_fragment = f"<li>{primary_button_fragment}</li>"
+        delete_button_fragment = f"<li>{delete_button_fragment}</li>"
+        delete_button_classes = "text-danger"
+        clone_button_classes = "text"
+        clone_icon += " text-muted"
+
+    if render_edit_button:
+        detail_view_action_buttons.append(
+            format_html(
+                primary_button_fragment,
+                label=f"Edit {bettertitle(context["verbose_name"])}",
+                attrs=render_tag_attrs(
+                    {
+                        "class": edit_button_classes,
+                        "id": "edit-button",
+                        "href": object_edit_url,
+                    }
+                ),
+                button_class=edit_button_classes,
+                icon="mdi mdi-pencil",
+            ),
+        )
+        if detail_view_action_button_count > 1:
+            detail_view_action_buttons[0] += format_html(
+                f"""
+                <button type="button" id="actions-dropdown" data-toggle="dropdown" class="{edit_button_classes} dropdown-toggle">
+                    <span class="caret"></span>
+                    <span class="sr-only">Toggle Dropdown</span>
+                </button>
+                """
+            )
+
+    # Render a generic "Bulk Actions" dropup button if the edit button is not present
+    elif detail_view_action_button_count > 1:
+        detail_view_action_buttons.append(
+            format_html(
+                """
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                    Actions <span class="caret"></span>
+                </button>
+                """
+            )
+        )
+    if render_clone_button:
+        param_string = views_utils.prepare_cloned_fields(instance)
+        if param_string:
+            object_clone_url = f"{object_clone_url}?{param_string}"
+        detail_view_action_buttons.append(
+            format_html(
+                child_button_fragment,
+                label=f"Clone {bettertitle(context["verbose_name"])}",
+                attrs=render_tag_attrs(
+                    {
+                        "class": clone_button_classes,
+                        "id": "clone-button",
+                        "href": object_clone_url,
+                    }
+                ),
+                icon=clone_icon,
+                button_class=clone_button_classes,
+            )
+        )
+    if render_delete_button:
+        detail_view_action_buttons.append(format_html('<li role="separator" class="divider"></li>'))
+        detail_view_action_buttons.append(
+            format_html(
+                delete_button_fragment,
+                label=f"Delete {bettertitle(context["verbose_name"])}",
+                attrs=render_tag_attrs(
+                    {
+                        "class": delete_button_classes,
+                        "id": "delete-button",
+                        "href": object_delete_url,
+                    }
+                ),
+                icon="mdi mdi-trash-can-outline",
+                button_class=delete_button_classes,
+            )
+        )
+
+    return {
+        "detail_view_action_buttons": detail_view_action_buttons,
     }
 
 

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -383,7 +383,8 @@ def consolidate_detail_view_action_buttons(context):
             )
         )
     if render_delete_button:
-        detail_view_action_buttons.append(format_html('<li role="separator" class="divider"></li>'))
+        if render_clone_button:
+            detail_view_action_buttons.append(format_html('<li role="separator" class="divider"></li>'))
         detail_view_action_buttons.append(
             format_html(
                 delete_button_fragment,

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -320,26 +320,21 @@ def consolidate_detail_view_action_buttons(context):
     """
 
     edit_button_classes = "btn btn-warning"
-    delete_button_classes = "btn btn-danger"
-    clone_button_classes = "btn btn-primary"
-    clone_icon = "mdi mdi-plus-thick"
-
-    if detail_view_action_button_count > 1:
-        child_button_fragment = f"<li>{primary_button_fragment}</li>"
-        delete_button_fragment = f"<li>{delete_button_fragment}</li>"
-        delete_button_classes = "text-danger"
-        clone_button_classes = "text"
-        clone_icon += " text-muted"
+    delete_button_classes = "text-danger"
+    clone_button_classes = "text"
+    clone_icon = "mdi mdi-plus-thick text-muted"
+    child_button_fragment = f"<li>{primary_button_fragment}</li>"
+    delete_button_fragment = f"<li>{delete_button_fragment}</li>"
 
     if render_edit_button:
         detail_view_action_buttons.append(
             format_html(
                 primary_button_fragment,
-                label=f"Edit {bettertitle(context["verbose_name"])}",
+                label=f"Edit {bettertitle(context['verbose_name'])}",
                 attrs=render_tag_attrs(
                     {
-                        "class": edit_button_classes,
                         "id": "edit-button",
+                        "class": edit_button_classes,
                         "href": object_edit_url,
                     }
                 ),
@@ -358,11 +353,11 @@ def consolidate_detail_view_action_buttons(context):
             )
 
     # Render a generic "Bulk Actions" dropup button if the edit button is not present
-    elif detail_view_action_button_count > 1:
+    elif detail_view_action_button_count >= 1:
         detail_view_action_buttons.append(
             format_html(
                 """
-                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                <button type="button" class="btn btn-warning dropdown-toggle" data-toggle="dropdown">
                     Actions <span class="caret"></span>
                 </button>
                 """
@@ -378,8 +373,8 @@ def consolidate_detail_view_action_buttons(context):
                 label=f"Clone {bettertitle(context['verbose_name'])}",
                 attrs=render_tag_attrs(
                     {
-                        "class": clone_button_classes,
                         "id": "clone-button",
+                        "class": clone_button_classes,
                         "href": object_clone_url,
                     }
                 ),
@@ -392,11 +387,11 @@ def consolidate_detail_view_action_buttons(context):
         detail_view_action_buttons.append(
             format_html(
                 delete_button_fragment,
-                label=f"Delete {bettertitle(context["verbose_name"])}",
+                label=f"Delete {bettertitle(context['verbose_name'])}",
                 attrs=render_tag_attrs(
                     {
-                        "class": delete_button_classes,
                         "id": "delete-button",
+                        "class": delete_button_classes,
                         "href": object_delete_url,
                     }
                 ),

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -133,6 +133,8 @@ class ThemePreviewView(LoginRequiredMixin, TemplateView):
         return {
             "content_type": ContentType.objects.get_for_model(Status),
             "object": Status.objects.first(),
+            "verbose_name": Status.objects.all().model._meta.verbose_name,
+            "verbose_name_plural": Status.objects.all().model._meta.verbose_name_plural,
         }
 
 

--- a/nautobot/dcim/templates/dcim/devicetype.html
+++ b/nautobot/dcim/templates/dcim/devicetype.html
@@ -7,54 +7,44 @@
                 <li><a href="{% url 'dcim:devicetype_list' %}?manufacturer={{ object.manufacturer.name }}">{{ object.manufacturer }}</a></li>
 {% endblock extra_breadcrumbs %}
 
-{% block buttons %}
-        {% plugin_buttons object %}
-        {% if perms.dcim.change_devicetype %}
-            <div class="btn-group">
-                <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add Components <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu">
-                    {% if perms.dcim.add_consoleporttemplate %}
-                        <li><a href="{% url 'dcim:consoleporttemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=consoleports">Console Ports</a></li>
-                    {% endif %}
-                    {% if perms.dcim.add_consoleserverporttemplate %}
-                        <li><a href="{% url 'dcim:consoleserverporttemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=consoleserverports">Console Server Ports</a></li>
-                    {% endif %}
-                    {% if perms.dcim.add_powerporttemplate %}
-                        <li><a href="{% url 'dcim:powerporttemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=powerports">Power Ports</a></li>
-                    {% endif %}
-                    {% if perms.dcim.add_poweroutlettemplate %}
-                        <li><a href="{% url 'dcim:poweroutlettemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=poweroutlets">Power Outlets</a></li>
-                    {% endif %}
-                    {% if perms.dcim.add_interfacetemplate %}
-                        <li><a href="{% url 'dcim:interfacetemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=interfaces">Interfaces</a></li>
-                    {% endif %}
-                    {% if perms.dcim.add_frontporttemplate %}
-                        <li><a href="{% url 'dcim:frontporttemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=frontports">Front Ports</a></li>
-                    {% endif %}
-                    {% if perms.dcim.add_rearporttemplate %}
-                        <li><a href="{% url 'dcim:rearporttemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=rearports">Rear Ports</a></li>
-                    {% endif %}
-                    {% if perms.dcim.add_devicebaytemplate %}
-                        <li><a href="{% url 'dcim:devicebaytemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=devicebays">Device Bays</a></li>
-                    {% endif %}
-                    {% if perms.dcim.add_modulebaytemplate %}
-                        <li><a href="{% url 'dcim:modulebaytemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=modulebays">Module Bays</a></li>
-                    {% endif %}
-                </ul>
-            </div>
-        {% endif %}
-        {% if perms.dcim.add_devicetype %}
-            {% clone_button object %}
-        {% endif %}
-        {% if perms.dcim.change_devicetype %}
-            {% edit_button object %}
-        {% endif %}
-        {% if perms.dcim.delete_devicetype %}
-            {% delete_button object %}
-        {% endif %}
-{% endblock buttons %}
+{% block extra_buttons %}
+    {% if perms.dcim.change_devicetype %}
+        <div class="btn-group">
+            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add Components <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+                {% if perms.dcim.add_consoleporttemplate %}
+                    <li><a href="{% url 'dcim:consoleporttemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=consoleports">Console Ports</a></li>
+                {% endif %}
+                {% if perms.dcim.add_consoleserverporttemplate %}
+                    <li><a href="{% url 'dcim:consoleserverporttemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=consoleserverports">Console Server Ports</a></li>
+                {% endif %}
+                {% if perms.dcim.add_powerporttemplate %}
+                    <li><a href="{% url 'dcim:powerporttemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=powerports">Power Ports</a></li>
+                {% endif %}
+                {% if perms.dcim.add_poweroutlettemplate %}
+                    <li><a href="{% url 'dcim:poweroutlettemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=poweroutlets">Power Outlets</a></li>
+                {% endif %}
+                {% if perms.dcim.add_interfacetemplate %}
+                    <li><a href="{% url 'dcim:interfacetemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=interfaces">Interfaces</a></li>
+                {% endif %}
+                {% if perms.dcim.add_frontporttemplate %}
+                    <li><a href="{% url 'dcim:frontporttemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=frontports">Front Ports</a></li>
+                {% endif %}
+                {% if perms.dcim.add_rearporttemplate %}
+                    <li><a href="{% url 'dcim:rearporttemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=rearports">Rear Ports</a></li>
+                {% endif %}
+                {% if perms.dcim.add_devicebaytemplate %}
+                    <li><a href="{% url 'dcim:devicebaytemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=devicebays">Device Bays</a></li>
+                {% endif %}
+                {% if perms.dcim.add_modulebaytemplate %}
+                    <li><a href="{% url 'dcim:modulebaytemplate_add' %}?device_type={{ object.pk }}&return_url={{ object.get_absolute_url }}%3Ftab=modulebays">Module Bays</a></li>
+                {% endif %}
+            </ul>
+        </div>
+    {% endif %}
+{% endblock extra_buttons %}
 
 {% block title %}{{ object.manufacturer }} {{ object.model }}{% endblock title %}
 

--- a/nautobot/extras/tests/integration/test_customfields.py
+++ b/nautobot/extras/tests/integration/test_customfields.py
@@ -320,6 +320,7 @@ class CustomFieldTestCase(SeleniumTestCase):
         self.browser.links.find_by_partial_text("Extensibility").click()
         self.browser.links.find_by_partial_text("Custom Fields").click()
         self.browser.links.find_by_partial_text("Device Selection Field").click()
+        self.browser.find_by_id("actions-dropdown").click()
         self.browser.links.find_by_partial_text("Delete").click()
         self.browser.find_by_xpath(".//button[contains(text(), 'Confirm')]").click()
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5871 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Consolidated the Detail View standard action buttons into a single dropdown. The dropdown is split if the user has edit permissions and there is additional buttons. If user does not have edit permissions, the dropdown button is rendered as a single "Actions" button.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
![image](https://github.com/user-attachments/assets/d11b2ccc-56e3-4c7b-bba4-a0152426656b)
![image](https://github.com/user-attachments/assets/52d82ca1-1494-462e-bb5a-417d26c2bf84)
![image](https://github.com/user-attachments/assets/90cd2e40-b9f1-4616-a42e-9262d23c4260)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
