### PR TITLE
Added missing controller references for DeviceRedundancyGroup in the UI.

### DIFF
--- a/changes/5965.added
+++ b/changes/5965.added
@@ -1,0 +1,1 @@
+Added missing controller references for DeviceRedundancyGroup in the UI.

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -1065,6 +1065,10 @@ class DeviceRedundancyGroup(PrimaryModel):
     def devices_sorted(self):
         return self.devices.order_by("device_redundancy_group_priority")
 
+    @property
+    def controllers_sorted(self):
+        return self.controllers.order_by("name")
+
     def __str__(self):
         return self.name
 

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -938,17 +938,32 @@ class VirtualChassisTable(BaseTable):
 class DeviceRedundancyGroupTable(BaseTable):
     pk = ToggleColumn()
     name = tables.Column(linkify=True)
-    device_count = tables.TemplateColumn(
-        template_code=LINKED_RECORD_COUNT,
+    device_count = LinkedCountColumn(
+        viewname="dcim:device_list",
+        url_params={"device_redundancy_group": "pk"},
         verbose_name="Devices",
+    )
+    controller_count = LinkedCountColumn(
+        viewname="dcim:controller_list",
+        url_params={"controller_device_redundancy_group": "pk"},
+        verbose_name="Controllers",
     )
     secrets_group = tables.Column(linkify=True)
     tags = TagColumn(url_name="dcim:deviceredundancygroup_list")
 
     class Meta(BaseTable.Meta):
         model = DeviceRedundancyGroup
-        fields = ("pk", "name", "status", "failover_strategy", "device_count", "secrets_group", "tags")
-        default_columns = ("pk", "name", "status", "failover_strategy", "device_count")
+        fields = (
+            "pk",
+            "name",
+            "status",
+            "failover_strategy",
+            "device_count",
+            "controller_count",
+            "secrets_group",
+            "tags",
+        )
+        default_columns = ("pk", "name", "status", "failover_strategy", "device_count", "controller_count")
 
 
 #

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -958,12 +958,12 @@ class DeviceRedundancyGroupTable(BaseTable):
             "name",
             "status",
             "failover_strategy",
-            "device_count",
             "controller_count",
+            "device_count",
             "secrets_group",
             "tags",
         )
-        default_columns = ("pk", "name", "status", "failover_strategy", "device_count", "controller_count")
+        default_columns = ("pk", "name", "status", "failover_strategy", "controller_count", "device_count")
 
 
 #

--- a/nautobot/dcim/templates/dcim/deviceredundancygroup_retrieve.html
+++ b/nautobot/dcim/templates/dcim/deviceredundancygroup_retrieve.html
@@ -47,14 +47,14 @@
 {% block content_full_width_page %}
         <div class="panel panel-default">
             <div class="panel-heading">
-                <strong>Devices</strong>
-            </div>
-            {% include 'responsive_table.html' with table=devices_table %}
-        </div>
-        <div class="panel panel-default">
-            <div class="panel-heading">
                 <strong>Controllers</strong>
             </div>
             {% include 'responsive_table.html' with table=controllers_table %}
+        </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <strong>Devices</strong>
+            </div>
+            {% include 'responsive_table.html' with table=devices_table %}
         </div>
 {% endblock content_full_width_page %}

--- a/nautobot/dcim/templates/dcim/deviceredundancygroup_retrieve.html
+++ b/nautobot/dcim/templates/dcim/deviceredundancygroup_retrieve.html
@@ -51,4 +51,10 @@
             </div>
             {% include 'responsive_table.html' with table=devices_table %}
         </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <strong>Controllers</strong>
+            </div>
+            {% include 'responsive_table.html' with table=controllers_table %}
+        </div>
 {% endblock content_full_width_page %}

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -3029,8 +3029,11 @@ class DeviceRedundancyGroupUIViewSet(NautobotUIViewSet):
     form_class = forms.DeviceRedundancyGroupForm
     queryset = (
         DeviceRedundancyGroup.objects.select_related("status")
-        .prefetch_related("devices")
-        .annotate(device_count=count_related(Device, "device_redundancy_group"))
+        .prefetch_related("controllers", "devices")
+        .annotate(
+            device_count=count_related(Device, "device_redundancy_group"),
+            controller_count=count_related(Controller, "controller_device_redundancy_group"),
+        )
     )
     serializer_class = serializers.DeviceRedundancyGroupSerializer
     table_class = tables.DeviceRedundancyGroupTable
@@ -3043,6 +3046,9 @@ class DeviceRedundancyGroupUIViewSet(NautobotUIViewSet):
             devices_table = tables.DeviceTable(devices)
             devices_table.columns.show("device_redundancy_group_priority")
             context["devices_table"] = devices_table
+            controllers = instance.controllers_sorted.restrict(request.user)
+            controllers_table = tables.ControllerTable(controllers)
+            context["controllers_table"] = controllers_table
         return context
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5965 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

1. Added `controller_count` column to `DeviceRedundancyGroupTable`
2. Added Controller related object table to `DeviceRedundancyGroupDetailView`

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
![Screenshot 2024-07-30 at 3 51 51 PM](https://github.com/user-attachments/assets/fbc56163-63bd-4557-97c4-ca15fae39782)
![Screenshot 2024-07-30 at 3 52 05 PM](https://github.com/user-attachments/assets/4ed14637-9215-41a1-b99d-9ad476a7739d)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
