### PR TITLE
Added description and weight on RoleBulkEditForm

### DIFF
--- a/changes/6586.added
+++ b/changes/6586.added
@@ -1,0 +1,1 @@
+Added description and weight on RoleBulkEditForm

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -1682,6 +1682,8 @@ class RoleBulkEditForm(NautobotBulkEditForm):
 
     pk = forms.ModelMultipleChoiceField(queryset=Role.objects.all(), widget=forms.MultipleHiddenInput)
     color = forms.CharField(max_length=6, required=False, widget=ColorSelect())
+    description = forms.CharField(max_length=CHARFIELD_MAX_LENGTH, required=False)
+    weight = forms.IntegerField(required=False)
     content_types = MultipleContentTypeField(
         queryset=RoleModelsQuery().as_queryset(), required=False, label="Content Type(s)"
     )

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -3607,6 +3607,8 @@ class RoleTestCase(ViewTestCases.OrganizationalObjectViewTestCase):
 
         cls.bulk_edit_data = {
             "color": "000000",
+            "description": "I used to be a new role object.",
+            "weight": 255,
         }
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])


### PR DESCRIPTION
# Closes #6586 
# What's Changed
Added description and weight on RoleBulkEditForm
# Screenshots
![image](https://github.com/user-attachments/assets/25ad4937-8ed0-45b8-b7f2-6d0d3f04fa46)
# TODO

- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
