### PR TITLE
Copy Object Display without the additional tab title

### DIFF
--- a/changes/6242.fixed
+++ b/changes/6242.fixed
@@ -1,0 +1,1 @@
+Copy button on Device Tabbed views will now only copy the Device Name.

--- a/nautobot/core/templates/generic/object_retrieve.html
+++ b/nautobot/core/templates/generic/object_retrieve.html
@@ -54,7 +54,7 @@
         <h1>
             <span class="hover_copy">
                 <span id="copy_title">{% block title %}{{object.display|default:object}}{% endblock %}</span>
-                <button type="button" class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#copy_title">
+                <button type="button" class="btn btn-inline btn-default hover_copy_button" data-clipboard-text="{{ object.display | default:object }}">
                     <span class="mdi mdi-content-copy"></span>
                 </button>
             </span>

--- a/nautobot/dcim/templates/dcim/device/base.html
+++ b/nautobot/dcim/templates/dcim/device/base.html
@@ -58,7 +58,7 @@
     <span class="hover_copy">
         <h1>
             <span id="devicename">{% block title %}{{ object }}{% endblock title %}</span>
-            <button class="btn btn-xs btn-default hover_copy_button" data-clipboard-target="#devicename">
+            <button class="btn btn-xs btn-default hover_copy_button" data-clipboard-text="{{ object }}">
                 <span class="mdi mdi-content-copy"></span>
             </button>
         </h1>

--- a/nautobot/ipam/templates/ipam/ipaddresstointerface_retrieve.html
+++ b/nautobot/ipam/templates/ipam/ipaddresstointerface_retrieve.html
@@ -4,7 +4,7 @@
 
 {% block masthead %}
 <h1>
-<span class="hover_copy"><span id="copy_title">{{ object }}</span><button type="button" class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#copy_title">
+<span class="hover_copy"><span id="copy_title">{{ object }}</span><button type="button" class="btn btn-inline btn-default hover_copy_button" data-clipboard-text="{{ object }}">
     <span class="mdi mdi-content-copy"></span>
 </button>
 </span>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6242 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

Changed the data-clipboard-target to data-clipboard-text in order to pass just the Object Display no matter what Object Detail Tab the user is on.

<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
