### PR TITLE
fix tests that always passed due to errors

### DIFF
--- a/changes/6455.fixed
+++ b/changes/6455.fixed
@@ -1,0 +1,1 @@
+Fixes two tests which always passed due to errors in their implementation. Ensured they provide value by checking against the correct results.

--- a/nautobot/core/testing/api.py
+++ b/nautobot/core/testing/api.py
@@ -699,13 +699,15 @@ class APIViewTestCases:
             serializer_class = get_serializer_for_model(self.model)
             old_serializer = serializer_class(instance, context={"request": None})
             old_data = old_serializer.data
+            # save the pk because .delete() will clear it, making the test below always pass
+            orig_pk = instance.pk
             instance.delete()
 
             response = self.client.post(self._get_list_url(), csv_data, content_type="text/csv", **self.header)
             self.assertHttpStatus(response, status.HTTP_201_CREATED, csv_data)
             # Note that create via CSV is always treated as a bulk-create, and so the response is always a list of dicts
             new_instance = self._get_queryset().get(pk=response.data[0]["id"])
-            self.assertNotEqual(new_instance.pk, instance.pk)
+            self.assertNotEqual(new_instance.pk, orig_pk)
 
             new_serializer = serializer_class(new_instance, context={"request": None})
             new_data = new_serializer.data

--- a/nautobot/core/tests/test_csv.py
+++ b/nautobot/core/tests/test_csv.py
@@ -267,6 +267,9 @@ class CSVParsingRelatedTestCase(TestCase):
         url = reverse("dcim:device_import")
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 200)
+        # uploading the CSV always returns a 200 code with a page with an error message on it
+        # ensure we don't have that error message
+        self.assertNotIn("FORM-ERROR", response.content.decode(response.charset))
         self.assertEqual(Device.objects.count(), 4)
 
         # Assert TestDevice3 got created with the right fields


### PR DESCRIPTION
These two tests always passed due to errors in how the tests were implemented. This ensures that the tests provide value by checking against the correct results.

