### PR TITLE
Change next version to 2.4

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -642,6 +642,7 @@ nav:
           - Release Checklist: "development/core/release-checklist.md"
   - Release Notes:
       - "release-notes/index.md"
+      - Version 2.4: "release-notes/version-2.4.md"
       - Version 2.3: "release-notes/version-2.3.md"
       - Version 2.2: "release-notes/version-2.2.md"
       - Version 2.1: "release-notes/version-2.1.md"

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -278,11 +278,9 @@ REST_FRAMEWORK_VERSION = VERSION.rsplit(".", 1)[0]  # Use major.minor as API ver
 VERSION_MAJOR, VERSION_MINOR = [int(v) for v in REST_FRAMEWORK_VERSION.split(".")]
 # We support all major.minor API versions from 2.0 to the present latest version.
 # Similar logic exists in tasks.py, please keep them in sync!
-if VERSION_MAJOR > 3:
+if VERSION_MAJOR != 2:
     raise RuntimeError(f"REST_FRAMEWORK_ALLOWED_VERSIONS needs to be updated to handle version {VERSION_MAJOR}")
-REST_FRAMEWORK_ALLOWED_VERSIONS = ["2.0", "2.1", "2.2", "2.3"] + [
-    f"{VERSION_MAJOR}.{minor}" for minor in range(0, VERSION_MINOR + 1)
-]
+REST_FRAMEWORK_ALLOWED_VERSIONS = [f"{VERSION_MAJOR}.{minor}" for minor in range(0, VERSION_MINOR + 1)]
 
 REST_FRAMEWORK = {
     "ALLOWED_VERSIONS": REST_FRAMEWORK_ALLOWED_VERSIONS,

--- a/nautobot/docs/release-notes/version-2.4.md
+++ b/nautobot/docs/release-notes/version-2.4.md
@@ -1,0 +1,21 @@
+<!-- markdownlint-disable MD024 -->
+
+# Nautobot v2.4
+
+This document describes all new features and changes in Nautobot 2.4.
+
+## Upgrade Actions
+
+### Administrators
+
+### Job Authors & App Developers
+
+## Release Overview
+
+### Added
+
+### Changed
+
+### Dependencies
+
+<!-- towncrier release notes start -->

--- a/poetry.lock
+++ b/poetry.lock
@@ -216,6 +216,17 @@ files = [
 ]
 
 [[package]]
+name = "bracex"
+version = "2.5"
+description = "Bash style brace expander."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "bracex-2.5-py3-none-any.whl", hash = "sha256:d2fcf4b606a82ac325471affe1706dd9bbaa3536c91ef86a31f6b766f3dad1d0"},
+    {file = "bracex-2.5.tar.gz", hash = "sha256:0725da5045e8d37ea9592ab3614d8b561e22c3c5fde3964699be672e072ab611"},
+]
+
+[[package]]
 name = "celery"
 version = "5.3.6"
 description = "Distributed Task Queue."
@@ -2088,6 +2099,24 @@ files = [
     {file = "mkdocs-glightbox-0.4.0.tar.gz", hash = "sha256:392b34207bf95991071a16d5f8916d1d2f2cd5d5bb59ae2997485ccd778c70d9"},
     {file = "mkdocs_glightbox-0.4.0-py3-none-any.whl", hash = "sha256:e0107beee75d3eb7380ac06ea2d6eac94c999eaa49f8c3cbab0e7be2ac006ccf"},
 ]
+
+[[package]]
+name = "mkdocs-include-markdown-plugin"
+version = "6.2.2"
+description = "Mkdocs Markdown includer plugin."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mkdocs_include_markdown_plugin-6.2.2-py3-none-any.whl", hash = "sha256:d293950f6499d2944291ca7b9bc4a60e652bbfd3e3a42b564f6cceee268694e7"},
+    {file = "mkdocs_include_markdown_plugin-6.2.2.tar.gz", hash = "sha256:f2bd5026650492a581d2fd44be6c22f90391910d76582b96a34c264f2d17875d"},
+]
+
+[package.dependencies]
+mkdocs = ">=1.4"
+wcmatch = "*"
+
+[package.extras]
+cache = ["platformdirs"]
 
 [[package]]
 name = "mkdocs-macros-plugin"
@@ -4018,6 +4047,20 @@ files = [
 watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
+name = "wcmatch"
+version = "9.0"
+description = "Wildcard/glob file name matcher."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "wcmatch-9.0-py3-none-any.whl", hash = "sha256:af25922e2b6dbd1550fa37a4c8de7dd558d6c1bb330c641de9b907b9776cb3c4"},
+    {file = "wcmatch-9.0.tar.gz", hash = "sha256:567d66b11ad74384954c8af86f607857c3bdf93682349ad32066231abd556c92"},
+]
+
+[package.dependencies]
+bracex = ">=2.1.1"
+
+[[package]]
 name = "wcwidth"
 version = "0.2.13"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -4200,4 +4243,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "6fe51fede6625e5fec93902ed0b1157c6b8aaf48b5aefde9b9bc81bad7a50eb6"
+content-hash = "8da15ebcff477b6b322b750410f4c3a3f49a9eb8cbe5632e31541aab69c4fffd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "3.0.0a1"
+version = "2.4.0a1"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"
@@ -187,6 +187,9 @@ markdown-version-annotations = "~1.0.1"
 mkdocs-gen-files = "~0.5.0"
 # Image lightboxing in mkdocs
 mkdocs-glightbox = "^0.4.0"
+# Allow Markdown files to include other files
+# 3.0 TODO: remove this, as we don't actually use it any more since 2.0?
+mkdocs-include-markdown-plugin = ">=4.0.4"
 # Use Jinja2 templating in docs - see optional-settings.md and required-settings.md
 mkdocs-macros-plugin = "~1.0.5"
 # Material for mkdocs theme
@@ -369,7 +372,7 @@ order-by-type = false
 [tool.towncrier]
 package = "nautobot"
 directory = "changes"
-filename = "nautobot/docs/release-notes/version-2.3.md"
+filename = "nautobot/docs/release-notes/version-2.4.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/nautobot/issues/{issue})"

--- a/tasks.py
+++ b/tasks.py
@@ -676,11 +676,9 @@ def check_schema(context, api_version=None):
         nautobot_version = get_nautobot_version()
         # logic equivalent to nautobot.core.settings REST_FRAMEWORK_ALLOWED_VERSIONS - keep them in sync!
         current_major, current_minor = [int(v) for v in nautobot_version.split(".")[:2]]
-        if current_major > 3:
+        if current_major != 2:
             raise RuntimeError(f"check_schemas version calc must be updated to handle version {current_major}")
-        api_versions = ["2.0", "2.1", "2.2", "2.3"] + [
-            f"{current_major}.{minor}" for minor in range(0, current_minor + 1)
-        ]
+        api_versions = [f"{current_major}.{minor}" for minor in range(0, current_minor + 1)]
 
     for api_vers in api_versions:
         command = f"nautobot-server spectacular --api-version {api_vers} --validate --fail-on-warn --file /dev/null"


### PR DESCRIPTION
Change `next` version number from 3.0.0a1 to 2.4.0a1, and revert some of the associated major-version changes from #6095.