### PR TITLE
allow id to be provided at object creation time

### DIFF
--- a/changes/6166.changed
+++ b/changes/6166.changed
@@ -1,0 +1,1 @@
+Enhanced the REST API to generally make it possible to create objects with known ids on request.

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -134,6 +134,7 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializ
 
     serializer_related_field = NautobotHyperlinkedRelatedField
 
+    id = serializers.UUIDField(read_only=False, default=serializers.CreateOnlyDefault(uuid.uuid4))
     display = serializers.SerializerMethodField(read_only=True, help_text="Human friendly display value")
     object_type = ObjectTypeField()
     # composite_key = serializers.SerializerMethodField()  # TODO: Revisit if we reintroduce composite keys

--- a/nautobot/core/testing/api.py
+++ b/nautobot/core/testing/api.py
@@ -707,7 +707,11 @@ class APIViewTestCases:
             self.assertHttpStatus(response, status.HTTP_201_CREATED, csv_data)
             # Note that create via CSV is always treated as a bulk-create, and so the response is always a list of dicts
             new_instance = self._get_queryset().get(pk=response.data[0]["id"])
-            self.assertNotEqual(new_instance.pk, orig_pk)
+            if isinstance(orig_pk, int):
+                self.assertNotEqual(new_instance.pk, orig_pk)
+            else:
+                # for our non-integer PKs, we're expecting the creation to respect the requested PK
+                self.assertEqual(new_instance.pk, orig_pk)
 
             new_serializer = serializer_class(new_instance, context={"request": None})
             new_data = new_serializer.data

--- a/nautobot/core/tests/test_csv.py
+++ b/nautobot/core/tests/test_csv.py
@@ -1,3 +1,6 @@
+import csv
+import io
+
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings, RequestFactory, TestCase
 from django.urls import reverse
@@ -261,9 +264,28 @@ class CSVParsingRelatedTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         response_data = response.content.decode(response.charset)
 
-        # Replace Device Name
-        import_data = response_data.replace("TestDevice1", "TestDevice3").replace("TestDevice2", "")
-        data = {"csv_data": import_data}
+        # parse the csv data
+        csv_reader = csv.DictReader(response_data.splitlines())
+        # remove the 'id' column so that all the items are imported new
+        fieldnames = [field for field in csv_reader.fieldnames if field != "id"]
+        # read all entries into a list
+        response_csv = list(csv_reader)
+
+        # mutate our data for testing purposes
+        for row in response_csv:
+            if row["name"] == "TestDevice1":
+                row["name"] = "TestDevice3"
+            elif row["name"] == "TestDevice2":
+                row["name"] = ""
+
+        # prep our data to write out
+        with io.StringIO() as import_csv:
+            writer = csv.DictWriter(import_csv, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in response_csv:
+                filtered_row = {key: row[key] for key in fieldnames}
+                writer.writerow(filtered_row)
+            data = {"csv_data": import_csv.getvalue()}
         url = reverse("dcim:device_import")
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 200)

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -270,6 +270,7 @@ class ContactAssociationSerializer(NautobotModelSerializer):
 
 
 class ContentTypeSerializer(BaseModelSerializer):
+    id = serializers.IntegerField(read_only=True)
     url = serializers.HyperlinkedIdentityField(view_name="extras-api:contenttype-detail")
     display = serializers.SerializerMethodField()
 

--- a/nautobot/users/api/serializers.py
+++ b/nautobot/users/api/serializers.py
@@ -59,6 +59,7 @@ class UserSerializer(ValidatedModelSerializer):
 
 
 class GroupSerializer(ValidatedModelSerializer):
+    id = serializers.IntegerField(read_only=True)
     url = serializers.HyperlinkedIdentityField(view_name="users-api:group-detail")
     user_count = serializers.IntegerField(read_only=True)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6166 
# What's Changed
When creating an object via the API, allow for the id to be defined to allow for idempotent object creation/updating, which is commonly referred to as upsert. This allows for bulk upload of records where some entries might already exist without creating duplicate entries.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
