### PR TITLE
Fix DynamicGroup.group_type automatic setting

### DIFF
--- a/changes/6329.fixed
+++ b/changes/6329.fixed
@@ -1,0 +1,1 @@
+Added a data migration to fix DynamicGroup `group_type` values set incorrectly in upgrading to Nautobot 2.3.x.

--- a/nautobot/extras/migrations/0112_dynamic_group_group_type_data_migration.py
+++ b/nautobot/extras/migrations/0112_dynamic_group_group_type_data_migration.py
@@ -10,6 +10,9 @@ def set_dynamic_group_group_types(apps, schema_editor):
     # The group_type field defaults to TYPE_DYNAMIC_FILTER
     # There are no preexisting TYPE_STATIC groups as that's a new feature
     # Any group that has children should be converted to TYPE_DYNAMIC_SET
+    # NOTE: The below is actually incorrect (see migration 0116) as for some reason, during migrations ONLY,
+    # Django somehow swaps the `parent` and `children` relations on DynamicGroup such that the below actually detects
+    # the opposite set of groups from what would be expected.
     DynamicGroup.objects.filter(children__isnull=False).distinct().update(
         group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_SET
     )

--- a/nautobot/extras/migrations/0116_fix_dynamic_group_group_type_data_migration.py
+++ b/nautobot/extras/migrations/0116_fix_dynamic_group_group_type_data_migration.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+from nautobot.extras.utils import fixup_dynamic_group_group_types
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("extras", "0115_scheduledjob_time_zone"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=fixup_dynamic_group_group_types,
+            reverse_code=migrations.operations.special.RunPython.noop,
+        ),
+    ]

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -597,7 +597,7 @@ def fixup_null_statuses(*, model, model_contenttype, status_model):
         print(f"    Found and fixed {updated_count} instances of {model.__name__} that had null 'status' fields.")
 
 
-def fixup_dynamic_group_group_types(apps, *args, **kwargs):
+def fixup_dynamic_group_group_types(apps, *args, **kwargs):  # pylint: disable=redefined-outer-name
     """Set dynamic group group_type values correctly."""
     DynamicGroup = apps.get_model("extras", "DynamicGroup")
     DynamicGroupMembership = apps.get_model("extras", "DynamicGroupMembership")

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -21,7 +21,7 @@ from nautobot.core.choices import ColorChoices
 from nautobot.core.constants import CHARFIELD_MAX_LENGTH
 from nautobot.core.models.managers import TagsManager
 from nautobot.core.models.utils import find_models_with_matching_fields
-from nautobot.extras.choices import ObjectChangeActionChoices
+from nautobot.extras.choices import DynamicGroupTypeChoices, ObjectChangeActionChoices
 from nautobot.extras.constants import (
     CHANGELOG_MAX_CHANGE_CONTEXT_DETAIL,
     EXTRAS_FEATURES,
@@ -595,6 +595,32 @@ def fixup_null_statuses(*, model, model_contenttype, status_model):
         null_status.content_types.add(model_contenttype)
         updated_count = instances_to_fixup.update(status=null_status)
         print(f"    Found and fixed {updated_count} instances of {model.__name__} that had null 'status' fields.")
+
+
+def fixup_dynamic_group_group_types(apps, *args, **kwargs):
+    """Set dynamic group group_type values correctly."""
+    DynamicGroup = apps.get_model("extras", "DynamicGroup")
+    DynamicGroupMembership = apps.get_model("extras", "DynamicGroupMembership")
+    count_1 = count_2 = 0
+    # See note in migration 0112 - for some reason, if we were to do the "intuitive" thing, and call
+    # `DynamicGroup.objects.filter(children__isnull=False)`, we would unexpectedly get those groups for which their
+    # *parent* is non-null. The below is an alternate approach that should remain correct even if that issue gets fixed.
+    parent_group_names = set(DynamicGroupMembership.objects.values_list("parent_group__name", flat=True))
+    parent_groups_with_wrong_type = DynamicGroup.objects.filter(name__in=parent_group_names).exclude(
+        group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_SET
+    )
+    if parent_groups_with_wrong_type.exists():
+        count_1 = parent_groups_with_wrong_type.update(group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_SET)
+        print(f'\n    Found and fixed {count_1} DynamicGroup(s) that should be typed as "Group of groups".')
+
+    filter_groups_with_wrong_type = DynamicGroup.objects.exclude(filter__exact={}).exclude(
+        group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_FILTER
+    )
+    if filter_groups_with_wrong_type.exists():
+        count_2 = filter_groups_with_wrong_type.update(group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_FILTER)
+        print(f'\n    Found and fixed {count_2} DynamicGroup(s) that should be typed as "Filter-defined".')
+
+    return count_1, count_2
 
 
 def migrate_role_data(


### PR DESCRIPTION
# Closes #6329
# What's Changed

I still don't understand the cause, but confirmed that, as reported in #6329, extras migration 0112 is updating a queryset different than what it should - while it's calling `DynamicGroup.objects.filter(children__isnull=False)`, it's actually getting the set of DynamicGroups whose `parents` are non-null, resulting in some groups being incorrectly set to TYPE_DYNAMIC_SET that should remain TYPE_DYNAMIC_FILTER, and some remaining as TYPE_DYNAMIC_FILTER that should be set to TYPE_DYNAMIC_SET.

(FWIW, I verified that this query gives the expected results in `nbshell` - it seems to only be in the migration context that it behaves incorrectly. My best *guess* at the moment is that this might be because the migration doesn't explicitly specify the `through_fields` on the `ManyToManyField`, while the actual final model does do so. But that's only a guess.)

Because I don't fully understand the root cause, and because the above migration has been in the wild for several releases already, rather than try and fix that migration, I've instead added a new migration with new logic to fix up the incorrect data.

```
  Applying extras.0116_fix_dynamic_group_group_type_data_migration...
    Found and fixed 1 DynamicGroup(s) that should be typed as "Group of groups".

    Found and fixed 2 DynamicGroup(s) that should be typed as "Filter-defined".
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
