### PR TITLE
VirtualDeviceContextTable should use RoleTableMixin

### DIFF
--- a/changes/6546.fixed
+++ b/changes/6546.fixed
@@ -1,1 +1,1 @@
-Fixed inconsistent rendering of the Role field on the Virtual Device Context.
+Fixed inconsistent rendering of the Role column on the Virtual Device Context list table.

--- a/changes/6546.fixed
+++ b/changes/6546.fixed
@@ -1,0 +1,1 @@
+Fixed inconsistent rendering of the Role field on the Virtual Device Context.

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -1468,10 +1468,9 @@ class ControllerManagedDeviceGroupTable(BaseTable):
         return format_html_join(" ", '<span class="label label-default">{}</span>', ((v,) for v in value))
 
 
-class VirtualDeviceContextTable(StatusTableMixin, BaseTable):
+class VirtualDeviceContextTable(StatusTableMixin, RoleTableMixin, BaseTable):
     pk = ToggleColumn()
     name = tables.Column(linkify=True)
-    role = tables.Column(linkify=True)
     tenant = TenantColumn()
     device = tables.Column(linkify=True)
     primary_ip = tables.Column(linkify=True, order_by=("primary_ip6", "primary_ip4"), verbose_name="IP Address")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

The Virtual Device Context List view was inconsistent with other list views that use Role. This PR adds the RoleTableMixin to resolve this Table.  Other Tables were already addressed in `develop` and will be resolved when we merge `develop` into `next`.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Before:
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/244f8138-aff1-4d53-b94d-8133bd3264b4">

After:
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/78525dac-103c-4376-9df6-ab609cc5abb7">


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
