### PR TITLE
Fixed lags on the JobResults UI page when viewing logs with 2000+ rows using pagination.

### DIFF
--- a/changes/5904.fixed
+++ b/changes/5904.fixed
@@ -1,1 +1,2 @@
 Fixed lags on the JobResults UI page when viewing logs with more than 2000+ rows using pagination.
+Fixed lags on the Bulk Importing of large csv files.

--- a/changes/5904.fixed
+++ b/changes/5904.fixed
@@ -1,0 +1,1 @@
+Fixed lags on the JobResults UI page when viewing logs with more than 2000+ rows using pagination.

--- a/changes/5904.fixed
+++ b/changes/5904.fixed
@@ -1,2 +1,2 @@
-Fixed lags on the JobResults UI page when viewing logs with more than 2000+ rows using pagination.
-Fixed lags on the Bulk Importing of large csv files.
+Fixed performance of JobResults UI when thousands of JobLogEntries are present.
+Fixed performance when Bulk Importing large csv files.

--- a/nautobot/extras/homepage.py
+++ b/nautobot/extras/homepage.py
@@ -7,14 +7,24 @@ def get_job_results(request):
     """Callback function to collect job history for panel."""
     return (
         JobResult.objects.filter(status__in=JobResultStatusChoices.READY_STATES)
-        .defer("result")
+        .restrict(request.user, "view")
+        .only("id", "name", "status", "date_done", "user")
         .order_by("-date_done")[:10]
     )
 
 
 def get_changelog(request):
     """Callback function to collect changelog for panel."""
-    return ObjectChange.objects.restrict(request.user, "view")[:15]
+    return ObjectChange.objects.restrict(request.user, "view").only(
+        "id",
+        "action",
+        "changed_object",
+        "changed_object_id",
+        "changed_object_type",
+        "object_repr",
+        "user_name",
+        "time",
+    )[:15]
 
 
 layout = (

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -20,7 +20,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.base import ContentFile
-from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.core.files.uploadedfile import UploadedFile
 from django.core.validators import RegexValidator
 from django.db.models import Model
 from django.db.models.query import QuerySet
@@ -539,7 +539,7 @@ class BaseJob:
             elif isinstance(value, Model):
                 return_data[field_name] = value.pk
             # FileVar (Save each FileVar as a FileProxy)
-            elif isinstance(value, InMemoryUploadedFile):
+            elif isinstance(value, UploadedFile):
                 return_data[field_name] = BaseJob._save_file_to_proxy(value)
             # IPAddressVar, IPAddressWithMaskVar, IPNetworkVar
             elif isinstance(value, netaddr.ip.BaseIP):

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1787,7 +1787,6 @@ class JobLogEntryTableView(generic.GenericView):
         else:
             queryset = instance.job_log_entries.all()
         log_table = tables.JobLogEntryTable(data=queryset, user=request.user)
-        # RequestConfig(request).configure(log_table)
         paginate = {
             "paginator_class": EnhancedPaginator,
             "per_page": get_paginate_count(request),

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1786,7 +1786,6 @@ class JobLogEntryTableView(generic.GenericView):
             )
         else:
             queryset = instance.job_log_entries.all()
-        # queryset = instance.job_log_entries.none()
         log_table = tables.JobLogEntryTable(data=queryset, user=request.user)
         # RequestConfig(request).configure(log_table)
         paginate = {

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1786,9 +1786,16 @@ class JobLogEntryTableView(generic.GenericView):
             )
         else:
             queryset = instance.job_log_entries.all()
+        # queryset = instance.job_log_entries.none()
         log_table = tables.JobLogEntryTable(data=queryset, user=request.user)
-        RequestConfig(request).configure(log_table)
-        return HttpResponse(log_table.as_html(request))
+        # RequestConfig(request).configure(log_table)
+        paginate = {
+            "paginator_class": EnhancedPaginator,
+            "per_page": get_paginate_count(request),
+        }
+        RequestConfig(request, paginate).configure(log_table)
+        table = log_table.as_html(request)
+        return HttpResponse(table)
 
 
 #


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5904 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
The lag was caused by {% ajax_table "log_table" "extras:jobresult_log-table" pk=result.pk %} attempting to fetch over 10,000 table rows. This process significantly slows down the Django server and the user's browser because converting such a large number of table rows into HTML and then sending this extensive HTML back via Ajax takes a considerable amount of time and displaying it on the user's page consumes a large amount of resources.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->



https://github.com/user-attachments/assets/dfc29646-6bf9-4d50-a5c3-e14da3fc5dbd


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
