### PR TITLE
Enhancements to nautobot-server runjob

### DIFF
--- a/changes/6089.added
+++ b/changes/6089.added
@@ -1,1 +1,2 @@
 Added enforcement of the Job execution soft time limit to the `nautobot-server runjob --local ...` management command.
+Added automatic refreshing of Git repository Jobs to the `nautobot-server runjob` management command.

--- a/changes/6089.added
+++ b/changes/6089.added
@@ -1,0 +1,1 @@
+Added enforcement of the Job execution soft time limit to the `nautobot-server runjob --local ...` management command.

--- a/changes/6089.fixed
+++ b/changes/6089.fixed
@@ -1,0 +1,1 @@
+Fixed warning message `No sanitizer support for <class 'NoneType'> data` emitted by the `nautobot-server runjob --local ...` command.

--- a/nautobot/extras/management/commands/runjob.py
+++ b/nautobot/extras/management/commands/runjob.py
@@ -38,10 +38,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if "." not in options["job"]:
             raise CommandError('Job must be specified in the Python module form: "<module_name>.<JobClassName>"')
-        job_class = get_job(options["job"])
-        if not job_class:
-            raise CommandError(f'Job "{options["job"]}" not found')
-
         User = get_user_model()
         try:
             user = User.objects.get(username=options["username"])
@@ -54,6 +50,9 @@ class Command(BaseCommand):
                 data = json.loads(options["data"])
         except json.decoder.JSONDecodeError as error:
             raise CommandError(f"Invalid JSON data:\n{error!s}") from error
+
+        if not get_job(options["job"], reload=True):
+            raise CommandError(f'Job "{options["job"]}" not found')
 
         try:
             job_model = Job.objects.get_for_class_path(options["job"])

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -829,6 +829,7 @@ class JobResult(BaseModel, CustomFieldModel):
             redirect_logger = get_logger("celery.redirected")
             proxy = LoggingProxy(redirect_logger, app.conf.worker_redirect_stdouts_level)
             with contextlib.redirect_stdout(proxy), contextlib.redirect_stderr(proxy):
+
                 def alarm_handler(*args, **kwargs):
                     raise SoftTimeLimitExceeded()
 
@@ -856,9 +857,15 @@ class JobResult(BaseModel, CustomFieldModel):
                     "exc_message": sanitize(str(eager_result.result)),
                 }
             else:
-                job_result.result = sanitize(eager_result.result)
+                if eager_result.result is not None:
+                    job_result.result = sanitize(eager_result.result)
+                else:
+                    job_result.result = None
             job_result.status = eager_result.status
-            job_result.traceback = sanitize(eager_result.traceback)
+            if eager_result.traceback is not None:
+                job_result.traceback = sanitize(eager_result.traceback)
+            else:
+                job_result.traceback = None
             job_result.date_done = timezone.now()
             job_result.save()
         else:


### PR DESCRIPTION
# Closes #6089 
# What's Changed

- `nautobot-server runjob --local` now respects the Job's soft time limit and will raise a SoftTimeLimitExceeded exception as appropriate. (Enforcement of the hard time limit will be done by k8s in the future)
- `nautobot-server runjob --local` no longer emits warnings about `No sanitizer support for <class 'NoneType'> data` in some cases
- `nautobot-server runjob` (with or without `--local`) now calls `get_job(... reload=True)` to ensure it has the latest code from any relevant Git repository(s).

Not included in this PR: any changes related to runjob file inputs; they may be provided on the CLI only by creating a FileProxy DB record in advance and passing the PK of that record as the relevant Job data input; I verified that this works already without changes required.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
