### PR TITLE
Add repo name to hash log of ensure_git_repository

### DIFF
--- a/changes/6350.changed
+++ b/changes/6350.changed
@@ -1,0 +1,1 @@
+Changed the way that ensure_git_repository logs hashes to include the name of the repository.

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -178,7 +178,7 @@ def ensure_git_repository(repository_record, logger=None, head=None):  # pylint:
         if changed:
             logger.info("Repository successfully refreshed")
         logger.info(
-            f'The current Git repository hash is "{repository_record.current_head}"',
+            f'{repository_record.name}: the current Git repository hash is "{repository_record.current_head}"',
             extra={"object": repository_record},
         )
 

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -178,7 +178,7 @@ def ensure_git_repository(repository_record, logger=None, head=None):  # pylint:
         if changed:
             logger.info("Repository successfully refreshed")
         logger.info(
-            f'{repository_record.name}: the current Git repository hash is "{repository_record.current_head}"',
+            '%s: the current Git repository hash is "%s"', repository_record.name, repository_record.current_head,
             extra={"object": repository_record},
         )
 

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -178,7 +178,9 @@ def ensure_git_repository(repository_record, logger=None, head=None):  # pylint:
         if changed:
             logger.info("Repository successfully refreshed")
         logger.info(
-            '%s: the current Git repository hash is "%s"', repository_record.name, repository_record.current_head,
+            '%s: the current Git repository hash is "%s"',
+            repository_record.name,
+            repository_record.current_head,
             extra={"object": repository_record},
         )
 

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -177,7 +177,10 @@ def ensure_git_repository(repository_record, logger=None, head=None):  # pylint:
     if logger:
         if changed:
             logger.info("Repository successfully refreshed")
-        logger.info(f'The current Git repository hash is "{repository_record.current_head}"')
+        logger.info(
+            f'The current Git repository hash is "{repository_record.current_head}"',
+            extra={"object": repository_record}
+        )
 
     return changed
 

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -179,7 +179,7 @@ def ensure_git_repository(repository_record, logger=None, head=None):  # pylint:
             logger.info("Repository successfully refreshed")
         logger.info(
             f'The current Git repository hash is "{repository_record.current_head}"',
-            extra={"object": repository_record}
+            extra={"object": repository_record},
         )
 
     return changed


### PR DESCRIPTION
Closes #6350

# What's Changed
When `ensure_git_repository` logs the HEAD hash, the name of the repo is now logged too as the `object`. Reason for the change is that this is especially useful when executing Jobs that run the function for multiple repositories.

# Screenshots
![image](https://github.com/user-attachments/assets/ebeed1d8-403f-4c99-bf5b-a2c0b1eaf76d)


# TODO
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
