### PR TITLE
Improve performance and usability of IPAddress list view

### DIFF
--- a/changes/6605.added
+++ b/changes/6605.added
@@ -1,0 +1,3 @@
+Added `BaseTable` support for a `data_transform_callback` function that can be used to modify the table data after performing automatic QuerySet optimizations. (Several IPAM tables now use this functionality).
+Enhanced `LinkedCountColumn` to support a `distinct` parameter to handle cases where counts may otherwise be incorrect.
+Added `ip_addresses` and `has_ip_addresses` filter support to Device, Interface, and VirtualMachine FilterSets.

--- a/changes/6605.fixed
+++ b/changes/6605.fixed
@@ -1,1 +1,2 @@
 Improved rendering performance of the IPAddress list view in cases where the `Interfaces`, `Devices`, `VM Interfaces`, `Virtual Machines`, and/or `Assigned` columns are not shown.
+Improved performance of `TreeModel.display` calculation by making better use of the cache.

--- a/changes/6605.fixed
+++ b/changes/6605.fixed
@@ -1,0 +1,1 @@
+Improved rendering performance of the IPAddress list view in cases where the `Interfaces`, `Devices`, `VM Interfaces`, `Virtual Machines`, and/or `Assigned` columns are not shown.

--- a/changes/6613.added
+++ b/changes/6613.added
@@ -1,0 +1,1 @@
+Enhanced Prefix detail view "Child Prefixes" table to render associated Locations more intelligently.

--- a/changes/6614.added
+++ b/changes/6614.added
@@ -1,0 +1,1 @@
+Enhanced IP Address tables to show the name of the associated Interface or VM Interface if only a single such association is present for a given IP Address.

--- a/nautobot/core/models/tree_queries.py
+++ b/nautobot/core/models/tree_queries.py
@@ -111,8 +111,11 @@ class TreeModel(TreeNode):
         if display_str:
             return display_str
         try:
-            if self.parent is not None:
-                display_str = self.parent.display + " → "
+            if self.parent_id is not None:
+                parent_display_str = cache.get(cache_key.replace(str(self.id), str(self.parent_id)), "")
+                if not parent_display_str:
+                    parent_display_str = self.parent.display
+                display_str = parent_display_str + " → "
         except self.DoesNotExist:
             # Expected to occur at times during bulk-delete operations
             pass

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -199,7 +199,8 @@ class BaseTable(django_tables2.Table):
                     if lookup is not None:
                         # Also attempt to prefetch the first matching record for display - see LinkedCountColumn
                         prefetch_fields.append(
-                            Prefetch(lookup, column_model.objects.all()[:1], to_attr=f"{lookup}_list")
+                            # Use order_by() because we don't care about ordering here and it's potentially expensive
+                            Prefetch(lookup, column_model.objects.order_by()[:1], to_attr=f"{lookup}_list")
                         )
                     continue
 

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -14,7 +14,8 @@ from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.text import Truncator
 import django_tables2
-from django_tables2.data import TableQuerysetData
+from django_tables2.data import TableData, TableQuerysetData
+from django_tables2.rows import BoundRows
 from django_tables2.utils import Accessor, OrderBy, OrderByTuple
 from tree_queries.models import TreeNode
 
@@ -46,8 +47,24 @@ class BaseTable(django_tables2.Table):
         user=None,
         hide_hierarchy_ui=False,
         order_by=None,
+        data_transform_callback=None,
         **kwargs,
     ):
+        """
+        Instantiate a BaseTable.
+
+        Args:
+            *args (list, optional): Passed through to django_tables2.Table
+            table_changes_pending (bool): TODO
+            saved_view (SavedView, optional): TODO
+            user (User, optional): TODO
+            hide_hierarchy_ui (bool): Whether to display or hide hierarchy indentation of nested objects.
+            order_by (list, optional): Field(s) to sort by
+            data_transform_callback (function, optional): A function that takes the given `data` as an input and
+                returns new data. Runs after all of the queryset auto-optimization performed by this class.
+                Used for example in IPAM views to inject "fake" records for "available" Prefixes, IPAddresses, or VLANs.
+            **kwargs (dict, optional): Passed through to django_tables2.Table
+        """
         # Add custom field columns
         model = self._meta.model
 
@@ -89,6 +106,14 @@ class BaseTable(django_tables2.Table):
         # Init table
         super().__init__(*args, order_by=order_by, **kwargs)
 
+        if not isinstance(self.data, TableQuerysetData):
+            # LinkedCountColumns don't work properly if the data is a list of dicts instead of a queryset,
+            # as they rely on a `queryset.annotate()` call to gather the data.
+            self.exclude = [
+                *self.exclude,
+                *[column.name for column in self.columns if isinstance(column.column, LinkedCountColumn)],
+            ]
+
         # Don't show hierarchy if we're sorted
         if order_by is not None and hide_hierarchy_ui is None:
             hide_hierarchy_ui = True
@@ -122,7 +147,7 @@ class BaseTable(django_tables2.Table):
                 columns = user.get_config(f"tables.{self.__class__.__name__}.columns")
         if columns:
             for name, column in self.base_columns.items():
-                if name in columns:
+                if name in columns and name not in self.exclude:
                     self.columns.show(name)
                 else:
                     self.columns.hide(name)
@@ -161,7 +186,8 @@ class BaseTable(django_tables2.Table):
                         logger.error("Couldn't find model for %s", column.column.viewname)
                         continue
                     reverse_lookup = column.column.reverse_lookup or next(iter(column.column.url_params.keys()))
-                    count_fields.append((column.name, column_model, reverse_lookup))
+                    distinct = column.column.distinct
+                    count_fields.append((column.name, column_model, reverse_lookup, distinct))
                     try:
                         lookup = column.column.lookup or get_related_field_for_models(model, column_model).name
                         # For some reason get_related_field_for_models(Tag, DynamicGroup) gives a M2M with the name
@@ -256,23 +282,33 @@ class BaseTable(django_tables2.Table):
                         )
 
             if count_fields:
-                for column_name, column_model, lookup_name in count_fields:
+                for column_name, column_model, lookup_name, distinct in count_fields:
                     if hasattr(queryset.first(), column_name):
                         continue
                     try:
                         logger.debug(
-                            "Applying .annotate(%s=count_related(%s, %r) to %s QuerySet",
+                            "Applying .annotate(%s=count_related(%s, %r, distinct=%s) to %s QuerySet",
                             column_name,
                             column_model.__name__,
                             lookup_name,
+                            distinct,
                             model.__name__,
                         )
-                        queryset = queryset.annotate(**{column_name: count_related(column_model, lookup_name)})
+                        queryset = queryset.annotate(
+                            **{column_name: count_related(column_model, lookup_name, distinct=distinct)}
+                        )
                     except FieldError:
                         # No error message logged here as the above is *very much* best-effort
                         pass
 
             self.data.data = queryset
+
+        # TODO: it would be better if we could apply this transformation and the above queryset optimizations
+        #       **before** calling super().__init__(), but the current implementation works for now, though inelegant.
+        if data_transform_callback is not None:
+            self.data = TableData.from_data(data_transform_callback(self.data.data))
+            self.data.set_table(self)
+            self.rows = BoundRows(data=self.data, table=self, pinned_data=self.pinned_data)
 
     @property
     def configurable_columns(self):
@@ -288,7 +324,7 @@ class BaseTable(django_tables2.Table):
 
     @property
     def visible_columns(self):
-        return [name for name in self.sequence if self.columns[name].visible]
+        return [name for name in self.sequence if self.columns[name].visible and name not in self.exclude]
 
     @property
     def order_by(self):
@@ -490,6 +526,7 @@ class LinkedCountColumn(django_tables2.Column):
             TODO: this currently does *not* support nested lookups via `__`. That may be solvable in the future.
         reverse_lookup (str, optional): The reverse lookup parameter to use to derive the count.
             If not specified, the first key in `url_params` will be implicitly used as the `reverse_lookup` value.
+        distinct (bool, optional): Parameter passed through to `count_related()`.
         **kwargs (dict, optional): As the parent Column class.
 
     Examples:
@@ -514,21 +551,33 @@ class LinkedCountColumn(django_tables2.Column):
                 # We'd like to do the below but this module isn't currently smart enough to build the right Prefetch()
                 # for a nested lookup:
                 # lookup="circuit_terminations__circuit",
-                # For the count, .annotate(circuit_count=count_related(Circuit, "circuit_terminations__cloud_network"))
+                # For the count,
+                # .annotate(circuit_count=count_related(Circuit, "circuit_terminations__cloud_network", distinct=True))
                 reverse_lookup="circuit_terminations__cloud_network",
+                distinct=True,
                 verbose_name="Circuits",
             )
         ```
     """
 
     def __init__(
-        self, viewname, *args, view_kwargs=None, url_params=None, lookup=None, reverse_lookup=None, default=0, **kwargs
+        self,
+        viewname,
+        *args,
+        view_kwargs=None,
+        url_params=None,
+        lookup=None,
+        reverse_lookup=None,
+        distinct=False,
+        default=None,
+        **kwargs,
     ):
         self.viewname = viewname
         self.lookup = lookup
         self.view_kwargs = view_kwargs or {}
         self.url_params = url_params
         self.reverse_lookup = reverse_lookup or next(iter(url_params.keys()))
+        self.distinct = distinct
         self.model = get_model_for_view_name(self.viewname)
         super().__init__(*args, default=default, **kwargs)
 

--- a/nautobot/dcim/filters/__init__.py
+++ b/nautobot/dcim/filters/__init__.py
@@ -1143,7 +1143,11 @@ class InterfaceFilterSet(
         queryset=InterfaceRedundancyGroup.objects.all(),
         to_field_name="name",
     )
-    ip_addresses = MultiValueCharFilter(method="filter_ip_addresses", label="IP addresses (address or ID)")
+    ip_addresses = MultiValueCharFilter(
+        method="filter_ip_addresses",
+        label="IP addresses (address or ID)",
+        distinct=True,
+    )
     has_ip_addresses = RelatedMembershipBooleanFilter(field_name="ip_addresses", label="Has IP addresses")
 
     def filter_ip_addresses(self, queryset, name, value):
@@ -1151,7 +1155,7 @@ class InterfaceFilterSet(
         addresses = set(item for item in value if item not in pk_values)
 
         ip_queryset = IPAddress.objects.filter_address_or_pk_in(addresses, pk_values)
-        return queryset.filter(ip_addresses__in=ip_queryset)
+        return queryset.filter(ip_addresses__in=ip_queryset).distinct()
 
     class Meta:
         model = Interface

--- a/nautobot/dcim/filters/__init__.py
+++ b/nautobot/dcim/filters/__init__.py
@@ -903,6 +903,15 @@ class DeviceFilterSet(
         to_field_name="version",
         label="Software version (version or ID)",
     )
+    ip_addresses = MultiValueCharFilter(method="filter_ip_addresses", label="IP addresses (address or ID)")
+    has_ip_addresses = RelatedMembershipBooleanFilter(field_name="interfaces__ip_addresses", label="Has IP addresses")
+
+    def filter_ip_addresses(self, queryset, name, value):
+        pk_values = set(item for item in value if is_uuid(item))
+        addresses = set(item for item in value if item not in pk_values)
+
+        ip_queryset = IPAddress.objects.filter_address_or_pk_in(addresses, pk_values)
+        return queryset.filter(interfaces__ip_addresses__in=ip_queryset)
 
     class Meta:
         model = Device
@@ -1130,6 +1139,15 @@ class InterfaceFilterSet(
         queryset=InterfaceRedundancyGroup.objects.all(),
         to_field_name="name",
     )
+    ip_addresses = MultiValueCharFilter(method="filter_ip_addresses", label="IP addresses (address or ID)")
+    has_ip_addresses = RelatedMembershipBooleanFilter(field_name="ip_addresses", label="Has IP addresses")
+
+    def filter_ip_addresses(self, queryset, name, value):
+        pk_values = set(item for item in value if is_uuid(item))
+        addresses = set(item for item in value if item not in pk_values)
+
+        ip_queryset = IPAddress.objects.filter_address_or_pk_in(addresses, pk_values)
+        return queryset.filter(ip_addresses__in=ip_queryset)
 
     class Meta:
         model = Interface
@@ -1144,7 +1162,6 @@ class InterfaceFilterSet(
             "description",
             "label",
             "tags",
-            "interface_redundancy_groups",
         ]
 
     def generate_query_filter_device(self, value):

--- a/nautobot/dcim/filters/__init__.py
+++ b/nautobot/dcim/filters/__init__.py
@@ -903,7 +903,11 @@ class DeviceFilterSet(
         to_field_name="version",
         label="Software version (version or ID)",
     )
-    ip_addresses = MultiValueCharFilter(method="filter_ip_addresses", label="IP addresses (address or ID)")
+    ip_addresses = MultiValueCharFilter(
+        method="filter_ip_addresses",
+        label="IP addresses (address or ID)",
+        distinct=True,
+    )
     has_ip_addresses = RelatedMembershipBooleanFilter(field_name="interfaces__ip_addresses", label="Has IP addresses")
 
     def filter_ip_addresses(self, queryset, name, value):
@@ -911,7 +915,7 @@ class DeviceFilterSet(
         addresses = set(item for item in value if item not in pk_values)
 
         ip_queryset = IPAddress.objects.filter_address_or_pk_in(addresses, pk_values)
-        return queryset.filter(interfaces__ip_addresses__in=ip_queryset)
+        return queryset.filter(interfaces__ip_addresses__in=ip_queryset).distinct()
 
     class Meta:
         model = Device

--- a/nautobot/dcim/tests/test_filters.py
+++ b/nautobot/dcim/tests/test_filters.py
@@ -1701,6 +1701,7 @@ class DeviceTestCase(
         ("front_ports", "front_ports__id"),
         ("interfaces", "interfaces__id"),
         ("interfaces", "interfaces__name"),
+        ("ip_addresses", "interfaces__ip_addresses__id"),
         ("mac_address", "interfaces__mac_address"),
         ("manufacturer", "device_type__manufacturer__id"),
         ("manufacturer", "device_type__manufacturer__name"),
@@ -1873,6 +1874,14 @@ class DeviceTestCase(
                 self.filterset(params, self.queryset).qs,
                 Device.objects.filter(primary_ip4__isnull=True, primary_ip6__isnull=True),
             )
+
+    def test_ip_addresses(self):
+        addresses = list(IPAddress.objects.filter(interfaces__isnull=False)[:2])
+        params = {"ip_addresses": [addresses[0].address, addresses[1].id]}
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(interfaces__ip_addresses__in=addresses).distinct(),
+        )
 
     def test_virtual_chassis_member(self):
         # TODO: Not a generic_filter_test because this is a boolean filter but not a RelatedMembershipBooleanFilter
@@ -2168,6 +2177,7 @@ class InterfaceTestCase(PathEndpointModelTestMixin, ModularDeviceComponentTestMi
         ("child_interfaces", "child_interfaces__name"),
         ("description",),
         # ("device", "device__id"),  # TODO - InterfaceFilterSet overrides device as a MultiValueCharFilter on name only
+        ("ip_addresses", "ip_addresses__id"),
         ("label",),
         ("lag", "lag__id"),
         ("lag", "lag__name"),
@@ -2413,6 +2423,21 @@ class InterfaceTestCase(PathEndpointModelTestMixin, ModularDeviceComponentTestMi
             status=interface_statuses[3],
         )
 
+        ipaddr_status = Status.objects.get_for_model(IPAddress).first()
+        prefix_status = Status.objects.get_for_model(Prefix).first()
+        namespace = Namespace.objects.first()
+        Prefix.objects.create(prefix="192.0.2.0/24", namespace=namespace, status=prefix_status)
+        Prefix.objects.create(prefix="2600::/64", namespace=namespace, status=prefix_status)
+        ipaddresses = (
+            IPAddress.objects.create(address="192.0.2.1/24", namespace=namespace, status=ipaddr_status),
+            IPAddress.objects.create(address="192.0.2.2/24", namespace=namespace, status=ipaddr_status),
+            IPAddress.objects.create(address="2600::1/120", namespace=namespace, status=ipaddr_status),
+            IPAddress.objects.create(address="2600::0100/120", namespace=namespace, status=ipaddr_status),
+        )
+
+        cabled_interfaces[0].add_ip_addresses([ipaddresses[0], ipaddresses[2]])
+        cabled_interfaces[1].add_ip_addresses([ipaddresses[1], ipaddresses[3]])
+
     def test_enabled(self):
         # TODO: Not a generic_filter_test because this is a boolean filter but not a RelatedMembershipBooleanFilter
         with self.subTest():
@@ -2645,6 +2670,14 @@ class InterfaceTestCase(PathEndpointModelTestMixin, ModularDeviceComponentTestMi
 
         with self.subTest("device (pk) filter with an invalid uuid"):
             self.assertFalse(self.filterset({"device": [uuid.uuid4()]}, self.queryset).is_valid())
+
+    def test_ip_addresses(self):
+        addresses = list(IPAddress.objects.filter(interfaces__isnull=False)[:2])
+        params = {"ip_addresses": [addresses[0].address, addresses[1].id]}
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(ip_addresses__in=addresses).distinct(),
+        )
 
     def test_kind(self):
         # TODO: Not a generic_filter_test because this is a single-value filter

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -442,13 +442,27 @@ class IPAddressTable(StatusTableMixin, RoleTableMixin, BaseTable):
     )
     tenant = TenantColumn()
     parent__namespace = tables.Column(linkify=True)
-    # Interface, Device, and VirtualMachine tables aren't currently filterable by IP address (?) so no LinkedCountColumn
-    interface_count = tables.Column(verbose_name="Interfaces")
-    interface_parent_count = tables.Column(verbose_name="Devices")
+    interface_count = LinkedCountColumn(
+        viewname="dcim:interface_list", url_params={"ip_addresses": "pk"}, verbose_name="Interfaces"
+    )
+    # TODO: what about interfaces assigned to modules?
+    interface_parent_count = LinkedCountColumn(
+        viewname="dcim:device_list",
+        url_params={"ip_addresses": "pk"},
+        reverse_lookup="interfaces__ip_addresses",
+        distinct=True,
+        verbose_name="Devices",
+    )
     vm_interface_count = LinkedCountColumn(
         viewname="virtualization:vminterface_list", url_params={"ip_addresses": "pk"}, verbose_name="VM Interfaces"
     )
-    vm_interface_parent_count = tables.Column(verbose_name="Virtual Machines")
+    vm_interface_parent_count = LinkedCountColumn(
+        viewname="virtualization:virtualmachine_list",
+        url_params={"ip_addresses": "pk"},
+        reverse_lookup="interfaces__ip_addresses",
+        distinct=True,
+        verbose_name="Virtual Machines",
+    )
 
     class Meta(BaseTable.Meta):
         model = IPAddress

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -2,7 +2,9 @@ import logging
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
 from django.db.models import Prefetch, ProtectedError, Q
 from django.forms.models import model_to_dict
@@ -23,7 +25,7 @@ from nautobot.core.views import generic, mixins as view_mixins
 from nautobot.core.views.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.core.views.utils import handle_protectederror
 from nautobot.dcim.models import Device, Interface, Location
-from nautobot.extras.models import Role, Status, Tag
+from nautobot.extras.models import Role, SavedView, Status, Tag
 from nautobot.ipam import choices, constants
 from nautobot.ipam.api import serializers
 from nautobot.tenancy.models import Tenant
@@ -101,22 +103,11 @@ class NamespaceIPAddressesView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Find all IPAddresses belonging to this Namespace
-        ip_addresses = (
-            instance.ip_addresses.restrict(request.user, "view")
-            .select_related("role", "status", "tenant")
-            .annotate(
-                interface_count=count_related(Interface, "ip_addresses"),
-                interface_parent_count=count_related(Device, "interfaces__ip_addresses", distinct=True),
-                vm_interface_count=count_related(VMInterface, "ip_addresses"),
-                vm_interface_parent_count=count_related(VirtualMachine, "interfaces__ip_addresses", distinct=True),
-            )
-        )
+        ip_addresses = instance.ip_addresses.restrict(request.user, "view").select_related("role", "status", "tenant")
 
-        ip_address_table = tables.IPAddressTable(ip_addresses)
+        ip_address_table = tables.IPAddressTable(ip_addresses, exclude=["namespace"])
         if request.user.has_perm("ipam.change_ipaddress") or request.user.has_perm("ipam.delete_ipaddress"):
             ip_address_table.columns.show("pk")
-
-        ip_address_table.exclude = ("namespace",)
 
         paginate = {
             "paginator_class": EnhancedPaginator,
@@ -154,11 +145,9 @@ class NamespacePrefixesView(generic.ObjectView):
         # Find all Prefixes belonging to this Namespace
         prefixes = instance.prefixes.restrict(request.user, "view").select_related("status")
 
-        prefix_table = tables.PrefixTable(prefixes)
+        prefix_table = tables.PrefixTable(prefixes, exclude=["namespace"])
         if request.user.has_perm("ipam.change_prefix") or request.user.has_perm("ipam.delete_prefix"):
             prefix_table.columns.show("pk")
-
-        prefix_table.exclude = ("namespace",)
 
         paginate = {
             "paginator_class": EnhancedPaginator,
@@ -196,11 +185,9 @@ class NamespaceVRFsView(generic.ObjectView):
         # Find all VRFs belonging to this Namespace
         vrfs = instance.vrfs.restrict(request.user, "view")
 
-        vrf_table = tables.VRFTable(vrfs)
+        vrf_table = tables.VRFTable(vrfs, exclude=["namespace"])
         if request.user.has_perm("ipam.change_vrf") or request.user.has_perm("ipam.delete_vrf"):
             vrf_table.columns.show("pk")
-
-        vrf_table.exclude = ("namespace",)
 
         paginate = {
             "paginator_class": EnhancedPaginator,
@@ -266,8 +253,7 @@ class VRFView(generic.ObjectView):
         # TODO(jathan): This table might need to live on Device and on VRFs
         # (possibly replacing `device_table` above.
         vrfs = instance.device_assignments.restrict(request.user, "view")
-        vrf_table = tables.VRFDeviceAssignmentTable(vrfs)
-        vrf_table.exclude = ("vrf",)
+        vrf_table = tables.VRFDeviceAssignmentTable(vrfs, exclude=["vrf"])
         # context["vrf_table"] = vrf_table
 
         paginate = {
@@ -466,8 +452,7 @@ class PrefixView(generic.ObjectView):
     def get_extra_context(self, request, instance):
         # Parent prefixes table
         parent_prefixes = instance.ancestors().restrict(request.user, "view")
-        parent_prefix_table = tables.PrefixTable(parent_prefixes)
-        parent_prefix_table.exclude = ("namespace",)
+        parent_prefix_table = tables.PrefixTable(parent_prefixes, exclude=["namespace"])
 
         vrfs = instance.vrf_assignments.restrict(request.user, "view")
         vrf_table = tables.VRFPrefixAssignmentTable(vrfs, orderable=False)
@@ -498,19 +483,22 @@ class PrefixPrefixesView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         # Child prefixes table
-        child_prefixes = (
-            instance.descendants()
-            .restrict(request.user, "view")
-            .select_related("parent", "status", "role", "vlan", "namespace")
-            .annotate(location_count=count_related(Location, "prefixes"))
-        )
+        child_prefixes = instance.descendants().restrict(request.user, "view")
 
         # Add available prefixes to the table if requested
         if child_prefixes and request.GET.get("show_available", "true") == "true":
-            child_prefixes = add_available_prefixes(instance.prefix, child_prefixes)
 
-        prefix_table = tables.PrefixDetailTable(child_prefixes, hide_hierarchy_ui=True)
-        prefix_table.exclude = ("namespace",)
+            def data_transform_callback(prefixes):
+                return add_available_prefixes(instance.prefix, prefixes)
+        else:
+            data_transform_callback = None
+
+        prefix_table = tables.PrefixDetailTable(
+            child_prefixes,
+            hide_hierarchy_ui=True,
+            exclude=["namespace"],
+            data_transform_callback=data_transform_callback,
+        )
         if request.user.has_perm("ipam.change_prefix") or request.user.has_perm("ipam.delete_prefix"):
             prefix_table.columns.show("pk")
 
@@ -550,21 +538,21 @@ class PrefixIPAddressesView(generic.ObjectView):
             .restrict(request.user, "view")
             .select_related("role", "status", "tenant")
             .prefetch_related("primary_ip4_for", "primary_ip6_for")
-            .annotate(
-                interface_count=count_related(Interface, "ip_addresses"),
-                interface_parent_count=count_related(Device, "interfaces__ip_addresses", distinct=True),
-                vm_interface_count=count_related(VMInterface, "ip_addresses"),
-                vm_interface_parent_count=count_related(VirtualMachine, "interfaces__ip_addresses", distinct=True),
-            )
         )
 
         # Add available IP addresses to the table if requested
         if request.GET.get("show_available", "true") == "true":
-            ipaddresses = add_available_ipaddresses(
-                instance.prefix, ipaddresses, instance.type == choices.PrefixTypeChoices.TYPE_POOL
-            )
 
-        ip_table = tables.IPAddressTable(ipaddresses)
+            def data_transform_callback(ip_addresses):
+                return add_available_ipaddresses(
+                    instance.prefix, ip_addresses, instance.type == choices.PrefixTypeChoices.TYPE_POOL
+                )
+        else:
+            data_transform_callback = None
+
+        ip_table = tables.IPAddressTable(
+            ipaddresses, exclude=["parent__namespace"], data_transform_callback=data_transform_callback
+        )
         if request.user.has_perm("ipam.change_ipaddress") or request.user.has_perm("ipam.delete_ipaddress"):
             ip_table.columns.show("pk")
 
@@ -761,18 +749,36 @@ class PrefixBulkDeleteView(generic.BulkDeleteView):
 
 
 class IPAddressListView(generic.ObjectListView):
-    queryset = IPAddress.objects.annotate(
-        interface_count=count_related(Interface, "ip_addresses"),
-        interface_parent_count=count_related(Device, "interfaces__ip_addresses", distinct=True),
-        vm_interface_count=count_related(VMInterface, "ip_addresses"),
-        vm_interface_parent_count=count_related(VirtualMachine, "interfaces__ip_addresses", distinct=True),
-        assigned_count=count_related(Interface, "ip_addresses") + count_related(VMInterface, "ip_addresses"),
-    )
+    queryset = IPAddress.objects.all()
     filterset = filters.IPAddressFilterSet
     filterset_form = forms.IPAddressFilterForm
     table = tables.IPAddressDetailTable
     template_name = "ipam/ipaddress_list.html"
-    use_new_ui = True
+
+    def alter_queryset(self, request):
+        queryset = super().alter_queryset(request)
+
+        # All of the below is just to determine whether we are displaying the "assigned_count" column, and if so,
+        # perform the relevant queryset annotation. Ref: nautobot/nautobot#6605
+        if request.user is None or isinstance(request.user, AnonymousUser):
+            table_columns = None
+        else:
+            table_columns = request.user.get_config("tables.IPAddressDetailTable.columns")
+        current_saved_view_pk = request.GET.get("saved_view", None)
+        if current_saved_view_pk:
+            try:
+                current_saved_view = SavedView.objects.get(view="ipam:ipaddress_list", pk=current_saved_view_pk)
+                view_table_config = current_saved_view.config.get("table_config", {}).get("IPAddressDetailTable", None)
+                if view_table_config is not None:
+                    table_columns = view_table_config.get("columns", table_columns)
+            except ObjectDoesNotExist:
+                pass
+
+        if table_columns and "assigned_count" in table_columns:
+            queryset = queryset.annotate(
+                assigned_count=count_related(Interface, "ip_addresses") + count_related(VMInterface, "ip_addresses"),
+            )
+        return queryset
 
 
 class IPAddressView(generic.ObjectView):
@@ -1270,12 +1276,15 @@ class VLANGroupView(generic.ObjectView):
             .prefetch_related(Prefetch("prefixes", queryset=Prefix.objects.restrict(request.user)))
         )
         vlans_count = vlans.count()
-        vlans = add_available_vlans(vlan_group=instance, vlans=vlans)
 
-        vlan_table = tables.VLANDetailTable(vlans)
+        def data_transform_callback(vlans):
+            return add_available_vlans(vlan_group=instance, vlans=vlans)
+
+        vlan_table = tables.VLANDetailTable(
+            vlans, exclude=["vlan_group"], data_transform_callback=data_transform_callback
+        )
         if request.user.has_perm("ipam.change_vlan") or request.user.has_perm("ipam.delete_vlan"):
             vlan_table.columns.show("pk")
-        vlan_table.columns.hide("vlan_group")
 
         paginate = {
             "paginator_class": EnhancedPaginator,
@@ -1350,8 +1359,7 @@ class VLANView(generic.ObjectView):
                 "namespace",
             )
         )
-        prefix_table = tables.PrefixTable(list(prefixes), hide_hierarchy_ui=True)
-        prefix_table.exclude = ("vlan",)
+        prefix_table = tables.PrefixTable(list(prefixes), hide_hierarchy_ui=True, exclude=["vlan"])
 
         paginate = {
             "paginator_class": EnhancedPaginator,

--- a/nautobot/virtualization/filters.py
+++ b/nautobot/virtualization/filters.py
@@ -224,7 +224,11 @@ class VirtualMachineFilterSet(
         to_field_name="version",
         label="Software version (version or ID)",
     )
-    ip_addresses = MultiValueCharFilter(method="filter_ip_addresses", label="IP addresses (address or ID)")
+    ip_addresses = MultiValueCharFilter(
+        method="filter_ip_addresses",
+        label="IP addresses (address or ID)",
+        distinct=True,
+    )
     has_ip_addresses = RelatedMembershipBooleanFilter(field_name="interfaces__ip_addresses", label="Has IP addresses")
 
     def filter_ip_addresses(self, queryset, name, value):
@@ -232,7 +236,7 @@ class VirtualMachineFilterSet(
         addresses = set(item for item in value if item not in pk_values)
 
         ip_queryset = IPAddress.objects.filter_address_or_pk_in(addresses, pk_values)
-        return queryset.filter(interfaces__ip_addresses__in=ip_queryset)
+        return queryset.filter(interfaces__ip_addresses__in=ip_queryset).distinct()
 
     class Meta:
         model = VirtualMachine

--- a/nautobot/virtualization/filters.py
+++ b/nautobot/virtualization/filters.py
@@ -354,7 +354,11 @@ class VMInterfaceFilterSet(
         queryset=VLAN.objects.all(),
         label="Untagged VLAN (VID or ID)",
     )
-    ip_addresses = MultiValueCharFilter(method="filter_ip_addresses", label="IP addresses (address or ID)")
+    ip_addresses = MultiValueCharFilter(
+        method="filter_ip_addresses",
+        label="IP addresses (address or ID)",
+        distinct=True,
+    )
     has_ip_addresses = RelatedMembershipBooleanFilter(field_name="ip_addresses", label="Has IP addresses")
 
     def filter_ip_addresses(self, queryset, name, value):
@@ -362,7 +366,7 @@ class VMInterfaceFilterSet(
         addresses = set(item for item in value if item not in pk_values)
 
         ip_queryset = IPAddress.objects.filter_address_or_pk_in(addresses, pk_values)
-        return queryset.filter(ip_addresses__in=ip_queryset)
+        return queryset.filter(ip_addresses__in=ip_queryset).distinct()
 
     class Meta:
         model = VMInterface

--- a/nautobot/virtualization/filters.py
+++ b/nautobot/virtualization/filters.py
@@ -224,6 +224,15 @@ class VirtualMachineFilterSet(
         to_field_name="version",
         label="Software version (version or ID)",
     )
+    ip_addresses = MultiValueCharFilter(method="filter_ip_addresses", label="IP addresses (address or ID)")
+    has_ip_addresses = RelatedMembershipBooleanFilter(field_name="interfaces__ip_addresses", label="Has IP addresses")
+
+    def filter_ip_addresses(self, queryset, name, value):
+        pk_values = set(item for item in value if is_uuid(item))
+        addresses = set(item for item in value if item not in pk_values)
+
+        ip_queryset = IPAddress.objects.filter_address_or_pk_in(addresses, pk_values)
+        return queryset.filter(interfaces__ip_addresses__in=ip_queryset)
 
     class Meta:
         model = VirtualMachine

--- a/nautobot/virtualization/tests/test_filters.py
+++ b/nautobot/virtualization/tests/test_filters.py
@@ -229,6 +229,7 @@ class VirtualMachineTestCase(FilterTestCases.FilterTestCase, FilterTestCases.Ten
     tenancy_related_name = "virtual_machines"
 
     generic_filter_tests = (
+        ["ip_addresses", "interfaces__ip_addresses__id"],
         ["software_image_files", "software_image_files__id"],
         ["software_image_files", "software_image_files__image_file_name"],
         ["software_version", "software_version__id"],
@@ -457,6 +458,14 @@ class VirtualMachineTestCase(FilterTestCases.FilterTestCase, FilterTestCases.Ten
     def test_comments(self):
         params = {"comments": ["This is VM 1", "This is VM 2"]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_ip_addresses(self):
+        ipaddresses = list(IPAddress.objects.filter(vm_interfaces__isnull=False)[:2])
+        params = {"ip_addresses": [ipaddresses[0].address, ipaddresses[1].id]}
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(interfaces__ip_addresses__in=ipaddresses).distinct(),
+        )
 
     def test_primary_ip4(self):
         params = {"primary_ip4": ["192.0.2.1/24", self.ipaddresses[0].pk]}


### PR DESCRIPTION
- Closes #6605 
- Closes #6613 
- Partial progress towards #6614

# What's Changed

- Added `ip_addresses` and `has_ip_addresses` filter support to Device, Interface, and VirtualMachine FilterSets.
- Enhanced `LinkedCountColumn` to add a `distinct=True` option.

- The above enhancements make it possible to replace the bespoke annotations of the queryset in `IPAddressListView` and generic text columns in `IPAddressTable` with proper `LinkedCountColumn` instances and automatic queryset optimization. 
- This in turn makes it so that hiding the "Interfaces", "VM Interfaces", "Devices", "Virtual Machines", and/or "Assigned Count" columns in this view (4 of these 5 are hidden by default) correspondingly reduces the query complexity and therefore rendering time of the view. (#6605)

- Enhanced `BaseTable` to add a `data_transform_callback` option.
- The above makes it possible to refactor related-object tables (in PrefixPrefixesView, PrefixIPAddressesView, VLANGroupView) that transform their queryset data into a list (adding "available" pseudo-records in the process) to still take advantage of LinkedCountColumn and the automatic queryset optimizations associated.

# Screenshots

Locations column in PrefixPrefixesView (fixing #6613):
![image](https://github.com/user-attachments/assets/b0cb6946-2710-4d15-9dad-e61b400564c6)

Interfaces and Devices columns in PrefixIPAddressesView (progress toward #6614):
![image](https://github.com/user-attachments/assets/e48e6d41-9a1e-4ab2-869a-034995bd8694)

IPAddressListView with all columns displayed:
![image](https://github.com/user-attachments/assets/2bd1d9f5-d7cd-404d-b070-40d0e547d6c9)

Same data set with count columns hidden:
![image](https://github.com/user-attachments/assets/708498ad-ac69-481e-8c50-0da241af8460)

Same data set after hiding the Dynamic Groups and Tags columns as well:
![image](https://github.com/user-attachments/assets/ba1546db-dc4a-45fd-a561-f6bcad73d41b)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
