### PR TITLE
Change rendering of ObjectMetadata scoped_fields in tables, etc.

### DIFF
--- a/changes/6003.changed
+++ b/changes/6003.changed
@@ -1,0 +1,2 @@
+Changed rendering of `scoped_fields` column in `ObjectMetadataTable`.
+Changed default ordering of `ObjectMetadata` list views.

--- a/changes/6003.fixed
+++ b/changes/6003.fixed
@@ -1,0 +1,1 @@
+Added missing `blank=True` to `ObjectMetadata.scoped_fields`.

--- a/changes/6003.housekeeping
+++ b/changes/6003.housekeeping
@@ -1,0 +1,1 @@
+Updated `ObjectMetadataFactory` to produce more realistic `scoped_fields` values. 

--- a/changes/6005.removed
+++ b/changes/6005.removed
@@ -1,0 +1,1 @@
+Removed "delete" and "bulk-delete" functionality from the ObjectMetadata views.

--- a/nautobot/core/management/commands/generate_test_data.py
+++ b/nautobot/core/management/commands/generate_test_data.py
@@ -329,6 +329,8 @@ class Command(BaseCommand):
         )
         _create_batch(MetadataChoiceFactory, 100)
         _create_batch(ObjectChangeFactory, 100)
+        _create_batch(JobResultFactory, 20)
+        _create_batch(JobLogEntryFactory, 100)
         _create_batch(ObjectMetadataFactory, 100)
         _create_batch(
             ObjectMetadataFactory,
@@ -344,8 +346,6 @@ class Command(BaseCommand):
             has_contact=False,
             description="with teams",
         )
-        _create_batch(JobResultFactory, 20)
-        _create_batch(JobLogEntryFactory, 100)
 
     def handle(self, *args, **options):
         if options["flush"]:

--- a/nautobot/core/views/utils.py
+++ b/nautobot/core/views/utils.py
@@ -360,7 +360,9 @@ def common_detail_view_context(request, instance):
 
     if instance.is_metadata_associable_model:
         paginate = {"paginator_class": EnhancedPaginator, "per_page": get_paginate_count(request)}
-        object_metadatas = instance.associated_object_metadatas.restrict(request.user, "view").order_by("scoped_fields")
+        object_metadatas = instance.associated_object_metadatas.restrict(request.user, "view").order_by(
+            "metadata_type", "scoped_fields"
+        )
         object_metadatas_table = ObjectMetadataTable(object_metadatas, orderable=False)
         object_metadatas_table.columns.hide("assigned_object")
         RequestConfig(request, paginate).configure(object_metadatas_table)

--- a/nautobot/extras/migrations/0111_metadata.py
+++ b/nautobot/extras/migrations/0111_metadata.py
@@ -72,7 +72,7 @@ class Migration(migrations.Migration):
                 ("last_updated", models.DateTimeField(auto_now=True, null=True)),
                 (
                     "scoped_fields",
-                    nautobot.core.models.fields.JSONArrayField(base_field=models.CharField(max_length=255)),
+                    nautobot.core.models.fields.JSONArrayField(base_field=models.CharField(max_length=255), blank=True),
                 ),
                 ("_value", models.JSONField(blank=True, null=True)),
                 ("assigned_object_id", models.UUIDField(db_index=True)),

--- a/nautobot/extras/models/metadata.py
+++ b/nautobot/extras/models/metadata.py
@@ -362,12 +362,17 @@ class ObjectMetadata(ChangeLoggedModel, BaseModel):
                         raise ValidationError("Date values must be in the format YYYY-MM-DD.")
             # Validate datetime
             elif metadata_type_data_type == MetadataTypeDataTypeChoices.TYPE_DATETIME:
-                acceptable_datetime_formats = [
-                    "YYYY-MM-DDTHH:MM:SS",
-                    "YYYY-MM-DDTHH:MM:SS(+,-)zzzz",
-                    "YYYY-MM-DDTHH:MM:SS(+,-)zz:zz",
-                ]
-                if not isinstance(value, datetime):
+                if isinstance(value, datetime):
+                    # check if datetime object has tzinfo
+                    if value.tzinfo is None:
+                        value = value.replace(tzinfo=timezone.utc)
+                    value = value.replace(microsecond=0).isoformat()
+                else:
+                    acceptable_datetime_formats = [
+                        "YYYY-MM-DDTHH:MM:SS",
+                        "YYYY-MM-DDTHH:MM:SS(+,-)zzzz",
+                        "YYYY-MM-DDTHH:MM:SS(+,-)zz:zz",
+                    ]
                     try:
                         datetime.strptime(value, "%Y-%m-%dT%H:%M:%S%z")
                     except ValueError:
@@ -381,12 +386,6 @@ class ObjectMetadata(ChangeLoggedModel, BaseModel):
                             )
                     except TypeError:
                         raise ValidationError("Value must be a datetime or str object.")
-                else:
-                    # if value is a datetime object
-                    # check if datetime object has tzinfo
-                    if value.tzinfo is None:
-                        value = value.replace(tzinfo=timezone.utc)
-                    value = value.replace(microsecond=0).isoformat()
             # Validate selected choice
             elif metadata_type_data_type == MetadataTypeDataTypeChoices.TYPE_SELECT:
                 if value not in self.metadata_type.choices.values_list("value", flat=True):

--- a/nautobot/extras/models/metadata.py
+++ b/nautobot/extras/models/metadata.py
@@ -365,8 +365,8 @@ class ObjectMetadata(ChangeLoggedModel, BaseModel):
                 if isinstance(value, datetime):
                     # check if datetime object has tzinfo
                     if value.tzinfo is None:
-                        value = value.replace(tzinfo=timezone.utc)
-                    value = value.replace(microsecond=0).isoformat()
+                        value = value.replace(tzinfo=timezone.utc)  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+                    value = value.replace(microsecond=0).isoformat()  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
                 else:
                     acceptable_datetime_formats = [
                         "YYYY-MM-DDTHH:MM:SS",

--- a/nautobot/extras/models/metadata.py
+++ b/nautobot/extras/models/metadata.py
@@ -186,6 +186,7 @@ class ObjectMetadata(ChangeLoggedModel, BaseModel):
         base_field=models.CharField(
             max_length=CHARFIELD_MAX_LENGTH,
         ),
+        blank=True,
         help_text="List of scoped fields, only direct fields on the model",
     )
     _value = models.JSONField(

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -957,10 +957,8 @@ class MetadataTypeTable(BaseTable):
 class ObjectMetadataTable(BaseTable):
     pk = ToggleColumn()
     metadata_type = tables.Column(linkify=True)
-    assigned_object = tables.TemplateColumn(template_code=ASSIGNED_OBJECT, orderable=False)
-    actions = ButtonsColumn(
-        ObjectMetadata,
-        buttons=("delete"),
+    assigned_object = tables.TemplateColumn(
+        template_code=ASSIGNED_OBJECT, verbose_name="Assigned object", orderable=False
     )
     # This is needed so that render_value method below does not skip itself
     # when metadata_type.data_type is TYPE_CONTACT_TEAM and we need it to display either contact or team
@@ -974,7 +972,6 @@ class ObjectMetadataTable(BaseTable):
             "metadata_type",
             "scoped_fields",
             "value",
-            "actions",
         )
         default_columns = (
             "pk",
@@ -982,7 +979,6 @@ class ObjectMetadataTable(BaseTable):
             "scoped_fields",
             "value",
             "metadata_type",
-            "actions",
         )
 
     def render_scoped_fields(self, value):

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 import django_tables2 as tables
 from django_tables2.utils import Accessor
 from jsonschema.exceptions import ValidationError as JSONSchemaValidationError
@@ -985,8 +985,10 @@ class ObjectMetadataTable(BaseTable):
             "actions",
         )
 
-    def render_scoped_fields(self, record):
-        return render_json(record.scoped_fields, pretty_print=True)
+    def render_scoped_fields(self, value):
+        if not value:
+            return "(all fields)"
+        return format_html_join(", ", "<code>{}</code>", ([v] for v in sorted(value)))
 
     def render_value(self, record):
         if record.value is not None and record.metadata_type.data_type == MetadataTypeDataTypeChoices.TYPE_JSON:

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -2741,21 +2741,21 @@ class ObjectMetadataTest(APIViewTestCases.APIViewTestCase):
             value="Hey",
             scoped_fields=["parent", "status"],
             assigned_object_type=ContentType.objects.get_for_model(IPAddress),
-            assigned_object_id=IPAddress.objects.first().pk,
+            assigned_object_id=IPAddress.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         ObjectMetadata.objects.create(
             metadata_type=mdts[0],
             value="Hello",
             scoped_fields=["namespace"],
             assigned_object_type=ContentType.objects.get_for_model(Prefix),
-            assigned_object_id=Prefix.objects.first().pk,
+            assigned_object_id=Prefix.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         ObjectMetadata.objects.create(
             metadata_type=mdts[2],
             contact=Contact.objects.first(),
             scoped_fields=["status"],
             assigned_object_type=ContentType.objects.get_for_model(Prefix),
-            assigned_object_id=Prefix.objects.last().pk,
+            assigned_object_id=Prefix.objects.filter(associated_object_metadatas__isnull=True).last().pk,
         )
         cls.create_data = [
             {
@@ -2763,28 +2763,28 @@ class ObjectMetadataTest(APIViewTestCases.APIViewTestCase):
                 "scoped_fields": ["location_type"],
                 "value": "random words",
                 "assigned_object_type": "dcim.location",
-                "assigned_object_id": Location.objects.first().pk,
+                "assigned_object_id": Location.objects.filter(associated_object_metadatas__isnull=True).first().pk,
             },
             {
                 "metadata_type": mdts[1].pk,
                 "scoped_fields": ["name"],
                 "value": "random words",
                 "assigned_object_type": "dcim.location",
-                "assigned_object_id": Location.objects.first().pk,
+                "assigned_object_id": Location.objects.filter(associated_object_metadatas__isnull=True).first().pk,
             },
             {
                 "metadata_type": mdts[2].pk,
-                "scoped_fields": ["device_type"],
+                "scoped_fields": [],
                 "contact": Contact.objects.first().pk,
                 "assigned_object_type": "dcim.device",
-                "assigned_object_id": Device.objects.first().pk,
+                "assigned_object_id": Device.objects.filter(associated_object_metadatas__isnull=True).first().pk,
             },
             {
                 "metadata_type": mdts[2].pk,
                 "scoped_fields": ["interfaces"],
                 "team": Team.objects.first().pk,
                 "assigned_object_type": "dcim.device",
-                "assigned_object_id": Device.objects.first().pk,
+                "assigned_object_id": Device.objects.filter(associated_object_metadatas__isnull=True).last().pk,
             },
         ]
         cls.update_data = {

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -15,7 +15,7 @@ from rest_framework import status
 from nautobot.core.choices import ColorChoices
 from nautobot.core.models.fields import slugify_dashes_to_underscores
 from nautobot.core.testing import APITestCase, APIViewTestCases
-from nautobot.core.testing.utils import disable_warnings
+from nautobot.core.testing.utils import disable_warnings, get_deletable_objects
 from nautobot.core.utils.lookup import get_route_for_model
 from nautobot.core.utils.permissions import get_permission_for_model
 from nautobot.dcim.models import (
@@ -2790,6 +2790,13 @@ class ObjectMetadataTest(APIViewTestCases.APIViewTestCase):
         cls.update_data = {
             "scoped_fields": ["pk"],
         }
+
+    def get_deletable_object(self):
+        # TODO: CSV round-trip doesn't work for empty scoped_fields values at present. :-(
+        instance = get_deletable_objects(self.model, self._get_queryset().exclude(scoped_fields=[])).first()
+        if instance is None:
+            self.fail("Couldn't find a single deletable object with non-empty scoped_fields")
+        return instance
 
 
 class NoteTest(APIViewTestCases.APIViewTestCase):

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -1352,7 +1352,7 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
                 value="Invalid assigned object type",
                 scoped_fields=["status"],
                 assigned_object_type=ContentType.objects.get_for_model(IPAddress),
-                assigned_object_id=Contact.objects.first().pk,
+                assigned_object_id=Contact.objects.filter(associated_object_metadatas__isnull=True).first().pk,
             )
             obj_metadata.validated_save()
 
@@ -1362,29 +1362,29 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
         )
         type_contact_team.content_types.add(ContentType.objects.get_for_model(Contact))
         type_contact_team.content_types.add(ContentType.objects.get_for_model(Team))
-        instance1 = ObjectMetadata.objects.create(
+        instance1 = ObjectMetadata(
             metadata_type=type_contact_team,
             contact=Contact.objects.first(),
             team=Team.objects.first(),
             scoped_fields=["address"],
             assigned_object_type=ContentType.objects.get_for_model(Contact),
-            assigned_object_id=Contact.objects.first().pk,
+            assigned_object_id=Contact.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
-        instance2 = ObjectMetadata.objects.create(
+        instance2 = ObjectMetadata(
             metadata_type=type_contact_team,
             contact=None,
             team=None,
             scoped_fields=["phone"],
             assigned_object_type=ContentType.objects.get_for_model(Contact),
-            assigned_object_id=Contact.objects.last().pk,
+            assigned_object_id=Contact.objects.filter(associated_object_metadatas__isnull=True).last().pk,
         )
-        instance3 = ObjectMetadata.objects.create(
+        instance3 = ObjectMetadata(
             metadata_type=type_contact_team,
             contact=Contact.objects.first(),
             team=None,
             scoped_fields=["email"],
             assigned_object_type=ContentType.objects.get_for_model(Team),
-            assigned_object_id=Team.objects.first().pk,
+            assigned_object_id=Team.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         with self.assertRaises(ValidationError):
             instance1.validated_save()
@@ -1407,7 +1407,7 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
             value="Some text value",
             scoped_fields=["status", "parent"],
             assigned_object_type=obj_type,
-            assigned_object_id=Location.objects.first().pk,
+            assigned_object_id=Location.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         obj_metadata.save()
 
@@ -1440,7 +1440,7 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
             value=15,
             scoped_fields=["status", "parent"],
             assigned_object_type=obj_type,
-            assigned_object_id=Location.objects.first().pk,
+            assigned_object_id=Location.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         obj_metadata.validated_save()
 
@@ -1484,7 +1484,7 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
             value=15.245,
             scoped_fields=["status", "parent"],
             assigned_object_type=obj_type,
-            assigned_object_id=Location.objects.first().pk,
+            assigned_object_id=Location.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         obj_metadata.validated_save()
 
@@ -1525,7 +1525,7 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
             value=False,
             scoped_fields=["status", "parent"],
             assigned_object_type=obj_type,
-            assigned_object_id=Location.objects.first().pk,
+            assigned_object_id=Location.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         obj_metadata.validated_save()
 
@@ -1559,7 +1559,7 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
             value="1994-01-01",
             scoped_fields=["status", "parent"],
             assigned_object_type=obj_type,
-            assigned_object_id=Location.objects.first().pk,
+            assigned_object_id=Location.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         obj_metadata.validated_save()
 
@@ -1596,7 +1596,7 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
             value="2024-06-27T17:58:47-0500",
             scoped_fields=["status", "parent"],
             assigned_object_type=obj_type,
-            assigned_object_id=Location.objects.first().pk,
+            assigned_object_id=Location.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         obj_metadata.validated_save()
 
@@ -1663,7 +1663,7 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
             value="Option A",
             scoped_fields=["status", "parent"],
             assigned_object_type=obj_type,
-            assigned_object_id=Location.objects.first().pk,
+            assigned_object_id=Location.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         obj_metadata.validated_save()
 
@@ -1689,7 +1689,7 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
             value=["Option A"],
             scoped_fields=["status", "parent"],
             assigned_object_type=obj_type,
-            assigned_object_id=Location.objects.first().pk,
+            assigned_object_id=Location.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         obj_metadata.validated_save()
 
@@ -1700,20 +1700,22 @@ class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):
         self.assertIn(f"Invalid choice(s) ({invalid_options})", str(context.exception))
 
     def test_no_scoped_fields_overlap(self):
-        """Test that overlapping between scoped_fields of ObjectMetadata with the same metadata_type and the same assigned_object is not allowed"""
+        """
+        Test that overlapping scoped_fields of ObjectMetadata with same metadata_type/assigned_object is not allowed.
+        """
         ObjectMetadata.objects.create(
             metadata_type=MetadataType.objects.first(),
             contact=Contact.objects.first(),
             scoped_fields=["host", "mask_length", "type", "role", "status"],
             assigned_object_type=ContentType.objects.get_for_model(IPAddress),
-            assigned_object_id=IPAddress.objects.first().pk,
+            assigned_object_id=IPAddress.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         instance2 = ObjectMetadata.objects.create(
             metadata_type=MetadataType.objects.first(),
             contact=Contact.objects.first(),
             scoped_fields=[],
             assigned_object_type=ContentType.objects.get_for_model(IPAddress),
-            assigned_object_id=IPAddress.objects.first().pk,
+            assigned_object_id=IPAddress.objects.filter(associated_object_metadatas__isnull=True).first().pk,
         )
         with self.assertRaises(ValidationError):
             # try scope all fields

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -3029,8 +3029,7 @@ class ObjectChangeTestCase(TestCase):
 
 
 class ObjectMetadataTestCase(
-    ViewTestCases.DeleteObjectViewTestCase,
-    ViewTestCases.BulkDeleteObjectsViewTestCase,
+    ViewTestCases.GetObjectViewTestCase,
     ViewTestCases.GetObjectChangelogViewTestCase,
     ViewTestCases.ListObjectsViewTestCase,
 ):

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2237,9 +2237,7 @@ class MetadataTypeUIViewSet(NautobotUIViewSet):
 
 
 class ObjectMetadataUIViewSet(
-    ObjectBulkDestroyViewMixin,
     ObjectChangeLogViewMixin,
-    ObjectDestroyViewMixin,
     ObjectDetailViewMixin,
     ObjectListViewMixin,
 ):

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2245,7 +2245,7 @@ class ObjectMetadataUIViewSet(
 ):
     filterset_class = filters.ObjectMetadataFilterSet
     filterset_form_class = forms.ObjectMetadataFilterForm
-    queryset = ObjectMetadata.objects.all().order_by("assigned_object_type", "scoped_fields")
+    queryset = ObjectMetadata.objects.all().order_by("assigned_object_type", "assigned_object_id", "scoped_fields")
     serializer_class = serializers.ObjectMetadataSerializer
     table_class = tables.ObjectMetadataTable
     action_buttons = ("export",)


### PR DESCRIPTION
# Closes #6003
# What's Changed

- Change rendering of `scoped_fields` column in ObjectMetadata tables from rendered JSON to a comma-separated list of `code` tags.
- Change factory generation for `scoped_fields` to produce values based on the actual model fields instead of a random list of strings.
- Added missing `blank=True` to the `scoped_fields` field definition to allow for `[]` (all fields) as a valid value.
- Changed default ordering of ObjectMetadata tables to be a bit more usable.

# Screenshots

![image](https://github.com/user-attachments/assets/93d0ea2d-7fd7-4450-a086-027df1d5d400)


![image](https://github.com/user-attachments/assets/fc79ba49-ba97-4a55-9ab1-f86ed413c939)


![image](https://github.com/user-attachments/assets/9eeee25d-da87-44cc-b3b0-28087bffa6c3)




# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
