### PR TITLE
UI components: refactor, add panels for custom fields, computed fields, relationships

### DIFF
--- a/nautobot/circuits/templates/circuits/inc/circuit_termination.html
+++ b/nautobot/circuits/templates/circuits/inc/circuit_termination.html
@@ -2,31 +2,7 @@
 
 <div class="panel panel-default">
     <div class="panel-heading">
-        <div class="pull-right">
-            {% if not termination and perms.circuits.add_circuittermination %}
-                <a href="{% url 'circuits:circuittermination_add' circuit=object.pk %}?term_side={{ side }}" class="btn btn-xs btn-success">
-                    <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add
-                </a>
-            {% endif %}
-            {% if termination and perms.circuits.change_circuittermination %}
-                <a href="{% url 'circuits:circuittermination_edit' pk=termination.pk %}" class="btn btn-xs btn-warning">
-                    <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit
-                </a>
-                <a href="{% url 'circuits:circuit_terminations_swap' pk=object.pk %}" class="btn btn-xs btn-primary">
-                    <span class="mdi mdi-swap-vertical" aria-hidden="true"></span> Swap
-                </a>
-            {% endif %}
-            {% if termination and perms.circuits.delete_circuittermination %}
-                <a href="{% url 'circuits:circuittermination_delete' pk=termination.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-xs btn-danger">
-                    <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
-                </a>
-            {% endif %}
-            {% if termination %}
-            <a href="{% url 'circuits:circuittermination' pk=termination.pk %}" class="btn btn-xs btn-default">
-                <span class="mdi mdi-information-outline" aria-hidden="true"></span> Detail
-            </a>
-            {% endif %}
-        </div>
+        {% include 'circuits/inc/circuit_termination_header_extra_content.html' with termination=termination %}
         <strong>Termination - {{ side }} Side</strong>
     </div>
     <table class="table table-hover panel-body attr-table">

--- a/nautobot/circuits/templates/circuits/inc/circuit_termination_cable_fragment.html
+++ b/nautobot/circuits/templates/circuits/inc/circuit_termination_cable_fragment.html
@@ -28,9 +28,9 @@
                     <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span> Connect
                 </button>
                 <ul class="dropdown-menu dropdown-menu-right">
-                    <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='interface' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Interface</a></li> 
+                    <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='interface' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Interface</a></li>
                     <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='front-port' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Front Port</a></li>
-                    <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='rear-port' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Rear Port</a></li> 
+                    <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='rear-port' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Rear Port</a></li>
                     <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='circuit-termination' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Circuit Termination</a></li>
                 </ul>
             </span>

--- a/nautobot/circuits/templates/circuits/inc/circuit_termination_cable_fragment.html
+++ b/nautobot/circuits/templates/circuits/inc/circuit_termination_cable_fragment.html
@@ -1,0 +1,40 @@
+{% load helpers %}
+{% if termination.cable %}
+    {% if perms.dcim.delete_cable %}
+        <div class="pull-right">
+            <a href="{% url 'dcim:cable_delete' pk=termination.cable.pk %}?return_url={{ termination.circuit.get_absolute_url }}" title="Remove cable" class="btn btn-danger btn-xs">
+                <i class="mdi mdi-ethernet-cable-off" aria-hidden="true"></i> Disconnect
+            </a>
+        </div>
+    {% endif %}
+    {{ termination.cable|hyperlinked_object }}
+    <a href="{% url 'circuits:circuittermination_trace' pk=termination.pk %}" class="btn btn-primary btn-xs" title="Trace">
+        <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
+    </a>
+    {% with peer=termination.get_cable_peer %}
+        to
+        {% if peer.device %}
+            {{ peer.device|hyperlinked_object }}
+        {% elif peer.circuit %}
+            {{ peer.circuit|hyperlinked_object }}
+        {% endif %}
+        ({{ peer }})
+    {% endwith %}
+{% else %}
+    {% if perms.dcim.add_cable %}
+        <div class="pull-right">
+            <span class="dropdown">
+                <button type="button" class="btn btn-success btn-xs dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span> Connect
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right">
+                    <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='interface' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Interface</a></li> 
+                    <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='front-port' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Front Port</a></li>
+                    <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='rear-port' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Rear Port</a></li> 
+                    <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='circuit-termination' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Circuit Termination</a></li>
+                </ul>
+            </span>
+        </div>
+    {% endif %}
+    <span class="text-muted">Not defined</span>
+{% endif %}

--- a/nautobot/circuits/templates/circuits/inc/circuit_termination_fragment.html
+++ b/nautobot/circuits/templates/circuits/inc/circuit_termination_fragment.html
@@ -10,45 +10,7 @@
     <tr>
         <td>Cable</td>
         <td>
-            {% if termination.cable %}
-                {% if perms.dcim.delete_cable %}
-                    <div class="pull-right">
-                        <a href="{% url 'dcim:cable_delete' pk=termination.cable.pk %}?return_url={{ termination.circuit.get_absolute_url }}" title="Remove cable" class="btn btn-danger btn-xs">
-                            <i class="mdi mdi-ethernet-cable-off" aria-hidden="true"></i> Disconnect
-                        </a>
-                    </div>
-                {% endif %}
-                {{ termination.cable|hyperlinked_object }}
-                <a href="{% url 'circuits:circuittermination_trace' pk=termination.pk %}" class="btn btn-primary btn-xs" title="Trace">
-                    <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
-                </a>
-                {% with peer=termination.get_cable_peer %}
-                    to
-                    {% if peer.device %}
-                        {{ peer.device|hyperlinked_object }}
-                    {% elif peer.circuit %}
-                        {{ peer.circuit|hyperlinked_object }}
-                    {% endif %}
-                    ({{ peer }})
-                {% endwith %}
-            {% else %}
-                {% if perms.dcim.add_cable %}
-                    <div class="pull-right">
-                        <span class="dropdown">
-                            <button type="button" class="btn btn-success btn-xs dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span> Connect
-                            </button>
-                            <ul class="dropdown-menu dropdown-menu-right">
-                                <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='interface' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Interface</a></li>
-                                <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='front-port' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Front Port</a></li>
-                                <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='rear-port' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Rear Port</a></li>
-                                <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='circuit-termination' %}?termination_b_location={{ termination.location.pk }}&return_url={{ object.get_absolute_url }}">Circuit Termination</a></li>
-                            </ul>
-                        </span>
-                    </div>
-                {% endif %}
-                <span class="text-muted">Not defined</span>
-            {% endif %}
+            {% include 'circuits/inc/circuit_termination_cable_fragment.html' %}
         </td>
     </tr>
     {% elif termination.provider_network %}

--- a/nautobot/circuits/templates/circuits/inc/circuit_termination_header_extra_content.html
+++ b/nautobot/circuits/templates/circuits/inc/circuit_termination_header_extra_content.html
@@ -1,0 +1,26 @@
+{% load helpers %}
+<div class="pull-right">
+    {% if not termination and perms.circuits.add_circuittermination %}
+        <a href="{% url 'circuits:circuittermination_add' circuit=object.pk %}?term_side={{ side }}" class="btn btn-xs btn-success">
+            <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add
+        </a>
+    {% endif %}
+    {% if termination and perms.circuits.change_circuittermination %}
+        <a href="{% url 'circuits:circuittermination_edit' pk=termination.pk %}" class="btn btn-xs btn-warning">
+            <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit
+        </a>
+        <a href="{% url 'circuits:circuit_terminations_swap' pk=object.pk %}" class="btn btn-xs btn-primary">
+            <span class="mdi mdi-swap-vertical" aria-hidden="true"></span> Swap
+        </a>
+    {% endif %}
+    {% if termination and perms.circuits.delete_circuittermination %}
+        <a href="{% url 'circuits:circuittermination_delete' pk=termination.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-xs btn-danger">
+            <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
+        </a>
+    {% endif %}
+    {% if termination %}
+    <a href="{% url 'circuits:circuittermination' pk=termination.pk %}" class="btn btn-xs btn-default">
+        <span class="mdi mdi-information-outline" aria-hidden="true"></span> Detail
+    </a>
+    {% endif %}
+</div>

--- a/nautobot/circuits/tests/integration/test_relationships.py
+++ b/nautobot/circuits/tests/integration/test_relationships.py
@@ -26,26 +26,18 @@ class CircuitRelationshipsTestCase(SeleniumTestCase):
         power_panel_ct = ContentType.objects.get_for_model(PowerPanel)
         circuit_status = Status.objects.get_for_model(Circuit).first()
         location_status = Status.objects.get_for_model(Location).first()
-        provider1 = Provider.objects.create(
-            name="A Test Provider 1",
-        )
-        provider2 = Provider.objects.create(
-            name="A Test Provider 2",
-        )
-        provider3 = Provider.objects.create(
-            name="A Test Provider 3",
-        )
-        provider4 = Provider.objects.create(
-            name="A Test Provider 4",
-        )
-        provider5 = Provider.objects.create(
-            name="A Test Provider 5",
-        )
+        providers = [
+            Provider.objects.create(name="A Test Provider 1"),
+            Provider.objects.create(name="A Test Provider 2"),
+            Provider.objects.create(name="A Test Provider 3"),
+            Provider.objects.create(name="A Test Provider 4"),
+            Provider.objects.create(name="A Test Provider 5"),
+        ]
         circuit_type = CircuitType.objects.create(
             name="A Test Circuit Type",
         )
         circuit = Circuit.objects.create(
-            provider=provider1,
+            provider=providers[0],
             cid="123456789",
             circuit_type=circuit_type,
             status=circuit_status,
@@ -71,7 +63,7 @@ class CircuitRelationshipsTestCase(SeleniumTestCase):
             destination_type=provider_ct,
             type=RelationshipTypeChoices.TYPE_MANY_TO_MANY,
         )
-        for provider in [provider1, provider2, provider3, provider4, provider5]:
+        for provider in providers:
             RelationshipAssociation.objects.create(
                 relationship=m2m,
                 source=circuit_termination,
@@ -79,7 +71,7 @@ class CircuitRelationshipsTestCase(SeleniumTestCase):
             )
         o2m = Relationship.objects.create(
             label="Termination 2 Location o2m",
-            key="termination_2_provider_o2m",
+            key="termination_2_location_o2m",
             source_type=circuit_termination_ct,
             destination_type=location_ct,
             type=RelationshipTypeChoices.TYPE_ONE_TO_MANY,

--- a/nautobot/circuits/views.py
+++ b/nautobot/circuits/views.py
@@ -161,6 +161,9 @@ class CircuitUIViewSet(NautobotUIViewSet):
                 **kwargs,
             )
 
+        def should_render(self, context):
+            return True
+
         def get_extra_context(self, context):
             return {"termination": context[self.context_object_key]}
 

--- a/nautobot/circuits/views.py
+++ b/nautobot/circuits/views.py
@@ -136,12 +136,11 @@ class CircuitUIViewSet(NautobotUIViewSet):
     table_class = tables.CircuitTable
 
     class CircuitTerminationPanel(ObjectFieldsPanel):
-        # TODO: provide fields as key-value data directly rather than using a custom content-template
         def __init__(self, **kwargs):
             super().__init__(
                 fields=(
                     "location",  # TODO: render location hierarchy
-                    "cable",  # TODO: render cable peer and connect/disconnect buttons, hide if no location
+                    "cable",
                     "provider_network",
                     "cloud_network",
                     "port_speed",
@@ -157,9 +156,13 @@ class CircuitUIViewSet(NautobotUIViewSet):
                     "upstream_speed": [humanize_speed],
                 },
                 hide_if_unset=("location", "provider_network", "cloud_network", "upstream_speed"),
-                ignore_nonexistent_fields=True,  # ip_addresses may be unset
+                ignore_nonexistent_fields=True,  # ip_addresses may be undefined
+                header_extra_content_template_path="circuits/inc/circuit_termination_header_extra_content.html",
                 **kwargs,
             )
+
+        def get_extra_context(self, context):
+            return {"termination": context[self.context_object_key]}
 
         def render_value(self, key, value, context):
             if key == "cable":
@@ -167,10 +170,6 @@ class CircuitUIViewSet(NautobotUIViewSet):
                     return ""
                 return get_template("circuits/inc/circuit_termination_cable_fragment.html").render(context)
             return super().render_value(key, value, context)
-
-        def render_header_extra_content(self, context):
-            context["termination"] = context[self.context_object_key]
-            return get_template("circuits/inc/circuit_termination_header_extra_content.html").render(context)
 
     object_detail_content = ObjectDetailContent(
         panels=(

--- a/nautobot/circuits/views.py
+++ b/nautobot/circuits/views.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from django.contrib import messages
 from django.db import transaction
 from django.db.models import Q
@@ -136,8 +138,9 @@ class CircuitUIViewSet(NautobotUIViewSet):
     serializer_class = serializers.CircuitSerializer
     table_class = tables.CircuitTable
 
+    @dataclass
     class CircuitTerminationPanel(KeyValueTablePanel):
-        content_template_path = "circuits/inc/circuit_termination_fragment.html"
+        content_template_path: str = "circuits/inc/circuit_termination_fragment.html"
 
         def render_header_extra_content(self, context):
             return get_template("circuits/inc/circuit_termination_header_extra_content.html").render(context)

--- a/nautobot/core/templates/components/layout/one_over_two.html
+++ b/nautobot/core/templates/components/layout/one_over_two.html
@@ -1,0 +1,19 @@
+{% load ui_framework %}
+{% load plugins %}
+
+<div class="row">
+    <div class="col-md-12">
+        {% render_components full_width_panels %}
+        {% if include_plugin_content %}{% plugin_full_width_page object %}{% endif %}
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-6">
+        {% render_components left_half_panels %}
+        {% if include_plugin_content %}{% plugin_left_page object %}{% endif %}
+    </div>
+    <div class="col-md-6">
+        {% render_components right_half_panels %}
+        {% if include_plugin_content %}{% plugin_right_page object %}{% endif %}
+    </div>
+</div>

--- a/nautobot/core/templates/components/layout/two_over_one.html
+++ b/nautobot/core/templates/components/layout/two_over_one.html
@@ -1,0 +1,19 @@
+{% load ui_framework %}
+{% load plugins %}
+
+<div class="row">
+    <div class="col-md-6">
+        {% render_components left_half_panels %}
+        {% if include_plugin_content %}{% plugin_left_page object %}{% endif %}
+    </div>
+    <div class="col-md-6">
+        {% render_components right_half_panels %}
+        {% if include_plugin_content %}{% plugin_right_page object %}{% endif %}
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        {% render_components full_width_panels %}
+        {% if include_plugin_content %}{% plugin_full_width_page object %}{% endif %}
+    </div>
+</div>

--- a/nautobot/core/templates/components/panel/body_generic.html
+++ b/nautobot/core/templates/components/panel/body_generic.html
@@ -1,3 +1,3 @@
-<div class="panel-body">
+<div class="panel-body"{% if body_id %} id="{{ body_id }}"{% endif %}>
     {{ body_content }}
 </div>

--- a/nautobot/core/templates/components/panel/body_generic.html
+++ b/nautobot/core/templates/components/panel/body_generic.html
@@ -1,3 +1,3 @@
 <div class="panel-body">
-    {{ content }}
+    {{ body_content }}
 </div>

--- a/nautobot/core/templates/components/panel/body_generic.html
+++ b/nautobot/core/templates/components/panel/body_generic.html
@@ -1,0 +1,3 @@
+<div class="panel-body">
+    {{ content }}
+</div>

--- a/nautobot/core/templates/components/panel/body_key_value_table.html
+++ b/nautobot/core/templates/components/panel/body_key_value_table.html
@@ -1,3 +1,3 @@
 <table class="table table-hover panel-body attr-table">
-    {{ content }}
+    {{ body_content }}
 </table>

--- a/nautobot/core/templates/components/panel/body_key_value_table.html
+++ b/nautobot/core/templates/components/panel/body_key_value_table.html
@@ -1,0 +1,3 @@
+<table class="table table-hover panel-body attr-table">
+    {{ content }}
+</table>

--- a/nautobot/core/templates/components/panel/body_key_value_table.html
+++ b/nautobot/core/templates/components/panel/body_key_value_table.html
@@ -1,3 +1,3 @@
-<table class="table table-hover panel-body attr-table">
+<table class="table table-hover panel-body attr-table"{% if body_id %} id="{{ body_id }}"{% endif %}>
     {{ body_content }}
 </table>

--- a/nautobot/core/templates/components/panel/body_table.html
+++ b/nautobot/core/templates/components/panel/body_table.html
@@ -1,0 +1,3 @@
+<div class="table-responsive">
+    {{ content }}
+</div>

--- a/nautobot/core/templates/components/panel/body_table.html
+++ b/nautobot/core/templates/components/panel/body_table.html
@@ -1,3 +1,3 @@
 <div class="table-responsive">
-    {{ content }}
+    {{ body_content }}
 </div>

--- a/nautobot/core/templates/components/panel/body_table.html
+++ b/nautobot/core/templates/components/panel/body_table.html
@@ -1,3 +1,3 @@
-<div class="table-responsive">
+<div class="table-responsive"{% if body_id %} id="{{ body_id }}"{% endif %}>
     {{ body_content }}
 </div>

--- a/nautobot/core/templates/components/panel/content_table.html
+++ b/nautobot/core/templates/components/panel/content_table.html
@@ -1,0 +1,2 @@
+{% load render_table from django_tables2 %}
+{% render_table content_table 'inc/table.html' %}

--- a/nautobot/core/templates/components/panel/footer.html
+++ b/nautobot/core/templates/components/panel/footer.html
@@ -1,5 +1,0 @@
-{% if extra_content %}
-    <div class="panel-footer">
-        {{ extra_content }}
-    </div>
-{% endif %}

--- a/nautobot/core/templates/components/panel/footer.html
+++ b/nautobot/core/templates/components/panel/footer.html
@@ -1,0 +1,5 @@
+{% if extra_content %}
+    <div class="panel-footer">
+        {{ extra_content }}
+    </div>
+{% endif %}

--- a/nautobot/core/templates/components/panel/footer_contacts_table.html
+++ b/nautobot/core/templates/components/panel/footer_contacts_table.html
@@ -1,0 +1,20 @@
+{% with request.path|add:"?tab=contacts"|urlencode as return_url %}
+    {% if perms.extras.change_contactassociation %}
+        <button type="submit" name="_edit" formaction="{% url 'extras:contactassociation_bulk_edit' %}?return_url={{return_url}}" class="btn btn-warning btn-xs">
+            <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit
+        </button>
+    {% endif %}
+    {% if perms.extras.delete_contactassociation %}
+        <button type="submit" formaction="{% url 'extras:contactassociation_bulk_delete' %}?return_url={{return_url}}" class="btn btn-danger btn-xs">
+            <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
+        </button>
+    {% endif %}
+    {% if perms.extras.add_contactassociation %}
+        <div class="pull-right">
+            <a href="{% url 'extras:object_contact_team_assign' %}?return_url={{return_url}}&associated_object_id={{object.id}}&associated_object_type={{content_type.id}}" class="btn btn-primary btn-xs">
+                <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add Contact
+            </a>
+        </div>
+    {% endif %}
+    <div class="clearfix"></div>
+{% endwith %}

--- a/nautobot/core/templates/components/panel/grouping_toggle.html
+++ b/nautobot/core/templates/components/panel/grouping_toggle.html
@@ -1,0 +1,16 @@
+<tr>
+    <td colspan="2">
+        <strong>
+            <!-- TODO: the font-size should be defined in base.css, not here -->
+            <!-- TODO: this is not very consistent with other button styling -->
+            <button type="button"
+                    class="accordion-toggle mdi mdi-chevron-down"
+                    name="grouping.{{ grouping }}"
+                    style="font-size: 14px;"
+                    data-toggle="collapse"
+                    data-target=".collapseme-{{ body_id }}-{{ counter }}">
+                {{ grouping }}
+            </button>
+        </strong>
+    </td>
+</tr>

--- a/nautobot/core/templates/components/panel/header.html
+++ b/nautobot/core/templates/components/panel/header.html
@@ -1,6 +1,0 @@
-{% if label or extra_content %}
-    <div class="panel-heading">
-        <strong>{{ label }}</strong>
-        {{ extra_content }}
-    </div>
-{% endif %}

--- a/nautobot/core/templates/components/panel/header.html
+++ b/nautobot/core/templates/components/panel/header.html
@@ -1,0 +1,6 @@
+{% if label or extra_content %}
+    <div class="panel-heading">
+        <strong>{{ label }}</strong>
+        {{ extra_content }}
+    </div>
+{% endif %}

--- a/nautobot/core/templates/components/panel/panel.html
+++ b/nautobot/core/templates/components/panel/panel.html
@@ -1,0 +1,5 @@
+<div class="panel panel-default">
+    {{ header }}
+    {{ body }}
+    {{ footer }}
+</div>

--- a/nautobot/core/templates/components/panel/panel.html
+++ b/nautobot/core/templates/components/panel/panel.html
@@ -1,5 +1,16 @@
 <div class="panel panel-default">
-    {{ header }}
+    {% if label or header_extra_content %}
+        <div class="panel-heading">
+            {% if label %}
+                <strong>{{ label }}</strong>
+            {% endif %}
+            {{ header_extra_content }}
+        </div>
+    {% endif %}
     {{ body }}
-    {{ footer }}
+    {% if footer_content %}
+        <div class="panel-footer">
+            {{ footer_content }}
+        </div>
+    {% endif %}
 </div>

--- a/nautobot/core/templates/components/tab/content.html
+++ b/nautobot/core/templates/components/tab/content.html
@@ -1,0 +1,3 @@
+<div id="{{ tab_id }}" role="tabpanel" class="tab-pane {% if request.GET.tab == tab_id %}active{% else %}fade{% endif %}">
+    {{ tab_content }}
+</div>

--- a/nautobot/core/templates/components/tab/tab.html
+++ b/nautobot/core/templates/components/tab/tab.html
@@ -1,0 +1,5 @@
+<li role="presentation"{% if request.GET.tab == tab_id %} class="active"{% endif %}>
+    <a href="{{ object.get_absolute_url }}#{{ tab_id }}" onclick="switch_tab(this.href)" aria-controls="{{ tab_id }}" role="tab" data-toggle="tab">
+        {{ tab_label }}
+    </a>
+</li>

--- a/nautobot/core/templates/generic/object_retrieve.html
+++ b/nautobot/core/templates/generic/object_retrieve.html
@@ -142,7 +142,7 @@
             <div class="row">
                 <div class="col-md-6">
                     {% block content_left_page %}{% endblock content_left_page %}
-                    {% include 'inc/custom_fields/panel.html' with custom_fields=object.get_custom_field_groupings_basic computed_fields=object.get_computed_fields_grouping_basic computed_fields_advanced_ui=False %}
+                    {% include 'inc/custom_fields/panel.html' with custom_fields=object.get_custom_field_groupings_basic custom_fields_advanced_ui=False computed_fields=object.get_computed_fields_grouping_basic computed_fields_advanced_ui=False %}
                     {% include 'inc/relationships_panel.html' %}
                     {% include 'extras/inc/tags_panel.html' %}
                     {% plugin_left_page object %}
@@ -334,28 +334,28 @@
             $(`#tabs a[href="{{ object.get_absolute_url }}#${event.state.id}"]`).tab('show');
     }
     // Toggle v -. >
-    $("#accordion .accordion-toggle").click(function () {
+    $(".accordion-toggle").click(function () {
         $(this).toggleClass("mdi-chevron-down mdi-chevron-right");
     });
     // Dynamically collapse/expand all when clicking the "Collapse All" button, and then update the button text.
-    $('#accordion-toggle-all').click(function () {
+    $('.accordion-toggle-all').click(function () {
 
         if ($(this).data("lastState") === null || $(this).data("lastState") === 1) {
-            $('.collapse').collapse('show');
+            $($(this).data("target") + ' .collapse').collapse('show');
             $(this).data("lastState", 0);
 
-            $("#accordion .accordion-toggle").addClass("mdi-chevron-down").removeClass("mdi-chevron-right");
+            $($(this).data("target") + " .accordion-toggle").addClass("mdi-chevron-down").removeClass("mdi-chevron-right");
 
             $(this).text("Collapse All");
         }
         else {
-            $('[class^=collapseme]').removeData('bs.collapse').collapse({parent: false, toggle: false})
+            $($(this).data("target") + ' [class^=collapseme]').removeData('bs.collapse').collapse({parent: false, toggle: false})
             .collapse('hide')
             .removeData('bs.collapse')
-            .collapse({parent: '#accordion', toggle: false});
+            .collapse({parent: $(this).data("target"), toggle: false});
 
             $(this).data("lastState", 1);
-            $("#accordion .accordion-toggle").addClass("mdi-chevron-right").removeClass("mdi-chevron-down");
+            $($(this).data("target") + " .accordion-toggle").addClass("mdi-chevron-right").removeClass("mdi-chevron-down");
 
             $(this).text("Expand All");
         }

--- a/nautobot/core/templates/inc/computed_fields/panel_data.html
+++ b/nautobot/core/templates/inc/computed_fields/panel_data.html
@@ -1,16 +1,13 @@
 {% load helpers %}
 {% if computed_fields %}
-<style>
-    .accordion-toggle {
-        font-size: 14px;
-    }
-</style>
     <div class="panel panel-default">
         <div class="panel-heading">
             <strong>Computed Fields</strong>
-            <button type="button" class="btn-xs btn-primary pull-right" id="accordion-toggle-all">Collapse All</button>
+            <button type="button"
+                    class="btn-xs btn-primary pull-right accordion-toggle-all"
+                    data-target="#computed_fields_accordion_{{ advanced_ui }}">Collapse All</button>
         </div>
-        <table id="accordion" class="table table-hover panel-body attr-table">
+        <table id="computed_fields_accordion_{{ advanced_ui }}" class="table table-hover panel-body attr-table">
             {% for grouping, fields in computed_fields.items %}
             {% with forloop.counter0 as count %}
                 {% if grouping != "" %}

--- a/nautobot/core/templates/inc/custom_fields/panel.html
+++ b/nautobot/core/templates/inc/custom_fields/panel.html
@@ -1,3 +1,3 @@
 {% load helpers %}
-{% include 'inc/custom_fields/panel_data.html' %}
+{% include 'inc/custom_fields/panel_data.html' with advanced_ui=custom_fields_advanced_ui %}
 {% include 'inc/computed_fields/panel_data.html' with advanced_ui=computed_fields_advanced_ui %}

--- a/nautobot/core/templates/inc/custom_fields/panel_data.html
+++ b/nautobot/core/templates/inc/custom_fields/panel_data.html
@@ -1,16 +1,13 @@
 {% load helpers %}
 {% if custom_fields %}
-<style>
-    .accordion-toggle {
-        font-size: 14px;
-    }
-</style>
     <div class="panel panel-default">
         <div class="panel-heading">
             <strong>Custom Fields</strong>
-            <button type="button" class="btn-xs btn-primary pull-right" id="accordion-toggle-all">Collapse All</button>
+            <button type="button"
+                    class="btn-xs btn-primary pull-right accordion-toggle-all"
+                    data-target="#custom_fields_accordion_{{ advanced_ui }}">Collapse All</button>
         </div>
-        <table id="accordion" class="table table-hover panel-body attr-table">
+        <table id="custom_fields_accordion_{{ advanced_ui }}" class="table table-hover panel-body attr-table">
             {% for grouping, fields in custom_fields.items %}
             {% with forloop.counter0 as count %}
                 {% if grouping != "" %}

--- a/nautobot/core/templates/inc/relationships_panel.html
+++ b/nautobot/core/templates/inc/relationships_panel.html
@@ -7,7 +7,7 @@
                 <strong>Relationships</strong>
             </div>
             <table class="table table-hover panel-body attr-table">
-                {% include 'inc/relationships_table_rows.html' with relationships_data=object.get_relationships_data %}
+                {% include 'inc/relationships_table_rows.html' with relationships_data=relationships %}
             </table>
         </div>
     {% endif %}

--- a/nautobot/core/templatetags/ui_framework.py
+++ b/nautobot/core/templatetags/ui_framework.py
@@ -1,4 +1,5 @@
 from django import template
+from django.utils.html import format_html_join
 
 register = template.Library()
 
@@ -11,3 +12,8 @@ def object_detail_tabs(context):
 @register.simple_tag(takes_context=True)
 def object_detail_tabs_content(context):
     return context["object_detail_content"].render_content(context)
+
+
+@register.simple_tag(takes_context=True)
+def render_components(context, components):
+    return format_html_join("\n", "{}", ([component.render(context)] for component in components))

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -224,7 +224,7 @@ class Panel(Component):
         header_extra_content_template_path=None,
         footer_content_template_path=None,
         template_path="components/panel/panel.html",
-        body_template_path="components/panel/body_generic.html",
+        body_wrapper_template_path="components/panel/body_generic.html",
         **kwargs,
     ):
         """
@@ -240,8 +240,8 @@ class Panel(Component):
                 if any, not including its label if any.
             footer_content_template_path (str): Template path to render content into the panel footer, if any.
             template_path (str): Template path to render the Panel as a whole. Generally you won't override this.
-            body_template_path (str): Template path to render the panel body, including its contents.
-                Generally you won't override this.
+            body_wrapper_template_path (str): Template path to render the panel body, including both its "wrapper"
+                (a `div` or `table`) as well as its contents. Generally you won't override this as a user.
         """
         self.label = label
         self.section = section
@@ -250,7 +250,7 @@ class Panel(Component):
         self.header_extra_content_template_path = header_extra_content_template_path
         self.footer_content_template_path = footer_content_template_path
         self.template_path = template_path
-        self.body_template_path = body_template_path
+        self.body_wrapper_template_path = body_wrapper_template_path
         super().__init__(**kwargs)
 
     def render(self, context):
@@ -279,8 +279,8 @@ class Panel(Component):
         return ""
 
     def render_body(self, context):
-        """Render `self.body_template_path` as panel body, with the rendered `body_content` as its content."""
-        return get_template(self.body_template_path).render(
+        """Render `self.body_wrapper_template_path` as panel body, with the rendered `body_content` as its content."""
+        return get_template(self.body_wrapper_template_path).render(
             {
                 **context,
                 "body_id": self.body_id,
@@ -308,7 +308,7 @@ class ObjectsTablePanel(Panel):
         self,
         *,
         table_key,
-        body_template_path="components/panel/body_table.html",
+        body_wrapper_template_path="components/panel/body_table.html",
         body_content_template_path="components/panel/content_table.html",
         **kwargs,
     ):
@@ -319,7 +319,9 @@ class ObjectsTablePanel(Panel):
         """
         self.table_key = table_key
         super().__init__(
-            body_template_path=body_template_path, body_content_template_path=body_content_template_path, **kwargs
+            body_wrapper_template_path=body_wrapper_template_path,
+            body_content_template_path=body_content_template_path,
+            **kwargs,
         )
 
     def get_extra_context(self, context):
@@ -335,7 +337,7 @@ class KeyValueTablePanel(Panel):
         data,
         hide_if_unset=(),
         value_transforms=None,
-        body_template_path="components/panel/body_key_value_table.html",
+        body_wrapper_template_path="components/panel/body_key_value_table.html",
         **kwargs,
     ):
         """
@@ -351,7 +353,7 @@ class KeyValueTablePanel(Panel):
         self.data = data
         self.hide_if_unset = hide_if_unset
         self.value_transforms = value_transforms or {}
-        super().__init__(body_template_path=body_template_path, **kwargs)
+        super().__init__(body_wrapper_template_path=body_wrapper_template_path, **kwargs)
 
     def should_render(self, context):
         return bool(self.get_data(context))

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -368,7 +368,7 @@ class KeyValueTablePanel(Panel):
         """
         For rendering queryset values - if provided, will be passed as a filter parameter to the corresponding list URL.
         """
-        return None
+        return ""
 
     def render_value(self, key, value, context):
         """Intelligently render the provided value in human-readable form."""
@@ -403,6 +403,7 @@ class KeyValueTablePanel(Panel):
 
                 # If we can find the list URL and the appropriate filter parameter for this listing, wrap the above
                 # in an appropriate hyperlink:
+                list_url = None
                 list_url_filter = self.queryset_list_url_filter(key, value, context)
                 if list_url_filter:
                     list_url_name = get_route_for_model(model, "list")
@@ -410,7 +411,7 @@ class KeyValueTablePanel(Panel):
                     try:
                         list_url = f"{reverse(list_url_name)}?{list_url_filter}"
                     except NoReverseMatch:
-                        list_url = None
+                        pass
 
                 display = format_html_join(
                     ", ", "{}", ([self.render_value(key, record, context)] for record in value[:3])

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -759,7 +759,10 @@ class _ObjectRelationshipsPanel(KeyValueTablePanel):
         """Render the relationship's label and key as well as the related-objects label."""
         relationship, side = key
         return format_html(
-            '<span title="{} ({})">{}</span>', relationship.label, relationship.key, relationship.get_label(side)
+            '<span title="{} ({})">{}</span>',
+            relationship.label,
+            relationship.key,
+            bettertitle(relationship.get_label(side)),
         )
 
     def queryset_list_url_filter(self, key, value, context):

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -105,7 +105,7 @@ class RelationshipModel(models.Model):
 
                 # Determine if the relationship is applicable to this object based on the filter
                 # To resolve the filter we are using the FilterSet for the given model
-                # If there is no match when we query the primary key of the device along with the filter
+                # If there is no match when we query our id along with the filter
                 # Then the relationship is not applicable to this object
                 if getattr(relationship, f"{side}_filter"):
                     filterset = get_filterset_for_model(self._meta.model)
@@ -247,7 +247,7 @@ class RelationshipModel(models.Model):
 
                 # Determine if the relationship is applicable to this object based on the filter
                 # To resolve the filter we are using the FilterSet for the given model
-                # If there is no match when we query the primary key of the device along with the filter
+                # If there is no match when we query our id along with the filter
                 # Then the relationship is not applicable to this object
                 if getattr(relationship, f"{side}_filter"):
                     filterset = get_filterset_for_model(self._meta.model)

--- a/nautobot/extras/templates/extras/job_list.html
+++ b/nautobot/extras/templates/extras/job_list.html
@@ -3,11 +3,6 @@
 
 {% block extra_styles %}
     <style>
-        .accordion-toggle {
-            font-size: 14px;
-            font-weight: 700;
-        }
-
         tr a.job_run .btn {
             margin: -4px 10px 0 0;
         }
@@ -37,7 +32,7 @@
         </a>
     </div>
 
-    <button type="button" class="btn btn-default" id="accordion-toggle-all"{% if display == "tiles" %} disabled="disabled"{% endif %}>Collapse All</button>
+    <button type="button" class="btn btn-default accordion-toggle-all"{% if display == "tiles" %} disabled="disabled"{% endif %}>Collapse All</button>
 {% endblock %}
 
 {% block table_config_button %}
@@ -55,7 +50,7 @@
             $(this).toggleClass("mdi-chevron-down mdi-chevron-right");
         });
         // Dynamically collapse/expand all when clicking the "Collapse All" button, and then update the button text.
-        $('#accordion-toggle-all').on('click', function () {
+        $('.accordion-toggle-all').on('click', function () {
 
            if ($(this).data("lastState") === null || $(this).data("lastState") === 1) {
                 $('.collapse').collapse('show');

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -581,7 +581,8 @@ td span.hover_copy:hover .hover_copy_button {
 .accordion-toggle {
     border: 0;
     color: black;
-    font-size: 24px;
+    font-size: 14px;
+    font-weight: 700;
     padding: 0;
     text-decoration: none;
 }
@@ -592,7 +593,7 @@ td span.hover_copy:hover .hover_copy_button {
     padding: 0;
     text-decoration: none;
 }
-#accordion-toggle-all {
+.accordion-toggle-all {
     display: inline;
 }
 


### PR DESCRIPTION
# Progress towards #6141 
# What's Changed

- Code and template cleanup in "Circuit" detail view implementation following the new patterns described below. The custom "Circuit Termination" panels in this view are now implemented as a custom Panel subclass with custom template fragments instead of the previous implementation as a TemplatePanel that overrides the entire panel template. This ends up being a bit more code in the Circuits app in total but reduces the amount of Bootstrap-isms that the app needs to implement.
- Pull a lot of the HTML fragments that were previously inlined in `object_detail.py` out into template fragments. If render performance becomes an issue, and template caching doesn't help enough, we can potentially re-inline them in the future but for now this makes a cleaner separation IMHO.
- Fix a pre-existing bug in the custom-field and computed-field grouping accordions - all of these panels were re-using the same `id="accordion"` and `id="accordion-toggle-all"`, meaning that when both grouped custom fields and grouped computed fields were present, various parts of the UI didn't work quite right ("Collapse All" button on one panel would collapse other panels as well, etc.) I fixed this by changing the aforementioned IDs to CSS classes, adding properly unique IDs to these elements, and adding a `data-target` attribute to each panel to constrain the scope of the "Collapse All" buttons. This should be a fix in both the existing UI templates as well as the new framework.
- Move custom `.accordion-toggle` CSS styling out of various places and into `base.css`, as AFAICT we were overriding it in every place this class was used instead of fixing it once in the base CSS.
- Refactors to object_detail.py. The diffs here look really messy because I moved all of the private/internal classes (`_ObjectDetailAdvancedTab`, etc.) to the end of the file, so you may have better luck just reading the "after" file itself.
- Added `KeyValueTablePanel` as a parent class of `ObjectFieldsPanel`; it now also serves as the base class for `_ObjectRelationshipsPanel` and `GroupedKeyValueTablePanel`, which in turn is the parent of `_ObjectCustomFieldsPanel` and `_ObjectComputedFieldsPanel`
   - Basically `KeyValueTablePanel` is the panel that "knows" how to consistently render various data values (text, object references, querysets, etc.) and its subclasses mostly just "know" how to massage the different sources of data into the structure that it operates against.
- Added `_ObjectCustomFieldsPanel`, `_ObjectComputedFieldsPanel`, and `_ObjectRelationshipsPanel` helper classes and added those to the standard "main" and "advanced" tabs.
  - In support of this (and towards #5773) I added a new `Model.get_relationships_with_related_objects()` API. This differs from `Model.get_relationships()` in that its leaf values are actual related-object querysets (e.g. Devices, Circuits, etc.) instead of querysets of RelationshipAssociation records. This made it so that the Relationships panel (currently new-UI-framework only) can render the actual related objects and their hyperlinks, instead of linking to our rudimentary RelationshipAssociation list view as previously.

# Screenshots

![image](https://github.com/user-attachments/assets/54893eb6-980d-49de-b3cf-c33125b5a299)

![image](https://github.com/user-attachments/assets/62629919-6bc7-4350-b684-e4f60500f9c7)

![image](https://github.com/user-attachments/assets/756434ac-2a01-4b88-ae9d-6f59634ef76e)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
