### PR TITLE
Move skip_db_logging condition in log.py

### DIFF
--- a/changes/6609.fixed
+++ b/changes/6609.fixed
@@ -1,0 +1,1 @@
+Fix useless call to the DB when logging the extra={"skip_db_logging": True}.

--- a/changes/6609.fixed
+++ b/changes/6609.fixed
@@ -1,1 +1,1 @@
-Fix useless call to the DB when logging with the parameter extra={"skip_db_logging": True}.
+Fixed unnecessary call to the database when logging from a Job with the parameter `extra={"skip_db_logging": True}`.

--- a/changes/6609.fixed
+++ b/changes/6609.fixed
@@ -1,1 +1,1 @@
-Fix useless call to the DB when logging the extra={"skip_db_logging": True}.
+Fix useless call to the DB when logging with the parameter extra={"skip_db_logging": True}.

--- a/nautobot/core/celery/log.py
+++ b/nautobot/core/celery/log.py
@@ -11,6 +11,10 @@ class NautobotDatabaseHandler(logging.Handler):
         if current_task is None:
             return
 
+        # Skip recording the log entry if it has been marked as such
+        if getattr(record, "skip_db_logging", False):
+            return
+
         from nautobot.extras.models.jobs import JobResult
 
         try:
@@ -22,10 +26,6 @@ class NautobotDatabaseHandler(logging.Handler):
                 # Both of these cases are very rare
                 # ValidationError - because the task_id might not a valid UUID
                 # JobResult.DoesNotExist - because we might not have a JobResult with that ID
-                return
-
-            # Skip recording the log entry if it has been marked as such
-            if getattr(record, "skip_db_logging", False):
                 return
 
             job_result.log(


### PR DESCRIPTION
# Closes  #6609
# What's Changed

Move skip_db_logging condition in log.py to avoid calling the db for the JobResult of the current Job. `job_result` is unused anyway when skip_db_logging is set to True.


# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
