### PR TITLE
Make "position" JS specific to ModuleBay form to avoid unintended interactions with other forms

### DIFF
--- a/changes/6441.fixed
+++ b/changes/6441.fixed
@@ -1,0 +1,1 @@
+Fixed a regression in 2.3.9 that broke the rendering of the Device create/edit form.

--- a/nautobot/dcim/templates/dcim/modulebay_create.html
+++ b/nautobot/dcim/templates/dcim/modulebay_create.html
@@ -1,0 +1,39 @@
+{% extends 'dcim/device_component_add.html' %}
+
+{% block javascript %}
+{{ block.super }}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var position_field = document.getElementById('id_position_pattern');
+    var source_arr = position_field.getAttribute('source').split(" ");
+    var length = position_field.getAttribute('maxlength');
+    position_field.setAttribute('_changed', Boolean(position_field.value))
+    position_field.addEventListener('change', function() {
+        position_field.setAttribute('_changed', Boolean(position_field.value))
+    });
+    function repopulate() {
+        let str = "";
+        for (source_str of source_arr) {
+            if (str != "") {
+                str += " ";
+            }
+            let source_id = 'id_' + source_str;
+            let source = document.getElementById(source_id)
+            str += source.value;
+        }
+        position_field.value = str.slice(0, length ? length : 255);
+    };
+    for (source_str of source_arr) {
+        let source_id = 'id_' + source_str;
+        let source = document.getElementById(source_id);
+        source.addEventListener('keyup', function() {
+            if (position_field && position_field.getAttribute('_changed')=="false") {
+                repopulate();
+            }
+        });
+    }
+    document.getElementsByClassName('reslugify')[0].addEventListener('click', repopulate);
+    document.getElementsByClassName('reslugify')[0].setAttribute('data-original-title', "Regenerate position");
+});
+</script>
+{% endblock javascript %}

--- a/nautobot/dcim/templates/dcim/modulebay_update.html
+++ b/nautobot/dcim/templates/dcim/modulebay_update.html
@@ -1,0 +1,39 @@
+{% extends 'generic/object_create.html' %}
+
+{% block javascript %}
+{{ block.super }}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var position_field = document.getElementById('id_position');
+    var source_arr = position_field.getAttribute('source').split(" ");
+    var length = position_field.getAttribute('maxlength');
+    position_field.setAttribute('_changed', Boolean(position_field.value))
+    position_field.addEventListener('change', function() {
+        position_field.setAttribute('_changed', Boolean(position_field.value))
+    });
+    function repopulate() {
+        let str = "";
+        for (source_str of source_arr) {
+            if (str != "") {
+                str += " ";
+            }
+            let source_id = 'id_' + source_str;
+            let source = document.getElementById(source_id)
+            str += source.value;
+        }
+        position_field.value = str.slice(0, length ? length : 255);
+    };
+    for (source_str of source_arr) {
+        let source_id = 'id_' + source_str;
+        let source = document.getElementById(source_id);
+        source.addEventListener('keyup', function() {
+            if (position_field && position_field.getAttribute('_changed')=="false") {
+                repopulate();
+            }
+        });
+    }
+    document.getElementsByClassName('reslugify')[0].addEventListener('click', repopulate);
+    document.getElementsByClassName('reslugify')[0].setAttribute('data-original-title', "Regenerate position");
+});
+</script>
+{% endblock javascript %}

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -3241,7 +3241,7 @@ class ModuleBayUIViewSet(ModuleBayCommonViewSetMixin, NautobotUIViewSet):
     model_form_class = forms.ModuleBayForm
     serializer_class = serializers.ModuleBaySerializer
     table_class = tables.ModuleBayTable
-    create_template_name = "dcim/device_component_add.html"
+    create_template_name = "dcim/modulebay_create.html"
 
     def get_extra_context(self, request, instance):
         if instance:

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -125,43 +125,6 @@ function initializeSlugField(context){
     }
 }
 
-function initializePositionField(context){
-    var position_field = document.getElementById('id_position');
-    if (!position_field) {
-        var position_field = document.getElementById('id_position_pattern');
-    }
-    if (position_field) {
-        var source_arr = position_field.getAttribute('source').split(" ");
-        var length = position_field.getAttribute('maxlength');
-        position_field.setAttribute('_changed', Boolean(position_field.value))
-        position_field.addEventListener('change', function() {
-            position_field.setAttribute('_changed', Boolean(position_field.value))
-        });
-        function repopulate() {
-            let str = "";
-            for (source_str of source_arr) {
-                if (str != "") {
-                    str += " ";
-                }
-                let source_id = 'id_' + source_str;
-                let source = document.getElementById(source_id)
-                str += source.value;
-            }
-            position_field.value = str.slice(0, length ? length : 255);
-        };
-        for (source_str of source_arr) {
-            let source_id = 'id_' + source_str;
-            let source = document.getElementById(source_id);
-            source.addEventListener('keyup', function() {
-                if (position_field && position_field.getAttribute('_changed')=="false") {
-                    repopulate();
-                }
-            });
-        }
-        document.getElementsByClassName('reslugify')[0].addEventListener('click', repopulate);
-    }
-}
-
 function initializeFormActionClick(context){
     this_context = $(context);
     // Set formaction and submit using a link
@@ -923,7 +886,6 @@ function initializeInputs(context) {
     initializeStaticChoiceSelection(this_context)
     initializeCheckboxes(this_context)
     initializeSlugField(this_context)
-    initializePositionField(this_context)
     initializeFormActionClick(this_context)
     initializeBulkEditNullification(this_context)
     initializeColorPicker(this_context)


### PR DESCRIPTION

# Closes #6441 
# What's Changed

- Device form UI was broken because the JS added in #6419 to add special behavior for the ModuleBay `position` form field was interacting unexpectedly with the Device `position` form field.
- Solution: since this JS is specific to ModuleBay, extract it from the shared `forms.js` into the specific ModuleBay page templates.
   - Since these templates didn't exist, I've created them.
   - Device components (including ModuleBay) have different create (bulk create) and edit page templates, so I did have to replicate the JS twice. It's actually *very slightly* different between the two since the (bulk) create form has `id_position_pattern` form field while the edit form has `id_position`. If this gives anyone too much heartburn I can look at creating a shared .js file between the two but I didn't think it critical for this specific case since there are only two replicas.
- Fix a very minor cosmetic bug I noticed in testing this, to make the "reslugify" button on these two pages have a tooltip of `Regenerate position` instead of the default `Regenerate slug` tooltip.

# Screenshots
Device form works again:

![image](https://github.com/user-attachments/assets/a9a24445-1a24-4766-b612-ae173b4c4392)

Module bay creation form still works:

![image](https://github.com/user-attachments/assets/d37de9f1-d31f-43aa-b70c-2414230e7cd0)

Module bay edit form still works:

![image](https://github.com/user-attachments/assets/b25c5c7f-7759-4466-b7eb-4509ed7b8ab9)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
