### PR TITLE
Add exception handling removed from django-constance upstream

### DIFF
--- a/changes/6337.fixed
+++ b/changes/6337.fixed
@@ -1,0 +1,1 @@
+Added exception handling for Constance config lookups as `django-constance` 4.x removed some built-in exception handling.

--- a/nautobot/apps/config.py
+++ b/nautobot/apps/config.py
@@ -1,7 +1,11 @@
 """Helper code for loading values that may be defined in settings.py/nautobot_config.py *or* in django-constance."""
 
+import contextlib
+
 from constance import config
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import OperationalError, ProgrammingError
 
 
 def get_app_settings_or_config(app_name, variable_name):
@@ -9,4 +13,7 @@ def get_app_settings_or_config(app_name, variable_name):
     # Explicitly set in settings.py or nautobot_config.py takes precedence, for now
     if variable_name in settings.PLUGINS_CONFIG[app_name]:
         return settings.PLUGINS_CONFIG[app_name][variable_name]
-    return getattr(config, f"{app_name}__{variable_name}")
+    # django-constance 4.x removed some built-in error handling here, so we have to do it ourselves now
+    with contextlib.suppress(ObjectDoesNotExist, OperationalError, ProgrammingError):
+        return getattr(config, f"{app_name}__{variable_name}")
+    return None

--- a/nautobot/core/utils/config.py
+++ b/nautobot/core/utils/config.py
@@ -1,7 +1,11 @@
 """Helper code for loading values that may be defined in settings.py/nautobot_config.py *or* in django-constance."""
 
+import contextlib
+
 from constance import config
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import OperationalError, ProgrammingError
 
 
 def get_settings_or_config(variable_name):
@@ -9,4 +13,7 @@ def get_settings_or_config(variable_name):
     # Explicitly set in settings.py or nautobot_config.py takes precedence, for now
     if hasattr(settings, variable_name):
         return getattr(settings, variable_name)
-    return getattr(config, variable_name)
+    # django-constance 4.x removed some built-in error handling here, so we have to do it ourselves now
+    with contextlib.suppress(ObjectDoesNotExist, OperationalError, ProgrammingError):
+        return getattr(config, variable_name)
+    return None


### PR DESCRIPTION

# Closes #6337
# What's Changed

In https://github.com/jazzband/django-constance/pull/538, `django-constance` v4.x removed some exception handling for the case where an attempt is made to read configs from Constance before the database is ready to provide them (e.g., migrations have not yet been run). When redeploying the `next` sandbox, we discovered that there are cases in some of our Apps that were relying on the existing exception handling because they're trying to check configs at app startup to determine e.g. which app features to enable.

The fix is simply to add our own exception handling to our `get_settings_or_config` and `get_app_settings_or_config` APIs. Note that these APIs are not designed for the caller to specify a default (fallback) value as *normally* the configuration of Constance attributes includes specification of that default value. *Rather than attempt to introspect the Constance configuration to find that default value, for now the exception case of these APIs is just returning `None`, so any app using these APIs must be aware of this possible return value and its significance.* 

Manual testing verified that startup with an empty database and `nautobot_chatops` enabled now is successful instead of erroring out.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
