### PR TITLE
Add tags panel to ObjectDetailContent

### DIFF
--- a/changes/6141.added
+++ b/changes/6141.added
@@ -1,0 +1,1 @@
+Added object tags display to Python UI framework.

--- a/nautobot/core/templates/components/panel/body_content_tags.html
+++ b/nautobot/core/templates/components/panel/body_content_tags.html
@@ -1,0 +1,6 @@
+{% load helpers %}
+{% for tag in tags %}
+    {% tag tag list_url_name %}
+{% empty %}
+    <span class="text-muted">No tags assigned</span>
+{% endfor %}

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -741,7 +741,7 @@ class _ObjectCustomFieldsPanel(GroupedKeyValueTablePanel):
         section=SectionChoices.LEFT_HALF,
         **kwargs,
     ):
-        """Instantiate an `ObjectCustomFieldsPanel`.
+        """Instantiate an `_ObjectCustomFieldsPanel`.
 
         Args:
             advanced_ui (bool): Whether this is on the "main" tab (False) or the "advanced" tab (True)
@@ -910,6 +910,37 @@ class _ObjectRelationshipsPanel(KeyValueTablePanel):
         return f"cr_{relationship.key}__{side}={obj.pk}"
 
 
+class _ObjectTagsPanel(Panel):
+    """Panel displaying an object's tags as a space-separated list of color-coded tag names."""
+
+    def __init__(
+        self,
+        *,
+        weight=Panel.WEIGHT_TAGS_PANEL,
+        label="Tags",
+        section=SectionChoices.LEFT_HALF,
+        body_content_template_path="components/panel/body_content_tags.html",
+        **kwargs,
+    ):
+        """Instantiate an `_ObjectTagsPanel`."""
+        super().__init__(
+            weight=weight,
+            label=label,
+            section=section,
+            body_content_template_path=body_content_template_path,
+            **kwargs,
+        )
+
+    def should_render(self, context):
+        return hasattr(context["object"], "tags")
+
+    def get_extra_context(self, context):
+        return {
+            "tags": context["object"].tags.all(),
+            "list_url_name": validated_viewname(context["object"], "list"),
+        }
+
+
 class _ObjectDetailMainTab(Tab):
     """Base class for a main display tab containing an overview of object fields and similar data."""
 
@@ -927,7 +958,7 @@ class _ObjectDetailMainTab(Tab):
         panels.append(_ObjectCustomFieldsPanel())
         panels.append(_ObjectComputedFieldsPanel())
         panels.append(_ObjectRelationshipsPanel())
-        # TODO: tags
+        panels.append(_ObjectTagsPanel())
 
         super().__init__(tab_id=tab_id, label=label, weight=weight, panels=panels, **kwargs)
 

--- a/nautobot/extras/templates/extras/inc/tags_panel.html
+++ b/nautobot/extras/templates/extras/inc/tags_panel.html
@@ -6,11 +6,7 @@
         <strong>Tags</strong>
     </div>
     <div class="panel-body">
-        {% for tag in tags.all %}
-            {% tag tag url %}
-        {% empty %}
-            <span class="text-muted">No tags assigned</span>
-        {% endfor %}
+        {% include "components/panel/body_content_tags.html" with tags=tags.all list_url_name=url %}
     </div>
 </div>
 {% endif %}


### PR DESCRIPTION
# Closes #6141
# What's Changed

- Add `_ObjectTagsPanel` helper class.
- Extract shared template logic out of `extras/inc/tags_panel.html` to a new template that can be shared between old and new frameworks.

# Screenshots

Now rendered in Circuit detail view (new framework):

![image](https://github.com/user-attachments/assets/39b4a7a4-909d-42b6-81bb-f4876132ba53)

Still rendered in Device detail view (old framework):

![image](https://github.com/user-attachments/assets/d1a58ba6-f145-408a-aa81-6123b4d37c08)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
