### PR TITLE
Fix regression #6131

### DIFF
--- a/changes/6131.fixed
+++ b/changes/6131.fixed
@@ -1,0 +1,1 @@
+Fixed a regression in which IP addresses and prefixes created through the `/api/ipam/prefixes/<uuid>/available-ips/` and `/api/ipam/prefixes/<uuid>/available-prefixes/` REST API endpoints could not be assigned custom field data during their creation.

--- a/nautobot/ipam/api/views.py
+++ b/nautobot/ipam/api/views.py
@@ -202,13 +202,17 @@ class PrefixViewSet(NautobotModelViewSet):
                         if requested_prefix["prefix_length"] >= available_prefix.prefixlen:
                             allocated_prefix = f"{available_prefix.network}/{requested_prefix['prefix_length']}"
                             requested_prefix["prefix"] = allocated_prefix
-                            requested_prefix["namespace"] = prefix.namespace.pk
+                            requested_prefix["namespace"] = prefix.namespace
                             break
                     else:
                         return Response(
                             {"detail": "Insufficient space is available to accommodate the requested prefix size(s)"},
                             status=status.HTTP_204_NO_CONTENT,
                         )
+
+                    # The serializer usage above has mapped "custom_fields" dict to "_custom_field_data".
+                    # We need to convert it back to "custom_fields" as we're going to deserialize it a second time below
+                    requested_prefix["custom_fields"] = requested_prefix.pop("_custom_field_data", {})
 
                     # Remove the allocated prefix from the list of available prefixes
                     available_prefixes.remove(allocated_prefix)
@@ -299,7 +303,10 @@ class PrefixViewSet(NautobotModelViewSet):
                 prefix_length = prefix.prefix.prefixlen
                 for requested_ip in requested_ips:
                     requested_ip["address"] = f"{next(available_ips)}/{prefix_length}"
-                    requested_ip["namespace"] = prefix.namespace.pk
+                    requested_ip["namespace"] = prefix.namespace
+                    # The serializer usage above has mapped "custom_fields" dict to "_custom_field_data".
+                    # We need to convert it back to "custom_fields" as we're going to deserialize it a second time below
+                    requested_ip["custom_fields"] = requested_ip.pop("_custom_field_data", {})
 
                 # Initialize the serializer with a list or a single object depending on what was requested
                 context = {"request": request, "depth": 0}


### PR DESCRIPTION
# Closes #6131 
# What's Changed

The POST logic for the `available-prefixes` and `available-ips` REST endpoints actually deserialize the provided JSON twice, the first time to assert that it's structurally valid per the unique requirements of these endpoints, then the validated data is modified inline and deserialized a second time with more standard Prefix or IPAddress serializers to actually create the new database records.

When #5856 updated the serializers used for the first stage from generic `Serializer` classes to `NautobotModelSerializer` classes, it had the side effect that the first-stage deserialization now automatically converts the REST API's JSON `custom_fields` key to a model-facing `_custom_field_data` key. The second-stage deserialization was then (per DRF usual behavior) throwing away the `_custom_field_data` key and value as an invalid/unrecognized parameter.

Therefore, the fix is to explicitly map `_custom_field_data` back to `custom_fields` between the first and second deserialization passes.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
