### PR TITLE
Fixed `table_config` field not showing up correctly in the saved view modal

### DIFF
--- a/changes/6466.fixed
+++ b/changes/6466.fixed
@@ -1,0 +1,1 @@
+Fixed `table_config` field not showing up correctly in the Saved View modal.

--- a/nautobot/core/templatetags/helpers.py
+++ b/nautobot/core/templatetags/helpers.py
@@ -795,7 +795,13 @@ def saved_view_modal(
         "clear_view",
     ]
 
-    table_name = lookup.get_table_for_model(model).__name__
+    view_class = lookup.get_view_for_model(model, "List")
+    table_name = None
+    if hasattr(view_class, "table"):
+        table_name = view_class.table.__name__
+    if hasattr(view_class, "table_class"):
+        table_name = view_class.table_class.__name__
+
     for param in non_filter_params:
         if param == "saved_view":
             current_saved_view_pk = filters_applied.pop(param, None)

--- a/nautobot/core/tests/test_utils.py
+++ b/nautobot/core/tests/test_utils.py
@@ -268,6 +268,14 @@ class GetFooForModelTest(TestCase):
                 lookup.get_model_for_view_name("unknown:plugins:example_app:examplemodel_list")
             self.assertEqual(str(err.exception), "Unexpected View Name: unknown:plugins:example_app:examplemodel_list")
 
+    def test_get_table_class_string_from_view_name(self):
+        # Testing UIViewSet
+        self.assertEqual(lookup.get_table_class_string_from_view_name("circuits:circuit_list"), "CircuitTable")
+        # Testing Legacy View
+        self.assertEqual(lookup.get_table_class_string_from_view_name("dcim:location_list"), "LocationTable")
+        # Testing unconventional table name
+        self.assertEqual(lookup.get_table_class_string_from_view_name("ipam:prefix_list"), "PrefixDetailTable")
+
 
 class IsTaggableTest(TestCase):
     def test_is_taggable_true(self):

--- a/nautobot/core/utils/lookup.py
+++ b/nautobot/core/utils/lookup.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Model
-from django.urls import get_resolver, URLPattern, URLResolver
+from django.urls import get_resolver, resolve, reverse, URLPattern, URLResolver
 from django.utils.module_loading import import_string
 
 
@@ -276,12 +276,9 @@ def get_table_class_string_from_view_name(view_name):
     Returns:
         table_class_name (String): The name of the model table class or None e.g. LocationTable, CircuitTable
     """
-    app_label, model_name = view_name.split(":")
-    model_name = model_name.split("_")[0]
-    model_name = f"{app_label}.{model_name}"
-    # model name should be in the form of "dcim.location".
-    model = get_model_from_name(model_name)
-    view_class = get_view_for_model(model, "List")
+
+    view_func = resolve(reverse(view_name)).func
+    view_class = getattr(view_func, "cls", getattr(view_func, "view_class", None))
     if hasattr(view_class, "table_class"):
         return view_class.table_class.__name__
     if hasattr(view_class, "table"):

--- a/nautobot/core/utils/lookup.py
+++ b/nautobot/core/utils/lookup.py
@@ -276,13 +276,17 @@ def get_table_class_string_from_view_name(view_name):
     Returns:
         table_class_name (String): The name of the model table class or None e.g. LocationTable, CircuitTable
     """
-    model = get_model_for_view_name(view_name)
-    if model:
-        table_class = get_table_for_model(model)
-        if table_class:
-            return table_class.__name__
+    app_label, model_name = view_name.split(":")
+    model_name = model_name.split("_")[0]
+    model_name = f"{app_label}.{model_name}"
+    # model name should be in the form of "dcim.location".
+    model = get_model_from_name(model_name)
+    view_class = get_view_for_model(model, "List")
+    if hasattr(view_class, "table_class"):
+        return view_class.table_class.__name__
+    if hasattr(view_class, "table"):
+        return view_class.table.__name__
     return None
-
 
 def get_created_and_last_updated_usernames_for_model(instance):
     """

--- a/nautobot/core/utils/lookup.py
+++ b/nautobot/core/utils/lookup.py
@@ -288,6 +288,7 @@ def get_table_class_string_from_view_name(view_name):
         return view_class.table.__name__
     return None
 
+
 def get_created_and_last_updated_usernames_for_model(instance):
     """
     Args:

--- a/nautobot/core/utils/lookup.py
+++ b/nautobot/core/utils/lookup.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Model
-from django.urls import get_resolver, URLPattern, URLResolver
+from django.urls import get_resolver, resolve, reverse, URLPattern, URLResolver
 from django.utils.module_loading import import_string
 
 
@@ -276,12 +276,9 @@ def get_table_class_string_from_view_name(view_name):
     Returns:
         table_class_name (String): The name of the model table class or None e.g. LocationTable, CircuitTable
     """
-    app_label, model_name = view_name.split(":")
-    model_name = model_name.split("_")[0]
-    model_name = f"{app_label}.{model_name}"
-    # model name should be in the form of "dcim.location".
-    model = get_model_from_name(model_name)
-    view_class = get_view_for_model(model, "List")
+    url = reverse(view_name)
+    match = resolve(url)
+    view_class = match.func.view_class
     if hasattr(view_class, "table_class"):
         return view_class.table_class.__name__
     if hasattr(view_class, "table"):

--- a/nautobot/core/utils/lookup.py
+++ b/nautobot/core/utils/lookup.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Model
-from django.urls import get_resolver, resolve, reverse, URLPattern, URLResolver
+from django.urls import get_resolver, URLPattern, URLResolver
 from django.utils.module_loading import import_string
 
 
@@ -276,9 +276,12 @@ def get_table_class_string_from_view_name(view_name):
     Returns:
         table_class_name (String): The name of the model table class or None e.g. LocationTable, CircuitTable
     """
-    url = reverse(view_name)
-    match = resolve(url)
-    view_class = match.func.view_class
+    app_label, model_name = view_name.split(":")
+    model_name = model_name.split("_")[0]
+    model_name = f"{app_label}.{model_name}"
+    # model name should be in the form of "dcim.location".
+    model = get_model_from_name(model_name)
+    view_class = get_view_for_model(model, "List")
     if hasattr(view_class, "table_class"):
         return view_class.table_class.__name__
     if hasattr(view_class, "table"):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6466 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Fixed `saved_view_modal` template tag helper method and `get_table_class_string_from_view_name` helper method to introspect the view class to obtain the table/table_class value instead of making a best guess.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
PrefixListView:
![Screenshot 2024-12-03 at 3 01 40 PM](https://github.com/user-attachments/assets/e31c51dd-2df6-4662-8a1a-ba8e71fc0027)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests

