### PR TITLE
Improve constance error handling further

### DIFF
--- a/changes/6337.fixed
+++ b/changes/6337.fixed
@@ -1,1 +1,1 @@
-Added exception handling for Constance config lookups as `django-constance` 4.x removed some built-in exception handling.
+Added exception handling and fallback logic for Constance config lookups as `django-constance` 4.x removed some built-in exception handling.

--- a/nautobot/apps/config.py
+++ b/nautobot/apps/config.py
@@ -1,19 +1,41 @@
 """Helper code for loading values that may be defined in settings.py/nautobot_config.py *or* in django-constance."""
 
 import contextlib
+import logging
 
 from constance import config
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import OperationalError, ProgrammingError
 
+logger = logging.getLogger(__name__)
 
-def get_app_settings_or_config(app_name, variable_name):
-    """Get a value from Django settings (if specified there) or Constance configuration (otherwise)."""
+
+def get_app_settings_or_config(app_name, variable_name, fallback=None):
+    """
+    Get a value from Django settings.PLUGINS_CONFIG (if specified there) or Constance configuration (otherwise).
+
+    The fallback value is returned *only* if the requested variable cannot be found at all - this is an error case,
+    and will generate warning logs.
+    """
     # Explicitly set in settings.py or nautobot_config.py takes precedence, for now
     if variable_name in settings.PLUGINS_CONFIG[app_name]:
         return settings.PLUGINS_CONFIG[app_name][variable_name]
     # django-constance 4.x removed some built-in error handling here, so we have to do it ourselves now
+    constance_key = f"{app_name}__{variable_name}"
     with contextlib.suppress(ObjectDoesNotExist, OperationalError, ProgrammingError):
-        return getattr(config, f"{app_name}__{variable_name}")
-    return None
+        return getattr(config, constance_key)
+    logger.warning(
+        '"PLUGINS_CONFIG[%r][%r]" is not in settings, and could not read from the Constance database table '
+        "(perhaps not initialized yet?)",
+        app_name,
+        variable_name,
+    )
+    if constance_key in settings.CONSTANCE_CONFIG:
+        default = settings.CONSTANCE_CONFIG[constance_key][0]
+        logger.warning('Using default value of "%s" from Constance configuration for "%s"', default, constance_key)
+        return default
+    logger.warning(
+        'Constance configuration does not include an entry for "%s" - must return %s', constance_key, fallback
+    )
+    return fallback

--- a/nautobot/core/api/pagination.py
+++ b/nautobot/core/api/pagination.py
@@ -1,5 +1,6 @@
 from rest_framework.pagination import LimitOffsetPagination
 
+from nautobot.core.constants import MAX_PAGE_SIZE_DEFAULT, PAGINATE_COUNT_DEFAULT
 from nautobot.core.utils.config import get_settings_or_config
 
 
@@ -38,7 +39,7 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
                 if limit < 0:
                     raise ValueError()
                 # Enforce maximum page size, if defined
-                max_page_size = get_settings_or_config("MAX_PAGE_SIZE")
+                max_page_size = get_settings_or_config("MAX_PAGE_SIZE", fallback=MAX_PAGE_SIZE_DEFAULT)
                 if max_page_size:
                     if limit == 0:
                         return max_page_size
@@ -48,7 +49,7 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
             except (KeyError, ValueError):
                 pass
 
-        return get_settings_or_config("PAGINATE_COUNT")
+        return get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
 
     def get_next_link(self):
         # Pagination has been disabled

--- a/nautobot/core/constants.py
+++ b/nautobot/core/constants.py
@@ -110,6 +110,10 @@ CONFIG_SETTING_SEPARATOR = ","
 
 CHARFIELD_MAX_LENGTH = 255
 
+# Default values for pagination settings.
+MAX_PAGE_SIZE_DEFAULT = 1000
+PAGINATE_COUNT_DEFAULT = 50
+
 # Models excluded from the global search list
 GLOBAL_SEARCH_EXCLUDE_LIST = [
     "anotherexamplemodel",

--- a/nautobot/core/jobs/cleanup.py
+++ b/nautobot/core/jobs/cleanup.py
@@ -50,7 +50,7 @@ class LogsCleanup(Job):
 
     def run(self, *, cleanup_types, max_age=None):
         if max_age in (None, ""):
-            max_age = get_settings_or_config("CHANGELOG_RETENTION")
+            max_age = get_settings_or_config("CHANGELOG_RETENTION", fallback=90)
             if max_age == 0:
                 self.logger.warning(
                     "CHANGELOG_RETENTION setting is set to zero, disabling this Job. "

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -10,7 +10,11 @@ import django.forms
 from django.utils.safestring import mark_safe
 
 from nautobot import __version__
-from nautobot.core.constants import CONFIG_SETTING_SEPARATOR as _CONFIG_SETTING_SEPARATOR
+from nautobot.core.constants import (
+    CONFIG_SETTING_SEPARATOR as _CONFIG_SETTING_SEPARATOR,
+    MAX_PAGE_SIZE_DEFAULT as _MAX_PAGE_SIZE_DEFAULT,
+    PAGINATE_COUNT_DEFAULT as _PAGINATE_COUNT_DEFAULT,
+)
 from nautobot.core.settings_funcs import ConstanceConfigItem, is_truthy, parse_redis_connection
 
 #
@@ -726,13 +730,13 @@ CONSTANCE_CONFIG = {
         field_type=bool,
     ),
     "MAX_PAGE_SIZE": ConstanceConfigItem(
-        default=1000,
+        default=_MAX_PAGE_SIZE_DEFAULT,
         help_text="Maximum number of objects that a user can list in one UI page or one API call.\n"
         "If set to 0, a user can retrieve an unlimited number of objects.",
         field_type=int,
     ),
     "PAGINATE_COUNT": ConstanceConfigItem(
-        default=50,
+        default=_PAGINATE_COUNT_DEFAULT,
         help_text="Default number of objects to display per page when listing objects in the UI and/or REST API.",
         field_type=int,
     ),

--- a/nautobot/core/tasks.py
+++ b/nautobot/core/tasks.py
@@ -49,7 +49,7 @@ def get_releases(pre_releases=False):
     cache.set(
         "nautobot.core.releases.get_latest_release",
         max(releases),
-        config.get_settings_or_config("RELEASE_CHECK_TIMEOUT"),
+        config.get_settings_or_config("RELEASE_CHECK_TIMEOUT", fallback=24 * 3600),
     )
 
     # Since this is a Celery task, we can't return Version objects as they are not JSON serializable.

--- a/nautobot/core/templatetags/helpers.py
+++ b/nautobot/core/templatetags/helpers.py
@@ -21,6 +21,7 @@ import yaml
 
 from nautobot.apps.config import get_app_settings_or_config
 from nautobot.core import forms
+from nautobot.core.constants import PAGINATE_COUNT_DEFAULT
 from nautobot.core.utils import color, config, data, logging as nautobot_logging, lookup
 from nautobot.core.utils.requests import add_nautobot_version_query_param_to_url
 
@@ -846,11 +847,11 @@ def saved_view_modal(
     elif current_saved_view is not None and not per_page:
         # no changes made, display current saved view pagination count
         param_dict["per_page"] = current_saved_view.config.get(
-            "pagination_count", config.get_settings_or_config("PAGINATE_COUNT")
+            "pagination_count", config.get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
         )
     else:
         # display default pagination count
-        param_dict["per_page"] = config.get_settings_or_config("PAGINATE_COUNT")
+        param_dict["per_page"] = config.get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
 
     if sort_order:
         # user made changes to saved view sort order

--- a/nautobot/core/utils/config.py
+++ b/nautobot/core/utils/config.py
@@ -1,19 +1,39 @@
 """Helper code for loading values that may be defined in settings.py/nautobot_config.py *or* in django-constance."""
 
 import contextlib
+import logging
 
 from constance import config
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import OperationalError, ProgrammingError
 
+logger = logging.getLogger(__name__)
 
-def get_settings_or_config(variable_name):
-    """Get a value from Django settings (if specified there) or Constance configuration (otherwise)."""
+
+def get_settings_or_config(variable_name, fallback=None):
+    """
+    Get a value from Django settings (if specified there) or Constance configuration (otherwise).
+
+    The fallback value is returned *only* if the requested variable cannot be found at all - this is an error case,
+    and will generate warning logs.
+    """
     # Explicitly set in settings.py or nautobot_config.py takes precedence, for now
     if hasattr(settings, variable_name):
         return getattr(settings, variable_name)
     # django-constance 4.x removed some built-in error handling here, so we have to do it ourselves now
     with contextlib.suppress(ObjectDoesNotExist, OperationalError, ProgrammingError):
         return getattr(config, variable_name)
-    return None
+    logger.warning(
+        'Configuration "%s" is not in settings, and could not read from the Constance database table '
+        "(perhaps not initialized yet?)",
+        variable_name,
+    )
+    if variable_name in settings.CONSTANCE_CONFIG:
+        default = settings.CONSTANCE_CONFIG[variable_name][0]
+        logger.warning('Using default value of "%s" from Constance configuration for "%s"', default, variable_name)
+        return default
+    logger.warning(
+        'Constance configuration does not include an entry for "%s" - must return %s', variable_name, fallback
+    )
+    return fallback

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -25,6 +25,7 @@ from django.views.generic import View
 from django_tables2 import RequestConfig
 
 from nautobot.core.api.utils import get_serializer_for_model
+from nautobot.core.constants import MAX_PAGE_SIZE_DEFAULT
 from nautobot.core.exceptions import AbortTransaction
 from nautobot.core.forms import (
     BootstrapMixin,
@@ -349,7 +350,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, View):
             }
             RequestConfig(request, paginate).configure(table)
             table_config_form = TableConfigForm(table=table)
-            max_page_size = get_settings_or_config("MAX_PAGE_SIZE")
+            max_page_size = get_settings_or_config("MAX_PAGE_SIZE", fallback=MAX_PAGE_SIZE_DEFAULT)
             if max_page_size and paginate["per_page"] > max_page_size:
                 messages.warning(
                     request,

--- a/nautobot/core/views/paginator.py
+++ b/nautobot/core/views/paginator.py
@@ -1,5 +1,6 @@
 from django.core.paginator import Page, Paginator
 
+from nautobot.core.constants import MAX_PAGE_SIZE_DEFAULT, PAGINATE_COUNT_DEFAULT
 from nautobot.core.utils import config
 
 
@@ -8,11 +9,11 @@ class EnhancedPaginator(Paginator):
         try:
             per_page = int(per_page)
             if per_page < 1:
-                per_page = config.get_settings_or_config("PAGINATE_COUNT")
+                per_page = config.get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
         except ValueError:
-            per_page = config.get_settings_or_config("PAGINATE_COUNT")
+            per_page = config.get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
 
-        max_page_size = config.get_settings_or_config("MAX_PAGE_SIZE")
+        max_page_size = config.get_settings_or_config("MAX_PAGE_SIZE", fallback=MAX_PAGE_SIZE_DEFAULT)
         if max_page_size:
             per_page = min(per_page, max_page_size)
 
@@ -65,5 +66,7 @@ def get_paginate_count(request, saved_view=None):
             return per_page
 
     if request.user.is_authenticated:
-        return request.user.get_config("pagination.per_page", config.get_settings_or_config("PAGINATE_COUNT"))
-    return config.get_settings_or_config("PAGINATE_COUNT")
+        return request.user.get_config(
+            "pagination.per_page", config.get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
+        )
+    return config.get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -9,6 +9,7 @@ from django.urls import resolve
 from django_tables2 import RequestConfig
 from rest_framework import renderers
 
+from nautobot.core.constants import MAX_PAGE_SIZE_DEFAULT
 from nautobot.core.forms import (
     restrict_form_fields,
     SearchForm,
@@ -124,7 +125,7 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
                 "paginator_class": EnhancedPaginator,
                 "per_page": get_paginate_count(request, self.saved_view),
             }
-            max_page_size = get_settings_or_config("MAX_PAGE_SIZE")
+            max_page_size = get_settings_or_config("MAX_PAGE_SIZE", fallback=MAX_PAGE_SIZE_DEFAULT)
             if max_page_size and paginate["per_page"] > max_page_size:
                 messages.warning(
                     request,

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -394,8 +394,8 @@ class RackElevationDetailFilterSerializer(serializers.Serializer):
     is_occupied = serializers.BooleanField(required=False, allow_null=True, default=None)
 
     def validate(self, attrs):
-        attrs.setdefault("unit_width", get_settings_or_config("RACK_ELEVATION_DEFAULT_UNIT_WIDTH"))
-        attrs.setdefault("unit_height", get_settings_or_config("RACK_ELEVATION_DEFAULT_UNIT_HEIGHT"))
+        attrs.setdefault("unit_width", get_settings_or_config("RACK_ELEVATION_DEFAULT_UNIT_WIDTH", fallback=230))
+        attrs.setdefault("unit_height", get_settings_or_config("RACK_ELEVATION_DEFAULT_UNIT_HEIGHT", fallback=22))
         return attrs
 
 

--- a/nautobot/dcim/models/racks.py
+++ b/nautobot/dcim/models/racks.py
@@ -391,9 +391,9 @@ class Rack(PrimaryModel):
             Defaults to True, showing device full name and hiding truncated.
         """
         if unit_width is None:
-            unit_width = get_settings_or_config("RACK_ELEVATION_DEFAULT_UNIT_WIDTH")
+            unit_width = get_settings_or_config("RACK_ELEVATION_DEFAULT_UNIT_WIDTH", fallback=230)
         if unit_height is None:
-            unit_height = get_settings_or_config("RACK_ELEVATION_DEFAULT_UNIT_HEIGHT")
+            unit_height = get_settings_or_config("RACK_ELEVATION_DEFAULT_UNIT_HEIGHT", fallback=22)
         elevation = RackElevationSVG(
             self, user=user, include_images=include_images, base_url=base_url, display_fullname=display_fullname
         )

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -72,7 +72,7 @@ def get_network_driver_mapping_tool_names():
     Tool names are "ansible", "hier_config", "napalm", "netmiko", etc...
     """
     network_driver_names = NETUTILS_NETWORK_DRIVER_MAPPING_NAMES.copy()
-    network_driver_names.update(get_settings_or_config("NETWORK_DRIVERS").keys())
+    network_driver_names.update(get_settings_or_config("NETWORK_DRIVERS", fallback={}).keys())
 
     return sorted(network_driver_names)
 
@@ -113,7 +113,7 @@ def get_all_network_driver_mappings():
             network_driver_mappings[normalized_name][tool_name] = mapped_name
 
     # add mappings from optional NETWORK_DRIVERS setting
-    network_drivers_config = get_settings_or_config("NETWORK_DRIVERS")
+    network_drivers_config = get_settings_or_config("NETWORK_DRIVERS", fallback={})
     for tool_name, mappings in network_drivers_config.items():
         for normalized_name, mapped_name in mappings.items():
             network_driver_mappings.setdefault(normalized_name, {})

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -739,7 +739,7 @@ class BaseJob:
         """
         if isinstance(content, str):
             content = content.encode("utf-8")
-        max_size = get_settings_or_config("JOB_CREATE_FILE_MAX_SIZE")
+        max_size = get_settings_or_config("JOB_CREATE_FILE_MAX_SIZE", fallback=10 << 20)
         actual_size = len(content)
         if actual_size > max_size:
             raise ValueError(f"Provided {actual_size} bytes of content, but JOB_CREATE_FILE_MAX_SIZE is {max_size}")

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -25,6 +25,7 @@ from jsonschema.validators import Draft7Validator
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 
+from nautobot.core.constants import PAGINATE_COUNT_DEFAULT
 from nautobot.core.forms import restrict_form_fields
 from nautobot.core.models.querysets import count_related
 from nautobot.core.models.utils import pretty_print_query
@@ -1907,7 +1908,7 @@ class SavedViewUIViewSet(
             if derived_instance and derived_instance.config.get("pagination_count", None):
                 pagination_count = derived_instance.config["pagination_count"]
             else:
-                pagination_count = get_settings_or_config("PAGINATE_COUNT")
+                pagination_count = get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
         sv.config["pagination_count"] = int(pagination_count)
         sort_order = param_dict.get("sort", [])
         if not sort_order:

--- a/nautobot/ipam/api/views.py
+++ b/nautobot/ipam/api/views.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import IntegerField, ListSerializer
 
 from nautobot.core.api.authentication import TokenPermissions
+from nautobot.core.constants import MAX_PAGE_SIZE_DEFAULT, PAGINATE_COUNT_DEFAULT
 from nautobot.core.models.querysets import count_related
 from nautobot.core.utils.config import get_settings_or_config
 from nautobot.dcim.models import Location
@@ -324,11 +325,15 @@ class PrefixViewSet(NautobotModelViewSet):
         # Determine the maximum number of IPs to return
         else:
             try:
-                limit = int(request.query_params.get("limit", get_settings_or_config("PAGINATE_COUNT")))
+                limit = int(
+                    request.query_params.get(
+                        "limit", get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
+                    )
+                )
             except ValueError:
-                limit = get_settings_or_config("PAGINATE_COUNT")
-            if get_settings_or_config("MAX_PAGE_SIZE"):
-                limit = min(limit, get_settings_or_config("MAX_PAGE_SIZE"))
+                limit = get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
+            if get_settings_or_config("MAX_PAGE_SIZE", fallback=MAX_PAGE_SIZE_DEFAULT):
+                limit = min(limit, get_settings_or_config("MAX_PAGE_SIZE", fallback=MAX_PAGE_SIZE_DEFAULT))
 
             # Calculate available IPs within the prefix
             ip_list = []
@@ -525,12 +530,16 @@ class VLANGroupViewSet(NautobotModelViewSet):
 
         else:
             try:
-                limit = int(request.query_params.get("limit", get_settings_or_config("PAGINATE_COUNT")))
+                limit = int(
+                    request.query_params.get(
+                        "limit", get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
+                    )
+                )
             except ValueError:
-                limit = get_settings_or_config("PAGINATE_COUNT")
+                limit = get_settings_or_config("PAGINATE_COUNT", fallback=PAGINATE_COUNT_DEFAULT)
 
-            if get_settings_or_config("MAX_PAGE_SIZE"):
-                limit = min(limit, get_settings_or_config("MAX_PAGE_SIZE"))
+            if get_settings_or_config("MAX_PAGE_SIZE", fallback=MAX_PAGE_SIZE_DEFAULT):
+                limit = min(limit, get_settings_or_config("MAX_PAGE_SIZE", fallback=MAX_PAGE_SIZE_DEFAULT))
 
             if isinstance(limit, int) and limit >= 0:
                 vids = vlan_group.available_vids[0:limit]

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -16,6 +16,7 @@ from django_tables2 import RequestConfig
 import netaddr
 
 from nautobot.cloud.tables import CloudNetworkTable
+from nautobot.core.constants import MAX_PAGE_SIZE_DEFAULT
 from nautobot.core.models.querysets import count_related
 from nautobot.core.utils.config import get_settings_or_config
 from nautobot.core.utils.permissions import get_permission_for_model
@@ -911,7 +912,7 @@ class IPAddressAssignView(view_mixins.GetReturnURLMixin, generic.ObjectView):
                 "per_page": get_paginate_count(request),
             }
             RequestConfig(request, paginate).configure(table)
-            max_page_size = get_settings_or_config("MAX_PAGE_SIZE")
+            max_page_size = get_settings_or_config("MAX_PAGE_SIZE", fallback=MAX_PAGE_SIZE_DEFAULT)
             if max_page_size and paginate["per_page"] > max_page_size:
                 messages.warning(
                     request,


### PR DESCRIPTION

# Closes #6337 (again)
# What's Changed

The previous PR didn't go far enough. In returning `None` when unable to access the Constance DB, it caused new errors at startup when various code was expecting dicts or ints instead of None. I've addressed this with a two-layered fix:

- If the requested setting has a default value defined in `settings.CONSTANCE_CONFIG`, look up and return that value.
- Else, return the `fallback` value passed as a new kwarg (defaulting to None for backwards compatibility) - this *should* never happen if `get_settings_or_config` is being used properly and `CONSTANCE_CONFIG` is defined as it should be, but... :-)

Correspondingly, audit all of the cases we're using `get_settings_or_config` in core and provide appropriate `fallback` values for cases where a return value of None would cause an immediate exception due to the wrong data type. In most cases this *should* be utterly redundant as if we're unable to read the Constance DB table, things are already in a very bad state, and other errors are likely to have occurred, but it doesn't hurt either.

# Screenshots

Startup with no existing DB and `nautobot_device_onboarding` installed now logs warnings and starts instead of erroring out immediately:

```
nautobot-1  | 14:13:58.815 WARNING nautobot.core.utils.config config.py               get_settings_or_config() :
nautobot-1  |   Configuration "NETWORK_DRIVERS" is not in settings, and could not read from the Constance database table (perhaps not initialized yet?)
nautobot-1  | 14:13:58.815 WARNING nautobot.core.utils.config config.py               get_settings_or_config() :
nautobot-1  |   Using default value of "{}" from Constance configuration for "NETWORK_DRIVERS"
...
nautobot-1  | Performing database migrations...
nautobot-1  | Operations to perform:
nautobot-1  |   Apply all migrations: admin, auth, circuits, cloud, constance, contenttypes, dcim, django_celery_beat, django_celery_results, example_app, extras, ipam, nautobot_device_onboarding, nautobot_ssot, sessions, silk, social_django, taggit, tenancy, users, virtualization
nautobot-1  | Running migrations:
nautobot-1  |   Applying contenttypes.0001_initial... OK
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
