### PR TITLE
Fix UI overflow issue Tenant Stats

### DIFF
--- a/changes/6158.fixed
+++ b/changes/6158.fixed
@@ -1,0 +1,1 @@
+Fixed a UI overflow issue with the Tenant Stats panel.

--- a/nautobot/tenancy/templates/tenancy/tenant.html
+++ b/nautobot/tenancy/templates/tenancy/tenant.html
@@ -42,7 +42,7 @@
             <div class="panel-heading">
                 <strong>Stats</strong>
             </div>
-            <div class="row panel-body">
+            <div class="panel-body">
                 <div class="col-md-4 text-center">
                     <h2><a href="{% url 'circuits:circuit_list' %}?tenant={{ object.name }}" class="btn {% if stats.circuit_count %}btn-primary{% else %}btn-default{% endif %} btn-lg">{{ stats.circuit_count }}</a></h2>
                     <p>Circuits</p>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6158 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Fixes the Stats Panel render issue on Tenants.  The Location Stats panel did not have this same issue.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Before: 
![image](https://github.com/user-attachments/assets/a98a0052-9bbd-4394-8522-01883233f381)

After:
![image](https://github.com/user-attachments/assets/abab8743-16c4-404f-aca3-48c7fe9d1913)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
