### PR TITLE
Update documentation for installation under Ubuntu 24.04 LTS

### DIFF
--- a/changes/5920.documentation
+++ b/changes/5920.documentation
@@ -1,0 +1,1 @@
+Updated documentation for installation under Ubuntu 24.04 LTS.

--- a/nautobot/docs/user-guide/administration/installation/http-server.md
+++ b/nautobot/docs/user-guide/administration/installation/http-server.md
@@ -212,7 +212,7 @@ sudo systemctl restart nginx
 !!! info
     If the restart fails, and you changed the default key location, check to make sure the `nautobot.conf` file you pasted has the updated key location. For example, CentOS requires keys to be in `/etc/pki/tls/` instead of `/etc/ssl/`.
 
-## Confirm Permissions for NAUTOBOT_ROOT
+## Confirm Permissions for `NAUTOBOT_ROOT`
 
 Ensure that the `NAUTOBOT_ROOT` permissions are set to `755`.
 If permissions need to be changed, as the `nautobot` user run:

--- a/nautobot/docs/user-guide/administration/installation/index.md
+++ b/nautobot/docs/user-guide/administration/installation/index.md
@@ -42,26 +42,26 @@ Nautobot will not work without these dependencies.
 
 Nautobot is written in the [Python programming language](https://www.python.org/). The official Python package installer is called [Pip](https://pip.pypa.io/en/stable/), and you will see the `pip` command referenced often to install or update Python packages.
 
-+++ 1.3.0
++++ 1.3.0 "Python 3.10 support added"
     Python 3.10 support was added.
 
---- 1.3.0
+--- 1.3.0 "Python 3.6 support removed"
     Python 3.6 support was removed.
 
-+/- 1.6.0
++/- 1.6.0 "Python 3.11 support added, Python 3.7 support removed"
     Python 3.11 support was added and Python 3.7 support was removed.
 
-+++ 2.3.0
++++ 2.3.0 "Python 3.12 support added"
     Python 3.12 support was added.
 
 #### Database
 
 Nautobot uses a relational database to store its data. Both MySQL and PostgreSQL are officially supported.
 
-+++ 1.1.0
++++ 1.1.0 "MySQL support added"
     MySQL support was added.
 
---- 2.1.0
+--- 2.1.0 "PostgreSQL minimum version became 12.0"
     Support for versions of PostgreSQL older than 12.0 was removed.
 
 !!! note "Only one database"

--- a/nautobot/docs/user-guide/administration/installation/install_system.md
+++ b/nautobot/docs/user-guide/administration/installation/install_system.md
@@ -2,7 +2,7 @@
 
 The documentation assumes that you are running one of the following:
 
-- Ubuntu 20.04 - 22.04
+- Ubuntu 20.04+
 - Debian 11+
 - RHEL/CentOS 8.2+
     - Delimited by `RHEL8` tabs in the docs, but also includes other derivatives of RHEL such as RockyLinux or AlmaLinux
@@ -19,9 +19,6 @@ This will install:
 - Redis server and client
 
 === "Ubuntu/Debian"
-
-    ???+ note "Ubuntu 24.04"
-        Ubuntu 24.04 is not officially supported by Nautobot 2.2 and prior yet. If you wish to attempt to use Nautobot 24.04 the one additional package in early testing to add would be `libjpeg-dev`. The pip resolution with Python 3.12 would require the use of the flag `--ignore-requires-python`.
 
     ```bash title="Install system dependencies"
     sudo apt update -y
@@ -75,7 +72,7 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
         ??? example "Example of Entering Postgres"
 
             ```no-highlight title="Entering Postgres DB"
-            psql (12.5 (Ubuntu 12.5-0ubuntu0.20.04.1))
+            psql (16.3 (Ubuntu 16.3-0ubuntu0.24.04.1))
             Type "help" for help.
 
             postgres=#
@@ -119,13 +116,13 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
 
             ```no-highlight title="Example output"
             Password for user nautobot:
-            psql (12.5 (Ubuntu 12.5-0ubuntu0.20.04.1))
-            SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
+            psql (16.3 (Ubuntu 16.3-0ubuntu0.24.04.1))
+            SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
             Type "help" for help.
 
             nautobot=> \conninfo
-            You are connected to database "nautobot" as user "nautobot" on host "localhost" (address "127.0.0.1") at port "5432".
-            SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
+            You are connected to database "nautobot" as user "nautobot" on host "localhost" (address "::1") at port "5432".
+            SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
             nautobot=> \q
             ```
 
@@ -133,10 +130,10 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
 
         <h3>Install MySQL</h3>
 
-        This will install the MySQL database server and client. Additionally, MySQL requires that the MySQL development libraries are installed so that we may compile the Python `mysqlclient` library during the Nautobot installation steps.
+        This will install the MySQL database server and client. Additionally, MySQL requires that the MySQL development libraries and the `pkg-config` package are both installed so that we may compile the Python `mysqlclient` library during the Nautobot installation steps.
 
         ```no-highlight title="Install MySQL required packages"
-        sudo apt install -y libmysqlclient-dev mysql-server
+        sudo apt install -y libmysqlclient-dev mysql-server pkg-config
         ```
 
         <h3>Create a MySQL Database</h3>
@@ -165,9 +162,9 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
             ```no-highlight title="Example MySQL DB creation output."
             Welcome to the MySQL monitor.  Commands end with ; or \g.
             Your MySQL connection id is 11
-            Server version: 8.0.25-0ubuntu0.20.04.1 (Ubuntu)
+            Server version: 8.0.37-0ubuntu0.24.04.1 (Ubuntu)
 
-            Copyright (c) 2000, 2021, Oracle and/or its affiliates.
+            Copyright (c) 2000, 2024, Oracle and/or its affiliates.
 
             Oracle is a registered trademark of Oracle Corporation and/or its
             affiliates. Other names may be trademarks of their respective
@@ -214,9 +211,9 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
             Enter password:
             Welcome to the MySQL monitor.  Commands end with ; or \g.
             Your MySQL connection id is 13
-            Server version: 8.0.25-0ubuntu0.20.04.1 (Ubuntu)
+            Server version: 8.0.37-0ubuntu0.24.04.1 (Ubuntu)
 
-            Copyright (c) 2000, 2021, Oracle and/or its affiliates.
+            Copyright (c) 2000, 2024, Oracle and/or its affiliates.
 
             Oracle is a registered trademark of Oracle Corporation and/or its
             affiliates. Other names may be trademarks of their respective
@@ -226,7 +223,7 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
 
             mysql> status
             --------------
-            mysql  Ver 8.0.25-0ubuntu0.20.04.1 for Linux on x86_64 ((Ubuntu))
+            mysql  Ver 8.0.37-0ubuntu0.24.04.1 for Linux on x86_64 ((Ubuntu))
 
             Connection id:          13
             Current database:       nautobot
@@ -235,7 +232,7 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
             Current pager:          stdout
             Using outfile:          ''
             Using delimiter:        ;
-            Server version:         8.0.25-0ubuntu0.20.04.1 (Ubuntu)
+            Server version:         8.0.37-0ubuntu0.24.04.1 (Ubuntu)
             Protocol version:       10
             Connection:             Localhost via UNIX socket
             Server characterset:    utf8mb4

--- a/nautobot/docs/user-guide/administration/installation/nautobot.md
+++ b/nautobot/docs/user-guide/administration/installation/nautobot.md
@@ -166,19 +166,21 @@ pip3 install --upgrade pip wheel
 ??? example "Example pip update output"
 
     ```no-highlight
-    Requirement already satisfied: pip in ./lib/python3.10/site-packages (22.0.2)
+    Requirement already satisfied: pip in ./lib/python3.12/site-packages (24.0)
     Collecting pip
-    Downloading pip-24.0-py3-none-any.whl (2.1 MB)
-        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 14.8 MB/s eta 0:00:00
+      Downloading pip-24.2-py3-none-any.whl.metadata (3.6 kB)
     Collecting wheel
+      Downloading wheel-0.43.0-py3-none-any.whl.metadata (2.2 kB)
+    Downloading pip-24.2-py3-none-any.whl (1.8 MB)
+       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 36.6 MB/s eta 0:00:00
     Downloading wheel-0.43.0-py3-none-any.whl (65 kB)
-        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 65.8/65.8 KB 11.8 MB/s eta 0:00:00
+       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 65.8/65.8 kB 7.5 MB/s eta 0:00:00
     Installing collected packages: wheel, pip
-    Attempting uninstall: pip
-        Found existing installation: pip 22.0.2
-        Uninstalling pip-22.0.2:
-        Successfully uninstalled pip-22.0.2
-    Successfully installed pip-24.0 wheel-0.43.0
+      Attempting uninstall: pip
+        Found existing installation: pip 24.0
+        Uninstalling pip-24.0:
+          Successfully uninstalled pip-24.0
+    Successfully installed pip-24.2 wheel-0.43.0
     ```
 
 By default, Pip will now install Python packages as wheels. In most cases this is desirable, however in some cases the wheel versions of packages may have been compiled with options differing from what is needed for a specific scenario. One such case presents itself here - the wheel for `pyuwsgi`, a key web server component of Nautobot, is built without SSL (HTTPS) support. This may be fine for a non-production deployment of Nautobot, such as in your lab, but for production deployments, not supporting HTTPS will not do at all. Fortunately, you can tell Pip when you don't want to use wheels for a specific package by passing the `--no-binary=<package>` CLI parameter. We'll use that below.
@@ -229,7 +231,8 @@ nautobot-server init
 
     ```no-highlight title="Example `nautobot-server init`"
     Nautobot would like to send anonymized installation metrics to the project's maintainers.
-    These metrics include the installed Nautobot version, the Python version in use, an anonymous "deployment ID", and a list of one-way-hashed names of enabled Nautobot Apps and their versions.
+    These metrics include the installed Nautobot version, the Python version in use, an anonymous
+    "deployment ID", and a list of one-way-hashed names of enabled Nautobot Apps and their versions.
     Allow Nautobot to send these metrics? [y/n]:
     ```
 
@@ -238,8 +241,8 @@ nautobot-server init
     Configuration file created at /opt/nautobot/nautobot_config.py
     ```
 
-+++ 1.6.0
-    The `nautobot-server init` command will now prompt you to set the initial value for the [`INSTALLATION_METRICS_ENABLED`](../configuration/optional-settings.md#installation_metrics_enabled) setting. See the [send_installation_metrics](../tools/nautobot-server.md#send_installation_metrics) command for more information about the feature that this setting toggles.
++++ 1.6.0 "Installation metrics selection"
+    The `nautobot-server init` command will now prompt you to set the initial value for the [`INSTALLATION_METRICS_ENABLED`](../configuration/optional-settings.md#installation_metrics_enabled) setting. See the [`send_installation_metrics`](../tools/nautobot-server.md#send_installation_metrics) command for more information about the feature that this setting toggles.
 
 ### Required Settings
 
@@ -253,13 +256,13 @@ Edit `$NAUTOBOT_ROOT/nautobot_config.py`, and head over to the documentation on 
 
 === "PostgreSQL"
 
-    - At a minimum, you'll need to update the `"USER"` and `"PASSWORD"` fields under `DATABASES`.
+    - At a minimum, you'll need to update the `"USER"` and `"PASSWORD"` fields under `DATABASES`. Depending on your security posture, you may wish to set these via environment variables (`NAUTOBOT_DB_USER` and `NAUTOBOT_DB_PASSWORD`) rather than writing them directly into your `nautobot_config.py`. Most Nautobot configuration settings can be set by environment variables if preferred.
 
 === "MySQL"
 
-    - At a minimum, you'll need to update the `"USER"` and `"PASSWORD"` fields under `DATABASES`.
+    - At a minimum, you'll need to update the `"USER"` and `"PASSWORD"` fields under `DATABASES`. Depending on your security posture, you may wish to set these via environment variables (`NAUTOBOT_DB_USER` and `NAUTOBOT_DB_PASSWORD`) rather than writing them directly into your `nautobot_config.py`. Most Nautobot configuration settings can be set by environment variables if preferred.
     - Additionally, since Nautobot's configuration defaults to assuming PostgreSQL, you must change the `"ENGINE"` setting from `django.db.backends.postgresql` to `django.db.backends.mysql`.
-    - If you want to enable support for Unicode text, including emojis, please make sure to add `"OPTIONS": {"charset": "utf8mb4"}`. Refer to the [configuration guide on MySQL Unicode settings](../configuration/required-settings.md#databases) for more information.
+    - If you want to enable support for Unicode text, including emojis, please make sure to include `"OPTIONS": {"charset": "utf8mb4"}`. Refer to the [configuration guide on MySQL Unicode settings](../configuration/required-settings.md#databases) for more information.
 
 !!! warning
     You absolutely must update your required settings in your `nautobot_config.py` or Nautobot will not work.
@@ -268,7 +271,7 @@ Save your changes to your `nautobot_config.py` and then proceed to the next step
 
 ### Optional Settings
 
-All Python packages required by Nautobot will be installed automatically when running `pip3 install nautobot`.
+All Python packages required by Nautobot were installed automatically when running `pip3 install nautobot` above.
 
 Nautobot also supports the ability to install optional Python packages. If desired, these packages should be listed in `local_requirements.txt` within the `NAUTOBOT_ROOT` directory, such as `/opt/nautobot/local_requirements.txt`.
 

--- a/nautobot/docs/user-guide/administration/installation/services.md
+++ b/nautobot/docs/user-guide/administration/installation/services.md
@@ -26,17 +26,17 @@ Nautobot requires at least one worker to consume background tasks required for a
 nautobot-server celery --help
 ```
 
-+/- 1.1.0
++/- 1.1.0 "Celery added to Nautobot"
     Prior to version 1.1.0, Nautobot utilized RQ as the primary background task worker. As of Nautobot 1.1.0, RQ is now *deprecated*. RQ and the `@job` decorator for custom tasks were still supported for the remainder of the 1.x.y releases, but users should [migrate the primary worker to Celery](#migrating-to-celery-from-rq).
 
---- 2.0.0
+--- 2.0.0 "RQ removed from Nautobot"
     Support for RQ has been completely removed from Nautobot.
 
 #### Advanced Task Queue Configuration
 
 You may want to deploy multiple workers and/or multiple queues. For more information see the [task queues](../guides/celery-queues.md) documentation.
 
-+/- 2.3.0
++++ 2.3.0 "Worker status view added"
     In Nautobot 2.3.0, `staff` accounts can access a new worker status page at `/worker-status/` to view the status of the Celery worker(s) and the configured queues. The link to this page appears in the "User" dropdown at the bottom of the navigation menu, under the link to the "Profile" page. Use this page with caution as it runs a live query against the Celery worker(s) and may impact performance of your web service.
 
 ## Configuration
@@ -171,17 +171,12 @@ WantedBy=multi-user.target
 
 ### Nautobot Background Services
 
-+/- 1.1.0
-    Prior to version 1.1.0, Nautobot utilized RQ as the primary background task worker. As of Nautobot 1.1.0, RQ is now *deprecated* and has been replaced with Celery. RQ and the `@job` decorator for custom tasks were still supported for the remainder of the 1.x.y releases, but users should [migrate the primary worker to Celery](#migrating-to-celery-from-rq).
-
---- 2.0.0
-    RQ support has been fully removed from Nautobot.
-
 Next, we will setup the `systemd` units for the Celery worker and Celery Beat scheduler.
 
 #### Celery Worker
 
-+++ 1.1.0
++++ 1.1.0 "Celery added to Nautobot"
+    Prior to version 1.1.0, Nautobot utilized RQ as the primary background task worker. As of Nautobot 1.1.0, RQ is now *deprecated* and has been replaced with Celery. RQ and the `@job` decorator for custom tasks were still supported for the remainder of the 1.x.y releases, but users should [migrate the primary worker to Celery](#migrating-to-celery-from-rq).
 
 The Celery worker service consumes tasks from background task queues and is required for taking advantage of advanced
 Nautobot features including [Jobs](../../platform-functionality/jobs/index.md), [Custom
@@ -229,7 +224,7 @@ WantedBy=multi-user.target
 
 #### Celery Beat Scheduler
 
-+++ 1.2.0
++++ 1.2.0 "Celery Beat added to Nautobot"
 
 The Celery Beat scheduler enables the periodic execution of and scheduling of background tasks. It is required to take advantage of the [job scheduling and approval](../../platform-functionality/jobs/job-scheduling-and-approvals.md) features.
 
@@ -281,43 +276,44 @@ WantedBy=multi-user.target
 
 #### Migrating to Celery from RQ
 
-Prior to migrating, you need to determine whether you have any Apps installed that run custom background tasks that still rely on the RQ worker. There are a few ways to do this. Two of them are:
+??? abstract "Details of migrating an existing Nautobot installation from RQ to Celery"
+    Prior to migrating, you need to determine whether you have any Apps installed that run custom background tasks that still rely on the RQ worker. There are a few ways to do this. Two of them are:
 
-* Ask your developer or administrator if there are any Apps running background tasks still using the RQ worker
-* If you are savvy with code, search your code for the `@job` decorator or for `from django_rq import job`
+    * Ask your developer or administrator if there are any Apps running background tasks still using the RQ worker
+    * If you are savvy with code, search your code for the `@job` decorator or for `from django_rq import job`
 
-If you're upgrading from Nautobot version 1.0.x and are NOT running Apps that use the RQ worker, all you really need to do are two things.
+    If you're upgrading from Nautobot version 1.0.x and are NOT running Apps that use the RQ worker, all you really need to do are two things.
 
-First, you must replace the contents of `/etc/systemd/system/nautobot-worker.service` with the `systemd` unit file provided just above.
+    First, you must replace the contents of `/etc/systemd/system/nautobot-worker.service` with the `systemd` unit file provided just above.
 
-Next, you must update any custom background tasks that you may have written. If you do not have any custom background tasks, then you may continue on to the next section to reload your worker service to use Celery.
+    Next, you must update any custom background tasks that you may have written. If you do not have any custom background tasks, then you may continue on to the next section to reload your worker service to use Celery.
 
-To update your custom tasks, you'll need to do the following.
+    To update your custom tasks, you'll need to do the following.
 
-* Replace each import `from django_rq import job` with `from nautobot.core.celery import nautobot_task`
-* Replace each decorator of `@job` with `@nautobot_task`
+    * Replace each import `from django_rq import job` with `from nautobot.core.celery import nautobot_task`
+    * Replace each decorator of `@job` with `@nautobot_task`
 
-For example:
+    For example:
 
-```diff title="Diff of tasks for celery vs rq"
-diff --git a/task_example.py b/task_example.py
-index f84073fb5..52baf6096 100644
---- a/task_example.py
-+++ b/task_example.py
-@@ -1,6 +1,6 @@
--from django_rq import job
-+from nautobot.core.celery import nautobot_task
+    ```diff title="Diff of tasks for celery vs rq"
+    diff --git a/task_example.py b/task_example.py
+    index f84073fb5..52baf6096 100644
+    --- a/task_example.py
+    +++ b/task_example.py
+    @@ -1,6 +1,6 @@
+    -from django_rq import job
+    +from nautobot.core.celery import nautobot_task
 
 
--@job("default")
-+@nautobot_task
- def example_task(*args, **kwargs):
-     return "examples are cool!"
-(END)
-```
+    -@job("default")
+    +@nautobot_task
+     def example_task(*args, **kwargs):
+         return "examples are cool!"
+    (END)
+    ```
 
-!!! warning
-    Failure to account for the RQ to Celery migration may break your custom background tasks.
+    !!! warning
+        Failure to account for the RQ to Celery migration may break your custom background tasks.
 
 ### Configure systemd
 
@@ -339,19 +335,16 @@ You can use the command `systemctl status nautobot.service` to verify that the W
 
 ```no-highlight title="Validate services are running"
 ● nautobot.service - Nautobot WSGI Service
-     Loaded: loaded (/etc/systemd/system/nautobot.service; enabled; vendor preset: enabled)
-     Active: active (running) since Fri 2021-03-05 22:23:33 UTC; 35min ago
+     Loaded: loaded (/etc/systemd/system/nautobot.service; enabled; preset: enabled)
+     Active: active (running) since Mon 2024-07-29 20:44:21 UTC; 5s ago
        Docs: https://docs.nautobot.com/projects/core/en/stable/
-   Main PID: 6992 (nautobot-server)
-      Tasks: 16 (limit: 9513)
-     Memory: 221.1M
+   Main PID: 7340 (nautobot-server)
+      Tasks: 2 (limit: 4658)
+     Memory: 135.2M (peak: 135.5M)
+        CPU: 3.445s
      CGroup: /system.slice/nautobot.service
-             ├─6992 /opt/nautobot/bin/python3 /opt/nautobot/bin/nautobot-server start />
-             ├─7007 /opt/nautobot/bin/python3 /opt/nautobot/bin/nautobot-server start />
-             ├─7010 /opt/nautobot/bin/python3 /opt/nautobot/bin/nautobot-server start />
-             ├─7013 /opt/nautobot/bin/python3 /opt/nautobot/bin/nautobot-server start />
-             ├─7016 /opt/nautobot/bin/python3 /opt/nautobot/bin/nautobot-server start />
-             └─7019 /opt/nautobot/bin/python3 /opt/nautobot/bin/nautobot-server start />
+             ├─7340 /opt/nautobot/bin/python3 /opt/nautobot/bin/nautobot-server start --pidfile /var/tmp/nautobot.pid
+             └─7351 /opt/nautobot/bin/python3 /opt/nautobot/bin/nautobot-server start --pidfile /var/tmp/nautobot.pid
 ```
 
 !!! note


### PR DESCRIPTION
# Progress toward #5920 (need to do the same for latest Fedora)
# What's Changed

Run through Postgres and MySQL installation variants under Ubuntu 24.04. The only required change I noticed was the need to `apt install pkg-config` in order to build the python `mysqlclient` package. 

Additionally:

- Add titles to the various version-related admonitions so that the reader can get the gist without expanding them
- Wrap the `Migrating to Celery from RQ` section into a default-collapsed admonition since it's irrelevant to most readers
- Update various example CLI output. 

https://docs-landing-page--6013.org.readthedocs.build/projects/core/en/6013/

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
