### PR TITLE
Fixed appropriate cable status coloring not applied for DeviceModule*Table rows in dark mode.

### DIFF
--- a/changes/6123.fixed
+++ b/changes/6123.fixed
@@ -1,1 +1,1 @@
-Fixed appropriate cable status coloring not applied for DeviceModule*Table rows in dark mode.
+Fixed cable status coloring for `DeviceModule*Table` rows in dark mode.

--- a/changes/6123.fixed
+++ b/changes/6123.fixed
@@ -1,0 +1,1 @@
+Fixed appropriate cable status coloring not applied for DeviceModule*Table rows in dark mode.

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -396,7 +396,7 @@ class DeviceModuleConsolePortTable(ConsolePortTable):
             "actions",
         )
         row_attrs = {
-            "style": cable_status_color_css,
+            "class": cable_status_color_css,
         }
 
 
@@ -460,7 +460,7 @@ class DeviceModuleConsoleServerPortTable(ConsoleServerPortTable):
             "actions",
         )
         row_attrs = {
-            "style": cable_status_color_css,
+            "class": cable_status_color_css,
         }
 
 
@@ -535,7 +535,7 @@ class DeviceModulePowerPortTable(PowerPortTable):
             "connection",
             "actions",
         )
-        row_attrs = {"style": cable_status_color_css}
+        row_attrs = {"class": cable_status_color_css}
 
 
 class PowerOutletTable(ModularDeviceComponentTable, PathEndpointTable):
@@ -613,7 +613,7 @@ class DeviceModulePowerOutletTable(PowerOutletTable):
             "connection",
             "actions",
         )
-        row_attrs = {"style": cable_status_color_css}
+        row_attrs = {"class": cable_status_color_css}
 
 
 class BaseInterfaceTable(BaseTable):
@@ -739,7 +739,7 @@ class DeviceModuleInterfaceTable(InterfaceTable):
             "actions",
         ]
         row_attrs = {
-            "style": cable_status_color_css,
+            "class": cable_status_color_css,
             "data-name": lambda record: record.name,
         }
 
@@ -815,7 +815,7 @@ class DeviceModuleFrontPortTable(FrontPortTable):
             "cable_peer",
             "actions",
         )
-        row_attrs = {"style": cable_status_color_css}
+        row_attrs = {"class": cable_status_color_css}
 
 
 class RearPortTable(ModularDeviceComponentTable, CableTerminationTable):
@@ -874,7 +874,7 @@ class DeviceModuleRearPortTable(RearPortTable):
             "cable_peer",
             "actions",
         )
-        row_attrs = {"style": cable_status_color_css}
+        row_attrs = {"class": cable_status_color_css}
 
 
 class DeviceBayTable(DeviceComponentTable):

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -14,7 +14,6 @@ from netutils.lib_mapper import (
     SCRAPLI_LIB_MAPPER_REVERSE,
 )
 
-from nautobot.core.utils.color import hex_to_rgb, lighten_color, rgb_to_hex
 from nautobot.core.utils.config import get_settings_or_config
 from nautobot.dcim.choices import InterfaceModeChoices
 from nautobot.dcim.constants import NETUTILS_NETWORK_DRIVER_MAPPING_NAMES

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -14,9 +14,11 @@ from netutils.lib_mapper import (
     SCRAPLI_LIB_MAPPER_REVERSE,
 )
 
+from nautobot.core.choices import ColorChoices
 from nautobot.core.utils.config import get_settings_or_config
-from nautobot.dcim.choices import InterfaceModeChoices
+from nautobot.dcim.choices import CableStatusChoices, InterfaceModeChoices
 from nautobot.dcim.constants import NETUTILS_NETWORK_DRIVER_MAPPING_NAMES
+from nautobot.extras.management import STATUS_COLOR_MAP
 
 
 def compile_path_node(ct_id, object_id):
@@ -52,16 +54,22 @@ def cable_status_color_css(record):
     """
     Given a record such as an Interface, return the CSS needed to apply appropriate coloring to it.
     """
-    CABLE_STATUS_TO_CSS_CLASS = {
-        "Connected": "success",
-        "Decommissioning": "danger",
-        "Planned": "info",
-    }
-
+    CABLE_STATUS_TO_CSS_CLASS = {}
     if not record.cable:
         return ""
     else:
-        return CABLE_STATUS_TO_CSS_CLASS.get(record.cable.status.name, "")
+        for choice in CableStatusChoices.CHOICES:
+            color_value = STATUS_COLOR_MAP[choice[1]]
+            if color_value == ColorChoices.COLOR_GREEN:
+                CABLE_STATUS_TO_CSS_CLASS[color_value] = "success"
+            elif color_value == ColorChoices.COLOR_AMBER:
+                CABLE_STATUS_TO_CSS_CLASS[color_value] = "danger"
+            elif color_value == ColorChoices.COLOR_CYAN:
+                CABLE_STATUS_TO_CSS_CLASS[color_value] = "info"
+            else:
+                continue
+        status_color = record.cable.get_status_color().strip("#")
+        return CABLE_STATUS_TO_CSS_CLASS.get(status_color, "")
 
 
 def get_network_driver_mapping_tool_names():

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -53,13 +53,16 @@ def cable_status_color_css(record):
     """
     Given a record such as an Interface, return the CSS needed to apply appropriate coloring to it.
     """
+    CABLE_STATUS_TO_CSS_CLASS = {
+        "Connected": "success",
+        "Decommissioning": "danger",
+        "Planned": "info",
+    }
+
     if not record.cable:
         return ""
-    # The status colors are for use with labels and such, and tend to be quite bright.
-    # For this function we want a much milder, mellower color suitable as a row background.
-    base_color = record.cable.get_status_color().strip("#")
-    lighter_color = rgb_to_hex(*lighten_color(*hex_to_rgb(base_color), 0.75))
-    return f"background-color: #{lighter_color}"
+    else:
+        return CABLE_STATUS_TO_CSS_CLASS.get(record.cable.status.name, "")
 
 
 def get_network_driver_mapping_tool_names():

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -54,20 +54,15 @@ def cable_status_color_css(record):
     """
     Given a record such as an Interface, return the CSS needed to apply appropriate coloring to it.
     """
-    CABLE_STATUS_TO_CSS_CLASS = {}
     if not record.cable:
         return ""
     else:
-        for choice in CableStatusChoices.CHOICES:
-            color_value = STATUS_COLOR_MAP[choice[1]]
-            if color_value == ColorChoices.COLOR_GREEN:
-                CABLE_STATUS_TO_CSS_CLASS[color_value] = "success"
-            elif color_value == ColorChoices.COLOR_AMBER:
-                CABLE_STATUS_TO_CSS_CLASS[color_value] = "danger"
-            elif color_value == ColorChoices.COLOR_CYAN:
-                CABLE_STATUS_TO_CSS_CLASS[color_value] = "info"
-            else:
-                continue
+        CABLE_STATUS_TO_CSS_CLASS = {
+            ColorChoices.COLOR_GREEN: "success",
+            ColorChoices.COLOR_AMBER: "warning",
+            ColorChoices.COLOR_CYAN: "info",
+
+        }
         status_color = record.cable.get_status_color().strip("#")
         return CABLE_STATUS_TO_CSS_CLASS.get(status_color, "")
 

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -16,9 +16,8 @@ from netutils.lib_mapper import (
 
 from nautobot.core.choices import ColorChoices
 from nautobot.core.utils.config import get_settings_or_config
-from nautobot.dcim.choices import CableStatusChoices, InterfaceModeChoices
+from nautobot.dcim.choices import InterfaceModeChoices
 from nautobot.dcim.constants import NETUTILS_NETWORK_DRIVER_MAPPING_NAMES
-from nautobot.extras.management import STATUS_COLOR_MAP
 
 
 def compile_path_node(ct_id, object_id):
@@ -61,7 +60,6 @@ def cable_status_color_css(record):
             ColorChoices.COLOR_GREEN: "success",
             ColorChoices.COLOR_AMBER: "warning",
             ColorChoices.COLOR_CYAN: "info",
-
         }
         status_color = record.cable.get_status_color().strip("#")
         return CABLE_STATUS_TO_CSS_CLASS.get(status_color, "")


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6123 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Fixed appropriate cable status coloring not applied for DeviceModule*Table rows in dark mode by using https://getbootstrap.com/docs/3.4/css/#tables-contextual-classes instead of hardcoded background-color attribute

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Dark Mode:
![Screenshot 2024-08-21 at 11 48 27 AM](https://github.com/user-attachments/assets/24e113bd-0277-4483-a711-09e78ca4de00)
Light Mode:
![Screenshot 2024-08-21 at 11 48 38 AM](https://github.com/user-attachments/assets/1ce04546-ac0d-401f-8bf6-395d9045283c)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
