### PR TITLE
Pin django-storages temporarily to 1.14.3

### DIFF
--- a/changes/6010.dependencies
+++ b/changes/6010.dependencies
@@ -1,0 +1,1 @@
+Pinned `django-storages` temporarily to 1.14.3 due to an [incompatibility](https://github.com/revsys/django-health-check/issues/434) between `django-health-check` and version 1.14.4 of `django-storages`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -961,13 +961,13 @@ django = ">=1.6"
 
 [[package]]
 name = "django-storages"
-version = "1.14.4"
+version = "1.14.3"
 description = "Support for many storage backends in Django"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "django-storages-1.14.4.tar.gz", hash = "sha256:69aca94d26e6714d14ad63f33d13619e697508ee33ede184e462ed766dc2a73f"},
-    {file = "django_storages-1.14.4-py3-none-any.whl", hash = "sha256:d61930acb4a25e3aebebc6addaf946a3b1df31c803a6bf1af2f31c9047febaa3"},
+    {file = "django-storages-1.14.3.tar.gz", hash = "sha256:95a12836cd998d4c7a4512347322331c662d9114c4344f932f5e9c0fce000608"},
+    {file = "django_storages-1.14.3-py3-none-any.whl", hash = "sha256:31f263389e95ce3a1b902fb5f739a7ed32895f7d8b80179fe7453ecc0dfe102e"},
 ]
 
 [package.dependencies]
@@ -4141,4 +4141,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "3e495c2c0c42bd0d0598f369d436d91b5e0c7342c2140e3d827dc74fd79d95dc"
+content-hash = "db8afb00eb578ec549bacb6b52d3eee9dab0fdb9207e73cb963ae95a202d0364"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ django-redis = "~5.4.0"
 # Django silk for request profiling
 django-silk = "~5.1.0"
 # External Storage support (i.e. S3)
-django-storages = {version = "~1.14.4", optional = true}
+# Pinned temporarily to 1.14.3 due to https://github.com/revsys/django-health-check/issues/434
+django-storages = {version = "1.14.3", optional = true}
 # Advanced HTML tables
 django-tables2 = "~2.7.0"
 # Tags


### PR DESCRIPTION
# Closes #6010
# What's Changed

Pinned `django-storages` temporarily to 1.14.3 due to an [incompatibility](https://github.com/revsys/django-health-check/issues/434) between `django-health-check` and version 1.14.4 of `django-storages`.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
