### PR TITLE
Add GraphQL filtering capability for forward and reverse M2M relations

### DIFF
--- a/changes/5906.fixed
+++ b/changes/5906.fixed
@@ -1,0 +1,1 @@
+Added support for filtering in GraphQL of objects identified by a many-to-many relation (`Location.prefixes`, `Prefix.locations`, etc.)

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -55,12 +55,12 @@ def generate_null_choices_resolver(name, resolver_name):
 
 def generate_filter_resolver(schema_type, resolver_name, field_name):
     """
-    Generate function to resolve OneToMany filtering.
+    Generate function to resolve filtering of ManyToOne and ManyToMany related objects.
 
     Args:
         schema_type (DjangoObjectType): DjangoObjectType for a given model
         resolver_name (str): name of the resolver
-        field_name (str): name of OneToMany field to filter
+        field_name (str): name of ManyToOneField, ManyToManyRel, or ManyToOneRel field to filter
     """
     filterset_class = schema_type._meta.filterset_class
 

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -6,7 +6,8 @@ import logging
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.validators import ValidationError
-from django.db.models.fields.reverse_related import ManyToOneRel, OneToOneRel
+from django.db.models import ManyToManyField
+from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel, OneToOneRel
 import graphene
 from graphene.types import generic
 
@@ -198,9 +199,11 @@ def extend_schema_type_filter(schema_type, model):
         (DjangoObjectType): The extended schema_type object
     """
     for field in model._meta.get_fields():
-        # Check attribute is a ManyToOne field
-        # OneToOneRel is a subclass of ManyToOneRel, but we don't want to treat is as a list
-        if not isinstance(field, ManyToOneRel) or isinstance(field, OneToOneRel):
+        # Check whether attribute is a ManyToOne or ManyToMany field
+        if not isinstance(field, (ManyToManyField, ManyToManyRel, ManyToOneRel)):
+            continue
+        # OneToOneRel is a subclass of ManyToOneRel, but we don't want to treat it as a list
+        if isinstance(field, OneToOneRel):
             continue
         child_schema_type = registry["graphql_types"].get(field.related_model._meta.label_lower)
         if child_schema_type:

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -729,8 +729,8 @@ class GraphQLQueryTest(GraphQLTestCaseBase):
         cls.location_type = LocationType.objects.get(name="Campus")
         cls.location1 = Location.objects.filter(location_type=cls.location_type).first()
         cls.location2 = Location.objects.filter(location_type=cls.location_type).last()
-        cls.location1.name = "Location-1"
-        cls.location2.name = "Location-2"
+        cls.location1.name = "Campus Location-1"
+        cls.location2.name = "Campus Location-2"
         cls.location1.status = cls.location_statuses[0]
         cls.location2.status = cls.location_statuses[1]
         cls.location1.validated_save()
@@ -930,6 +930,7 @@ class GraphQLQueryTest(GraphQLTestCaseBase):
         cls.prefix1 = Prefix.objects.create(
             prefix="10.0.1.0/24", namespace=cls.namespace, status=cls.prefix_statuses[0]
         )
+        cls.prefix1.locations.add(cls.location1, cls.location2)
         cls.ipaddr1 = IPAddress.objects.create(
             address="10.0.1.1/24", namespace=cls.namespace, status=cls.ip_statuses[0]
         )
@@ -968,6 +969,7 @@ class GraphQLQueryTest(GraphQLTestCaseBase):
         cls.prefix2 = Prefix.objects.create(
             prefix="10.0.2.0/24", namespace=cls.namespace, status=cls.prefix_statuses[1]
         )
+        cls.prefix2.locations.add(cls.location1, cls.location2)
         cls.ipaddr2 = IPAddress.objects.create(
             address="10.0.2.1/30", namespace=cls.namespace, status=cls.ip_statuses[1]
         )
@@ -1507,9 +1509,9 @@ query {
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_locations_filter(self):
         filters = (
-            ('name: "Location-1"', 1),
-            ('name: ["Location-1"]', 1),
-            ('name: ["Location-1", "Location-2"]', 2),
+            ('name: "Campus Location-1"', 1),
+            ('name: ["Campus Location-1"]', 1),
+            ('name: ["Campus Location-1", "Campus Location-2"]', 2),
             ('name__ic: "Location"', Location.objects.filter(name__icontains="Location").count()),
             ('name__ic: ["Location"]', Location.objects.filter(name__icontains="Location").count()),
             ('name__nic: "Location"', Location.objects.exclude(name__icontains="Location").count()),
@@ -1540,6 +1542,50 @@ query {
                 result = self.execute_query(query)
                 self.assertIsNone(result.errors)
                 self.assertEqual(len(result.data["locations"]), nbr_expected_results)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_query_prefixes_nested_m2m_filter(self):
+        """
+        Test functionality added to address https://github.com/nautobot/nautobot/issues/5906.
+
+        Prefix.locations is a ManyToManyField, which was not filterable in our GraphQL schema before this fix.
+        """
+        query = 'query { prefixes (prefix_length__gte:16) { prefix locations (location_type:["Campus"]) { name } } }'
+        result = self.execute_query(query)
+        self.assertIsNone(result.errors)
+        found_valid_location = False
+        found_invalid_location = False
+        for prefix_data in result.data["prefixes"]:
+            for location_data in prefix_data["locations"]:
+                if location_data["name"].startswith("Campus"):
+                    found_valid_location = True
+                else:
+                    print(f"Found unexpected unfiltered location {location_data['name']} under {prefix_data['prefix']}")
+                    found_invalid_location = True
+        self.assertTrue(found_valid_location)
+        self.assertFalse(found_invalid_location)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_query_locations_nested_reverse_m2m_filter(self):
+        """
+        Test functionality added to address https://github.com/nautobot/nautobot/issues/5906.
+
+        Location.prefixes is a (reverse) ManyToManyRel, which was not filterable in our GraphQL schema before this fix.
+        """
+        query = "query { locations { name prefixes (prefix_length:24) { prefix } } }"
+        result = self.execute_query(query)
+        self.assertIsNone(result.errors)
+        found_valid_prefix = False
+        found_invalid_prefix = False
+        for location_data in result.data["locations"]:
+            for prefix_data in location_data["prefixes"]:
+                if prefix_data["prefix"].endswith("/24"):
+                    found_valid_prefix = True
+                else:
+                    print(f"Found unexpected unfiltered prefix {prefix_data['prefix']} under {location_data['name']}")
+                    found_invalid_prefix = True
+        self.assertTrue(found_valid_prefix)
+        self.assertFalse(found_invalid_prefix)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_query_devices_filter(self):


### PR DESCRIPTION
# Closes #5906 
# What's Changed

Enhance the GraphQL filtering logic to support filtering not only ManyToOneRel (reverse ForeignKey, supported way back in #799) but also ManyToManyField and its reverse ManyToOneRel.

# Screenshots

<img width="843" alt="image" src="https://github.com/user-attachments/assets/37ff92a8-88c8-4b22-9b79-0c1e5247f301">

<img width="839" alt="image" src="https://github.com/user-attachments/assets/e2698bb4-82d8-4675-bbda-b13059ab6ebc">



# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
