### PR TITLE
Release 1.6.29

### DIFF
--- a/changes/5924.fixed
+++ b/changes/5924.fixed
@@ -1,1 +1,0 @@
-Fixed the redirect URL for the Device Bay Populate/Depopulate view to take the user back to the Device Bays tab on the Device page.

--- a/changes/6502.fixed
+++ b/changes/6502.fixed
@@ -1,2 +1,0 @@
-Fixed a bug in the dockerfile that prevented "docker build" from working on some platforms.
-Fixed docker builds failing in Gitlab CI.

--- a/changes/6625.security
+++ b/changes/6625.security
@@ -1,1 +1,0 @@
-Patched `set_values()` method of Query class from django.db.models.sql.query to address `CVE-2024-42005`.

--- a/examples/example_plugin/docs/requirements.txt
+++ b/examples/example_plugin/docs/requirements.txt
@@ -4,4 +4,4 @@ mkdocs-include-markdown-plugin==4.0.4
 mkdocs-material==9.1.18
 mkdocstrings==0.22.0
 mkdocstrings-python==1.3.0
-zipp==3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+zipp==3.19.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/example_plugin/docs/requirements.txt
+++ b/examples/example_plugin/docs/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-include-markdown-plugin==4.0.4
 mkdocs-material==9.1.18
 mkdocstrings==0.22.0
 mkdocstrings-python==1.3.0
+zipp==3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/nautobot/docs/release-notes/version-1.6.md
+++ b/nautobot/docs/release-notes/version-1.6.md
@@ -72,7 +72,7 @@ The default Python version for Nautobot Docker images has been changed from 3.7 
 As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support installation or operation under Python 3.7.
 
 <!-- towncrier release notes start -->
-## v1.6.29 (2024-12-09)
+## v1.6.29 (2024-12-10)
 
 ### Security
 

--- a/nautobot/docs/release-notes/version-1.6.md
+++ b/nautobot/docs/release-notes/version-1.6.md
@@ -76,7 +76,7 @@ As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support ins
 
 ### Security
 
-- [#5911](https://github.com/nautobot/nautobot/issues/5911) - Updated `zipp` to `3.19.1` to address `CVE-2024-5569`. This is not a direct dependency so it will not auto-update when upgrading. Please be sure to upgrade your local environment.
+- [#5911](https://github.com/nautobot/nautobot/issues/5911) - Updated `zipp` to `3.19.2` to address `CVE-2024-5569`. This is not a direct dependency so it will not auto-update when upgrading. Please be sure to upgrade your local environment.
 - [#6625](https://github.com/nautobot/nautobot/issues/6625) - Patched `set_values()` method of Query class from django.db.models.sql.query to address `CVE-2024-42005`.
 
 ### Fixed

--- a/nautobot/docs/release-notes/version-1.6.md
+++ b/nautobot/docs/release-notes/version-1.6.md
@@ -76,6 +76,7 @@ As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support ins
 
 ### Security
 
+- [#5911](https://github.com/nautobot/nautobot/issues/5911) - Updated `zipp` to `3.19.1` to address `CVE-2024-5569`. This is not a direct dependency so it will not auto-update when upgrading. Please be sure to upgrade your local environment.
 - [#6625](https://github.com/nautobot/nautobot/issues/6625) - Patched `set_values()` method of Query class from django.db.models.sql.query to address `CVE-2024-42005`.
 
 ### Fixed

--- a/nautobot/docs/release-notes/version-1.6.md
+++ b/nautobot/docs/release-notes/version-1.6.md
@@ -72,6 +72,18 @@ The default Python version for Nautobot Docker images has been changed from 3.7 
 As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support installation or operation under Python 3.7.
 
 <!-- towncrier release notes start -->
+## v1.6.29 (2024-12-09)
+
+### Security
+
+- [#6625](https://github.com/nautobot/nautobot/issues/6625) - Patched `set_values()` method of Query class from django.db.models.sql.query to address `CVE-2024-42005`.
+
+### Fixed
+
+- [#5924](https://github.com/nautobot/nautobot/issues/5924) - Fixed the redirect URL for the Device Bay Populate/Depopulate view to take the user back to the Device Bays tab on the Device page.
+- [#6502](https://github.com/nautobot/nautobot/issues/6502) - Fixed a bug in the dockerfile that prevented "docker build" from working on some platforms.
+- [#6502](https://github.com/nautobot/nautobot/issues/6502) - Fixed docker builds failing in Gitlab CI.
+
 ## v1.6.28 (2024-09-24)
 
 ### Fixed

--- a/nautobot/docs/requirements.txt
+++ b/nautobot/docs/requirements.txt
@@ -8,3 +8,4 @@ mkdocs-material==9.1.18
 mkdocs-version-annotations==1.0.0
 mkdocstrings==0.22.0
 mkdocstrings-python==1.2.0
+zipp==3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/nautobot/docs/requirements.txt
+++ b/nautobot/docs/requirements.txt
@@ -8,4 +8,4 @@ mkdocs-material==9.1.18
 mkdocs-version-annotations==1.0.0
 mkdocstrings==0.22.0
 mkdocstrings-python==1.2.0
-zipp==3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+zipp==3.19.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "1.6.28"
+version = "1.6.29"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# TODO

- [x] Check for any security updates in `develop` that can be backported
- [x] Towncrier
- [x] Version Bump

### Security

- [#6625](https://github.com/nautobot/nautobot/issues/6625) - Patched `set_values()` method of Query class from django.db.models.sql.query to address `CVE-2024-42005`.

### Fixed

- [#5924](https://github.com/nautobot/nautobot/issues/5924) - Fixed the redirect URL for the Device Bay Populate/Depopulate view to take the user back to the Device Bays tab on the Device page.
- [#6502](https://github.com/nautobot/nautobot/issues/6502) - Fixed a bug in the dockerfile that prevented "docker build" from working on some platforms.
- [#6502](https://github.com/nautobot/nautobot/issues/6502) - Fixed docker builds failing in Gitlab CI.