### PR TITLE
Fix #6629 - only call add_query_param if supported

### DIFF
--- a/changes/6629.fixed
+++ b/changes/6629.fixed
@@ -1,0 +1,1 @@
+Fixed an `AttributeError` that could be raised if a `DynamicModelChoiceField` uses a non-standard `widget`.

--- a/nautobot/core/forms/fields.py
+++ b/nautobot/core/forms/fields.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import re
 
 from django import forms as django_forms
@@ -45,9 +44,6 @@ __all__ = (
     "SlugField",
     "TagFilterField",
 )
-
-
-logger = logging.getLogger(__name__)
 
 
 class CSVDataField(django_forms.CharField):
@@ -521,16 +517,6 @@ class DynamicModelChoiceMixin:
         self.data_queryset = kwargs.get("queryset")  # may be updated in get_bound_field()
 
         super().__init__(*args, **kwargs)
-
-        if not isinstance(self.widget, widgets.APISelect):
-            logger.warning(
-                "This %s has a specified widget (%s) which is not an APISelect instance, which may not work well. "
-                "Perhaps you should use a standard Model%sChoiceField instead?",
-                self.__class__.__name__,
-                self.widget.__class__.__name__,
-                "Multiple" if "Multiple" in self.__class__.__name__ else "",
-                stacklevel=2,  # so that the message reports at the point of declaration of this field
-            )
 
     def widget_attrs(self, widget):
         attrs = {


### PR DESCRIPTION
# Closes #6629
# What's Changed

- Add a check to avoid calling `widget.add_query_param()` if the given widget doesn't have this API.
- Add a warning log in general for the case where a `DynamicModel(Multiple)ChoiceField` has a non-standard widget.

# Screenshots

```
14:20:54.036 WARNING nautobot.core.forms.fields forms.py             DeviceComponentFilterForm() :
  This DynamicModelMultipleChoiceField has a specified widget (HiddenInput) which is not an APISelect instance, which may not work well. Perhaps you should use a standard ModelMultipleChoiceField instead?
```


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
