### PR TITLE
Add atomicity and rollback to GitRepositorySync system Job

### DIFF
--- a/changes/6386.changed
+++ b/changes/6386.changed
@@ -1,0 +1,1 @@
+Changed `GitRepositorySync` system Job to run atomically (all-or-nothing), such that any failure in the resync will cause all associated database updates to be reverted.

--- a/changes/6386.changed
+++ b/changes/6386.changed
@@ -1,1 +1,2 @@
 Changed `GitRepositorySync` system Job to run atomically (all-or-nothing), such that any failure in the resync will cause all associated database updates to be reverted.
+Changed behavior of change logging `web_request_context()` to only reload Job code when a relevant JobHook is found to apply to the change in question.

--- a/changes/6386.fixed
+++ b/changes/6386.fixed
@@ -1,0 +1,1 @@
+Fixed reversed chronological ordering of JobHooks and Webhooks sent from a single `web_request_context` session.

--- a/nautobot/core/jobs/__init__.py
+++ b/nautobot/core/jobs/__init__.py
@@ -68,7 +68,7 @@ class GitRepositorySync(Job):
             # Re-check-out previous commit if any
             repository.refresh_from_db()
             if repository.current_head:
-                job_result.log(f"Reverting local repository clone to previous commit {repository.current_head}")
+                job_result.log(f"Attempting to revert local repository clone to commit {repository.current_head}")
                 ensure_git_repository(repository, logger=self.logger, head=repository.current_head)
                 refresh_job_code_from_repository(repository.slug, ignore_import_errors=True)
             raise

--- a/nautobot/core/jobs/__init__.py
+++ b/nautobot/core/jobs/__init__.py
@@ -19,7 +19,12 @@ from nautobot.core.jobs.cleanup import LogsCleanup
 from nautobot.core.jobs.groups import RefreshDynamicGroupCaches
 from nautobot.core.utils.lookup import get_filterset_for_model
 from nautobot.core.utils.requests import get_filterable_params_from_filter_params
-from nautobot.extras.datasources import ensure_git_repository, git_repository_dry_run, refresh_datasource_content
+from nautobot.extras.datasources import (
+    ensure_git_repository,
+    git_repository_dry_run,
+    refresh_datasource_content,
+    refresh_job_code_from_repository,
+)
 from nautobot.extras.jobs import BooleanVar, ChoiceVar, FileVar, Job, ObjectVar, RunJobTaskFailed, StringVar, TextVar
 from nautobot.extras.models import ExportTemplate, GitRepository
 
@@ -49,13 +54,24 @@ class GitRepositorySync(Job):
         self.logger.info(f'Creating/refreshing local copy of Git repository "{repository.name}"...')
 
         try:
-            ensure_git_repository(repository, logger=self.logger)
-            refresh_datasource_content("extras.gitrepository", repository, user, job_result, delete=False)
-            # Given that the above succeeded, tell all workers (including ourself) to call ensure_git_repository()
-            app.control.broadcast("refresh_git_repository", repository_pk=repository.pk, head=repository.current_head)
-        finally:
-            if job_result.duration:
-                self.logger.info("Repository synchronization completed in %s", job_result.duration)
+            with transaction.atomic():
+                ensure_git_repository(repository, logger=self.logger)
+                refresh_datasource_content("extras.gitrepository", repository, user, job_result, delete=False)
+                # Given that the above succeeded, tell all workers (including ourself) to call ensure_git_repository()
+                app.control.broadcast(
+                    "refresh_git_repository", repository_pk=repository.pk, head=repository.current_head
+                )
+                if job_result.duration:
+                    self.logger.info("Repository synchronization completed in %s", job_result.duration)
+        except Exception:
+            job_result.log("Changes to database records have been reverted.")
+            # Re-check-out previous commit if any
+            repository.refresh_from_db()
+            if repository.current_head:
+                job_result.log(f"Reverting local repository clone to previous commit {repository.current_head}")
+                ensure_git_repository(repository, logger=self.logger, head=repository.current_head)
+                refresh_job_code_from_repository(repository.slug, ignore_import_errors=True)
+            raise
 
 
 class GitRepositoryDryRun(Job):

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -180,7 +180,7 @@ def web_request_context(
         Valid choices are in `nautobot.extras.choices.ObjectChangeEventContextChoices`.
     :param request: Optional web request instance, one will be generated if not supplied
     """
-    from nautobot.extras.jobs import enqueue_job_hooks # prevent circular import
+    from nautobot.extras.jobs import enqueue_job_hooks  # prevent circular import
 
     valid_contexts = {
         ObjectChangeEventContextChoices.CONTEXT_JOB: JobChangeContext,

--- a/nautobot/extras/datasources/__init__.py
+++ b/nautobot/extras/datasources/__init__.py
@@ -4,6 +4,7 @@ from .git import (
     ensure_git_repository,
     get_repo_access_url,
     git_repository_dry_run,
+    refresh_job_code_from_repository,
 )
 from .registry import (
     get_datasource_content_choices,
@@ -20,4 +21,5 @@ __all__ = (
     "get_repo_access_url",
     "git_repository_dry_run",
     "refresh_datasource_content",
+    "refresh_job_code_from_repository",
 )

--- a/nautobot/extras/datasources/registry.py
+++ b/nautobot/extras/datasources/registry.py
@@ -32,7 +32,7 @@ def refresh_datasource_content(model_name, record, user, job_result, delete=Fals
         job_result (JobResult): Passed through to the callback functions to use with logging their actions.
         delete (bool): True if the record is being deleted; False if it is being created/updated.
     """
-    job_result.log(f"Refreshing data provided by {record}...", level_choice=LogLevelChoices.LOG_INFO)
+    job_result.log(f"Refreshing data provided by {record}...", level_choice=LogLevelChoices.LOG_INFO, obj=record)
 
     for entry in get_datasource_contents(model_name):
         job_result.log(f"Refreshing {entry.name}...", level_choice=LogLevelChoices.LOG_INFO)
@@ -54,4 +54,4 @@ def refresh_datasource_content(model_name, record, user, job_result, delete=Fals
         raise RuntimeError(msg)
 
     # Otherwise, log a friendly info message.
-    job_result.log(f"Data refresh from {record} complete!", level_choice=LogLevelChoices.LOG_INFO)
+    job_result.log(f"Data refresh from {record} complete!", level_choice=LogLevelChoices.LOG_INFO, obj=record)

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1149,7 +1149,7 @@ def enqueue_job_hooks(object_change, may_reload_jobs=True):
     Find job hook(s) assigned to this changed object type + action and enqueue them to be processed.
 
     Returns:
-        bool: whether Jobs needed to be refreshed to make this happen
+        jobs_reloaded (bool): whether Jobs were reloaded to make this happen
     """
 
     # Job hooks cannot trigger other job hooks

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1144,20 +1144,22 @@ def run_job(self, job_class_path, *args, **kwargs):
         raise
 
 
-def enqueue_job_hooks(object_change):
+def enqueue_job_hooks(object_change, may_reload_jobs=True):
     """
-    Find job hook(s) assigned to this changed object type + action and enqueue them
-    to be processed
+    Find job hook(s) assigned to this changed object type + action and enqueue them to be processed.
+
+    Returns:
+        bool: whether Jobs needed to be refreshed to make this happen
     """
 
     # Job hooks cannot trigger other job hooks
     if object_change.change_context == ObjectChangeEventContextChoices.CONTEXT_JOB_HOOK:
-        return
+        return False
 
     # Determine whether this type of object supports job hooks
     content_type = object_change.changed_object_type
     if content_type not in change_logged_models_queryset():
-        return
+        return False
 
     # Retrieve any applicable job hooks
     action_flag = {
@@ -1167,7 +1169,13 @@ def enqueue_job_hooks(object_change):
     }[object_change.action]
     job_hooks = JobHook.objects.filter(content_types=content_type, enabled=True, **{action_flag: True})
 
+    if not job_hooks.exists():
+        return False
+
     # Enqueue the jobs related to the job_hooks
+    if may_reload_jobs:
+        get_jobs(reload=True)
+
     for job_hook in job_hooks:
         job_model = job_hook.job
         if not job_model.installed or not job_model.enabled:
@@ -1178,3 +1186,5 @@ def enqueue_job_hooks(object_change):
             logger.error("JobHook %s is enabled, but the underlying Job implementation is missing", job_hook)
         else:
             JobResult.enqueue_job(job_model, object_change.user, object_change=object_change.pk)
+
+    return may_reload_jobs

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -115,6 +115,12 @@ class GitRepository(PrimaryModel):
                     "provides contents overlapping with this repository."
                 )
 
+        # Changing branch or remote_url invalidates current_head
+        if self.present_in_database:
+            past = GitRepository.objects.get(id=self.id)
+            if self.remote_url != past.remote_url or self.branch != past.branch:
+                self.current_head = ""
+
     def get_latest_sync(self):
         """
         Return a `JobResult` for the latest sync operation.

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -754,7 +754,7 @@ class JobResult(BaseModel, CustomFieldModel):
         grouping="main",
     ):
         """
-        General-purpose API for storing log messages in a JobResult's 'data' field.
+        General-purpose API for creating JobLogEntry records associated with a JobResult.
 
         message (str): Message to log (an attempt will be made to sanitize sensitive information from this message)
         obj (object): Object associated with this message, if any

--- a/nautobot/extras/tests/test_context_managers.py
+++ b/nautobot/extras/tests/test_context_managers.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from nautobot.core.celery import app
-from nautobot.core.testing import TransactionTestCase
+from nautobot.core.testing import get_job_class_and_model, TransactionTestCase
 from nautobot.core.utils.lookup import get_changes_for_model
 from nautobot.dcim.models import (
     DeviceType,
@@ -22,7 +22,7 @@ from nautobot.extras.context_managers import (
     deferred_change_logging_for_bulk_operation,
     web_request_context,
 )
-from nautobot.extras.models import Status, Webhook
+from nautobot.extras.models import JobHook, Status, Webhook
 from nautobot.extras.utils import bulk_delete_with_bulk_change_logging
 
 # Use the proper swappable User model
@@ -74,7 +74,7 @@ class WebRequestContextTestCase(TestCase):
         self.assertEqual(oc_list[0].changed_object, location)
         self.assertEqual(oc_list[0].action, ObjectChangeActionChoices.ACTION_CREATE)
 
-    @mock.patch("nautobot.extras.jobs.enqueue_job_hooks")
+    @mock.patch("nautobot.extras.jobs.enqueue_job_hooks", return_value=True)
     @mock.patch("nautobot.extras.context_managers.enqueue_webhooks")
     def test_create_then_delete(self, mock_enqueue_webhooks, mock_enqueue_job_hooks):
         """Test that a create followed by a delete is logged as two changes"""
@@ -88,11 +88,13 @@ class WebRequestContextTestCase(TestCase):
 
         location = Location.objects.filter(pk=location_pk)
         self.assertFalse(location.exists())
-        oc_list = get_changes_for_model(Location).filter(changed_object_id=location_pk)
+        oc_list = get_changes_for_model(Location).filter(changed_object_id=location_pk).order_by("time")
         self.assertEqual(len(oc_list), 2)
-        self.assertEqual(oc_list[0].action, ObjectChangeActionChoices.ACTION_DELETE)
-        self.assertEqual(oc_list[1].action, ObjectChangeActionChoices.ACTION_CREATE)
-        mock_enqueue_job_hooks.assert_has_calls([mock.call(oc_list[0]), mock.call(oc_list[1])])
+        self.assertEqual(oc_list[0].action, ObjectChangeActionChoices.ACTION_CREATE)
+        self.assertEqual(oc_list[1].action, ObjectChangeActionChoices.ACTION_DELETE)
+        mock_enqueue_job_hooks.assert_has_calls(
+            [mock.call(oc_list[0], may_reload_jobs=True), mock.call(oc_list[1], may_reload_jobs=False)],
+        )
         mock_enqueue_webhooks.assert_has_calls([mock.call(oc_list[0]), mock.call(oc_list[1])])
 
     def test_update_then_delete(self):
@@ -307,6 +309,13 @@ class BulkEditDeleteChangeLogging(TestCase):
             for i in range(1, 4)
         ]
         Location.objects.bulk_create(locations)
+        # Create a JobHook that applies to Locations
+        _, job_model = get_job_class_and_model("job_hook_receiver", "TestJobHookReceiverLog")
+        mock_import_jobs.assert_called_once()
+        mock_import_jobs.reset_mock()
+        job_hook = JobHook.objects.create(name="JobHookTest", type_update=True, job=job_model)
+        job_hook.content_types.set([ContentType.objects.get_for_model(Location)])
+
         pk_list = []
         with web_request_context(self.user):
             with deferred_change_logging_for_bulk_operation():


### PR DESCRIPTION
# Closes #6386 
# What's Changed

- Add `transaction.atomic` wrapper to `GitRepositorySync` system Job so that any failure during the sync will cause rollback of all changes to this point. Add exception handler so that a failure during the sync also causes the local clone to be reverted to the previous "good" commit (if any) and a reloading of Job code from the reverted clone.
- Some various cleanup in `nautobot/extras/datasources/git.py` that I made during an initial plan to implement the atomicity within `refresh_datasource_content()` itself - I believe these are valid improvements to the code but am happy to revert them if asked.
   - Atomicity needs to be implemented in the Job rather than in `refresh_datasource_content()` because in case of failure, we need to atomically rollback both the data changes attempted in `refresh_datasource_content()` *and also* the update to `repository.current_head` that was made in `ensure_git_repository()`.
- Add test case coverage for the atomic rollback.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
