### PR TITLE
A number of various fixes

### DIFF
--- a/changes/6205.changed
+++ b/changes/6205.changed
@@ -1,0 +1,1 @@
+Changed initial `Nautobot initialized!` message logged on startup to include the Nautobot version number.

--- a/changes/xxxx.fixed
+++ b/changes/xxxx.fixed
@@ -1,0 +1,1 @@
+Fixed duplicate loading of `nautobot_config.py` during Nautobot startup.

--- a/changes/xxxx.housekeeping
+++ b/changes/xxxx.housekeeping
@@ -1,0 +1,4 @@
+Fixed an error when rerunning parallel tests with a cached database and test factories enabled.
+Fixed a permission-denied error on the `MEDIA_ROOT` volume when running the local development environment with `docker-compose.final.yml`.
+Increased the healthcheck start_period in the local development environment to 10 minutes.
+Added `--remove-orphans` to the docker compose commands for `invoke stop` and `invoke destroy`.

--- a/development/docker-compose.final.yml
+++ b/development/docker-compose.final.yml
@@ -1,14 +1,28 @@
 # Used to run the final container images vs the dev containers
 ---
 services:
+  # The final image runs as user "nautobot", not as root, so we have to fix ownership of the media_root volume
+  # to avoid a "permission denied" error at startup.
+  permission_fixup:
+    image: "local/nautobot-dev:local-py${PYTHON_VER}"
+    restart: "no"
+    entrypoint: "/bin/sh -c 'chown nautobot:nautobot /opt/nautobot/media'"
+    volumes:
+      - media_root:/opt/nautobot/media
   nautobot:
     build:
       target: final
     image: "local/nautobot-final:local-py${PYTHON_VER}"
     ports:
       - 8443:8443
+    depends_on:
+      - permission_fixup
   celery_worker:
     image: "local/nautobot-final:local-py${PYTHON_VER}"
     entrypoint: "nautobot-server celery worker -l INFO --events"
+    depends_on:
+      - permission_fixup
   celery_beat:
     image: "local/nautobot-final:local-py${PYTHON_VER}"
+    depends_on:
+      - permission_fixup

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
       target: dev
+    healthcheck:
+      start_period: 10m
     image: "local/nautobot-dev:local-py${PYTHON_VER}"
     ports:
       - "8080:8080"

--- a/nautobot/__init__.py
+++ b/nautobot/__init__.py
@@ -1,6 +1,7 @@
 from importlib import metadata
 import logging
 import os
+import sys
 
 import django
 
@@ -28,8 +29,9 @@ def setup(config_path=None):
     # Point Django to our 'nautobot_config' pseudo-module that we'll load from the provided config path
     os.environ["DJANGO_SETTINGS_MODULE"] = "nautobot_config"
 
-    load_settings(config_path)
+    if "nautobot_config" not in sys.modules:
+        load_settings(config_path)
     django.setup()
 
-    logger.info("Nautobot initialized!")
+    logger.info("Nautobot %s initialized!", __version__)
     __initialized = True

--- a/nautobot/core/tests/runner.py
+++ b/nautobot/core/tests/runner.py
@@ -157,8 +157,9 @@ class NautobotTestRunner(DiscoverRunner):
                                     suffix=str(index + 1),
                                     verbosity=self.verbosity,
                                     keepdb=self.keepdb
-                                    # Extra check added for Nautobot:
-                                    and self.reusedb,
+                                    # Extra checks added for Nautobot:
+                                    and self.reusedb
+                                    and not settings.TEST_USE_FACTORIES,  # w/ factory data, clones can't be reused
                                 )
 
                 # Configure all other connections as mirrors of the first one
@@ -188,7 +189,9 @@ class NautobotTestRunner(DiscoverRunner):
                         connection.creation.destroy_test_db(
                             suffix=str(index + 1),
                             verbosity=self.verbosity,
-                            keepdb=self.keepdb,
+                            keepdb=self.keepdb
+                            # Extra check added for Nautobot
+                            and not settings.TEST_USE_FACTORIES,  # with factory data, clones cannot be reused
                         )
 
                 # Extra block added for Nautobot

--- a/tasks.py
+++ b/tasks.py
@@ -408,7 +408,7 @@ def stop(context, service=None):
     """Stop Nautobot and its dependencies."""
     print("Stopping Nautobot...")
     if not service:
-        docker_compose(context, "--profile '*' down")
+        docker_compose(context, "--profile '*' down --remove-orphans")
     else:
         docker_compose(context, "stop", service=service)
 
@@ -417,7 +417,7 @@ def stop(context, service=None):
 def destroy(context):
     """Destroy all containers and volumes."""
     print("Destroying Nautobot...")
-    docker_compose(context, "down --volumes")
+    docker_compose(context, "down --volumes --remove-orphans")
 
 
 @task


### PR DESCRIPTION
# Closes #6205

# What's Changed

- Add version information to `Nautobot initialized!` log message (fixes #6205, backport from #6312)
- Fix duplicate loading of `nautobot_config.py` during startup (backport from #6312)
   - In testing this with `final` image, I uncovered the need for a couple more fixes:
       - Add a container to `docker-compose.final.yml` to chown the MEDIA_ROOT volume from `root:root` to `nautobot:nautobot`
       - Ensure that `invoke stop` and `invoke destroy` remove orphan containers, such as the above added one
- Fix regression introduced in #6285 that made reruns of parallel tests with `--keepdb` fail (backport from #6312)
- Increase healthcheck start_period to 10 minutes (currently just in the dev environment, not the main Dockerfile) as our number of migrations keeps growing

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
