### PR TITLE
Update installation docs based on Fedora 40 and AlmaLinux 9

### DIFF
--- a/changes/5920.documentation
+++ b/changes/5920.documentation
@@ -1,1 +1,1 @@
-Updated documentation for installation under Ubuntu 24.04 LTS.
+Updated documentation for installation under Ubuntu 24.04 LTS and Fedora 40.

--- a/changes/5920.documentation
+++ b/changes/5920.documentation
@@ -1,1 +1,1 @@
-Updated documentation for installation under Ubuntu 24.04 LTS and Fedora 40.
+Updated documentation for installation under Ubuntu 24.04 LTS, Fedora 40, AlmaLinux 9, and similar distros.

--- a/changes/6019.documentation
+++ b/changes/6019.documentation
@@ -1,0 +1,1 @@
+Updated the installation documentation to recommend a more secure set of filesystem permissions.

--- a/changes/6019.fixed
+++ b/changes/6019.fixed
@@ -1,0 +1,1 @@
+Marked the `JobLogEntry` model as invalid for association of `ObjectMetadata`.

--- a/nautobot/docs/user-guide/administration/installation/http-server.md
+++ b/nautobot/docs/user-guide/administration/installation/http-server.md
@@ -22,7 +22,7 @@ Two files will be created: the public certificate (`nautobot.crt`) and the priva
       -out /etc/ssl/certs/nautobot.crt
     ```
 
-=== "RHEL"
+=== "Fedora/RHEL"
 
     ```no-highlight title="Create SSL certificate"
     sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
@@ -39,8 +39,7 @@ Any HTTP server of your choosing is supported. For your convenience, setup instr
 
 ### NGINX
 
-[NGINX](https://www.nginx.com/resources/wiki/) is a free, open source, high-performance HTTP server and reverse proxy
-and is by far the most popular choice.
+[NGINX](https://www.nginx.com/resources/wiki/) is a free, open source, high-performance HTTP server and reverse proxy.
 
 #### Install NGINX
 
@@ -52,7 +51,7 @@ Begin by installing NGINX:
     sudo apt install -y nginx
     ```
 
-=== "RHEL"
+=== "Fedora/RHEL"
 
     ```no-highlight title="Install NGINX"
     sudo dnf install -y nginx
@@ -122,7 +121,7 @@ Begin by installing NGINX:
     }
     ```
 
-=== "RHEL"
+=== "Fedora/RHEL"
     Once NGINX is installed, copy and paste the following NGINX configuration for the Nautobot NGINX site.
 
     === "Vim"
@@ -193,7 +192,7 @@ Begin by installing NGINX:
     sudo ln -s /etc/nginx/sites-available/nautobot.conf /etc/nginx/sites-enabled/nautobot.conf
     ```
 
-=== "RHEL"
+=== "Fedora/RHEL"
 
     Run the following command to disable the default site that comes with the `nginx` package:
 

--- a/nautobot/docs/user-guide/administration/installation/http-server.md
+++ b/nautobot/docs/user-guide/administration/installation/http-server.md
@@ -22,7 +22,7 @@ Two files will be created: the public certificate (`nautobot.crt`) and the priva
       -out /etc/ssl/certs/nautobot.crt
     ```
 
-=== "RHEL8"
+=== "RHEL"
 
     ```no-highlight title="Create SSL certificate"
     sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
@@ -52,7 +52,7 @@ Begin by installing NGINX:
     sudo apt install -y nginx
     ```
 
-=== "RHEL8"
+=== "RHEL"
 
     ```no-highlight title="Install NGINX"
     sudo dnf install -y nginx
@@ -122,7 +122,7 @@ Begin by installing NGINX:
     }
     ```
 
-=== "RHEL8"
+=== "RHEL"
     Once NGINX is installed, copy and paste the following NGINX configuration for the Nautobot NGINX site.
 
     === "Vim"
@@ -193,13 +193,29 @@ Begin by installing NGINX:
     sudo ln -s /etc/nginx/sites-available/nautobot.conf /etc/nginx/sites-enabled/nautobot.conf
     ```
 
-=== "RHEL8"
+=== "RHEL"
 
     Run the following command to disable the default site that comes with the `nginx` package:
 
     ```no-highlight title="Link Nautobot NGINX site config"
     sudo sed -i 's@ default_server@@' /etc/nginx/nginx.conf
     ```
+
+#### Add NGINX User Account to Nautobot Group
+
+The NGINX service needs to be able to read the files in `/opt/nautobot/static/` (CSS files, fonts, etc.) to serve them to users. There are various ways this could be accomplished (including changing the `STATIC_ROOT` configuration in Nautobot to a different location then re-running `nautobot-server collectstatic`), but we'll go with the simple approach of adding the `nginx` user to the `nautobot` user group and opening `$NAUTOBOT_ROOT` to be readable by members of that group.
+
+```no-highlight title="Add nginx user to nautobot group"
+sudo usermod -aG nautobot nginx
+```
+
+#### Set Permissions for `NAUTOBOT_ROOT`
+
+Ensure that the `NAUTOBOT_ROOT` permissions are set to `750`, allowing other members of the `nautobot` user group (including the `nginx` account) to read and execute files in this directory:
+
+```no-highlight title="Update access permissions to 750 for `$NAUTOBOT_ROOT`"
+chmod 750 $NAUTOBOT_ROOT
+```
 
 #### Restart NGINX
 
@@ -211,15 +227,6 @@ sudo systemctl restart nginx
 
 !!! info
     If the restart fails, and you changed the default key location, check to make sure the `nautobot.conf` file you pasted has the updated key location. For example, CentOS requires keys to be in `/etc/pki/tls/` instead of `/etc/ssl/`.
-
-## Confirm Permissions for `NAUTOBOT_ROOT`
-
-Ensure that the `NAUTOBOT_ROOT` permissions are set to `755`.
-If permissions need to be changed, as the `nautobot` user run:
-
-```no-highlight title="Update all permissions to 755 in Nautobot Root"
-chmod 755 $NAUTOBOT_ROOT
-```
 
 ## Confirm Connectivity
 
@@ -242,57 +249,7 @@ If you are unable to connect to the HTTP server, check that:
 
 ### Static Media Failure
 
-If you get a *Static Media Failure; The following static media file failed to load: css/base.css*, verify the permissions on the `$NAUTOBOT_ROOT` directory are `755`.
-
-Example of correct permissions (at the `[root@localhost ~]#` prompt)
-
-```no-highlight title="List /opt/ files"
-ls -l /opt/
-```
-
-??? example "Output of list files"
-
-    ```no-highlight title="Example output of list"
-    total 4
-    drwxr-xr-x. 11 nautobot nautobot 4096 Apr  5 11:24 nautobot
-    [root@localhost ~]#
-    ```
-
-If the permissions are not correct, modify them accordingly.
-
-Example of modifying the permissions:
-
-```no-highlight title="List /opt/ files"
-ls -l /opt/
-```
-
-??? example "Output of list files in `/opt`"
-
-    ```no-highlight title="Example output of list"
-    total 4
-    drwx------. 11 nautobot nautobot 4096 Apr  5 10:00 nautobot
-    ```
-
-At the prompt `[nautobot@localhost ~]$` execute:
-
-```no-highlight title="Update all permissions to 755 in Nautobot Root"
-chmod 755 $NAUTOBOT
-```
-
-Then to verify that the user has the permissions to the directory execute at the `[nautobot@localhost ~]$` prompt:
-
-```no-highlight title="List files of /opt/"
-ls -l /opt/
-```
-
-??? example "Output of list files in /opt"
-
-    Example output shows that the user and group are both `nautobot` below:
-
-    ```no-highlight title="Example output of ls"
-    total 4
-    drwxr-xr-x. 11 nautobot nautobot 4096 Apr  5 11:24 nautobot
-    ```
+If you get a *Static Media Failure; The following static media file failed to load: css/base.css*, verify that the permissions on the `$NAUTOBOT_ROOT` directory are correctly set and that the `nginx` account is a member of the `nautobot` group, as described above.
 
 ### 502 Bad Gateway
 

--- a/nautobot/docs/user-guide/administration/installation/http-server.md
+++ b/nautobot/docs/user-guide/administration/installation/http-server.md
@@ -213,7 +213,7 @@ sudo usermod -aG nautobot nginx
 
 Ensure that the `NAUTOBOT_ROOT` permissions are set to `750`, allowing other members of the `nautobot` user group (including the `nginx` account) to read and execute files in this directory:
 
-```no-highlight title="Update access permissions to 750 for `$NAUTOBOT_ROOT`"
+```no-highlight title="Update access permissions to 750 for $NAUTOBOT_ROOT"
 chmod 750 $NAUTOBOT_ROOT
 ```
 

--- a/nautobot/docs/user-guide/administration/installation/install_system.md
+++ b/nautobot/docs/user-guide/administration/installation/install_system.md
@@ -4,8 +4,8 @@ The documentation assumes that you are running one of the following:
 
 - Ubuntu 20.04+
 - Debian 11+
-- RHEL/CentOS 8.2+
-    - Delimited by `RHEL8` tabs in the docs, but also includes other derivatives of RHEL such as RockyLinux or AlmaLinux
+- RHEL/CentOS 8.2+ and derivatives
+    - Delimited by `RHEL` tabs in the docs, but also includes other derivatives of RHEL such as RockyLinux or AlmaLinux
 
 ## Install System Packages
 
@@ -25,11 +25,11 @@ This will install:
     sudo apt install -y git python3 python3-pip python3-venv python3-dev redis-server
     ```
 
-=== "RHEL8"
+=== "RHEL"
 
     ```bash title="Install system dependencies"
     sudo dnf check-update
-    sudo dnf install -y git python38 python38-devel python38-pip redis
+    sudo dnf install -y git python3 python3-devel python3-pip redis
     ```
 
 ## Database Setup
@@ -250,7 +250,7 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
             Bye
             ```
 
-=== "RHEL8"
+=== "RHEL"
 
     === "PostgreSQL"
 
@@ -272,9 +272,9 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
 
         <h3>Configure Authentication</h3>
 
-        CentOS/RHEL configures PostgreSQL to use [`ident`](https://www.postgresql.org/docs/current/auth-ident.html) host-based authentication by default. Because Nautobot will need to authenticate using a username and password, we must update `pg_hba.conf` to support [`md5` password](https://www.postgresql.org/docs/current/auth-password.html) authentication.
+        CentOS/RHEL configures PostgreSQL to use [`ident`](https://www.postgresql.org/docs/current/auth-ident.html) host-based authentication by default. Because Nautobot will need to authenticate using a username and password, we must update `pg_hba.conf` to support [`scram-sha-256` password](https://www.postgresql.org/docs/current/auth-password.html) authentication.
 
-        As root, edit `/var/lib/pgsql/data/pg_hba.conf` and change `ident` to `md5` for the lines below.
+        As root, edit `/var/lib/pgsql/data/pg_hba.conf` and change `ident` to `scram-sha-256` for the lines below.
 
         Before:
 
@@ -289,9 +289,9 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
 
         ```no-highlight title="After /var/lib/pgsql/data/pg_hba.conf"
         # IPv4 local connections:
-        host    all             all             127.0.0.1/32            md5
+        host    all             all             127.0.0.1/32            scram-sha-256
         # IPv6 local connections:
-        host    all             all             ::1/128                 md5
+        host    all             all             ::1/128                 scram-sha-256
         ```
 
         <h3>Start PostgreSQL</h3>
@@ -355,11 +355,11 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
 
             ```no-highlight
             Password for user nautobot:
-            psql (10.15)
+            psql (16.3)
             Type "help" for help.
 
             nautobot=> \conninfo
-            You are connected to database "nautobot" as user "nautobot" on host "localhost" (address "127.0.0.1") at port "5432".
+            You are connected to database "nautobot" as user "nautobot" on host "localhost" (address "::1") at port "5432".
             nautobot=> \q
             ```
 
@@ -380,6 +380,9 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
         ```no-highlight title="Start and enable at start up of the MySQL service"
         sudo systemctl enable --now mysql
         ```
+
+        !!! tip
+            Depending on your Linux distribution, the service may be named `mysqld` instead of `mysql`. If you get an error with the above command, try `sudo systemctl enable --now mysqld` instead.
 
         <h3>Create a MySQL Database</h3>
 
@@ -407,9 +410,9 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
             ```no-highlight title="Example output creation of DB"
             Welcome to the MySQL monitor.  Commands end with ; or \g.
             Your MySQL connection id is 8
-            Server version: 8.0.21 Source distribution
+            Server version: 8.0.37 Source distribution
 
-            Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+            Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
 
             Oracle is a registered trademark of Oracle Corporation and/or its
             affiliates. Other names may be trademarks of their respective
@@ -449,9 +452,9 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
             Enter password:
             Welcome to the MySQL monitor.  Commands end with ; or \g.
             Your MySQL connection id is 10
-            Server version: 8.0.21 Source distribution
+            Server version: 8.0.37 Source distribution
 
-            Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+            Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
 
             Oracle is a registered trademark of Oracle Corporation and/or its
             affiliates. Other names may be trademarks of their respective
@@ -461,7 +464,7 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
 
             mysql> status
             --------------
-            mysql  Ver 8.0.21 for Linux on x86_64 (Source distribution)
+            mysql  Ver 8.0.37 for Linux on x86_64 (Source distribution)
 
             Connection id:          10
             Current database:       nautobot
@@ -470,7 +473,7 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
             Current pager:          stdout
             Using outfile:          ''
             Using delimiter:        ;
-            Server version:         8.0.21 Source distribution
+            Server version:         8.0.37 Source distribution
             Protocol version:       10
             Connection:             Localhost via UNIX socket
             Server characterset:    utf8mb4
@@ -511,7 +514,7 @@ Django requires the database encoding for PostgreSQL databases to be set to UTF-
         PONG
         ```
 
-=== "RHEL8"
+=== "RHEL"
 
     <h3>Start Redis</h3>
 

--- a/nautobot/docs/user-guide/administration/installation/install_system.md
+++ b/nautobot/docs/user-guide/administration/installation/install_system.md
@@ -4,8 +4,8 @@ The documentation assumes that you are running one of the following:
 
 - Ubuntu 20.04+
 - Debian 11+
-- RHEL/CentOS 8.2+ and derivatives
-    - Delimited by `RHEL` tabs in the docs, but also includes other derivatives of RHEL such as RockyLinux or AlmaLinux
+- Fedora, RHEL/CentOS 8.2+ and derivatives
+    - Delimited by `Fedora/RHEL` tabs in the docs, but also includes other derivatives of RHEL such as RockyLinux or AlmaLinux
 
 ## Install System Packages
 
@@ -25,7 +25,7 @@ This will install:
     sudo apt install -y git python3 python3-pip python3-venv python3-dev redis-server
     ```
 
-=== "RHEL"
+=== "Fedora/RHEL"
 
     ```bash title="Install system dependencies"
     sudo dnf check-update
@@ -250,7 +250,7 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
             Bye
             ```
 
-=== "RHEL"
+=== "Fedora/RHEL"
 
     === "PostgreSQL"
 
@@ -264,7 +264,7 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
 
         <h3>Initialize PostgreSQL</h3>
 
-        CentOS/RHEL requires a manual step to generate the initial configurations required by PostgreSQL.
+        Fedora/RHEL and related distros typically require a manual step to generate the initial configurations required by PostgreSQL.
 
         ```no-highlight title="Setup initial required configurations"
         sudo postgresql-setup --initdb
@@ -272,9 +272,12 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
 
         <h3>Configure Authentication</h3>
 
-        CentOS/RHEL configures PostgreSQL to use [`ident`](https://www.postgresql.org/docs/current/auth-ident.html) host-based authentication by default. Because Nautobot will need to authenticate using a username and password, we must update `pg_hba.conf` to support [`scram-sha-256` password](https://www.postgresql.org/docs/current/auth-password.html) authentication.
+        Fedora/RHEL and related distros typically configure PostgreSQL to use [`ident`](https://www.postgresql.org/docs/current/auth-ident.html) host-based authentication by default. Because Nautobot will need to authenticate using a username and password, we must update `pg_hba.conf` to support [`md5` password](https://www.postgresql.org/docs/current/auth-password.html) authentication.
 
-        As root, edit `/var/lib/pgsql/data/pg_hba.conf` and change `ident` to `scram-sha-256` for the lines below.
+        !!! tip
+            Under many distros, you may be able to use the more secure `scram-sha-256` as an alternative to `md5`, but this option may not be available by default; enabling it is beyond the scope of this documentation.
+
+        As root, edit `/var/lib/pgsql/data/pg_hba.conf` and change `ident` to `md5` for the lines below.
 
         Before:
 
@@ -289,9 +292,9 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
 
         ```no-highlight title="After /var/lib/pgsql/data/pg_hba.conf"
         # IPv4 local connections:
-        host    all             all             127.0.0.1/32            scram-sha-256
+        host    all             all             127.0.0.1/32            md5
         # IPv6 local connections:
-        host    all             all             ::1/128                 scram-sha-256
+        host    all             all             ::1/128                 md5
         ```
 
         <h3>Start PostgreSQL</h3>
@@ -372,6 +375,9 @@ to have multiple "Install PostgreSQL", "Create a PostgreSQL Database", etc. entr
         ```no-highlight title="Install MySQL packages"
         sudo dnf install -y gcc mysql-server mysql-devel
         ```
+
+        !!! tip
+            If you get an error about `Unable to find a match: mysql-devel`, you may need to enable additional sources for packages. On at least CentOS 9 and AlmaLinux 9, the command `sudo dnf config-manager --set-enabled crb` is the way to enable the necessary repository.
 
         <h3>Start MySQL</h3>
 
@@ -514,7 +520,7 @@ Django requires the database encoding for PostgreSQL databases to be set to UTF-
         PONG
         ```
 
-=== "RHEL"
+=== "Fedora/RHEL"
 
     <h3>Start Redis</h3>
 

--- a/nautobot/docs/user-guide/administration/installation/nautobot.md
+++ b/nautobot/docs/user-guide/administration/installation/nautobot.md
@@ -51,17 +51,9 @@ In the following steps, we will have you create the virtualenv within the `NAUTO
 
 As root, we're going to create the virtualenv in our `NAUTOBOT_ROOT` as the `nautobot` user to populate the `/opt/nautobot` directory with a self-contained Python environment including a `bin` directory for scripts and a `lib` directory for Python libraries.
 
-=== "Ubuntu/Debian"
-
-    ```no-highlight title="Create the Virtual Environment"
-    sudo -u nautobot python3 -m venv /opt/nautobot
-    ```
-
-=== "RHEL8"
-
-    ```no-highlight title="Create the Virtual Environment"
-    sudo -u nautobot python3.8 -m venv /opt/nautobot
-    ```
+```no-highlight title="Create the Virtual Environment"
+sudo -u nautobot python3 -m venv /opt/nautobot
+```
 
 ### Update the Nautobot `.bashrc`
 
@@ -89,7 +81,7 @@ It is critical to install Nautobot as the `nautobot` user so that we don't have 
 sudo -iu nautobot
 ```
 
-??? note "Validate the NAUTOBOT_ROOT variable"
+??? note "Validate the `NAUTOBOT_ROOT` variable"
     Observe also that you can now echo the value of the `NAUTOBOT_ROOT` environment variable that is automatically set because we added to `.bashrc`:
 
     ```no-highlight title="Verify Nautobot Root"
@@ -123,7 +115,7 @@ sudo -iu nautobot
             /opt/nautobot/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             ```
 
-    === "RHEL8"
+    === "RHEL"
 
         ```no-highlight title="Print out the PATH variable"
         echo $PATH
@@ -132,7 +124,7 @@ sudo -iu nautobot
         ??? example "Example path output"
 
             ```no-highlight title="Example output of a PATH variable"
-            /opt/nautobot/.local/bin:/opt/nautobot/bin:/opt/nautobot/.local/bin:/opt/nautobot/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin
+            /opt/nautobot/.local/bin:/opt/nautobot/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin
             ```
 
     Therefore, any commands executed by the `nautobot` user will always check `$NAUTOBOT_ROOT/bin` first.
@@ -350,7 +342,7 @@ nautobot-server collectstatic
 
     ```no title="Collect static output"
 
-    1103 static files copied to '/opt/nautobot/static'.
+    1156 static files copied to '/opt/nautobot/static'.
     ```
 
 ## Install Local Requirements

--- a/nautobot/docs/user-guide/administration/installation/nautobot.md
+++ b/nautobot/docs/user-guide/administration/installation/nautobot.md
@@ -115,7 +115,7 @@ sudo -iu nautobot
             /opt/nautobot/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             ```
 
-    === "RHEL"
+    === "Fedora/RHEL"
 
         ```no-highlight title="Print out the PATH variable"
         echo $PATH

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -456,6 +456,8 @@ class JobLogEntry(BaseModel):
     log_object = models.CharField(max_length=JOB_LOG_MAX_LOG_OBJECT_LENGTH, blank=True, default="")
     absolute_url = models.CharField(max_length=JOB_LOG_MAX_ABSOLUTE_URL_LENGTH, blank=True, default="")
 
+    is_metadata_associable_model = False
+
     documentation_static_path = "docs/user-guide/platform-functionality/jobs/models.html"
 
     def __str__(self):


### PR DESCRIPTION
# Closes #5920
# What's Changed

Sequel to #6013, this time for Fedora 40 and AlmaLinux 9 as representatives of the RHEL family.

Additionally, updated the permissions recommendation for `NAUTOBOT_ROOT` to make STATIC_ROOT accessible to NGINX without exposing the directory to all users of the system.


# Screenshots

https://docs-landing-page--6019.org.readthedocs.build/projects/core/en/6019/

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
