### PR TITLE
docs: Additional example for custom job template.

### DIFF
--- a/changes/5958.documentation
+++ b/changes/5958.documentation
@@ -1,0 +1,1 @@
+Added an example job that uses a custom template to render the job form.

--- a/examples/example_app/example_app/jobs.py
+++ b/examples/example_app/example_app/jobs.py
@@ -13,6 +13,7 @@ from nautobot.apps.jobs import (
     JobHookReceiver,
     JSONVar,
     register_jobs,
+    StringVar,
 )
 from nautobot.dcim.models import Device, Location
 from nautobot.extras.choices import ObjectChangeActionChoices
@@ -63,6 +64,37 @@ class ExampleJob(Job):
         # some_json_data is passed to the run method as a Python object (e.g. dictionary)
         pass
 
+class ExampleCustomFormJob(Job):
+    """This job provides a simple HTML form instead of the dynamically generated form.
+
+    The Nautobot `Job` base class provides a mechanism to automatically generate a form
+    to be displayed in the run view. This covers most use cases for displaying job
+    input forms. However, it is sometimes necessary to provide some customization
+    in the view. This particular job will simply replace the form element with
+    a different element.
+    """
+
+    # Nautobot jobs use the script variables to generate the dynamic form, but
+    # this form is also used for processing the submitted data. Therefore, to
+    # get data into a submitted job, script vars must be used and the submitted
+    # form field names must match these script var names. As long as the
+    # form field name matches this and includes an id matching `id_{form_field_name}` then
+    # everything should work as expected.
+    #
+    # The `StringVar` here would display a simple input field, but we are going to
+    # display a text area instead in the template.
+    custom_job_data = StringVar(label="Input Data", description="Some input data", default="Lorem Ipsum")
+
+    # specify template_name to override the default job scheduling template
+    template_name = "example_app/custom_job_form.html"
+
+    class Meta:
+        name = "Custom form."
+        has_sensitive_variables = False
+
+    def run(self, custom_job_data):
+        """Run the job."""
+        self.logger.debug("Data is %s", custom_job_data)
 
 class ExampleHiddenJob(Job):
     class Meta:
@@ -189,6 +221,7 @@ class ExampleComplexJobButtonReceiver(JobButtonReceiver):
 jobs = (
     ExampleDryRunJob,
     ExampleJob,
+    ExampleCustomFormJob,
     ExampleHiddenJob,
     ExampleLoggingJob,
     ExampleFileInputOutputJob,

--- a/examples/example_app/example_app/jobs.py
+++ b/examples/example_app/example_app/jobs.py
@@ -64,6 +64,7 @@ class ExampleJob(Job):
         # some_json_data is passed to the run method as a Python object (e.g. dictionary)
         pass
 
+
 class ExampleCustomFormJob(Job):
     """This job provides a simple HTML form instead of the dynamically generated form.
 
@@ -95,6 +96,7 @@ class ExampleCustomFormJob(Job):
     def run(self, custom_job_data):
         """Run the job."""
         self.logger.debug("Data is %s", custom_job_data)
+
 
 class ExampleHiddenJob(Job):
     class Meta:

--- a/examples/example_app/example_app/templates/example_app/custom_job_form.html
+++ b/examples/example_app/example_app/templates/example_app/custom_job_form.html
@@ -16,7 +16,7 @@
         {% with field_value=job_form.initial.custom_job_data|default:field.initial %}
     <label class="col-md-3 control-label required" for="id_custom_job_data">{{ field.label }}</label>
     <div class="col-md-9">
-        <textarea id="id_custom_job_data" name="custom_job_data">{{ field_value }}</textarea>
+        <textarea class="form-control" id="id_custom_job_data" name="custom_job_data">{{ field_value }}</textarea>
         <span class="help-block">{{ field.help_text|safe }}</span>
     </div>
         {% endwith %}

--- a/examples/example_app/example_app/templates/example_app/custom_job_form.html
+++ b/examples/example_app/example_app/templates/example_app/custom_job_form.html
@@ -1,10 +1,15 @@
 {% extends 'extras/job.html' %}
 {% load form_helpers %}
+<!-- The `job_form` block is where the actual job form is displayed. -->
 {% block job_form %}
 
-<!-- Here we are rendering a simple HTML form element with bootstrap formatting.
-The field name is `custom_job_data` which must match the script variable name
-in the job.
+<!-- 
+    We are going to render a simple HTML form element with bootstrap formatting.
+    The field name is `custom_job_data` which exactly matches the script variable name
+    in the job.
+
+    Note that we are not calling `block.super` here because we don't want any
+    part of the parent job_form block to be rendered (in this case).
 -->
 <div class="form-group">
     {% with field=job_form.fields.custom_job_data %}
@@ -17,11 +22,13 @@ in the job.
         {% endwith %}
     {% endwith %}
 </div>
-<!--
-The `job_form` block is where the actual job form is displayed. The job form really
-should be rendered so that all of the submit functionality (queues, approval required, etc)
-is included, but fields can be excluded. Here we are going to exclude the `custom_job_data`
-field since we've rendered it above.
+<!-- 
+    Even though we want full control over the rendering of the job form, we do need
+    to render the form object (as opposed to the parent template) so so that all of 
+    the submit functionality (queues, approval required, etc) is included. We can 
+    exclude fields from the render so that the fields defined above are not re-rendered
+    here. Here we are going to exclude the `custom_job_data` field since we've rendered
+    it above.
 -->
 {% render_form job_form excluded_fields="['custom_job_data']" %}
 {% endblock %}

--- a/examples/example_app/example_app/templates/example_app/custom_job_form.html
+++ b/examples/example_app/example_app/templates/example_app/custom_job_form.html
@@ -1,0 +1,27 @@
+{% extends 'extras/job.html' %}
+{% load form_helpers %}
+{% block job_form %}
+
+<!-- Here we are rendering a simple HTML form element with bootstrap formatting.
+The field name is `custom_job_data` which must match the script variable name
+in the job.
+-->
+<div class="form-group">
+    {% with field=job_form.fields.custom_job_data %}
+        {% with field_value=job_form.initial.custom_job_data|default:field.initial %}
+    <label class="col-md-3 control-label required" for="id_custom_job_data">{{ field.label }}</label>
+    <div class="col-md-9">
+        <textarea id="id_custom_job_data" name="custom_job_data">{{ field_value }}</textarea>
+        <span class="help-block">{{ field.help_text|safe }}</span>
+    </div>
+        {% endwith %}
+    {% endwith %}
+</div>
+<!--
+The `job_form` block is where the actual job form is displayed. The job form really
+should be rendered so that all of the submit functionality (queues, approval required, etc)
+is included, but fields can be excluded. Here we are going to exclude the `custom_job_data`
+field since we've rendered it above.
+-->
+{% render_form job_form excluded_fields="['custom_job_data']" %}
+{% endblock %}

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2531,6 +2531,7 @@ class JobButtonRenderingTestCase(TestCase):
                 content,
             )
 
+
 class JobCustomTemplateTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2531,6 +2531,26 @@ class JobButtonRenderingTestCase(TestCase):
                 content,
             )
 
+class JobCustomTemplateTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Job model objects are automatically created during database migrations
+
+        # But we do need to make sure the ones we're testing are flagged appropriately
+        cls.example_job = Job.objects.get(job_class_name="ExampleCustomFormJob")
+        cls.example_job.enabled = True
+        cls.example_job.save()
+
+        cls.run_url = reverse("extras:job_run", kwargs={"pk": cls.example_job.pk})
+
+    def test_rendering_custom_template(self):
+        obj_perm = ObjectPermission(name="Test permission", actions=["view", "run"])
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ContentType.objects.get_for_model(Job))
+        with self.assertTemplateUsed("example_app/custom_job_form.html"):
+            self.client.get(self.run_url)
+
 
 # TODO: Convert to StandardTestCases.Views
 class ObjectChangeTestCase(TestCase):


### PR DESCRIPTION
# What's Changed
Added an example job with a custom template that provides an overridden form element.

In this case, an example job is included that overrides a `StringVar` field (which would typically use a standard `<input type="text">` field) to display a `<textarea>` field in the custom template:

![Screenshot 2024-07-31 at 12 29 33 PM](https://github.com/user-attachments/assets/b66b5cc2-dcde-486d-a026-b45c1ab7084c)

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] ~Documentation Updates (when adding/changing features)~
- [x] Example App Updates (when adding/changing features)
- [ ] ~Outline Remaining Work, Constraints from Design~
