### PR TITLE
Disable coverage during test database setup

### DIFF
--- a/changes/5376.housekeeping
+++ b/changes/5376.housekeeping
@@ -1,0 +1,1 @@
+Disabled `coverage` during initial test database setup to improve test performance.

--- a/tasks.py
+++ b/tasks.py
@@ -746,7 +746,7 @@ def unittest(
         command += " --keepdb"
     if failfast:
         command += " --failfast"
-    if buffer and not parallel:  # Django 3.x doesn't support '--parallel --buffer'; can remove this after Django 4.x
+    if buffer:
         command += " --buffer"
     if verbose:
         command += " --verbosity 2"


### PR DESCRIPTION
# Closes #5376 
# What's Changed

Disable `coverage` from running while doing initial setup of the test database. This reduces reported test coverage (both lines executed and lines missed) somewhat (as migrations are no longer counted as executed code) but saves, on my Mac, about 4 minutes of test setup time when run without a preexisting test database or cached test fixtures.

# Screenshots

Running `time invoke unittest --skip-docs-build --parallel --parallel-workers 6 --label nautobot.tenancy.tests.test_filters`

Before:

```
TOTAL                                                     40999  16477    60%

129 files skipped due to complete coverage.

invoke unittest --skip-docs-build --parallel --parallel-workers 6 --label  5.24s user 2.33s system 1% cpu 10:22.41 total
```

After:

```
TOTAL                                                     36578  15899    57%

102 files skipped due to complete coverage.

invoke unittest --skip-docs-build --parallel --parallel-workers 6 --label   3.77s user 1.71s system 1% cpu 6:34.97 total
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
