### PR TITLE
Updating datetime.timedelta

### DIFF
--- a/changes/6230.fixed
+++ b/changes/6230.fixed
@@ -1,0 +1,1 @@
+Fixed an issue with Celery Scheduler around datetime imports.

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 from pathlib import Path
 
@@ -83,7 +83,7 @@ class NautobotScheduleEntry(ModelEntry):
             # This will trigger the job to run at start_time
             # and avoid the heap block.
             if model.start_time:
-                model.last_run_at = model.last_run_at - datetime.timedelta(days=365 * 30)
+                model.last_run_at = model.last_run_at - timedelta(days=365 * 30)
 
         self.last_run_at = model.last_run_at
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #<ISSUE NUMBER GOES HERE>

celery-beat error log
```
[2024-09-17 17:59:56,675: WARNING/MainProcess]   File "/usr/local/lib/python3.11/site-packages/nautobot/core/celery/schedulers.py", line 86, in __init__
[2024-09-17 17:59:56,676: WARNING/MainProcess] model.last_run_at = model.last_run_at - datetime.timedelta(days=365 * 30)
[2024-09-17 17:59:56,681: WARNING/MainProcess] AttributeError
[2024-09-17 17:59:56,682: WARNING/MainProcess] :
[2024-09-17 17:59:56,682: WARNING/MainProcess] type object 'datetime.datetime' has no attribute 'timedelta'
```

# What's Changed
Issue with Nautobot 2.3.2 and later introduced in #6122 where datetime is imported and used incorrectly with timedelta
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
