### PR TITLE
Fix whitespace in Jinja template renderer

### DIFF
--- a/changes/6601.fixed
+++ b/changes/6601.fixed
@@ -1,0 +1,1 @@
+Fixed whitespace in Jinja template renderer.

--- a/nautobot/core/templates/utilities/render_jinja2.html
+++ b/nautobot/core/templates/utilities/render_jinja2.html
@@ -10,7 +10,7 @@
     }
     #render_jinja_template_form textarea {
         resize: vertical;
-        white-space: nowrap;
+        white-space: pre;
     }
 
 </style>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6601
# What's Changed

Changed the whitespace css property of the textarea so that linebreaks are preserved. See screenshots
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots

## Before

![image](https://github.com/user-attachments/assets/18d2ac9d-db14-4a9c-89d1-ee37580cd619)


## After

![image](https://github.com/user-attachments/assets/933fc81c-a55c-4f02-a884-4b7a0da59d3e)

![image](https://github.com/user-attachments/assets/b2db0d00-6d1b-4556-baf7-7670898b4d3e)


<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
