### PR TITLE
Restrict scope of name_pattern help text to ModularComponentTemplateCreateForm

### DIFF
--- a/changes/6400.fixed
+++ b/changes/6400.fixed
@@ -1,0 +1,1 @@
+Removed misleading help text from ModularComponentForm, as the `{module}` auto-substitution in names only applies through component _templates_ at present.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -269,23 +269,7 @@ class ComponentForm(BootstrapMixin, forms.Form):
 
 
 class ModularComponentForm(ComponentForm):
-    name_pattern = ExpandableNameField(
-        label="Name",
-        help_text="""
-            Alphanumeric ranges are supported for bulk creation. Mixed cases and types within a single range
-            are not supported. Examples:
-            <ul>
-                <li><code>[ge,xe]-0/0/[0-9]</code></li>
-                <li><code>e[0-3][a-d,f]</code></li>
-            </ul>
-
-            The variables <code>{module}</code>, <code>{module.parent}</code>, <code>{module.parent.parent}</code>, etc.
-            may be used in the name field and will be replaced by the <code>position</code> of the module bay that the
-            module occupies (skipping over any bays with a blank <code>position</code>). These variables can be used
-            multiple times in the component name and there is no limit to the depth of parent levels.
-            Any variables that cannot be replaced by a suitable position value will remain unchanged.
-                """,
-    )
+    """Base class for forms for components that can be assigned to either a device or a module."""
 
 
 #
@@ -1064,11 +1048,27 @@ class ComponentTemplateCreateForm(ComponentForm):
     description = forms.CharField(required=False)
 
 
-class ModularComponentTemplateCreateForm(ModularComponentForm):
+class ModularComponentTemplateCreateForm(ComponentTemplateCreateForm):
     """
     Base form for the creation of modular device component templates (subclassed from ModularComponentTemplateModel).
     """
 
+    name_pattern = ExpandableNameField(
+        label="Name",
+        help_text="""
+        Alphanumeric ranges are supported for bulk creation. Mixed cases and types within a single range
+        are not supported. Examples:
+        <ul>
+            <li><code>[ge,xe]-0/0/[0-9]</code></li>
+            <li><code>e[0-3][a-d,f]</code></li>
+        </ul>
+
+        The variables <code>{module}</code>, <code>{module.parent}</code>, <code>{module.parent.parent}</code>, etc.
+        may be used in the name field and will be replaced by the <code>position</code> of the module bay that the
+        module occupies (skipping over any bays with a blank <code>position</code>). These variables can be used
+        multiple times in the component name and there is no limit to the depth of parent levels.
+        Any variables that cannot be replaced by a suitable position value will remain unchanged.""",
+    )
     device_type = DynamicModelChoiceField(
         queryset=DeviceType.objects.all(),
         required=False,
@@ -1077,7 +1077,6 @@ class ModularComponentTemplateCreateForm(ModularComponentForm):
         queryset=ModuleType.objects.all(),
         required=False,
     )
-    description = forms.CharField(required=False)
 
 
 class ConsolePortTemplateForm(ModularComponentTemplateForm):
@@ -2542,12 +2541,8 @@ class DeviceBulkAddComponentForm(ComponentForm, CustomFieldModelBulkEditFormMixi
         nullable_fields = []
 
 
-class ModuleBulkAddComponentForm(ModularComponentForm, CustomFieldModelBulkEditFormMixin):
+class ModuleBulkAddComponentForm(DeviceBulkAddComponentForm):
     pk = forms.ModelMultipleChoiceField(queryset=Module.objects.all(), widget=forms.MultipleHiddenInput())
-    description = forms.CharField(max_length=CHARFIELD_MAX_LENGTH, required=False)
-
-    class Meta:
-        nullable_fields = []
 
 
 #


### PR DESCRIPTION
# Closes #6400
# What's Changed

- Move the `name_pattern.help_text` describing usage of the `{module}` template variables from the common `ModularComponentForm` base class to the more narrowly scoped `ModularComponentTemplateCreateForm` base class, so that it doesn't appear in cases where this feature isn't actually valid/supported at this time.
- Revert some class inheritance that was changed in #5779 specifically to use `ModularComponentForm` now that it's no longer relevant to those classes.

# Screenshots

![image](https://github.com/user-attachments/assets/78ac97d9-3db2-47a0-997b-b623d5cfabe7)

![image](https://github.com/user-attachments/assets/20a4592a-4f01-4ebd-b6e6-75457cb7fd0e)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
