### PR TITLE
[LTM] Fixed issue in which a save() could be called unnecessarily on child devices

### DIFF
--- a/changes/5935.fixed
+++ b/changes/5935.fixed
@@ -1,0 +1,1 @@
+Fixed issue in which a save() could be called unnecessarily on child devices.

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -842,15 +842,15 @@ class Device(PrimaryModel, ConfigContextModel, StatusModel):
         # Update Site and Rack assignment for any child Devices
         devices = Device.objects.filter(parent_bay__device=self)
         for device in devices:
-            save_child_devices = False
+            save_child_device = False
             if device.site != self.site:
                 device.site = self.site
-                save_child_devices = True
+                save_child_device = True
             if device.rack != self.rack:
                 device.rack = self.rack
-                save_child_devices = True
+                save_child_device = True
 
-            if save_child_devices:
+            if save_child_device:
                 device.save()
 
     def create_components(self):

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -842,9 +842,16 @@ class Device(PrimaryModel, ConfigContextModel, StatusModel):
         # Update Site and Rack assignment for any child Devices
         devices = Device.objects.filter(parent_bay__device=self)
         for device in devices:
-            device.site = self.site
-            device.rack = self.rack
-            device.save()
+            save_child_devices = False
+            if device.site != self.site:
+                device.site = self.site
+                save_child_devices = True
+            if device.rack != self.rack:
+                device.rack = self.rack
+                save_child_devices = True
+
+            if save_child_devices:
+                device.save()
 
     def create_components(self):
         """Create device components from the device type definition."""


### PR DESCRIPTION
…devices.

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5935 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Added conditionals around updated child rack/position information so that they're only updated when needed, and that `child_device.save()` is only called if one or both of the values has changed.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design