### PR TITLE
Fix performance regression in web_request_context

### DIFF
--- a/changes/6203.fixed
+++ b/changes/6203.fixed
@@ -1,0 +1,1 @@
+Fixed a performance regression observed when change logging resulted in a large number of ObjectChange records (such as in an SSOT Job).

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -175,11 +175,12 @@ def web_request_context(
     :param user: User object
     :param context_detail: Optional extra details about the transaction (ex: the plugin name that initiated the change)
     :param change_id: Optional uuid object to uniquely identify the transaction. One will be generated if not supplied
-    :param context: Optional string value of the generated change log entries' "change_context" field, defaults to ObjectChangeEventContextChoices.CONTEXT_ORM.
-        Valid choices are in nautobot.extras.choices.ObjectChangeEventContextChoices
+    :param context: Optional string value of the generated change log entries' "change_context" field.
+        Defaults to `ObjectChangeEventContextChoices.CONTEXT_ORM`.
+        Valid choices are in `nautobot.extras.choices.ObjectChangeEventContextChoices`.
     :param request: Optional web request instance, one will be generated if not supplied
     """
-    from nautobot.extras.jobs import enqueue_job_hooks  # prevent circular import
+    from nautobot.extras.jobs import enqueue_job_hooks, get_jobs  # prevent circular import
 
     valid_contexts = {
         ObjectChangeEventContextChoices.CONTEXT_JOB: JobChangeContext,
@@ -202,9 +203,13 @@ def web_request_context(
         with change_logging(change_context):
             yield request
     finally:
+        # For anything except a JOB_HOOK context, we might be triggering job hooks, so make sure they're up to date
+        if context != ObjectChangeEventContextChoices.CONTEXT_JOB_HOOK:
+            get_jobs(reload=True)
         # enqueue jobhooks and webhooks, use change_context.change_id in case change_id was not supplied
         for object_change in ObjectChange.objects.filter(request_id=change_context.change_id).iterator():
-            enqueue_job_hooks(object_change)
+            if context != ObjectChangeEventContextChoices.CONTEXT_JOB_HOOK:
+                enqueue_job_hooks(object_change)
             enqueue_webhooks(object_change)
 
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1168,7 +1168,6 @@ def enqueue_job_hooks(object_change):
     job_hooks = JobHook.objects.filter(content_types=content_type, enabled=True, **{action_flag: True})
 
     # Enqueue the jobs related to the job_hooks
-    get_jobs(reload=True)
     for job_hook in job_hooks:
         job_model = job_hook.job
         if not job_model.installed or not job_model.enabled:

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -1091,12 +1091,15 @@ class JobModelTest(ModelTestCases.BaseModelTestCase):
         cls.app_job = JobModel.objects.get(job_class_name="ExampleJob")
 
     def test_job_class(self):
+        self.assertIsNotNone(self.local_job.job_class)
         self.assertEqual(self.local_job.job_class.description, "Validate job import")
 
+        self.assertIsNotNone(self.app_job.job_class)
         self.assertEqual(self.app_job.job_class, ExampleJob)
 
     def test_class_path(self):
         self.assertEqual(self.local_job.class_path, "pass.TestPass")
+        self.assertIsNotNone(self.local_job.job_class)
         self.assertEqual(self.local_job.class_path, self.local_job.job_class.class_path)
 
         self.assertEqual(self.app_job.class_path, "example_app.jobs.ExampleJob")
@@ -1118,6 +1121,7 @@ class JobModelTest(ModelTestCases.BaseModelTestCase):
                         self.assertTrue(job_model.enabled)
                     else:
                         self.assertFalse(job_model.enabled)
+                    self.assertIsNotNone(job_model.job_class)
                     for field_name in JOB_OVERRIDABLE_FIELDS:
                         if field_name == "name" and "duplicate_name" in job_model.job_class.__module__:
                             pass  # name field for test_duplicate_name jobs tested in test_duplicate_job_name below
@@ -1173,6 +1177,7 @@ class JobModelTest(ModelTestCases.BaseModelTestCase):
             setattr(self.job_containing_sensitive_variables, f"{field_name}_override", False)
         self.job_containing_sensitive_variables.validated_save()
         self.job_containing_sensitive_variables.refresh_from_db()
+        self.assertIsNotNone(self.job_containing_sensitive_variables.job_class)
         for field_name in overridden_attrs:
             self.assertEqual(
                 getattr(self.job_containing_sensitive_variables, field_name),

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -3008,6 +3008,7 @@ class JobCustomTemplateTestCase(TestCase):
         cls.run_url = reverse("extras:job_run", kwargs={"pk": cls.example_job.pk})
 
     def test_rendering_custom_template(self):
+        self.assertIsNotNone(self.example_job.job_class)
         obj_perm = ObjectPermission(name="Test permission", actions=["view", "run"])
         obj_perm.save()
         obj_perm.users.add(self.user)


### PR DESCRIPTION
# Closes #6203
# What's Changed

Fix a significant performance regression in SSOT jobs and similar object-change-heavy change-logged tasks that was inadvertently introduced in #5825. Basically, when post-processing a `web_request_context` to enqueue JobHooks and Webhooks, we were calling `get_jobs(reload=True)` **once per processed ObjectChange**, resulting in a tremendous amount of unnecessary churn. The fix is simply to move the `get_jobs()` call outside of the for loop so it gets called *once per `web_request_context`* instead.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
