### PR TITLE
Improve error handling in Celery inspect

### DIFF
--- a/changes/6299.dependencies
+++ b/changes/6299.dependencies
@@ -1,0 +1,1 @@
+Added a direct dependency on `kombu` to guarantee the presence of some essential fixes for this Celery dependency.

--- a/changes/6299.fixed
+++ b/changes/6299.fixed
@@ -1,0 +1,1 @@
+Added retry logic and error handling for several cases where an intermittent Redis connection error could cause Celery to throw an exception.

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -24,6 +24,7 @@ from graphql import get_default_backend
 from graphql.execution import ExecutionResult
 from graphql.execution.middleware import MiddlewareManager
 from graphql.type.schema import GraphQLSchema
+import redis.exceptions
 from rest_framework import routers, status
 from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.permissions import IsAuthenticated
@@ -57,6 +58,10 @@ HTTP_ACTIONS = {
     "PATCH": "change",
     "DELETE": "delete",
 }
+
+
+logger = logging.getLogger(__name__)
+
 
 #
 # Mixins
@@ -467,7 +472,16 @@ class StatusView(NautobotAPIVersionMixin, APIView):
         nautobot_apps = dict(sorted(nautobot_apps.items()))
 
         # Gather Celery workers
-        workers = celery_app.control.inspect().active()  # list or None
+        try:
+            workers = celery_app.control.inspect().active()  # list or None
+        except redis.exceptions.ConnectionError:
+            # Celery seems to be not smart enough to auto-retry on intermittent failures, so let's do it ourselves:
+            try:
+                workers = celery_app.control.inspect().active()  # list or None
+            except redis.exceptions.ConnectionError as err:
+                logger.error("Repeated ConnectionError from Celery/Redis: %s", err)
+                workers = None
+
         worker_count = len(workers) if workers is not None else 0
 
         return Response(
@@ -872,7 +886,6 @@ class GetObjectCountsView(NautobotAPIVersionMixin, APIView):
             try:
                 data["url"] = django_reverse(get_route_for_model(model, "list"))
             except NoReverseMatch:
-                logger = logging.getLogger(__name__)
                 route = get_route_for_model(model, "list")
                 logger.warning(f"Handled expected exception when generating filter field: {route}")
             manager = model.objects
@@ -975,7 +988,6 @@ class GetFilterSetFieldDOMElementAPIView(NautobotAPIVersionMixin, APIView):
             # Cant determine the exceptions to handle because any exception could be raised,
             # e.g InterfaceForm would raise a ObjectDoesNotExist Error since no device was provided
             # While other forms might raise other errors, also if model_form is None a TypeError would be raised.
-            logger = logging.getLogger(__name__)
             logger.debug(f"Handled expected exception when generating filter field: {err}")
 
             # Create a temporary form and get a BoundField for the specified field

--- a/nautobot/extras/tests/test_utils.py
+++ b/nautobot/extras/tests/test_utils.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+from django.core.cache import cache
+
 from nautobot.core.testing import TestCase
 from nautobot.extras.registry import registry
 from nautobot.extras.utils import get_celery_queues, get_worker_count, populate_model_features_registry
@@ -17,6 +19,7 @@ class UtilsTestCase(TestCase):
             self.assertDictEqual(get_celery_queues(), {"queue1": 1})
 
         with self.subTest("2 workers 2 shared queues"):
+            cache.clear()
             mock_active_queues.return_value = {
                 "celery@worker1": [{"name": "queue1"}, {"name": "queue2"}],
                 "celery@worker2": [{"name": "queue1"}, {"name": "queue2"}],
@@ -24,6 +27,7 @@ class UtilsTestCase(TestCase):
             self.assertDictEqual(get_celery_queues(), {"queue1": 2, "queue2": 2})
 
         with self.subTest("2 workers 2 individual queues"):
+            cache.clear()
             mock_active_queues.return_value = {
                 "celery@worker1": [{"name": "queue1"}],
                 "celery@worker2": [{"name": "queue2"}],
@@ -31,6 +35,7 @@ class UtilsTestCase(TestCase):
             self.assertDictEqual(get_celery_queues(), {"queue1": 1, "queue2": 1})
 
         with self.subTest("2 workers 3 queues"):
+            cache.clear()
             mock_active_queues.return_value = {
                 "celery@worker1": [{"name": "queue1"}, {"name": "queue3"}],
                 "celery@worker2": [{"name": "queue2"}],

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -366,17 +366,31 @@ def get_celery_queues():
     """
     from nautobot.core.celery import app  # prevent circular import
 
-    celery_queues = {}
+    celery_queues = None
+    with contextlib.suppress(redis.exceptions.ConnectionError):
+        celery_queues = cache.get("nautobot.extras.utils.get_celery_queues")
 
-    celery_inspect = app.control.inspect()
-    active_queues = celery_inspect.active_queues()
-    if active_queues is None:
-        return celery_queues
-    for task_queue_list in active_queues.values():
-        distinct_queues = {q["name"] for q in task_queue_list}
-        for queue in distinct_queues:
-            celery_queues.setdefault(queue, 0)
-            celery_queues[queue] += 1
+    if celery_queues is None:
+        celery_queues = {}
+        celery_inspect = app.control.inspect()
+        try:
+            active_queues = celery_inspect.active_queues()
+        except redis.exceptions.ConnectionError:
+            # Celery seems to be not smart enough to auto-retry on intermittent failures, so let's do it ourselves:
+            try:
+                active_queues = celery_inspect.active_queues()
+            except redis.exceptions.ConnectionError as err:
+                logger.error("Repeated ConnectionError from Celery/Redis: %s", err)
+                active_queues = None
+        if active_queues is None:
+            return celery_queues
+        for task_queue_list in active_queues.values():
+            distinct_queues = {q["name"] for q in task_queue_list}
+            for queue in distinct_queues:
+                celery_queues.setdefault(queue, 0)
+                celery_queues[queue] += 1
+        with contextlib.suppress(redis.exceptions.ConnectionError):
+            cache.set("nautobot.extras.utils.get_celery_queues", celery_queues, timeout=5)
 
     return celery_queues
 

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -387,8 +387,7 @@ def get_celery_queues():
         for task_queue_list in active_queues.values():
             distinct_queues = {q["name"] for q in task_queue_list}
             for queue in distinct_queues:
-                celery_queues.setdefault(queue, 0)
-                celery_queues[queue] += 1
+                celery_queues[queue] = celery_queues.get(queue, 0) + 1
         with contextlib.suppress(redis.exceptions.ConnectionError):
             cache.set("nautobot.extras.utils.get_celery_queues", celery_queues, timeout=5)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1648,30 +1648,31 @@ yamlordereddictloader = "*"
 
 [[package]]
 name = "kombu"
-version = "5.3.7"
+version = "5.4.2"
 description = "Messaging library for Python."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "kombu-5.3.7-py3-none-any.whl", hash = "sha256:5634c511926309c7f9789f1433e9ed402616b56836ef9878f01bd59267b4c7a9"},
-    {file = "kombu-5.3.7.tar.gz", hash = "sha256:011c4cd9a355c14a1de8d35d257314a1d2456d52b7140388561acac3cf1a97bf"},
+    {file = "kombu-5.4.2-py3-none-any.whl", hash = "sha256:14212f5ccf022fc0a70453bb025a1dcc32782a588c49ea866884047d66e14763"},
+    {file = "kombu-5.4.2.tar.gz", hash = "sha256:eef572dd2fd9fc614b37580e3caeafdd5af46c1eff31e7fba89138cdb406f2cf"},
 ]
 
 [package.dependencies]
 amqp = ">=5.1.1,<6.0.0"
 "backports.zoneinfo" = {version = ">=0.2.1", extras = ["tzdata"], markers = "python_version < \"3.9\""}
-typing-extensions = {version = "*", markers = "python_version < \"3.10\""}
-vine = "*"
+typing-extensions = {version = "4.12.2", markers = "python_version < \"3.10\""}
+tzdata = {version = "*", markers = "python_version >= \"3.9\""}
+vine = "5.1.0"
 
 [package.extras]
 azureservicebus = ["azure-servicebus (>=7.10.0)"]
 azurestoragequeues = ["azure-identity (>=1.12.0)", "azure-storage-queue (>=12.6.0)"]
 confluentkafka = ["confluent-kafka (>=2.2.0)"]
-consul = ["python-consul2"]
+consul = ["python-consul2 (==0.1.5)"]
 librabbitmq = ["librabbitmq (>=2.0.0)"]
 mongodb = ["pymongo (>=4.1.1)"]
-msgpack = ["msgpack"]
-pyro = ["pyro4"]
+msgpack = ["msgpack (==1.1.0)"]
+pyro = ["pyro4 (==4.82)"]
 qpid = ["qpid-python (>=0.26)", "qpid-tools (>=0.26)"]
 redis = ["redis (>=4.5.2,!=4.5.5,!=5.0.2)"]
 slmq = ["softlayer-messaging (>=1.0.3)"]
@@ -2188,7 +2189,6 @@ optional = false
 python-versions = ">=3.6"
 files = [
     {file = "mkdocs-redirects-1.2.1.tar.gz", hash = "sha256:9420066d70e2a6bb357adf86e67023dcdca1857f97f07c7fe450f8f1fb42f861"},
-    {file = "mkdocs_redirects-1.2.1-py3-none-any.whl", hash = "sha256:497089f9e0219e7389304cffefccdfa1cac5ff9509f2cb706f4c9b221726dffb"},
 ]
 
 [package.dependencies]
@@ -2683,7 +2683,6 @@ files = [
     {file = "psycopg2_binary-2.9.9-cp311-cp311-win32.whl", hash = "sha256:dc4926288b2a3e9fd7b50dc6a1909a13bbdadfc67d93f3374d984e56f885579d"},
     {file = "psycopg2_binary-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:b76bedd166805480ab069612119ea636f5ab8f8771e640ae103e05a4aae3e417"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8532fd6e6e2dc57bcb3bc90b079c60de896d2128c5d9d6f24a63875a95a088cf"},
-    {file = "psycopg2_binary-2.9.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0605eaed3eb239e87df0d5e3c6489daae3f7388d455d0c0b4df899519c6a38d"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f8544b092a29a6ddd72f3556a9fcf249ec412e10ad28be6a0c0d948924f2212"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2d423c8d8a3c82d08fe8af900ad5b613ce3632a1249fd6a223941d0735fce493"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e5afae772c00980525f6d6ecf7cbca55676296b580c0e6abb407f15f3706996"},
@@ -2692,8 +2691,6 @@ files = [
     {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:cb16c65dcb648d0a43a2521f2f0a2300f40639f6f8c1ecbc662141e4e3e1ee07"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:911dda9c487075abd54e644ccdf5e5c16773470a6a5d3826fda76699410066fb"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:57fede879f08d23c85140a360c6a77709113efd1c993923c59fde17aa27599fe"},
-    {file = "psycopg2_binary-2.9.9-cp312-cp312-win32.whl", hash = "sha256:64cf30263844fa208851ebb13b0732ce674d8ec6a0c86a4e160495d299ba3c93"},
-    {file = "psycopg2_binary-2.9.9-cp312-cp312-win_amd64.whl", hash = "sha256:81ff62668af011f9a48787564ab7eded4e9fb17a4a6a74af5ffa6a457400d2ab"},
     {file = "psycopg2_binary-2.9.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2293b001e319ab0d869d660a704942c9e2cce19745262a8aba2115ef41a0a42a"},
     {file = "psycopg2_binary-2.9.9-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03ef7df18daf2c4c07e2695e8cfd5ee7f748a1d54d802330985a78d2a5a6dca9"},
     {file = "psycopg2_binary-2.9.9-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a602ea5aff39bb9fac6308e9c9d82b9a35c2bf288e184a816002c9fae930b77"},
@@ -4348,4 +4345,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "8bea368ca6e6217b62ffac4628ebc39cad3777751a1a511c638671306cfd0aac"
+content-hash = "24e807cbf8f4c5977ac68db220b664bb083eb423278ebab4f1eacd6734d76ebd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ graphene-django-optimizer = "~0.8.0"
 Jinja2 = "~3.1.4"
 # Optional data validation of config contexts - loose dependency since our usage is light but apps may be more specific
 jsonschema = "^4.7.0"
+# Messaging library for Python - dependency of Celery
+# Included as an explicit dependency (for now?) to require a version with https://github.com/celery/kombu/pull/2007
+kombu = "~5.4.2"
 # Rendering of markdown files to HTML
 Markdown = "~3.6"
 # Escape text to use HTML and XML


### PR DESCRIPTION
# Closes #6299
# What's Changed

- In `get_celery_queues()`, add retry logic and error handling around the possibility that Celery `app.control.inspect.active_queues()` might throw an intermittent error such as "Connection closed by server". Verified the issue and fix manually by restarting the Redis service while refreshing a Job "run" view.
   - I also backported the short-term caching in this API that was added for `next` by #6154.
- `grep` identified two other cases where we were using `app.control.inspect`, one in the `/api/status/` view and one in the "Worker Status" view. Added and manually verified similar fixes there as well.
- Restarting the Redis service caused the Celery workers to lose their connectivity to Redis and fail to re-establish it. This was recently fixed upstream by celery/kombu#2007, so I've added a direct dependency on the latest version of `kombu` to guarantee the presence of that fix.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
