### PR TITLE
Performance improvements for custom-field provisioning and web_request_context

### DIFF
--- a/changes/6421.added
+++ b/changes/6421.added
@@ -1,0 +1,4 @@
+Added cacheable `CustomField.objects.keys_for_model(model)` API.
+Added queryset caching in `web_request_context` for more efficient JobHook and Webhook dispatching on bulk requests.
+Added logging to JobResults for CustomField provisioning background tasks.
+Added more efficient database calls for most cases of bulk-provisioning CustomField data on model objects.

--- a/changes/6421.changed
+++ b/changes/6421.changed
@@ -1,0 +1,1 @@
+Increased soft/hard time limits on CustomField provisioning background tasks to 1800 and 2000 seconds respectively.

--- a/changes/6421.fixed
+++ b/changes/6421.fixed
@@ -1,0 +1,1 @@
+Fixed long-running-at-scale transaction lock on records while adding/removing a CustomField definition.

--- a/nautobot/core/models/query_functions.py
+++ b/nautobot/core/models/query_functions.py
@@ -1,5 +1,7 @@
 from django.db import NotSupportedError
-from django.db.models import Aggregate, Func, JSONField
+from django.db.models import Aggregate, Func, JSONField, Value
+from django.db.models.fields.json import compile_json_path
+from django.db.models.functions import Cast
 
 
 class CollateAsChar(Func):
@@ -24,6 +26,115 @@ class CollateAsChar(Func):
         function = func_map[connection.vendor]
 
         return super().as_sql(compiler, connection, function, template, arg_joiner, **extra_context)
+
+
+class JSONSet(Func):
+    """
+    Set or create the value of a single key in a JSONField.
+
+    Example:
+        model.objects.all().update(_custom_field_data=JSONSet("_custom_field_data", "cf_key", "new_value"))
+
+    Limitations:
+        - Postgres and MySQL only.
+        - Does *not* support nested lookups (`key1__key2`), only a single top-level key.
+
+    References:
+        - https://code.djangoproject.com/ticket/32519
+        - https://github.com/django/django/pull/18489/files
+    """
+
+    function = None
+
+    def __init__(self, expression, path, value, output_field=None):
+        self.path = path
+        self.value = value
+        super().__init__(expression, output_field=output_field)
+
+    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
+        c = super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
+        # Resolve expressions in the JSON update values.
+        c.fields = {
+            self.path: (
+                self.value.resolve_expression(query, allow_joins, reuse, summarize, for_save)
+                if hasattr(self.value, "resolve_expression")
+                else self.value
+            )
+        }
+        return c
+
+    def as_sql(self, compiler, connection, function=None, **extra_context):
+        """`JSON_SET(obj, path, value)`"""
+        copy = self.copy()
+        new_source_expressions = copy.get_source_expressions()
+        path = compile_json_path([self.path])
+        value = self.value
+        if not hasattr(value, "resolve_expression"):
+            # Use Value to serialize the value to a string, then Cast to ensure it's treated as JSON.
+            value = Cast(Value(value, output_field=self.output_field), output_field=self.output_field)
+
+        new_source_expressions.extend((Value(path), value))
+        copy.set_source_expressions(new_source_expressions)
+        return super(JSONSet, copy).as_sql(compiler, connection, function="JSON_SET", **extra_context)
+
+    def as_postgresql(self, compiler, connection, function=None, **extra_context):
+        """`JSONB_SET(obj, path, value)`"""
+        copy = self.copy()
+        new_source_expressions = copy.get_source_expressions()
+        path = self.path
+        value = self.value
+        if not hasattr(value, "resolve_expression"):
+            # We don't need Cast() here because Value with a JSONFIeld is correctly handled as JSONB by Postgres
+            value = Value(value, output_field=self.output_field)
+        else:
+
+            class ToJSONB(Func):
+                function = "TO_JSONB"
+
+            value = ToJSONB(value, output_field=self.output_field)
+
+        new_source_expressions.extend((Value(f"{{{path}}}"), value))
+        copy.set_source_expressions(new_source_expressions)
+        return super(JSONSet, copy).as_sql(compiler, connection, function="JSONB_SET", **extra_context)
+
+
+class JSONRemove(Func):
+    """
+    Unset and remove a single key in a JSONField.
+
+    Example:
+        model.objects.all().update(_custom_field_data=JSONRemove("_custom_field_data", "cf_key"))
+
+    Limitations:
+        - Postgres and MySQL only.
+        - Does *not* support nested lookups (`key1__key2`), only a single top-level key.
+
+    References:
+        - https://code.djangoproject.com/ticket/32519
+        - https://github.com/django/django/pull/18489/files
+    """
+
+    def __init__(self, expression, path):
+        self.path = path
+        super().__init__(expression)
+
+    def as_sql(self, compiler, connection, function=None, **extra_context):
+        """`JSON_REMOVE(obj, path)`"""
+        copy = self.copy()
+        new_source_expressions = copy.get_source_expressions()
+        new_source_expressions.append(Value(compile_json_path([self.path])))
+        copy.set_source_expressions(new_source_expressions)
+        return super(JSONRemove, copy).as_sql(compiler, connection, function="JSON_REMOVE", **extra_context)
+
+    def as_postgresql(self, compiler, connection, function=None, **extra_context):
+        """`obj #- path`"""
+        copy = self.copy()
+        new_source_expressions = copy.get_source_expressions()
+        new_source_expressions.append(Value(f"{{{self.path}}}"))
+        copy.set_source_expressions(new_source_expressions)
+        return super(JSONRemove, copy).as_sql(
+            compiler, connection, template="%(expressions)s", arg_joiner="#- ", **extra_context
+        )
 
 
 class JSONBAgg(Aggregate):

--- a/nautobot/core/tests/test_models_query_functions.py
+++ b/nautobot/core/tests/test_models_query_functions.py
@@ -1,0 +1,108 @@
+from nautobot.core.models.query_functions import JSONRemove, JSONSet
+from nautobot.core.testing import TestCase
+from nautobot.dcim.models import Manufacturer
+
+
+class JSONFuncTests(TestCase):
+    """Test JSONSet and JSONRemove functionality."""
+
+    def test_json_set(self):
+        # Setting a key/value should efficiently work
+        with self.assertNumQueries(1):
+            Manufacturer.objects.all().update(_custom_field_data=JSONSet("_custom_field_data", "a", 1))
+        for mfr in Manufacturer.objects.all():
+            self.assertIn("a", mfr._custom_field_data)
+            self.assertEqual(1, mfr._custom_field_data["a"])
+
+        # Setting a different key/value shouldn't overwrite other keys
+        with self.assertNumQueries(1):
+            Manufacturer.objects.all().update(_custom_field_data=JSONSet("_custom_field_data", "b", "text"))
+        for mfr in Manufacturer.objects.all():
+            self.assertIn("a", mfr._custom_field_data)
+            self.assertEqual(1, mfr._custom_field_data["a"])
+            self.assertIn("b", mfr._custom_field_data)
+            self.assertEqual("text", mfr._custom_field_data["b"])
+
+        # Setting a key/value again should overwrite that value only
+        with self.assertNumQueries(1):
+            Manufacturer.objects.all().update(_custom_field_data=JSONSet("_custom_field_data", "b", "more text"))
+        for mfr in Manufacturer.objects.all():
+            self.assertIn("a", mfr._custom_field_data)
+            self.assertEqual(1, mfr._custom_field_data["a"])
+            self.assertIn("b", mfr._custom_field_data)
+            self.assertEqual("more text", mfr._custom_field_data["b"])
+
+        # A filtered query should be updatable
+        with self.assertNumQueries(1):
+            Manufacturer.objects.filter(name__istartswith="a").update(
+                _custom_field_data=JSONSet("_custom_field_data", "a", None)
+            )
+        for mfr in Manufacturer.objects.filter(name__istartswith="a"):
+            self.assertIn("a", mfr._custom_field_data)
+            self.assertEqual(None, mfr._custom_field_data["a"])
+        for mfr in Manufacturer.objects.exclude(name__istartswith="a"):
+            self.assertIn("a", mfr._custom_field_data)
+            self.assertEqual(1, mfr._custom_field_data["a"])
+        for mfr in Manufacturer.objects.all():
+            self.assertIn("b", mfr._custom_field_data)
+            self.assertEqual("more text", mfr._custom_field_data["b"])
+
+        # Setting a value doesn't require all existing values to be homogeneous
+        with self.assertNumQueries(1):
+            Manufacturer.objects.all().update(_custom_field_data=JSONSet("_custom_field_data", "a", "hello"))
+        for mfr in Manufacturer.objects.all():
+            self.assertIn("a", mfr._custom_field_data)
+            self.assertEqual("hello", mfr._custom_field_data["a"])
+            self.assertIn("b", mfr._custom_field_data)
+            self.assertEqual("more text", mfr._custom_field_data["b"])
+
+    def test_json_remove(self):
+        Manufacturer.objects.all().update(_custom_field_data=JSONSet("_custom_field_data", "a", 1))
+        Manufacturer.objects.filter(name__istartswith="a").update(
+            _custom_field_data=JSONSet("_custom_field_data", "b", "hello")
+        )
+        Manufacturer.objects.exclude(name__istartswith="a").update(
+            _custom_field_data=JSONSet("_custom_field_data", "b", "world")
+        )
+
+        # Should be able to clear all values for a key without impacting other keys
+        with self.assertNumQueries(1):
+            Manufacturer.objects.all().update(_custom_field_data=JSONRemove("_custom_field_data", "a"))
+        for mfr in Manufacturer.objects.all():
+            self.assertNotIn("a", mfr._custom_field_data)
+            self.assertIn("b", mfr._custom_field_data)
+        for mfr in Manufacturer.objects.filter(name__istartswith="a"):
+            self.assertEqual("hello", mfr._custom_field_data["b"])
+        for mfr in Manufacturer.objects.exclude(name__istartswith="a"):
+            self.assertEqual("world", mfr._custom_field_data["b"])
+
+        # Clearing a value that doesn't exist should be safe
+        with self.assertNumQueries(1):
+            Manufacturer.objects.all().update(_custom_field_data=JSONRemove("_custom_field_data", "a"))
+        for mfr in Manufacturer.objects.all():
+            self.assertNotIn("a", mfr._custom_field_data)
+            self.assertIn("b", mfr._custom_field_data)
+        for mfr in Manufacturer.objects.filter(name__istartswith="a"):
+            self.assertEqual("hello", mfr._custom_field_data["b"])
+        for mfr in Manufacturer.objects.exclude(name__istartswith="a"):
+            self.assertEqual("world", mfr._custom_field_data["b"])
+
+        # Subsets should be updateable
+        with self.assertNumQueries(1):
+            Manufacturer.objects.filter(name__istartswith="a").update(
+                _custom_field_data=JSONRemove("_custom_field_data", "b")
+            )
+        for mfr in Manufacturer.objects.all():
+            self.assertNotIn("a", mfr._custom_field_data)
+        for mfr in Manufacturer.objects.filter(name__istartswith="a"):
+            self.assertNotIn("b", mfr._custom_field_data)
+        for mfr in Manufacturer.objects.exclude(name__istartswith="a"):
+            self.assertIn("b", mfr._custom_field_data)
+            self.assertEqual("world", mfr._custom_field_data["b"])
+
+        # Non-homogeneous data should be updatable
+        with self.assertNumQueries(1):
+            Manufacturer.objects.all().update(_custom_field_data=JSONRemove("_custom_field_data", "b"))
+        for mfr in Manufacturer.objects.all():
+            self.assertNotIn("a", mfr._custom_field_data)
+            self.assertNotIn("b", mfr._custom_field_data)

--- a/nautobot/extras/api/customfields.py
+++ b/nautobot/extras/api/customfields.py
@@ -40,9 +40,6 @@ class CustomFieldDefaultValues:
 class CustomFieldsDataField(Field):
     @property
     def custom_field_keys(self):
-        """
-        Cache CustomField keys assigned to this model to avoid redundant database queries
-        """
         return CustomField.objects.keys_for_model(self.parent.Meta.model)
 
     def to_representation(self, obj):
@@ -53,7 +50,8 @@ class CustomFieldsDataField(Field):
 
         # Discard any entries in data that do not align with actual CustomFields - this matches the REST API behavior
         # for top-level serializer fields that do not exist or are not writable
-        data = {key: value for key, value in data.items() if key in self.custom_field_keys}
+        custom_field_keys = self.custom_field_keys
+        data = {key: value for key, value in data.items() if key in custom_field_keys}
 
         # If updating an existing instance, start with existing _custom_field_data
         if self.parent.instance:

--- a/nautobot/extras/api/customfields.py
+++ b/nautobot/extras/api/customfields.py
@@ -43,12 +43,7 @@ class CustomFieldsDataField(Field):
         """
         Cache CustomField keys assigned to this model to avoid redundant database queries
         """
-        if not hasattr(self, "_custom_field_keys"):
-            content_type = ContentType.objects.get_for_model(self.parent.Meta.model)
-            self._custom_field_keys = CustomField.objects.filter(content_types=content_type).values_list(
-                "key", flat=True
-            )
-        return self._custom_field_keys
+        return CustomField.objects.keys_for_model(self.parent.Meta.model)
 
     def to_representation(self, obj):
         return {key: obj.get(key) for key in self.custom_field_keys}

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -204,14 +204,34 @@ def web_request_context(
             yield request
     finally:
         jobs_reloaded = False
+        # In the case of bulk operations, we perform the same create/update/delete operation on the same model.
+        # Save some repeated database queries by reusing the same queryset where applicable:
+        jobhook_queryset = None
+        webhook_queryset = None
+        last_action = None
+        last_content_type = None
         # enqueue jobhooks and webhooks, use change_context.change_id in case change_id was not supplied
         for object_change in (
-            ObjectChange.objects.filter(request_id=change_context.change_id).order_by("time").iterator()
+            ObjectChange.objects.select_related("changed_object_type")
+            .filter(request_id=change_context.change_id)
+            .order_by("time")
+            .iterator()
         ):
+            if object_change.action != last_action or object_change.changed_object_type != last_content_type:
+                jobhook_queryset = None
+                webhook_queryset = None
+
             if context != ObjectChangeEventContextChoices.CONTEXT_JOB_HOOK:
                 # Make sure JobHooks are up to date (only once) before calling them
-                jobs_reloaded |= enqueue_job_hooks(object_change, may_reload_jobs=(not jobs_reloaded))
-            enqueue_webhooks(object_change)
+                did_reload_jobs, jobhook_queryset = enqueue_job_hooks(
+                    object_change, may_reload_jobs=(not jobs_reloaded), jobhook_queryset=jobhook_queryset
+                )
+                if did_reload_jobs:
+                    jobs_reloaded = True
+
+            webhook_queryset = enqueue_webhooks(object_change, webhook_queryset=webhook_queryset)
+            last_action = object_change.action
+            last_content_type = object_change.changed_object_type
 
 
 @contextmanager

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1154,7 +1154,7 @@ def enqueue_job_hooks(object_change, may_reload_jobs=True, jobhook_queryset=None
         jobhook_queryset (QuerySet): Previously retrieved set of JobHooks to potentially enqueue
 
     Returns:
-        result (tuple): whether Jobs were reloaded here, and the jobhooks that were considered
+        result (tuple[bool, QuerySet]): whether Jobs were reloaded here, and the jobhooks that were considered
     """
     jobs_reloaded = False
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1144,41 +1144,47 @@ def run_job(self, job_class_path, *args, **kwargs):
         raise
 
 
-def enqueue_job_hooks(object_change, may_reload_jobs=True):
+def enqueue_job_hooks(object_change, may_reload_jobs=True, jobhook_queryset=None):
     """
     Find job hook(s) assigned to this changed object type + action and enqueue them to be processed.
 
+    Args:
+        object_change (ObjectChange): The change that may trigger JobHooks to execute.
+        may_reload_jobs (bool): Whether to reload JobHook source code from disk to guarantee up-to-date code.
+        jobhook_queryset (QuerySet): Previously retrieved set of JobHooks to potentially enqueue
+
     Returns:
-        jobs_reloaded (bool): whether Jobs were reloaded to make this happen
+        result (tuple): whether Jobs were reloaded here, and the jobhooks that were considered
     """
     jobs_reloaded = False
 
     # Job hooks cannot trigger other job hooks
     if object_change.change_context == ObjectChangeEventContextChoices.CONTEXT_JOB_HOOK:
-        return jobs_reloaded
+        return jobs_reloaded, jobhook_queryset
 
     # Determine whether this type of object supports job hooks
     content_type = object_change.changed_object_type
     if content_type not in change_logged_models_queryset():
-        return jobs_reloaded
+        return jobs_reloaded, jobhook_queryset
 
     # Retrieve any applicable job hooks
-    action_flag = {
-        ObjectChangeActionChoices.ACTION_CREATE: "type_create",
-        ObjectChangeActionChoices.ACTION_UPDATE: "type_update",
-        ObjectChangeActionChoices.ACTION_DELETE: "type_delete",
-    }[object_change.action]
-    job_hooks = JobHook.objects.filter(content_types=content_type, enabled=True, **{action_flag: True})
+    if jobhook_queryset is None:
+        action_flag = {
+            ObjectChangeActionChoices.ACTION_CREATE: "type_create",
+            ObjectChangeActionChoices.ACTION_UPDATE: "type_update",
+            ObjectChangeActionChoices.ACTION_DELETE: "type_delete",
+        }[object_change.action]
+        jobhook_queryset = JobHook.objects.filter(content_types=content_type, enabled=True, **{action_flag: True})
 
-    if not job_hooks.exists():
-        return jobs_reloaded
+    if not jobhook_queryset:  # not .exists() as we *want* to populate the queryset cache
+        return jobs_reloaded, jobhook_queryset
 
     # Enqueue the jobs related to the job_hooks
     if may_reload_jobs:
         get_jobs(reload=True)
         jobs_reloaded = True
 
-    for job_hook in job_hooks:
+    for job_hook in jobhook_queryset:
         job_model = job_hook.job
         if not job_model.installed or not job_model.enabled:
             logger.warning(
@@ -1189,4 +1195,4 @@ def enqueue_job_hooks(object_change, may_reload_jobs=True):
         else:
             JobResult.enqueue_job(job_model, object_change.user, object_change=object_change.pk)
 
-    return jobs_reloaded
+    return jobs_reloaded, jobhook_queryset

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -391,6 +391,18 @@ class CustomFieldManager(BaseManager.from_queryset(RestrictedQuerySet)):
 
     get_for_model.cache_key_prefix = "nautobot.extras.customfield.get_for_model"
 
+    def keys_for_model(self, model):
+        """Return list of all keys for CustomFields assigned to the given model."""
+        concrete_model = model._meta.concrete_model
+        cache_key = f"{self.keys_for_model.cache_key_prefix}.{concrete_model._meta.label_lower}"
+        keys = cache.get(cache_key)
+        if keys is None:
+            keys = list(self.get_for_model(model).values_list("key", flat=True))
+            cache.set(cache_key, keys)
+        return keys
+
+    keys_for_model.cache_key_prefix = "nautobot.extras.customfield.keys_for_model"
+
 
 @extras_features("webhooks")
 class CustomField(

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -808,12 +808,7 @@ class CustomField(
         from nautobot.extras.signals import change_context_state
 
         change_context = change_context_state.get()
-        if change_context is None:
-            context = None
-        else:
-            context = change_context.as_dict(instance=self)
-            context["context_detail"] = "delete custom field data"
-        delete_custom_field_data(self.key, content_types, context)
+        delete_custom_field_data(self.key, content_types, change_context)
 
     def add_prefix_to_cf_key(self):
         return "cf_" + str(self.key)
@@ -877,17 +872,12 @@ class CustomFieldChoice(BaseModel, ChangeLoggedModel):
             from nautobot.extras.signals import change_context_state
 
             change_context = change_context_state.get()
-            if change_context is None:
-                context = None
-            else:
-                context = change_context.as_dict(instance=self)
-                context["context_detail"] = "update custom field choice data"
             transaction.on_commit(
                 lambda: update_custom_field_choice_data(
                     self.custom_field.pk,
                     database_object.value,
                     self.value,
-                    context,
+                    change_context,
                 )
             )
 

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -801,7 +801,7 @@ class CustomField(
         else:
             context = change_context.as_dict(instance=self)
             context["context_detail"] = "delete custom field data"
-        delete_custom_field_data.delay(self.key, content_types, context)
+        delete_custom_field_data(self.key, content_types, context)
 
     def add_prefix_to_cf_key(self):
         return "cf_" + str(self.key)
@@ -871,7 +871,7 @@ class CustomFieldChoice(BaseModel, ChangeLoggedModel):
                 context = change_context.as_dict(instance=self)
                 context["context_detail"] = "update custom field choice data"
             transaction.on_commit(
-                lambda: update_custom_field_choice_data.delay(
+                lambda: update_custom_field_choice_data(
                     self.custom_field.pk,
                     database_object.value,
                     self.value,

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -91,6 +91,8 @@ def invalidate_models_cache(sender, **kwargs):
     with contextlib.suppress(redis.exceptions.ConnectionError):
         # TODO: *maybe* target more narrowly, e.g. only clear the cache for specific related content-types?
         cache.delete_pattern(f"{manager.get_for_model.cache_key_prefix}.*")
+        if hasattr(manager, "keys_for_model"):
+            cache.delete_pattern(f"{manager.keys_for_model.cache_key_prefix}.*")
 
 
 @receiver(post_save, sender=Relationship)

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -315,13 +315,21 @@ def handle_cf_removed_obj_types(instance, action, pk_set, **kwargs):
     """
 
     change_context = change_context_state.get()
+    if change_context is None:
+        context = None
+    else:
+        context = change_context.as_dict(instance=instance)
     if action == "post_remove":
         # Existing content types have been removed from the custom field, delete their data
-        transaction.on_commit(lambda: delete_custom_field_data(instance.key, pk_set, change_context))
+        if context:
+            context["context_detail"] = "delete custom field data from existing content types"
+        transaction.on_commit(lambda: delete_custom_field_data.delay(instance.key, pk_set, context))
 
     elif action == "post_add":
         # New content types have been added to the custom field, provision them
-        transaction.on_commit(lambda: provision_field(instance.pk, pk_set, change_context))
+        if context:
+            context["context_detail"] = "provision custom field data for new content types"
+        transaction.on_commit(lambda: provision_field.delay(instance.pk, pk_set, context))
 
 
 m2m_changed.connect(handle_cf_removed_obj_types, sender=CustomField.content_types.through)

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -315,21 +315,13 @@ def handle_cf_removed_obj_types(instance, action, pk_set, **kwargs):
     """
 
     change_context = change_context_state.get()
-    if change_context is None:
-        context = None
-    else:
-        context = change_context.as_dict(instance=instance)
     if action == "post_remove":
         # Existing content types have been removed from the custom field, delete their data
-        if context:
-            context["context_detail"] = "delete custom field data from existing content types"
-        transaction.on_commit(lambda: delete_custom_field_data(instance.key, pk_set, context))
+        transaction.on_commit(lambda: delete_custom_field_data(instance.key, pk_set, change_context))
 
     elif action == "post_add":
         # New content types have been added to the custom field, provision them
-        if context:
-            context["context_detail"] = "provision custom field data for new content types"
-        transaction.on_commit(lambda: provision_field(instance.pk, pk_set, context))
+        transaction.on_commit(lambda: provision_field(instance.pk, pk_set, change_context))
 
 
 m2m_changed.connect(handle_cf_removed_obj_types, sender=CustomField.content_types.through)

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -321,13 +321,13 @@ def handle_cf_removed_obj_types(instance, action, pk_set, **kwargs):
         # Existing content types have been removed from the custom field, delete their data
         if context:
             context["context_detail"] = "delete custom field data from existing content types"
-        transaction.on_commit(lambda: delete_custom_field_data.delay(instance.key, pk_set, context))
+        transaction.on_commit(lambda: delete_custom_field_data(instance.key, pk_set, context))
 
     elif action == "post_add":
         # New content types have been added to the custom field, provision them
         if context:
             context["context_detail"] = "provision custom field data for new content types"
-        transaction.on_commit(lambda: provision_field.delay(instance.pk, pk_set, context))
+        transaction.on_commit(lambda: provision_field(instance.pk, pk_set, context))
 
 
 m2m_changed.connect(handle_cf_removed_obj_types, sender=CustomField.content_types.through)

--- a/nautobot/extras/tasks.py
+++ b/nautobot/extras/tasks.py
@@ -28,6 +28,7 @@ def _generate_bulk_object_changes(context, queryset, task_logger):
     #       trigger jobhooks and webhooks.
     # TODO: this could be made much faster if we ensure the queryset has appropriate select_related/prefetch_related?
     change_context = ChangeContext(**context)
+    i = 0
     with change_logging(change_context):
         with deferred_change_logging_for_bulk_operation():
             for i, instance in enumerate(queryset.iterator(), start=1):

--- a/nautobot/extras/tasks.py
+++ b/nautobot/extras/tasks.py
@@ -16,7 +16,9 @@ logger = getLogger("nautobot.extras.tasks")
 def _generate_bulk_object_changes(context, queryset, task_logger):
     # Circular import
     from nautobot.extras.context_managers import (
-        ChangeContext, change_logging, deferred_change_logging_for_bulk_operation
+        change_logging,
+        ChangeContext,
+        deferred_change_logging_for_bulk_operation,
     )
     from nautobot.extras.signals import _handle_changed_object
 

--- a/nautobot/extras/tasks.py
+++ b/nautobot/extras/tasks.py
@@ -67,9 +67,11 @@ def update_custom_field_choice_data(field_id, old_value, new_value, change_conte
             if change_context is not None:
                 pk_list = list(queryset.values_list("pk", flat=True))
             task_logger.info(
-                "Updating selection for custom field `%s` on %s records...",
+                "Updating selection for custom field `%s` from `%s` to `%s` on %s records...",
                 field.key,
-                ct.label_lower,
+                old_value,
+                new_value,
+                ct.model,
                 extra={"object": field},
             )
             count = queryset.update(_custom_field_data=JSONSet("_custom_field_data", field.key, new_value))

--- a/nautobot/extras/tests/test_context_managers.py
+++ b/nautobot/extras/tests/test_context_managers.py
@@ -74,8 +74,8 @@ class WebRequestContextTestCase(TestCase):
         self.assertEqual(oc_list[0].changed_object, location)
         self.assertEqual(oc_list[0].action, ObjectChangeActionChoices.ACTION_CREATE)
 
-    @mock.patch("nautobot.extras.jobs.enqueue_job_hooks", return_value=True)
-    @mock.patch("nautobot.extras.context_managers.enqueue_webhooks")
+    @mock.patch("nautobot.extras.jobs.enqueue_job_hooks", return_value=(True, None))
+    @mock.patch("nautobot.extras.context_managers.enqueue_webhooks", return_value=None)
     def test_create_then_delete(self, mock_enqueue_webhooks, mock_enqueue_job_hooks):
         """Test that a create followed by a delete is logged as two changes"""
         location_type = LocationType.objects.get(name="Campus")
@@ -93,9 +93,13 @@ class WebRequestContextTestCase(TestCase):
         self.assertEqual(oc_list[0].action, ObjectChangeActionChoices.ACTION_CREATE)
         self.assertEqual(oc_list[1].action, ObjectChangeActionChoices.ACTION_DELETE)
         mock_enqueue_job_hooks.assert_has_calls(
-            [mock.call(oc_list[0], may_reload_jobs=True), mock.call(oc_list[1], may_reload_jobs=False)],
+            [
+                mock.call(oc_list[0], may_reload_jobs=True, jobhook_queryset=None),
+                mock.call(oc_list[1], may_reload_jobs=False, jobhook_queryset=None)],
         )
-        mock_enqueue_webhooks.assert_has_calls([mock.call(oc_list[0]), mock.call(oc_list[1])])
+        mock_enqueue_webhooks.assert_has_calls(
+            [mock.call(oc_list[0], webhook_queryset=None), mock.call(oc_list[1], webhook_queryset=None)]
+        )
 
     def test_update_then_delete(self):
         """Test that an update followed by a delete is logged as a single delete"""

--- a/nautobot/extras/tests/test_context_managers.py
+++ b/nautobot/extras/tests/test_context_managers.py
@@ -95,7 +95,8 @@ class WebRequestContextTestCase(TestCase):
         mock_enqueue_job_hooks.assert_has_calls(
             [
                 mock.call(oc_list[0], may_reload_jobs=True, jobhook_queryset=None),
-                mock.call(oc_list[1], may_reload_jobs=False, jobhook_queryset=None)],
+                mock.call(oc_list[1], may_reload_jobs=False, jobhook_queryset=None),
+            ],
         )
         mock_enqueue_webhooks.assert_has_calls(
             [mock.call(oc_list[0], webhook_queryset=None), mock.call(oc_list[1], webhook_queryset=None)]

--- a/nautobot/extras/tests/test_webhooks.py
+++ b/nautobot/extras/tests/test_webhooks.py
@@ -345,7 +345,7 @@ class WebhookTest(APITestCase):
 
         all_changes = get_changes_for_model(location)
         self.assertEqual(all_changes.count(), 1)
-        mock_enqueue_webhooks.assert_called_once_with(all_changes.first())
+        mock_enqueue_webhooks.assert_called_once_with(all_changes.first(), webhook_queryset=None)
 
     def test_all_webhook_supported_models(self):
         """

--- a/nautobot/extras/webhooks.py
+++ b/nautobot/extras/webhooks.py
@@ -6,16 +6,22 @@ from nautobot.extras.registry import registry
 from nautobot.extras.tasks import process_webhook
 
 
-def enqueue_webhooks(object_change):
+def enqueue_webhooks(object_change, webhook_queryset=None):
     """
-    Find Webhook(s) assigned to this instance + action and enqueue them
-    to be processed
+    Find Webhook(s) assigned to this instance + action and enqueue them to be processed.
+
+    Args:
+        object_change (ObjectChange): The change that may trigger Webhooks to be sent.
+        webhook_queryset (QuerySet): Previously retrieved set of Webhooks to potentially send.
+
+    Returns:
+        webhook_queryset (QuerySet): for reuse when processing multiple ObjectChange with the same content-type+action.
     """
     # Determine whether this type of object supports webhooks
     app_label = object_change.changed_object_type.app_label
     model_name = object_change.changed_object_type.model
     if model_name not in registry["model_features"]["webhooks"].get(app_label, []):
-        return
+        return webhook_queryset
 
     # Retrieve any applicable Webhooks
     content_type = object_change.changed_object_type
@@ -24,16 +30,17 @@ def enqueue_webhooks(object_change):
         ObjectChangeActionChoices.ACTION_UPDATE: "type_update",
         ObjectChangeActionChoices.ACTION_DELETE: "type_delete",
     }[object_change.action]
-    webhooks = Webhook.objects.filter(content_types=content_type, enabled=True, **{action_flag: True})
+    if webhook_queryset is None:
+        webhook_queryset = Webhook.objects.filter(content_types=content_type, enabled=True, **{action_flag: True})
 
-    if webhooks.exists():
+    if webhook_queryset:  # not .exists() as we *want* to populate the queryset cache
         # fall back to object_data if object_data_v2 is not available
         serialized_data = object_change.object_data_v2
         if serialized_data is None:
             serialized_data = object_change.object_data
 
         # Enqueue the webhooks
-        for webhook in webhooks:
+        for webhook in webhook_queryset:
             args = [
                 webhook.pk,
                 serialized_data,
@@ -45,3 +52,5 @@ def enqueue_webhooks(object_change):
                 object_change.get_snapshots(),
             ]
             process_webhook.apply_async(args=args)
+
+    return webhook_queryset


### PR DESCRIPTION
# Closes #6421
# Closes #5834 
# What's Changed

- Increased soft/hard time limits on CustomField provisioning background tasks to 1800 and 2000 seconds respectively. (fixes #5834)
- Fixed long-running-at-scale transaction lock on records while adding/removing a CustomField definition. (fixes #6421)
    - Add `JSONSet` and `JSONRemove` database helpers based on a currently-in-flight upstream Django PR, and use these to efficiently provision/deprovision specific keys on `_custom_field_data` on all impacted objects in a single query.
        - I don't currently have an equivalent function for the specific case of "Change the defined choices for a TYPE_MULTI_SELECT custom field" as that involves changing members of a list rather than just setting/deleting a single key/value pair, so for now that one will remain relatively inefficient/slow.
    - Instead of one combined `transaction.atomic()`/`web_request_context()` block that covers both updating the `_custom_field_data` on every affected record (quick) and generating the corresponding ObjectChange records (slow), we now use the efficient single query to update the `_custom_field_data` very quickly, then a separate transaction (via `deferred_change_logging_for_bulk_operation()`) to generate the ObjectChanges, avoiding the long-running lock on the object records that was reported in #6421.
- Added logging to JobResults for CustomField provisioning background tasks.

Additionally, before settling on the above approach, I went down a few rabbit holes investigating the *large* number of database queries being executed in the original implementation of these tasks, which led to the following fixes:

- Added cacheable `CustomField.objects.keys_for_model(model)` API. This makes the API serializer calls involved in creating the ObjectChange records more efficient at scale, because we can hit the database once to get the CF keys, then all subsequent calls for other instances of the same model will just be a cache hit instead of another query.
- Added queryset caching in `web_request_context` for more efficient JobHook and Webhook dispatching on bulk requests.If we're processing, say, a web_request_context that updated 1000 Manufacturers, we can look up the relevant JobHook and Webhook records for the dcim.manufacturer content-type once instead of repeating 1000 times.
- Added appropriate `select_related` to the ObjectChange queryset used in `web_request_context`.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots

Tested manually by repeatedly creating, updating, and deleting CustomFields that applied to Manufacturer and Status models while having 100000 Manufacturer records and several hundred Status records. Even in the Manufacturer case, the UI is responsive, and the background task runs to completion in about 5 minutes (5 seconds for the efficient `_custom_field_data` update, and the remaining time spent generating 100000 ObjectChange records atomically).

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
