### PR TITLE
Avoid exceptions when encountering a model that doesn't inherit from BaseModel

### DIFF
--- a/changes/6175.fixed
+++ b/changes/6175.fixed
@@ -1,0 +1,1 @@
+Prevented some `AttributeError` exceptions from being raised when an App contains a model that doesn't inherit from `BaseModel`.

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -49,7 +49,7 @@ class BaseTable(django_tables2.Table):
         # Add custom field columns
         model = self._meta.model
 
-        if model.is_dynamic_group_associable_model:
+        if getattr(model, "is_dynamic_group_associable_model", False):
             self.base_columns["dynamic_group_count"] = LinkedCountColumn(
                 viewname="extras:dynamicgroup_list",
                 url_params={"member_id": "pk"},

--- a/nautobot/core/templatetags/buttons.py
+++ b/nautobot/core/templatetags/buttons.py
@@ -165,7 +165,7 @@ def consolidate_bulk_action_buttons(context):
 
     render_edit_button = bool(context["bulk_edit_url"] and context["permissions"]["change"])
     render_static_group_assign_button = bool(
-        context["model"].is_dynamic_group_associable_model
+        getattr(context["model"], "is_dynamic_group_associable_model", False)
         and context["user"].has_perms(["extras.add_staticgroupassociation"])
     )
     render_delete_button = bool(context["bulk_delete_url"] and context["permissions"]["delete"])

--- a/nautobot/core/views/utils.py
+++ b/nautobot/core/views/utils.py
@@ -337,7 +337,7 @@ def common_detail_view_context(request, instance):
     context["created_by"] = created_by
     context["last_updated_by"] = last_updated_by
 
-    if instance.is_contact_associable_model:
+    if getattr(instance, "is_contact_associable_model", False):
         paginate = {"paginator_class": EnhancedPaginator, "per_page": get_paginate_count(request)}
         associations = instance.associated_contacts.restrict(request.user, "view").order_by("role__name")
         associations_table = AssociatedContactsTable(associations, orderable=False)
@@ -347,7 +347,7 @@ def common_detail_view_context(request, instance):
     else:
         context["associated_contacts_table"] = None
 
-    if instance.is_dynamic_group_associable_model:
+    if getattr(instance, "is_dynamic_group_associable_model", False):
         paginate = {"paginator_class": EnhancedPaginator, "per_page": get_paginate_count(request)}
         dynamic_groups = instance.dynamic_groups.restrict(request.user, "view")
         dynamic_groups_table = DynamicGroupTable(dynamic_groups, orderable=False)
@@ -358,7 +358,7 @@ def common_detail_view_context(request, instance):
     else:
         context["associated_dynamic_groups_table"] = None
 
-    if instance.is_metadata_associable_model:
+    if getattr(instance, "is_metadata_associable_model", False):
         paginate = {"paginator_class": EnhancedPaginator, "per_page": get_paginate_count(request)}
         object_metadata = instance.associated_object_metadata.restrict(request.user, "view").order_by(
             "metadata_type", "scoped_fields"

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -174,7 +174,7 @@ class DynamicGroupModelFormMixin(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self._meta.model.is_dynamic_group_associable_model:
+        if getattr(self._meta.model, "is_dynamic_group_associable_model", False):
             self.fields["dynamic_groups"] = DynamicModelMultipleChoiceField(
                 required=False,
                 initial=self.instance.dynamic_groups if self.instance else None,
@@ -193,7 +193,7 @@ class DynamicGroupModelFormMixin(forms.ModelForm):
 
     def save(self, commit=True):
         obj = super().save(commit=commit)
-        if commit and obj.is_dynamic_group_associable_model:
+        if commit and getattr(obj, "is_dynamic_group_associable_model", False):
             current_groups = set(obj.dynamic_groups.filter(group_type=DynamicGroupTypeChoices.TYPE_STATIC))
             for dynamic_group in set(self.cleaned_data.get("dynamic_groups")).difference(current_groups):
                 dynamic_group.add_members([obj])


### PR DESCRIPTION
# Closes N/A
# What's Changed

Don't assume that all encountered models will inherit from `BaseModel` or otherwise define the `.is_*_associable_model` flags. They *should*, but there may always exist deviations from this best practice and we shouldn't raise `AttributeError` for something that's so trivial to avoid.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
