### PR TITLE
Catch OperationalError during initial Nautobot setup

### DIFF
--- a/changes/6116.fixed
+++ b/changes/6116.fixed
@@ -1,0 +1,1 @@
+Added handling for an `OperationalError` that might be raised when running `pylint-nautobot` or similar linters that depend on successfully running `nautobot.setup()`.

--- a/nautobot/core/celery/__init__.py
+++ b/nautobot/core/celery/__init__.py
@@ -8,7 +8,7 @@ from celery import Celery, shared_task, signals
 from celery.app.log import TaskFormatter
 from celery.utils.log import get_logger
 from django.conf import settings
-from django.db.utils import ProgrammingError
+from django.db.utils import OperationalError, ProgrammingError
 from django.utils.functional import SimpleLazyObject
 from django.utils.module_loading import import_string
 from kombu.serialization import register
@@ -55,7 +55,10 @@ def import_jobs(sender=None, **kwargs):
 
     try:
         _import_jobs_from_git_repositories()
-    except ProgrammingError:  # Database not ready yet, as may be the case on initial startup and migration
+    except (
+        OperationalError,  # Database not present, as may be the case when running pylint-nautobot
+        ProgrammingError,  # Database not ready yet, as may be the case on initial startup and migration
+    ):
         pass
 
 


### PR DESCRIPTION
# Closes #n/a
# What's Changed

Since 2.2.3, we run `_import_jobs_from_git_repositories()` during Nautobot initial app startup. This can fail with a `ProgrammingError` if migrations have not yet been, which we have existing error handling for, but it can also fail with an `OperationalError` if the database is inaccessible, as might be the case when running `pylint-nautobot` for an App. This PR just augments the existing error handling to catch `OperationalError` as well to unblock the pylint usage.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
