### PR TITLE
Fix some reverse migration issues

### DIFF
--- a/nautobot/dcim/migrations/0064_virtualdevicecontext_status_data_migration.py
+++ b/nautobot/dcim/migrations/0064_virtualdevicecontext_status_data_migration.py
@@ -15,12 +15,6 @@ def clear_virtual_device_context_status(apps, schema_editor):
     """
     Clear the status field on all VirtualDeviceContext, and de-link/delete all Status records from the VirtualDeviceContext content-type.
     """
-    VirtualDeviceContext = apps.get_model("dcim.VirtualDeviceContext")
-
-    for vdc in VirtualDeviceContext.objects.filter(status__isnull=False):
-        vdc.status = None
-        vdc.save()
-
     clear_status_choices(apps, schema_editor, models=["dcim.VirtualDeviceContext"])
 
 

--- a/nautobot/extras/migrations/0118_task_queue_to_job_queue_migration.py
+++ b/nautobot/extras/migrations/0118_task_queue_to_job_queue_migration.py
@@ -50,7 +50,7 @@ def reverse_migrate_task_queues_to_job_queues(apps, schema):
     JobQueueAssignment = apps.get_model("extras", "JobQueueAssignment")
 
     for job in Job.objects.all():
-        queue_names = job.job_queues.all().values_list("name", flat=True)
+        queue_names = list(job.job_queues.all().values_list("name", flat=True))
         job.task_queues = queue_names
         job.save()
     JobQueueAssignment.objects.all().delete()

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -493,9 +493,13 @@ def refresh_job_models(sender, *, apps, **kwargs):
     from nautobot.extras.jobs import get_jobs  # avoid circular import
 
     Job = apps.get_model("extras", "Job")
-    JobQueue = apps.get_model("extras", "JobQueue")
 
     # To make reverse migrations safe
+    try:
+        JobQueue = apps.get_model("extras", "JobQueue")
+    except LookupError:
+        JobQueue = None
+
     if not hasattr(Job, "job_class_name"):
         logger.info("Skipping refresh_job_models() as it appears Job model has not yet been migrated to latest.")
         return


### PR DESCRIPTION
# What's Changed

I tried to reverse-migrate my `next` database back to be usable with `develop` and ran into the following issues:

- `clear_virtual_device_context_status` fails because Status field is non-nullable but we're trying to set it to None
- `reverse_migrate_task_queues_to_job_queues` fails because `queue_names` is a queryset where a list is expected.
- The `refresh_job_models` signal fails at the end of the migration because `JobQueue` model no longer exists.

This PR addresses all three of those issues.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
