### PR TITLE
Move django-constance back to v3

### DIFF
--- a/changes/5963.dependencies
+++ b/changes/5963.dependencies
@@ -1,2 +1,1 @@
-Updated `django-constance` to `~4.1.0`.
 Updated `django-taggit` to `~6.1.0`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -729,14 +729,17 @@ Django = ">=3.2.18"
 
 [[package]]
 name = "django-constance"
-version = "4.1.2"
+version = "3.1.0"
 description = "Django live settings with pluggable backends, including Redis."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "django_constance-4.1.2-py3-none-any.whl", hash = "sha256:bd8e847a5a6225cfc69da9d87de909dbb765e4150507eb3f555327ba32ac6fd6"},
-    {file = "django_constance-4.1.2.tar.gz", hash = "sha256:52163529d4b1be4404d4f8568c6742f76f4d4fc90dc31355849ea2c1e0c525d7"},
+    {file = "django-constance-3.1.0.tar.gz", hash = "sha256:2b96e51de63751ef63f8f92f74e0f6aea30fb6453f3a736c21e1f8b3f6cf0b4f"},
+    {file = "django_constance-3.1.0-py3-none-any.whl", hash = "sha256:6242486a346e396d765a9333d17f3101c8613cabc92e0b98dcb70c2a391bc53b"},
 ]
+
+[package.dependencies]
+django-picklefield = "*"
 
 [package.extras]
 redis = ["redis"]
@@ -859,6 +862,23 @@ files = [
 [package.dependencies]
 django = ">=3.2"
 jinja2 = ">=3"
+
+[[package]]
+name = "django-picklefield"
+version = "3.2"
+description = "Pickled object field for Django"
+optional = false
+python-versions = ">=3"
+files = [
+    {file = "django-picklefield-3.2.tar.gz", hash = "sha256:aa463f5d79d497dbe789f14b45180f00a51d0d670067d0729f352a3941cdfa4d"},
+    {file = "django_picklefield-3.2-py3-none-any.whl", hash = "sha256:e9a73539d110f69825d9320db18bcb82e5189ff48dbed41821c026a20497764c"},
+]
+
+[package.dependencies]
+Django = ">=3.2"
+
+[package.extras]
+tests = ["tox"]
 
 [[package]]
 name = "django-prometheus"
@@ -4280,4 +4300,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "0ecae313305b11ab59eb623f0ddd4356870c6f6bd67f9a179f4eec444863c6bc"
+content-hash = "1b2701cbe4dfdaf2274da769c7f9f8e4f2d63d95fdcdd264368b2ca89a4c73fc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ django-celery-beat = "~2.6.0"
 # Provides a database backend & models for Celery task results
 django-celery-results = "~2.5.1"
 # Management of app configuration via the Django admin UI
-django-constance = "~4.1.0"
+# TODO: Do not upgrade to 4.x until https://github.com/jazzband/django-constance/issues/592 is resolved
+django-constance = "~3.1.0"
 # Permit cross-domain API requests
 django-cors-headers = "~4.4.0"
 # Store files in the database for background tasks


### PR DESCRIPTION
# What's Changed

We're seeing migration errors in redeploying next.demo.nautobot.com still with django-constance 4.x, even after the last couple of PRs (#6349, #6339). I've filed https://github.com/jazzband/django-constance/issues/592 upstream but I don't know what kind of turnaround time we can expect, so in the interim, let's move back to a known-working version.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
