### PR TITLE
Adds check to __str__ method on the Note model for created attribute.

### DIFF
--- a/changes/6533.fixed
+++ b/changes/6533.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where the string representation of the Note model does not throw an error if accessed pre_save.

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -831,7 +831,7 @@ class Note(ChangeLoggedModel, BaseModel):
         unique_together = [["assigned_object_type", "assigned_object_id", "user_name", "created"]]
 
     def __str__(self):
-        return f"{self.assigned_object} - {self.created.isoformat()}"
+        return f"{self.assigned_object} - {self.created.isoformat() if self.created else None}"
 
     def save(self, *args, **kwargs):
         # Record the user's name as static strings


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6533 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Adds a check to __str__ method on the Note model for the `self.created` attribute prior to accessing the `.isoformat()` method.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
