### PR TITLE
Improvements to GraphQL query performance

### DIFF
--- a/changes/5980.added
+++ b/changes/5980.added
@@ -1,0 +1,1 @@
+Added caching to `FeatureQuery().get_choices()` and `FeatureQuery().list_subclasses()`.

--- a/changes/5980.fixed
+++ b/changes/5980.fixed
@@ -1,0 +1,1 @@
+Improved performance of GraphQL queries by no longer unnecessarily creating `FilterSet` instances when no filter is present.

--- a/changes/5992.fixed
+++ b/changes/5992.fixed
@@ -1,0 +1,1 @@
+Added signal to clear relevant content-type caches after running migrations.

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -64,8 +64,8 @@ def generate_filter_resolver(schema_type, resolver_name, field_name):
     """
     filterset_class = schema_type._meta.filterset_class
 
-    def resolve_filter(self, *args, **kwargs):
-        if not filterset_class:
+    def resolve_filter(self, info, **kwargs):
+        if not filterset_class or not kwargs:
             return getattr(self, field_name).all()
 
         # Inverse of substitution logic from get_filtering_args_from_filterset() - transform "_type" back to "type"

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -370,10 +370,9 @@ def extend_schema_type_relationships(schema_type, model):
     """Extend the schema type with attributes and resolvers corresponding
     to the relationships associated with this model."""
 
-    ct = ContentType.objects.get_for_model(model)
     relationships_by_side = {
-        "source": Relationship.objects.filter(source_type=ct),
-        "destination": Relationship.objects.filter(destination_type=ct),
+        "source": Relationship.objects.get_for_model_source(model),
+        "destination": Relationship.objects.get_for_model_destination(model),
     }
 
     prefix = ""

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -15,7 +15,7 @@ from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.files.storage import get_storage_class
 from django.db import transaction
-from django.db.models.signals import m2m_changed, post_delete, post_save, pre_delete, pre_save
+from django.db.models.signals import m2m_changed, post_delete, post_migrate, post_save, pre_delete, pre_save
 from django.dispatch import receiver
 from django.utils import timezone
 from django_prometheus.models import model_deletes, model_inserts, model_updates
@@ -266,6 +266,17 @@ def _handle_deleted_object(sender, instance, **kwargs):
 
     # Increment metric counters
     model_deletes.labels(instance._meta.model_name).inc()
+
+
+#
+# Content types
+#
+
+@receiver(post_migrate)
+def post_migrate_clear_content_type_caches(sender, app_config, signal, **kwargs):
+    """Clear various content-type caches after a migration."""
+    cache.delete("nautobot.extras.utils.change_logged_models_queryset")
+    cache.delete_pattern("nautobot.extras.utils.FeatureQuery.*")
 
 
 #

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -276,8 +276,9 @@ def _handle_deleted_object(sender, instance, **kwargs):
 @receiver(post_migrate)
 def post_migrate_clear_content_type_caches(sender, app_config, signal, **kwargs):
     """Clear various content-type caches after a migration."""
-    cache.delete("nautobot.extras.utils.change_logged_models_queryset")
-    cache.delete_pattern("nautobot.extras.utils.FeatureQuery.*")
+    with contextlib.suppress(redis.exceptions.ConnectionError):
+        cache.delete("nautobot.extras.utils.change_logged_models_queryset")
+        cache.delete_pattern("nautobot.extras.utils.FeatureQuery.*")
 
 
 #

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -272,6 +272,7 @@ def _handle_deleted_object(sender, instance, **kwargs):
 # Content types
 #
 
+
 @receiver(post_migrate)
 def post_migrate_clear_content_type_caches(sender, app_config, signal, **kwargs):
     """Clear various content-type caches after a migration."""


### PR DESCRIPTION
# Closes #5980, #5992.
# What's Changed

- In the graphql `resolve_filter()` method, return early if no filter kwargs are present, avoiding the overhead of instantiating a FilterSet unnecessarily. #5931 added a lot more potential filter locations, which resulted in the performance regression described in #5980. (Fixes #5980.) 
- Use the cacheable `Relationship.objects.get_for_model_source()`/`get_for_model_destination()` functions when building the schema to include relationships. This may give a minor performance improvement?
- Add caching to the `FeatureQuery.get_choices()` and `FeatureQuery.list_subclasses()` APIs as cprofile showed a lot of database hits when running GraphQL queries.
   - Add `post_migrate` signal handler to clear these caches as well as the existing `change_logged_models_queryset` cache (fixes #5992).

# Screenshots

Running a complex GraphQL query without any inner filters, similar to the one described in #5980, ten times and getting the total execution time.

```shell
time for i in {1..10}; do nautobot-server nbshell --command 'from nautobot.core.graphql import execute_saved_query; execute_saved_query("Complex Query", variables={"device_id": "14998cc8-6efa-4b2a-a183-f18793f863e3"}, user=User.objects.get(username="admin"))'; done
```

v2.2.7:

```
real	2m22.925s
user	2m5.332s
sys	0m5.945s
```

v2.2.8:

```
real	5m27.954s
user	4m58.190s
sys	0m8.586s
```

This branch:

```
real	2m43.663s
user	2m24.337s
sys	0m6.255s
```


Running the same query but with an added inner filter (not supported in 2.2.7 / before #5931):

```shell
time for i in {1..10}; do nautobot-server nbshell --command 'from nautobot.core.graphql import execute_saved_query; execute_saved_query("Complex Filtered Query", variables={"device_id": "14998cc8-6efa-4b2a-a183-f18793f863e3"}, user=User.objects.get(username="admin"))'; done
```

v2.2.8:

```
real	4m58.987s
user	4m31.414s
sys	0m7.807s
```

This branch:

```
real	4m35.217s
user	4m12.621s
sys	0m7.531s
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
