### PR TITLE
Mark ObjectMetadata as is_metadata_associable_model=False, and remove unused ObjectMetadata detail view

### DIFF
--- a/changes/6509.fixed
+++ b/changes/6509.fixed
@@ -1,0 +1,2 @@
+Disallowed association of `ObjectMetadata` as metadata to other `ObjectMetadata` records.
+Removed unused object-detail view for `ObjectMetadata` records.

--- a/nautobot/core/testing/views.py
+++ b/nautobot/core/testing/views.py
@@ -1,3 +1,4 @@
+import contextlib
 import re
 from typing import Optional, Sequence
 from unittest import skipIf
@@ -792,11 +793,16 @@ class ViewTestCases:
             response = self.client.get(f"{self._get_url('list')}?id={instance1.pk}")
             self.assertHttpStatus(response, 200)
             content = utils.extract_page_body(response.content.decode(response.charset))
+            # There should be only one row in the table
+            self.assertIn('<tr class="even', content)
+            self.assertNotIn('<tr class="odd', content)
             if hasattr(self.model, "name"):
                 self.assertRegex(content, r">\s*" + re.escape(escape(instance1.name)) + r"\s*<", msg=content)
                 self.assertNotRegex(content, r">\s*" + re.escape(escape(instance2.name)) + r"\s*<", msg=content)
-            if instance1.get_absolute_url() in content:
-                self.assertNotIn(instance2.get_absolute_url(), content, msg=content)
+            with contextlib.suppress(AttributeError):
+                # Some models, such as ObjectMetadata, don't have a detail URL
+                if instance1.get_absolute_url() in content:
+                    self.assertNotIn(instance2.get_absolute_url(), content, msg=content)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"], STRICT_FILTERING=True)
         def test_list_objects_unknown_filter_strict_filtering(self):
@@ -833,11 +839,16 @@ class ViewTestCases:
             content = utils.extract_page_body(response.content.decode(response.charset))
             self.assertNotIn("Unknown filter field", content, msg=content)
             self.assertIn("None", content, msg=content)
+            # There should be at least two rows in the table
+            self.assertIn('<tr class="even', content)
+            self.assertIn('<tr class="odd', content)
             if hasattr(self.model, "name"):
                 self.assertRegex(content, r">\s*" + re.escape(escape(instance1.name)) + r"\s*<", msg=content)
                 self.assertRegex(content, r">\s*" + re.escape(escape(instance2.name)) + r"\s*<", msg=content)
-            if instance1.get_absolute_url() in content:
-                self.assertIn(instance2.get_absolute_url(), content, msg=content)
+            with contextlib.suppress(AttributeError):
+                # Some models, such as ObjectMetadata, don't have a detail URL
+                if instance1.get_absolute_url() in content:
+                    self.assertIn(instance2.get_absolute_url(), content, msg=content)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
         def test_list_objects_without_permission(self):

--- a/nautobot/extras/models/metadata.py
+++ b/nautobot/extras/models/metadata.py
@@ -201,6 +201,7 @@ class ObjectMetadata(ChangeLoggedModel, BaseModel):
     objects = ObjectMetadataManager()
     natural_key_field_names = ["pk"]
     documentation_static_path = "docs/user-guide/platform-functionality/objectmetadata.html"
+    is_metadata_associable_model = False
 
     class Meta:
         ordering = ["metadata_type"]

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -978,6 +978,7 @@ class MetadataTypeTable(BaseTable):
 
 class ObjectMetadataTable(BaseTable):
     pk = ToggleColumn()
+    # NOTE: there is no identity column in this table; this is intentional as we have no detail view for ObjectMetadata
     metadata_type = tables.Column(linkify=True)
     assigned_object = tables.TemplateColumn(
         template_code=ASSIGNED_OBJECT, verbose_name="Assigned object", orderable=False

--- a/nautobot/extras/templates/extras/inc/job_table.html
+++ b/nautobot/extras/templates/extras/inc/job_table.html
@@ -28,7 +28,7 @@
                 </th>
             </tr>
             {% endifchanged %}
-            <tr class="collapseme-{{ row.record.grouping|slugify }}{% if not perms.extras.run_job or not row.record.runnable %} disabled{% endif %} collapse in" data-parent="#accordion" {{ row.attrs.as_html }}>
+            <tr class="{% cycle 'even' 'odd' %} collapseme-{{ row.record.grouping|slugify }}{% if not perms.extras.run_job or not row.record.runnable %} disabled{% endif %} collapse in" data-parent="#accordion" {{ row.attrs.as_html }}>
                 {% for column, cell in row.items %}
                     <td {{ column.attrs.td.as_html }}>{{ cell }}</td>
                 {% endfor %}

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -3033,8 +3033,6 @@ class ObjectChangeTestCase(TestCase):
 
 
 class ObjectMetadataTestCase(
-    ViewTestCases.GetObjectViewTestCase,
-    ViewTestCases.GetObjectChangelogViewTestCase,
     ViewTestCases.ListObjectsViewTestCase,
 ):
     model = ObjectMetadata

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2228,8 +2228,6 @@ class MetadataTypeUIViewSet(NautobotUIViewSet):
 
 
 class ObjectMetadataUIViewSet(
-    ObjectChangeLogViewMixin,
-    ObjectDetailViewMixin,
     ObjectListViewMixin,
 ):
     filterset_class = filters.ObjectMetadataFilterSet


### PR DESCRIPTION
# Closes #6509
# What's Changed

- Intermittent test failures reported in `next` in #6509 were because the ObjectMetadataTable doesn't actually have an "identity" column that would link to the ObjectMetadata detail view.
    - The tests were only *ever* detecting `object_metadata.get_absolute_url()` and passing because by coincidence our ObjectMetadataFactory was producing ObjectMetadata that was becoming metadata for other ObjectMetadata, and so the `associated_object` column was containing the `object_metadata.get_absolute_url()` by coincidence. 
        - This in turn was happening because the `ObjectMetadata` model itself was not marked as `is_metadata_associable_model=False` as it should be.

Fixes:

1) Add `is_metadata_associable_model=False` to `ObjectMetadata`
2) Remove detail and change-log views from `ObjectMetadataUIViewSet` as the detail view wasn't ever implemented (no template, just using the default (blank) `generic/object_retrieve.html` template)
3) Remove detail and change-log tests from `ObjectMetadataTestCase`
4) Update the two list-view test cases that were checking for `instance.get_absolute_url()` to handle the possibility that the model in question might have a list view but no detail URL.
5) Update these two list-view test cases with an alternate approach to detecting how many rows are in the table (checking for "odd" and "even" table rows)
6) Update the `job_list.html` template (custom table rendering) to include the `odd` and `even` table row classes that it was missing, fixing a failure in the newly introduced test logic.

Not addressed in this PR:

- `ObjectMetadata.Meta.ordering` is underspecified as it only orders by `metadata_type` which can be shared by many records. Probably this should be changed to something like `associated_object_id, metadata_type, scoped_fields` or something similar to guarantee a consistent ordering among records.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
