### PR TITLE
increase the minimum number of content-types for MetadataTypes created by factories

### DIFF
--- a/changes/6308.housekeeping
+++ b/changes/6308.housekeeping
@@ -1,1 +1,1 @@
-Increase the minimum number of content-types for MetadataType instances created by MetadataTypeFactory.
+Increase the minimum number of content-types to three and capped the maximum to five for MetadataType instances created by MetadataTypeFactory.

--- a/changes/6308.housekeeping
+++ b/changes/6308.housekeeping
@@ -1,0 +1,1 @@
+Increase the minimum number of content-types for MetadataType instances created by factories.

--- a/changes/6308.housekeeping
+++ b/changes/6308.housekeeping
@@ -1,1 +1,1 @@
-Increase the minimum number of content-types for MetadataType instances created by factories.
+Increase the minimum number of content-types for MetadataType instances created by MetadataTypeFactory.

--- a/nautobot/extras/factory.py
+++ b/nautobot/extras/factory.py
@@ -246,7 +246,8 @@ class MetadataTypeFactory(PrimaryModelFactory):
                         lambda: ContentType.objects.filter(
                             FeatureQuery("metadata").get_query(), pk__in=existing_content_type_pks
                         ),
-                        minimum=1,
+                        minimum=3,
+                        maximum=5,
                     )
                 )
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes N/A
# What's Changed
increase the minimum number of content-types for MetadataTypes created by factories