### PR TITLE
Fix upstream testing workflow to work with new Dockerfile

### DIFF
--- a/.github/workflows/plugin_upstream_testing_base.yml
+++ b/.github/workflows/plugin_upstream_testing_base.yml
@@ -33,6 +33,10 @@ jobs:
           poetry-install-options: ""  # override default "--only dev"
           poetry-version: "1.8.2"
           python-version: "${{ env.PYTHON_VERSION }}"
+      - name: "Constrain Nautobot version and regenerate lock file"
+        env:
+          INVOKE_NAUTOBOT_DEV_EXAMPLE_LOCAL: "true"
+        run: "poetry add --lock git+https://github.com/nautobot/nautobot.git#${{ matrix.nautobot-version }} --python ${{ env.PYTHON_VERSION }}"
       - name: "Set up Docker Buildx"
         id: "buildx"
         uses: "docker/setup-buildx-action@v1"
@@ -48,6 +52,7 @@ jobs:
           build-args: |
             NAUTOBOT_VER=${{ matrix.nautobot-version }}
             PYTHON_VER=${{ env.PYTHON_VERSION }}
+            CI=true
           outputs: "type=docker,dest=/tmp/nautobot_${{ matrix.nautobot-version }}.tar"
       - name: Upload docker image artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Closes #DNE (tracked in https://github.com/nautobot/cookiecutter-nautobot-app/issues/167)
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
A new dockerfile+ci.yml was introduced to apps in https://github.com/nautobot/cookiecutter-nautobot-app/pull/152. This required changing how we constrain the nautobot version in the docker build and I overlooked the upstream testing portion of this. This change adds the `poetry add nautobot` step and sets the `CI` build arg to fix the current failures in app upstream testing workflows. Tested in a fork of `nautobot-app-dev-example` at https://github.com/gsnider2195/nautobot-app-dev-example/actions/runs/10892662923

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
