### PR TITLE
feat: Added `get_http_session` to ExternalIntegration

### DIFF
--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -524,7 +524,6 @@ class ExternalIntegration(PrimaryModel):
 
     def get_http_session(
         self,
-        accept="application/json",
         include_auth=True,
         authorization_header="Authorization",
         authorization_prefix="Bearer ",
@@ -545,7 +544,6 @@ class ExternalIntegration(PrimaryModel):
         If `include_auth` is `True` and no valid secrets are found then a ValueError is raised.
 
         Args:
-            accept (str): The content-type to accept from the remote endpoint.
             include_auth (bool, optional): Whether or not to set basic auth or token auth
                 values in the session. Defaults to True.
             authorization_header (str, optional): Used if `include_auth` is set. Sets the token header
@@ -564,7 +562,7 @@ class ExternalIntegration(PrimaryModel):
         if session.verify is False:
             urllib3.disable_warnings(category=urllib3.exceptions.InsecureRequestWarning)
 
-        session.header["Accept"] = accept
+        session.headers.update(self.render_headers({}))
 
         if include_auth:
             secrets_group: SecretsGroup = self.secrets_group


### PR DESCRIPTION
# What's Changed

This feature provides a method to create a `requests.Session` initialized with the relevant configuration provided by an `ExternalIntegration`. This includes potential auth tokens, basic auth, ssl verification and custom CA file path. The reasoning behind this feature is to provide a re-usable interface for app developers to get http sessions for API clients defined as ExternalIntegrations. For instance, to interface with AWX a client needs the URL, ssl verification info, token or username/password. These can all be defined in `ExternalIntegration` and `get_http_session` can then be used to initialize an API client.

# Screenshots
This is an internal API available for APP developers, so there aren't any UI components.

# TODO
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
