### PR TITLE
Move rack unit validation to save()

### DIFF
--- a/changes/6585.fixed
+++ b/changes/6585.fixed
@@ -1,0 +1,1 @@
+Added checks to prevent being able to put devices in the same rack unit


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6585 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Move rack unit conflict checks to Device.save() so they run even when calling Device.objects.create()

As of today, these checks are only run when interacting via GUI or API
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [X] Example App Updates (when adding/changing features)
- [X] Outline Remaining Work, Constraints from Design
