### PR TITLE
Save m2m fields on Dynamic Groups

### DIFF
--- a/changes/5877.fixed
+++ b/changes/5877.fixed
@@ -1,0 +1,1 @@
+Resolved issue with tags not saving on Dynamic Groups.

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -798,6 +798,7 @@ class DynamicGroupTestCase(
             "content_type": content_type.pk,
             "group_type": DynamicGroupTypeChoices.TYPE_DYNAMIC_FILTER,
             "tenant": Tenant.objects.first().pk,
+            "tags": [t.pk for t in Tag.objects.get_for_model(DynamicGroup)],
             # Management form fields required for the dynamic formset
             "dynamic_group_memberships-TOTAL_FORMS": "0",
             "dynamic_group_memberships-INITIAL_FORMS": "1",

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -813,6 +813,8 @@ class DynamicGroupEditView(generic.ObjectEditView):
 
                     # After filters have been set, now we save the object to the database.
                     obj.save()
+                    # Save m2m fields, such as Tags https://docs.djangoproject.com/en/3.2/topics/forms/modelforms/#the-save-method
+                    form.save_m2m()
                     # Check that the new object conforms with any assigned object-level permissions
                     self.queryset.get(pk=obj.pk)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5877 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Add form.save_m2m() to the DynamicGroupEditView so that m2m fields are saved after the object is created.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
![image](https://github.com/user-attachments/assets/a3c2fd1c-3c28-4224-8d1f-bfd6e8871eda)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
