### PR TITLE
Fixed Device Type link and count from Device Family Detail View.

### DIFF
--- a/changes/6248.fixed
+++ b/changes/6248.fixed
@@ -1,0 +1,1 @@
+Fixed Device Type link and count from Device Family Detail View.

--- a/nautobot/dcim/templates/dcim/devicefamily_retrieve.html
+++ b/nautobot/dcim/templates/dcim/devicefamily_retrieve.html
@@ -16,7 +16,7 @@
                 </tr>
                 <tr>
                     <td>Device Types</td>
-                    <td><a href="{% url 'dcim:devicetype_list' %}?device_family={{ object.name }}">{{ object.device_type_count }}</a></td>
+                    <td><a href="{% url 'dcim:devicetype_list' %}?device_family={{ object.name }}">{{ device_type_count }}</a></td>
                 </tr>
                 <tr>
                     <td>Total Devices</td>

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -4139,9 +4139,12 @@ class DeviceFamilyUIViewSet(NautobotUIViewSet):
             context["device_type_table"] = device_type_table
 
             total_devices = 0
+            device_type_count = 0
             for device_type in device_types:
                 total_devices += device_type.device_count
+                device_type_count += 1
             context["total_devices"] = total_devices
+            context["device_type_count"] = device_type_count
 
         return context
 


### PR DESCRIPTION

Fixed Device Type link and count from Device Family Detail View.

Seems to be regression during #5668, I checked a few, and they did not affect anything, but probably better suited for someone that knows the pattern where this may happen a bit better. 