### PR TITLE
add group_sync for SSO groups in a generic way

### DIFF
--- a/changes/6543.added
+++ b/changes/6543.added
@@ -1,0 +1,1 @@
+Defined a generic SSO group authentication module that can be shared by any OAuth2/OIDC backend.

--- a/examples/azure_ad/README.md
+++ b/examples/azure_ad/README.md
@@ -1,6 +1,8 @@
 # Social Auth Pipeline AzureAD Group Sync Example
 
-This example shows how to extend the Social Auth Pipeline to read groups from a groups claim in AzureAD and sync those with Nautobot.  
+NOTE: In newer versions of Nautobot this is built-in via the `nautobot.extras.group_sync` module.
+
+This example shows how to extend the Social Auth Pipeline to read groups from a groups claim in AzureAD and sync those with Nautobot.
 
 Create a python module with the provided `group_sync.py` file in it. This could be done as part of a Nautobot App, or as a standalone python module.
 

--- a/examples/okta/README.md
+++ b/examples/okta/README.md
@@ -1,6 +1,8 @@
 # Social Auth Pipeline Okta Group Sync Example
 
-This example shows how to extend the Social Auth Pipeline to read groups from a groups claim in Okta and sync those with Nautobot.  
+NOTE: In newer versions of Nautobot this is built-in via the `nautobot.extras.group_sync` module.
+
+This example shows how to extend the Social Auth Pipeline to read groups from a groups claim in Okta and sync those with Nautobot.
 
 Create a python module with the `group_sync.py` file in it, this could be done as part of a Nautobot App, or as a standalone python module.
 

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -212,6 +212,32 @@ SOCIAL_AUTH_POSTGRES_JSONFIELD = False
 # Nautobot related - May be overridden if using custom social auth backend
 SOCIAL_AUTH_BACKEND_PREFIX = "social_core.backends"
 
+# Enables adding the OAuth2/OIDC group sync module to the authentication pipeline
+SSO_ENABLE_GROUP_SYNC = is_truthy(os.getenv("NAUTOBOT_SSO_ENABLE_GROUP_SYNC", "false"))
+if SSO_ENABLE_GROUP_SYNC:
+    SOCIAL_AUTH_PIPELINE = (
+        "social_core.pipeline.social_auth.social_details",
+        "social_core.pipeline.social_auth.social_uid",
+        "social_core.pipeline.social_auth.auth_allowed",
+        "social_core.pipeline.social_auth.social_user",
+        "social_core.pipeline.user.get_username",
+        "social_core.pipeline.user.create_user",
+        "social_core.pipeline.social_auth.associate_user",
+        "social_core.pipeline.social_auth.load_extra_data",
+        "social_core.pipeline.user.user_details",
+        "nautobot.extras.group_sync",
+    )
+# OAuth2/OIDC claim where the list of groups the authenticating user is a part of
+SSO_CLAIMS_GROUP = os.getenv("NAUTOBOT_SSO_CLAIMS_GROUP", "groups")
+# list of groups that an authenticating user can be a part of to get the Django staff permission
+SSO_STAFF_GROUPS = [
+    group for group in os.getenv("NAUTOBOT_SSO_STAFF_GROUPS", "").split(_CONFIG_SETTING_SEPARATOR) if group != ""
+]
+# list of groups that an authenticating user can be a part of to be a Django super user
+SSO_SUPERUSER_GROUPS = [
+    group for group in os.getenv("NAUTOBOT_SSO_SUPERUSER_GROUPS", "").split(_CONFIG_SETTING_SEPARATOR) if group != ""
+]
+
 # Job log entry sanitization and similar
 SANITIZER_PATTERNS = [
     # General removal of username-like and password-like tokens

--- a/nautobot/core/settings.yaml
+++ b/nautobot/core/settings.yaml
@@ -1705,6 +1705,37 @@ properties:
       "Single Sign On": "./authentication/sso.md"
       "`social-auth-app-django`": "https://python-social-auth.readthedocs.io/en/latest/configuration/django.html"
     type: "string"
+  SSO_CLAIMS_GROUP:
+    default: "groups"
+    description: "OAuth2/OIDC claim which will contain the groups which the authenticated user is a member of."
+    environment_variable: "NAUTOBOT_SSO_CLAIMS_GROUP"
+    see_also:
+      "Single Sign On": "./authentication/sso.md"
+  SSO_ENABLE_GROUP_SYNC:
+    default: false
+    type: "boolean"
+    description: "Enables the group syncing authentication module."
+    environment_variable: "NAUTOBOT_SSO_ENABLE_GROUP_SYNC"
+    see_also:
+      "Single Sign On": "./authentication/sso.md"
+  SSO_STAFF_GROUPS:
+    default: []
+    description: "List of groups that a user can be a member of to get the Django Staff permission."
+    environment_variable: "NAUTOBOT_SSO_STAFF_GROUPS"
+    see_also:
+      "Single Sign On": "./authentication/sso.md"
+    items:
+      type: "string"
+    type: "array"
+  SSO_SUPERUSER_GROUPS:
+    default: []
+    description: "List of groups that a user can be a member of to be a Django Super User."
+    environment_variable: "NAUTOBOT_SSO_SUPERUSER_GROUPS"
+    see_also:
+      "Single Sign On": "./authentication/sso.md"
+    items:
+      type: "string"
+    type: "array"
   STATIC_ROOT:
     "$ref": "#/definitions/absolute_path"
     default: "~/.nautobot/static"

--- a/nautobot/extras/group_sync.py
+++ b/nautobot/extras/group_sync.py
@@ -1,0 +1,42 @@
+"""Additional functions to process an OAuth2/OIDC user."""
+
+import logging
+
+from django.conf import settings
+from django.contrib.auth.models import Group
+
+logger = logging.getLogger(__name__)
+
+
+CLAIMS_GROUP_NAME = getattr(settings, "NAUTOBOT_SSO_CLAIMS_GROUP", "groups")
+""" Which claim to look at in the OAuth2/OIDC response
+
+    For Okta you can look at `Okta -> Authorization Servers -> Claims`. And a reasonable
+    default is "groups". For Azure a reasonable default is "roles".
+"""
+
+SUPERUSER_GROUPS = getattr(settings, "NAUTOBOT_SSO_SUPERUSER_GROUPS", [])
+STAFF_GROUPS = getattr(settings, "NAUTOBOT_SSO_STAFF_GROUPS", [])
+
+
+def group_sync(uid, user=None, response=None, *args, **kwargs):
+    """Sync the users groups from OAuth2/OIDC auth and set staff/superuser as appropriate."""
+    if user and response and CLAIMS_GROUP_NAME and response.get(CLAIMS_GROUP_NAME, False):
+        group_memberships = response.get(CLAIMS_GROUP_NAME)
+        is_staff = False
+        is_superuser = False
+        logger.debug(f"User {uid} is a member of {', '.join(group_memberships)}")
+        # Make sure all groups exist in Nautobot
+        group_ids = []
+        for group in group_memberships:
+            if group in SUPERUSER_GROUPS:
+                is_superuser = True
+            if group in STAFF_GROUPS:
+                is_staff = True
+            group_ids.append(Group.objects.get_or_create(name=group)[0].id)
+        user.groups.set(group_ids)
+        user.is_superuser = is_superuser
+        user.is_staff = is_staff
+        user.save()
+    else:
+        logger.debug(f"Did not receive groups from OAuth2/OIDC, response: {response}")


### PR DESCRIPTION
Defined a generic SSO group authentication module that can be shared by any OAuth2/OIDC backend.

# Closes #6543 
# What's Changed

- added `nautobot.extras.group_sync` so that we can use any generic authentication backend.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
