### PR TITLE
Fix Prefix not displaying the correct utilization for IP Addresses

### DIFF
--- a/changes/6170.changed
+++ b/changes/6170.changed
@@ -1,0 +1,1 @@
+Fix Prefix IPAddresses not accounting for Child Prefix IPAddresses in the UI.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -898,6 +898,7 @@ class Prefix(PrimaryModel):
         Returns:
             IPAddress QuerySet
         """
+        # Question: This is a possible fix for this PR; should this be uncommented?
         # 3.0 TODO: uncomment this to enable this logic
         # if self.type == choices.PrefixTypeChoices.TYPE_POOL:
         #     return IPAddress.objects.filter(

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -889,23 +889,16 @@ class Prefix(PrimaryModel):
         )
         return available_ips
 
-    def get_child_ips(self):
+    def get_all_ips(self):
         """
-        Return IP addresses with this prefix as parent.
-
-        In a future release, if this prefix is a pool, it will return IP addresses within the pool's address space.
+        Return IP addresses with this prefix as parent including child prefixes IP addresses.
 
         Returns:
             IPAddress QuerySet
         """
-        # Question: This is a possible fix for this PR; should this be uncommented?
-        # 3.0 TODO: uncomment this to enable this logic
-        # if self.type == choices.PrefixTypeChoices.TYPE_POOL:
-        #     return IPAddress.objects.filter(
-        #         parent__namespace=self.namespace, host__gte=self.network, host__lte=self.broadcast
-        #     )
-        # else:
-        return self.ip_addresses.all()
+        return IPAddress.objects.filter(
+            parent__namespace=self.namespace, host__gte=self.network, host__lte=self.broadcast
+        )
 
     def get_first_available_prefix(self):
         """

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -891,7 +891,7 @@ class Prefix(PrimaryModel):
 
     def get_all_ips(self):
         """
-        Return IP addresses with this prefix as parent including child prefixes IP addresses.
+        Return all IP addresses contained within this prefix, including child prefixes' IP addresses.
 
         Returns:
             IPAddress QuerySet

--- a/nautobot/ipam/templates/ipam/prefix.html
+++ b/nautobot/ipam/templates/ipam/prefix.html
@@ -33,7 +33,7 @@
         </li>
         {% if perms.ipam.view_ipaddress %}
             <li role="presentation"{% if active_tab == 'ip-addresses' %} class="active"{% endif %}>
-                <a href="{% url 'ipam:prefix_ipaddresses' pk=object.pk %}">IP Addresses <span class="badge">{{ object.get_child_ips.count }}</span></a>
+                <a href="{% url 'ipam:prefix_ipaddresses' pk=object.pk %}">IP Addresses <span class="badge">{{ object.get_all_ips.count }}</span></a>
             </li>
         {% endif %}
 {% endblock extra_nav_tabs %}

--- a/nautobot/ipam/tests/test_views.py
+++ b/nautobot/ipam/tests/test_views.py
@@ -338,18 +338,18 @@ class PrefixTestCase(ViewTestCases.PrimaryObjectViewTestCase, ViewTestCases.List
             status=self.statuses[1],
         )
         Prefix.objects.create(
-            prefix="5.5.10.2/30",
+            prefix="5.5.10.0/30",
             namespace=self.namespace,
             type=PrefixTypeChoices.TYPE_POOL,
             status=self.statuses[1],
         )
         IPAddress.objects.create(
-            address="5.5.10.1/32",
+            address="5.5.10.1/23",
             status=ip_status,
             namespace=self.namespace,
         )
         IPAddress.objects.create(
-            address="5.5.10.4/30",
+            address="5.5.10.4/23",
             status=ip_status,
             namespace=self.namespace,
         )
@@ -358,8 +358,8 @@ class PrefixTestCase(ViewTestCases.PrimaryObjectViewTestCase, ViewTestCases.List
         self.assertHttpStatus(response, 200)
         content = response.content.decode(response.charset)
         # This validates that both parent prefix and child prefix IPAddresses are present in parent prefix IPAddresses list
-        self.assertIn("5.5.10.1/32", strip_tags(content))
-        self.assertIn("5.5.10.4/30", strip_tags(content))
+        self.assertIn("5.5.10.1/23", strip_tags(content))
+        self.assertIn("5.5.10.4/23", strip_tags(content))
         print(response.content.decode(response.charset))
         ip_address_tab = (
             f'<li role="presentation" class="active"><a href="{url}">IP Addresses <span class="badge">2</span></a></li>'

--- a/nautobot/ipam/tests/test_views.py
+++ b/nautobot/ipam/tests/test_views.py
@@ -353,14 +353,18 @@ class PrefixTestCase(ViewTestCases.PrimaryObjectViewTestCase, ViewTestCases.List
             status=ip_status,
             namespace=self.namespace,
         )
-        response = self.client.get(reverse("ipam:prefix_ipaddresses", args=(instance.pk,)))
+        url = reverse("ipam:prefix_ipaddresses", args=(instance.pk,))
+        response = self.client.get(url)
         self.assertHttpStatus(response, 200)
-        content = extract_page_body(response.content.decode(response.charset))
+        content = response.content.decode(response.charset)
         # This validates that both parent prefix and child prefix IPAddresses are present in parent prefix IPAddresses list
-        # TODO(timizuo): Also test for IP Addresses count is correct after count is fixed in `prefix_ipaddresses.html`;
-        # currently it shows 1 instead of 2
         self.assertIn("5.5.10.1/32", strip_tags(content))
         self.assertIn("5.5.10.4/30", strip_tags(content))
+        print(response.content.decode(response.charset))
+        ip_address_tab = (
+            f'<li role="presentation" class="active"><a href="{url}">IP Addresses <span class="badge">2</span></a></li>'
+        )
+        self.assertInHTML(ip_address_tab, content)
 
 
 class IPAddressTestCase(ViewTestCases.PrimaryObjectViewTestCase):

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -521,8 +521,9 @@ class PrefixIPAddressesView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Find all IPAddresses belonging to this Prefix
+        descendants = instance.descendants(include_self=True)
         ipaddresses = (
-            instance.ip_addresses.all()
+            IPAddress.objects.filter(parent__in=descendants)
             .restrict(request.user, "view")
             .select_related("role", "status", "tenant")
             .prefetch_related("primary_ip4_for", "primary_ip6_for")

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -521,9 +521,8 @@ class PrefixIPAddressesView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Find all IPAddresses belonging to this Prefix
-        descendants = instance.descendants(include_self=True)
         ipaddresses = (
-            IPAddress.objects.filter(parent__in=descendants)
+            instance.get_all_ips()
             .restrict(request.user, "view")
             .select_related("role", "status", "tenant")
             .prefetch_related("primary_ip4_for", "primary_ip6_for")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6170 


# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots

**Child Prefix and its IP**

![Screenshot 2024-09-25 at 10 28 17 PM](https://github.com/user-attachments/assets/18815359-a6ce-4f10-b8de-2077116c8263)

**Parent Prefix including Childs IPs**
![Screenshot 2024-09-27 at 3 01 18 PM](https://github.com/user-attachments/assets/679d7216-3afa-42eb-b1a3-5493dd3975ab)

<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
