### PR TITLE
feature: implement installed apps page tile view

### DIFF
--- a/changes/6539.added
+++ b/changes/6539.added
@@ -1,0 +1,1 @@
+Added Installed Apps page tile view.

--- a/nautobot/core/templatetags/helpers.py
+++ b/nautobot/core/templatetags/helpers.py
@@ -740,15 +740,15 @@ def querystring(request, **kwargs):
 
 
 @register.simple_tag()
-def table_config_button(table, table_name=None, extra_classes=""):
+def table_config_button(table, table_name=None, extra_classes="", disabled=False):
     if table_name is None:
         table_name = table.__class__.__name__
     html_template = (
         '<button type="button" class="btn btn-default {}'
-        '" data-toggle="modal" data-target="#{}_config" title="Configure table">'
+        '" data-toggle="modal" data-target="#{}_config" {} title="Configure table">'
         '<i class="mdi mdi-cog"></i> Configure</button>'
     )
-    return format_html(html_template, extra_classes, table_name)
+    return format_html(html_template, extra_classes, table_name, 'disabled="disabled"' if disabled else "")
 
 
 @register.simple_tag()

--- a/nautobot/extras/templates/extras/marketplace.html
+++ b/nautobot/extras/templates/extras/marketplace.html
@@ -4,14 +4,6 @@
 
 {% block extra_styles %}
 <style>
-    a.tile,
-    a.tile:hover,
-    a.tile:focus,
-    a.tile:visited {
-        color: inherit;
-        text-decoration: none;
-    }
-
     .tile-header {
         display: block;
     }

--- a/nautobot/extras/templates/extras/plugins_list.html
+++ b/nautobot/extras/templates/extras/plugins_list.html
@@ -15,10 +15,10 @@
 
     <div class="pull-right noprint">
         <div class="btn-group">
-            <a class="btn btn-default set-plugins_list-display" data-display="tiles" href="" title="Tiles">
+            <a class="btn btn-default set-apps-display" data-display="tiles" href="" title="Tiles">
                 <i class="mdi mdi-view-grid{% if display == "list" %}-outline{% endif %}"></i>
             </a>
-            <a class="btn btn-default set-plugins_list-display" data-display="list" href="" title="List">
+            <a class="btn btn-default set-apps-display" data-display="list" href="" title="List">
                 <i class="mdi mdi-view-sequential{% if display == "tiles" %}-outline{% endif %}"></i>
             </a>
         </div>
@@ -58,7 +58,7 @@
 
 <script>
     // Set display anchor links without losing other potentially active query params such as applied filters.
-    [...document.querySelectorAll('.set-plugins_list-display')].forEach(button => {
+    [...document.querySelectorAll('.set-apps-display')].forEach(button => {
         const queryParams = new URLSearchParams(window.location.search);
         queryParams.set('display', button.dataset.display);
         button.setAttribute('href', `?${queryParams.toString()}`);

--- a/nautobot/extras/templates/extras/plugins_list.html
+++ b/nautobot/extras/templates/extras/plugins_list.html
@@ -24,7 +24,11 @@
         </div>
 
         {% if request.user.is_authenticated and table_config_form %}
-            {% table_config_button table table_name="ObjectTable" %}
+            {% if display == "tiles" %}
+                {% table_config_button table table_name="ObjectTable" disabled=True %}
+            {% else %}
+                {% table_config_button table table_name="ObjectTable" %}
+            {% endif %}
         {% endif %}
 
         <a class="btn btn-primary" href="{% url 'apps:apps_marketplace' %}">Visit Apps Marketplace</a>

--- a/nautobot/extras/templates/extras/plugins_list.html
+++ b/nautobot/extras/templates/extras/plugins_list.html
@@ -3,10 +3,31 @@
 {% load static %}
 
 {% block content %}
+    <div class="row noprint">
+        <div class="col-md-12">
+            <ol class="breadcrumb">
+                {% block breadcrumbs %}
+                    <li><a href="{% url 'apps:apps_list' %}">Installed Apps</a></li>
+                {% endblock breadcrumbs %}
+            </ol>
+        </div>
+    </div>
+
     <div class="pull-right noprint">
+        <div class="btn-group">
+            <a class="btn btn-default set-plugins_list-display" data-display="tiles" href="" title="Tiles">
+                <i class="mdi mdi-view-grid{% if display == "list" %}-outline{% endif %}"></i>
+            </a>
+            <a class="btn btn-default set-plugins_list-display" data-display="list" href="" title="List">
+                <i class="mdi mdi-view-sequential{% if display == "tiles" %}-outline{% endif %}"></i>
+            </a>
+        </div>
+
         {% if request.user.is_authenticated and table_config_form %}
             {% table_config_button table table_name="ObjectTable" %}
         {% endif %}
+
+        <a class="btn btn-primary" href="{% url 'apps:apps_marketplace' %}">Visit Apps Marketplace</a>
     </div>
 
     <h1>{% block title %}Installed Apps{% endblock %}</h1>
@@ -30,4 +51,13 @@
 {% block javascript %}
 {{ block.super }}
 <script src="{% static 'js/tableconfig.js' %}"></script>
+
+<script>
+    // Set display anchor links without losing other potentially active query params such as applied filters.
+    [...document.querySelectorAll('.set-plugins_list-display')].forEach(button => {
+        const queryParams = new URLSearchParams(window.location.search);
+        queryParams.set('display', button.dataset.display);
+        button.setAttribute('href', `?${queryParams.toString()}`);
+    });
+</script>
 {% endblock %}

--- a/nautobot/extras/templates/extras/plugins_tiles.html
+++ b/nautobot/extras/templates/extras/plugins_tiles.html
@@ -1,0 +1,79 @@
+{% load helpers %}
+{% load static %}
+
+{% block extra_styles %}
+<style>
+    .tile-header {
+        align-items: flex-start;
+        display: block;
+    }
+
+    .tile-header h2 {
+        margin-top: 0;
+    }
+
+    .tile-actions-placeholder {
+        height: 30px;
+        margin-left: 3px;
+    }
+
+    .tile-actions {
+        position: absolute;
+        right: 21px;
+        top: 21px;
+    }
+
+    .tile-actions .btn {
+        padding: 3px 8px;  /* Enlarge action buttons to 32px x 32px */
+    }
+</style>
+{% endblock %}
+
+<section class="tiles">
+    {% for row in table.page.object_list|default:table.rows %}
+        <div style="position: relative;">
+            <a class="tile clickable" href="{% url 'apps:app_detail' app=row.record.app_label %}">
+                <header class="tile-header">
+                    <img
+                        alt="{{ row.record.name }}"
+                        src="{% if app_icons|get_item:row.record.package_name != None %}{{ app_icons|get_item:row.record.package_name }}{% else %}{% static 'img/nautobot_icon_192x192.png' %}{% endif %}"
+                        height="64"
+                        width="64"
+                    />
+
+                    <!--
+                       Occupy `.tile-actions` dedicated space with `.tile-actions-placeholder`. See comment above
+                       `.tile-actions` element for detailed explanation of this solution and why it is required here.
+                    -->
+                    <div
+                        aria-hidden="true"
+                        class="tile-actions-placeholder pull-right"
+                        style="width: calc(32px * {{ row.record.actions|length }} + 3px * {{ row.record.actions|length|add:-1 }})">
+                    </div>
+
+                    <h2>{{ row.record.name }}</h2>
+
+                    <p class="tile-description">{{ row.record.description }}</p>
+                </header>
+
+                <footer class="tile-footer">
+                    <div>Author: {{ row.record.author }}</div>
+                    <div>Version: {{ row.record.version }}</div>
+                </footer>
+            </a>
+
+            <!--
+                Place app action links outside the "main" `a` tile to adhere to HTML rule that forbid nesting anchors
+                within anchors. Absolutely position the actions to make them appear inside the tile though. Fill their
+                dedicated space with `.tile-actions-placeholder` element.
+            -->
+            <div class="tile-actions">
+                {% for column, cell in row.items %}
+                    {% if column.verbose_name == "" %}
+                        {{ cell }}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+    {% endfor %}
+</section>

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -934,7 +934,7 @@ code.hljs {
 .tiles {
     display: grid;
     grid-gap: 20px;
-    grid-template-columns: repeat(auto-fit, minmax(445px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(445px, 1fr));
 }
 @media (max-width: 1007px) {
     .tiles {
@@ -961,6 +961,13 @@ code.hljs {
 .tile.clickable:hover {
     border-color: #007dff;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+}
+a.tile.clickable,
+a.tile.clickable:hover,
+a.tile.clickable:focus,
+a.tile.clickable:visited {
+    color: inherit;
+    text-decoration: none;
 }
 .tile.disabled {
     background: #f4f4f4;


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6432
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
**This PR is continuation of #6504**

Implement Installed Apps page tile view. This includes:
1. Tiles, similar to previously implemented Apps Marketplace tiles (see attached screenshot).
2. List/Tiles view switch. Selected view is persisted in user preferences the same way as views on Jobs page.
3. Link to Apps Marketplace page in the upper right corner of the page (next to Configure table button).
4. Disabled Configure table button when `tiles` display is on.
5. Breadcrumbs at the top of the page.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
![installed_apps_tiles](https://github.com/user-attachments/assets/e94a1a05-754b-4fa2-abbf-a2329363cff0)

