### PR TITLE
Add ExampleEverythingJob to Example App

### DIFF
--- a/changes/6590.documentation
+++ b/changes/6590.documentation
@@ -1,0 +1,1 @@
+Added an `ExampleEverythingJob` to the Example App and updated Job developer documentation to reference it as an example.

--- a/examples/example_app/example_app/jobs.py
+++ b/examples/example_app/example_app/jobs.py
@@ -3,22 +3,270 @@ import time
 
 from django.conf import settings
 from django.db import transaction
+from django.forms import widgets
 
 from nautobot.apps.jobs import (
+    BooleanVar,
+    ChoiceVar,
     DryRunVar,
     FileVar,
     IntegerVar,
+    IPAddressVar,
+    IPAddressWithMaskVar,
+    IPNetworkVar,
     Job,
     JobButtonReceiver,
     JobHookReceiver,
     JSONVar,
+    MultiChoiceVar,
+    MultiObjectVar,
+    ObjectVar,
     register_jobs,
     StringVar,
+    TextVar,
 )
-from nautobot.dcim.models import Device, Location
+from nautobot.dcim.models import Device, Location, LocationType
 from nautobot.extras.choices import ObjectChangeActionChoices
+from nautobot.extras.models import Status
 
-name = "Example App jobs"
+name = "Example App jobs"  # The "grouping" that will contain all Jobs defined in this file.
+
+
+class ExampleEverythingJob(Job):
+    """An example Job that uses and documents as much Job functionality as possible."""
+
+    class Meta:
+        """Metaclass attributes, describing and configuring this Job."""
+
+        name = "Example Job of Everything"
+        description = """\
+This is a Job that demonstrates as many Job features as it can.
+
+- All of the magic methods (before_start, run, on_success, on_failure, after_return).
+- All of the Meta attributes.
+- All of the ScriptVariable types as Job inputs.
+- Etc."""
+        approval_required = True  # Default: False
+        # Set to True to make it so that another user must approve any run of this Job
+        # before it can be executed.
+        dryrun_default = False  # Default: False
+        # Set to True to default Job execution to "dry-run" mode.
+        # Exactly what that means is up to the Job implementation.
+        field_order = []  # Default: unspecified (empty list)
+        # The order the input variables appear in the UI.
+        # If unspecified, they appear in declaration order.
+        has_sensitive_variables = False  # Default: True
+        # Set to False to assert that this Job's variables are non-sensitive;
+        # that is, they are permissible to save to the database and be made visible to
+        # any user who can view this Job's results.
+        hidden = False  # Default: False
+        # Set to True for a Job that's not shown in the UI by default.
+        read_only = False  # Default: False
+        # Set to True to assert that this Job does not make any changes to Nautobot data or the
+        # broader environment; exactly what this means is up to the job implementation.
+        soft_time_limit = 1000  # Default: None (follow global configuration)
+        # Time in seconds before Celery will automatically attempt to gracefully end the Job
+        # by raising a SoftTimeLimitExceeded exception.
+        task_queues = []  # Default: []
+        # The list of task queue names this Job wants to be routable to.
+        # Typically you'll configure this in the database, not hard-code it into the Job itself.
+        template_name = ""  # Default: ""
+        # App-only feature at present as only Apps can provide additional Django template files.
+        # Relative path of a Django template to display this Job's inputs in the UI for execution.
+        time_limit = 2000  # Default: None (follow global configuration)
+        # Time in seconds before Celery will automatically attempt terminate the Job by killing the
+        # Celery worker process.
+
+    # Definition of input variables requested when running this Job
+    should_fail = BooleanVar(description="Check this box to force this Job to fail")
+    string_input = StringVar(
+        # Common optional parameters to all ScriptVariable types:
+        default="Hello World!",
+        description="Say hello to somebody...",
+        label="Brief String Input",
+        required=True,  # default is True for all input variables unless specified otherwise
+        widget=widgets.TextInput,  # default widget for StringVar
+        # Additional optional parameters specific to StringVar
+        min_length=5,  # minimum number of characters
+        max_length=255,  # maximum number of characters
+        regex=r"^Hello .*!$",  # regex that any provided value must match
+    )
+    text_input = TextVar(
+        default="Lorem ipsum...",
+        description="You could type a whole essay here.",
+        label="Longer Text Input",
+        required=True,
+    )
+    integer_input = IntegerVar(
+        default=0,
+        min_value=-100,
+        max_value=100,
+    )
+    choice_input = ChoiceVar(
+        description="Select a single value from the given choices",
+        choices=(
+            ("#ff0000", "Red"),  # value, display string
+            ("#00ff00", "Green"),
+            ("#0000ff", "Blue"),
+        ),
+    )
+    multiple_choice_input = MultiChoiceVar(
+        description="Select any number of values from the given choices",
+        choices=(
+            ("#ff0000", "Red"),  # value, display string
+            ("#00ff00", "Green"),
+            ("#0000ff", "Blue"),
+        ),
+        required=False,
+    )
+    location_type_input = ObjectVar(
+        description="Select a single object instance",
+        model=LocationType,
+    )
+    object_input = ObjectVar(
+        description="Select a single object instance from an API endpoint filtered by the previous selection",
+        model=Location,
+        display_field="name",
+        query_params={"location_type": "$location_type_input"},
+        null_option="(none)",
+        required=False,
+    )
+    multiple_object_input = MultiObjectVar(
+        description="Select any number of object instances",
+        model=Status,
+        required=False,
+    )
+    file_input = FileVar(
+        required=False,
+        description="Upload a file here",
+    )
+    ip_address_input = IPAddressVar(
+        label="IP Address",
+        description="An IPv4 or IPv6 address, without a netmask",
+        default="10.0.0.1",
+    )
+    ip_address_with_mask_input = IPAddressWithMaskVar(
+        label="IP Address with Mask",
+        description="An IPv4 or IPv6 address plus netmask",
+        default="10.0.0.1/24",
+    )
+    ip_network_input = IPNetworkVar(
+        label="IP Network",
+        description="An IPv4 or IPv6 network with mask",
+        min_prefix_length=8,
+        max_prefix_length=24,
+        default="10.0.0.0/24",
+    )
+    json_input = JSONVar(
+        label="JSON Data",
+        description="A JSON value that can be parsed by Nautobot",
+        default={},
+    )
+    # the name `dryrun` is significant!
+    dryrun = DryRunVar(description="Set to True to run in dry-run mode, bypassing approval requirements")
+
+    def before_start(self, task_id, args, kwargs):
+        """
+        Called before starting the Job run() method.
+
+        If any unhandled exception is raised, run() will not be called and instead the Job will proceed directly to
+        calling on_failure().
+
+        Args:
+            task_id (str): Present for Celery compatibility, can be ignored in most cases.
+            args (list): Present for Celery compatibility, can be ignored in most cases.
+            kwargs (dict): The keyword args that will be passed into `run()`.
+        """
+        self.logger.info("Before start! The provided kwargs are `%s`", kwargs)
+
+    def run(self, **kwargs):
+        """
+        The main worker function of any Job.
+
+        Considered to have "succeeded" if it returns without raising any exception; any raised and unhandled exception
+        will be considered a "failure".
+
+        Args:
+            **kwargs (dict): Arguments corresponding to the ScriptVariables defined for this Job. Be sure to define
+                default values for any variables that are marked as optional!
+
+        Returns:
+            data (any): Data that will be saved to the JobResult. **Must** be serializable to JSON.
+        """
+        self.logger.info("Running!")
+        for key, value in kwargs.items():
+            self.logger.info("For kwarg %s, the provided value was `%s` `%s`", key, type(value), value)
+
+        # A few relevant instance attributes are automatically set when a Job runs:
+        self.logger.debug("The user who requested this Job to run is %s", self.user.username)
+        self.logger.debug("The JobResult for this Job has id %s", self.job_result.id)
+
+        # Since Jobs are Python classes, you can define any custom methods you like and call them yourself:
+        self.demonstrate_logging(kwargs)
+
+        # The create_file() helper method takes a filename and either a string or bytestring as input.
+        # Users can subsequently download the created file.
+        self.create_file("example.txt", "\n".join([kwargs["string_input"], kwargs["text_input"]]))
+
+        if kwargs["should_fail"]:
+            raise RuntimeError("This unhandled exception will cause the Job to fail")
+        # else:
+        return {"my job result": {"The return value on success can contain any": ["JSON", "serializable", "data"]}}
+
+    def demonstrate_logging(self, kwargs):
+        """Not a magic method - this is a custom Python function manually called from run()."""
+        self.logger.debug("This is a simple debug message, with **Markdown** formatting.")
+        self.logger.info(
+            "This is an info message, with an associated database object",
+            extra={"object": kwargs["location_type_input"]},
+        )
+        self.logger.warning(
+            "You can specify a custom grouping for messages, but do so with consideration.",
+            extra={"grouping": "warning messages"},
+        )
+        self.logger.error("Note that *logging* an error does _not_ automatically cause the job to fail.")
+        self.logger.exception("Any supported Python log level can be logged but not all are automatically colorized.")
+
+    def on_success(self, retval, task_id, args, kwargs):
+        """
+        Called if both before_start() and run() ran without raising any exceptions.
+
+        Args:
+            retval (any): The value returned by `run()`, if any.
+            task_id (str): Present for Celery compatibility, can be ignored in most cases.
+            args (list): Present for Celery compatibility, can be ignored in most cases.
+            kwargs (dict): The keyword args that were passed into `run()`.
+        """
+        self.logger.info("Success! The retval is `%s`, kwargs were `%s`", retval, kwargs)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        """
+        Called if either before_start() or run() raised an unhandled exception.
+
+        Args:
+            exc (Exception): The exception that was raised.
+            task_id (str): Present for Celery compatibility, can be ignored in most cases.
+            args (list): Present for Celery compatibility, can be ignored in most cases.
+            kwargs (dict): The keyword args that were (or would have been) passed into `run()`.
+            einfo (any): Present for Celery compatibility, can be ignored in most cases.
+        """
+        self.logger.error("Failure! The exception is `%s`, kwargs were `%s`", exc, kwargs)
+
+    def after_return(self, status, retval, task_id, args, kwargs, einfo):
+        """
+        Called after both on_success() and on_failure(), regardless of the success or failure of the Job.
+
+        Args:
+            status (JobResultStatusChoices): Either `STATUS_SUCCESS` or `STATUS_FAILURE`.
+            retval (any): The return value of `run()` (on success) or the `Exception` raised (on failure).
+            task_id (str): Present for Celery compatibility, can be ignored in most cases.
+            args (list): Present for Celery compatibility, can be ignored in most cases.
+            kwargs (dict): The keyword args that were passed into `run()`.
+            einfo (any): Present for Celery compatibility, can be ignored in most cases.
+        """
+        self.logger.info(
+            "After return! The status is `%s`, retval is `%s`, Job kwargs were `%s`", status, retval, kwargs
+        )
 
 
 class ExampleDryRunJob(Job):
@@ -221,6 +469,7 @@ class ExampleComplexJobButtonReceiver(JobButtonReceiver):
 
 
 jobs = (
+    ExampleEverythingJob,
     ExampleDryRunJob,
     ExampleJob,
     ExampleCustomFormJob,

--- a/nautobot/docs/development/jobs/index.md
+++ b/nautobot/docs/development/jobs/index.md
@@ -2,81 +2,90 @@
 
 Familiarity with the basic concepts of [Jobs](../../user-guide/platform-functionality/jobs/index.md), especially the distinction between Job classes (Python code) and Job records (Nautobot database records), is recommended before authoring your first Job.
 
-!!! tip
+??? tip "More about Job class source code loading"
     From a development standpoint, it's especially important to understand that the Job database record never stores the Job class code. It only describes the **existence** of a Job class. The actual Job class source code is loaded into memory only.
 
-!!! info
     As an implementation detail in Nautobot 2.2.3 and later, all known Job **classes** are cached in the [application registry](../core/application-registry.md#jobs), which is refreshed at various times including Nautobot application startup and immediately prior to actually executing any given Job by a worker. This implementation detail should not be relied on directly; instead you should always use the `get_job()` and/or `get_jobs()` APIs to obtain a Job class when needed.
 
 ## Migrating Jobs from v1 to v2
 
-+/- 2.0.0
-    See [Migrating Jobs From Nautobot v1](migration/from-v1.md) for more information on how to migrate your existing jobs to Nautobot v2.
+See [Migrating Jobs From Nautobot v1](migration/from-v1.md) for more information on how to migrate your existing Jobs to Nautobot v2.
 
 ## Installing Jobs
 
 Jobs may be installed in one of three ways:
 
 * Manually installed as files in the [`JOBS_ROOT`](../../user-guide/administration/configuration/settings.md#jobs_root) path (which defaults to `$NAUTOBOT_ROOT/jobs/`).
-    * Python files and subdirectories containing Python files will be dynamically loaded at Nautobot startup in order to discover and register available Job classes. For example, a job class named `MyJobClass` in `$JOBS_ROOT/my_job.py` will be loaded into Nautobot as `my_job.MyJobClass`.
+    * Python files and subdirectories containing Python files will be dynamically loaded at Nautobot startup in order to discover and register available Job classes. For example, a Job class named `MyJobClass` in `$JOBS_ROOT/my_job.py` will be loaded into Nautobot as `my_job.MyJobClass`.
     * All Python modules in this directory are imported by Nautobot and all worker processes at startup. If you have a `custom_jobs.py` and a `custom_jobs_module/__init__.py` file in your `JOBS_ROOT`, both of these files will be imported at startup.
 * Imported from an external [Git repository](../../user-guide/platform-functionality/gitrepository.md#jobs).
-    * Git repositories are loaded into the module namespace of the `GitRepository.slug` value at startup. For example, if your `slug` value is `my_git_jobs` your jobs will be loaded into Python as `my_git_jobs.jobs.MyJobClass`.
-    * All git repositories providing jobs must include a `__init__.py` file at the root of the repository.
+    * Git repositories are loaded into the module namespace of the `GitRepository.slug` value at startup. For example, if your `slug` value is `my_git_jobs` your Jobs will be loaded into Python as `my_git_jobs.jobs.MyJobClass`.
+    * All git repositories providing Jobs must include a `__init__.py` file at the root of the repository.
     * Nautobot and all worker processes will import the git repository's `jobs` module at startup so a `jobs.py` or `jobs/__init__.py` file must exist in the root of the repository.
 * Packaged as part of an [App](../apps/api/platform-features/jobs.md).
     * Jobs installed this way are part of the App's Python module and can import code from elsewhere in the App or even have dependencies on other packages, if needed, via the standard Python packaging mechanisms.
 
-In any case, each module holds one or more Job classes (Python classes), each of which serves a specific purpose. The logic of each job can be split into a number of distinct methods, each of which performs a discrete portion of the overall job logic.
+In any case, each module holds one or more Job classes (Python classes), each of which serves a specific purpose. The logic of each Job can be split into a number of distinct methods, each of which performs a discrete portion of the overall Job logic.
 
-For example, we can create a module named `devices.py` to hold all of our jobs which pertain to devices in Nautobot. Within that module, we might define several jobs. Each job is defined as a Python class inheriting from `nautobot.apps.jobs.Job`, which provides the base functionality needed to accept user input and log activity.
+For example, we can create a module named `device_jobs.py` to hold all of our Jobs which pertain to devices in Nautobot. Within that module, we might define several Jobs. Each Job is defined as a Python class inheriting from `nautobot.apps.jobs.Job`, which provides the base functionality needed to accept user input and log activity.
 
-+/- 2.0.0
-    All job classes that are intended to be runnable must now be registered by a call to `nautobot.apps.jobs.register_jobs()` on module import. This allows for a module to, if desired, define "abstract" base Job classes that are defined in code but are not registered (and therefore are not runnable in Nautobot). The `register_jobs` method accepts one or more job classes as arguments.
++/- 2.0.0 "`register_jobs()` must be called"
+    All Job classes that are intended to be runnable must now be registered by a call to `nautobot.apps.jobs.register_jobs()` on module import. This allows for a module to, if desired, define "abstract" base Job classes that are defined in code but are not registered (and therefore are not runnable in Nautobot). The `register_jobs` method accepts one or more Job classes as arguments.
 
 ## Writing Jobs
 
+### Introduction to Writing Jobs
+
 !!! warning
-    Make sure your Job subclasses inherit from `nautobot.apps.Job` and *not* from `nautobot.extras.models.Job` instead; if you mistakenly inherit from the latter, Django will think you want to define a new database model.
+    Make sure your Job subclasses inherit from `nautobot.apps.jobs.Job` and *not* from `nautobot.extras.models.Job` instead; if you mistakenly inherit from the latter, Django will think you want to define a new database model!
+
+The most basic structure of a Python file providing one or more Jobs is as follows:
 
 ```python
-from nautobot.apps.jobs import Job, register_jobs
+from nautobot.apps import jobs
 
-class CreateDevices(Job):
-    ...
+name = "My Group Of Jobs"  # optional, but recommended to define a grouping name
 
-class DeviceConnectionsReport(Job):
-    ...
+class MyNewJob(jobs.Job):
+    class Meta:
+        # metadata attributes go here
+        name = "My New Job"
+        # ... etc.
 
-class DeviceIPsReport(Job):
-    ...
+    # input variable definitions go here
+    some_text_input = jobs.StringVar(...)
+    # ... etc.
 
-register_jobs(CreateDevices, DeviceConnectionsReport, DeviceIPsReport)
+    def run(self, *, some_text_input, ...):
+        # code to execute when the Job is run goes here
+        self.logger.info("some_text_input: %s", some_text_input)
+
+jobs.register_jobs(MyNewJob)
 ```
 
-Each job class will implement some or all of the following components:
+Each Job class will implement some or all of the following components:
 
-* Module and class attributes, providing for default behavior, documentation and discoverability
-* a set of variables for user input via the Nautobot UI (if your job requires any user inputs)
-* a `run()` method, which is the only required attribute on a Job class and receives the user input values, if any, as keyword arguments.
-* Optionally, any of the special methods `before_start()`, `on_success()`, `on_failure()`, and/or `after_return()` (more on these later).
+* [Module](#module-metadata-attributes) and class [metadata attributes](#class-metadata-attributes), configuring the system-level behavior of the Job and providing for documentation and discoverability by users.
+* A set of [variables](#variables) for user input via the Nautobot UI or API.
+* The [`run()` method](#the-run-method), which is the only **required** attribute on a Job class and receives the user input values as keyword arguments.
+* Optionally, any of the special methods [`before_start()`](#the-before_start-method), [`on_success()`](#the-on_success-method), [`on_failure()`](#the-on_failure-method), and/or [`after_return()`](#the-after_return-method).
 
-It's important to understand that jobs execute on the server asynchronously as background tasks; they log messages and report their status to the database by updating [`JobResult`](../../user-guide/platform-functionality/jobs/models.md#job-results) records and creating [`JobLogEntry`](../../user-guide/platform-functionality/jobs/models.md#job-log-entry) records.
+It's important to understand that Jobs execute on the server asynchronously as background tasks; they log messages and report their status to the database by updating [`JobResult`](../../user-guide/platform-functionality/jobs/models.md#job-results) records and creating [`JobLogEntry`](../../user-guide/platform-functionality/jobs/models.md#job-log-entry) records.
 
-!!! note
+!!! note "About detection of changes while developing a Job"
     When actively developing a Job utilizing a development environment it's important to understand that the "automatically reload when code changes are detected" debugging functionality provided by `nautobot-server runserver` does **not** automatically restart the Celery `worker` process when code changes are made; therefore, it is required to restart the `worker` after each update to your Job source code or else it will continue to run the version of the Job code that was present when it first started. In the Nautobot core development environment, we use `watchmedo auto-restart` as a helper tool to auto-restart the workers as well on code changes; you may wish to configure your local development environment similarly for convenience.
 
     Additionally, as of Nautobot 1.3, the Job database records corresponding to installed Jobs are *not* automatically refreshed when the development server auto-restarts. If you make changes to any of the class and module metadata attributes described in the following sections, the database will be refreshed to reflect these changes only after running `nautobot-server migrate` or `nautobot-server post_upgrade` (recommended) or if you manually edit a Job database record to force it to be refreshed. The exception here is Git-repository-provided Jobs; resyncing the Git repository through Nautobot will also trigger a refresh of the Job records corresponding to this repository's contents.
 
 ### Job Registration
 
-+/- 2.0.0
++/- 2.0.0 "`register_jobs()` is now required"
 
-All Job classes, including `JobHookReceiver` and `JobButtonReceiver` classes must be registered at **import time** using the `nautobot.apps.jobs.register_jobs` method. This method accepts one or more job classes as arguments. You must account for how your jobs are imported when deciding where to call this method.
+All Job classes, including `JobHookReceiver` and `JobButtonReceiver` classes must be registered at **import time** using the `nautobot.apps.jobs.register_jobs` method. This method accepts one or more Job classes as arguments. You must account for how your Jobs are imported when deciding where to call this method.
 
 #### Registering Jobs in `JOBS_ROOT` or Git Repositories
 
-Only top level module names within `JOBS_ROOT` are imported by Nautobot at runtime. This means that if you're using submodules, you need to ensure that your jobs are either registered in your top level `__init__.py` or that this file imports your submodules where the jobs are registered:
+Only top level module names within `JOBS_ROOT` are imported by Nautobot at runtime. This means that if you're using submodules, you need to ensure that your Jobs are either registered in your top level `__init__.py` or that this file imports your submodules where the Jobs are registered:
 
 ```py title="$JOBS_ROOT/my_jobs/__init__.py"
 from . import my_job_module
@@ -91,14 +100,14 @@ class MyJob(Job):
 register_jobs(MyJob)
 ```
 
-Similarly, only the `jobs` module is loaded from Git repositories. If you're using submodules, you need to ensure that your jobs are either registered in the repository's `jobs/__init__.py` or that this file imports your submodules where the jobs are registered.
+Similarly, only the `jobs` module is loaded from Git repositories. If you're using submodules, you need to ensure that your Jobs are either registered in the repository's `jobs/__init__.py` or that this file imports your submodules where the Jobs are registered.
 
-If not using submodules, you should register your job in the file where your job is defined.
+If not using submodules, you should register your Job in the file where it is defined.
 
-Examples of the different directory structures when registering jobs in Git repositories:  
+Examples of the different directory structures when registering Jobs in Git repositories:
 
-!!! note
-    Take note of the `__init__.py` at the root of the repository.  This is required to register jobs in a Git repository.
+!!! note "`__init__.py`"
+    Take note of the `__init__.py` at the root of the repository.  This is required to register Jobs in a Git repository.
 
 ``` title="jobs.py"
 .
@@ -116,7 +125,7 @@ Examples of the different directory structures when registering jobs in Git repo
 
 #### Registering Jobs in an App
 
-Apps should register jobs in the module defined in their [`NautobotAppConfig.jobs`](../apps/api/nautobot-app-config.md#nautobotappconfig-code-location-attributes) property. This defaults to the `jobs` module of the App.
+Apps should register Jobs in the module defined in their [`NautobotAppConfig.jobs`](../apps/api/nautobot-app-config.md#nautobotappconfig-code-location-attributes) property. This defaults to the `jobs` module of the App.
 
 ### Reserved Attribute Names
 
@@ -174,25 +183,25 @@ As of Nautobot 2.2.3, the current list of reserved names (not including low-leve
 
 #### `name` (Grouping)
 
-You can define a global constant called `name` within a job module (the Python file which contains one or more job classes) to set the default grouping under which jobs in this module will be displayed in the Nautobot UI. If this value is not defined, the module's file name will be used. This "grouping" value may also be defined or overridden when editing Job records in the database.
+You can define a global constant called `name` within a job module (the Python file which contains one or more Job classes) to set the default grouping under which the Jobs in this module will be displayed in the Nautobot UI. If this value is not defined, the module's file name will be used. This "grouping" value may also be defined or overridden when editing Job records in the database.
 
 !!! note
     In some UI elements and API endpoints, the module file name is displayed in addition to or in place of this attribute, so even if defining this attribute, you should still choose an appropriately explanatory file name as well.
 
 ### Class Metadata Attributes
 
-Job-specific attributes may be defined under a class named `Meta` within each job class you implement. All of these are optional, but encouraged.
+Job-specific attributes may be defined under a class named `Meta` within each Job class you implement. All of these are optional, but encouraged.
 
 #### `name`
 
-This is the human-friendly name of your job, as will be displayed in the Nautobot UI. If not set, the class name will be used.
+This is the human-friendly name of your Job, as will be displayed in the Nautobot UI. If not set, the class name will be used.
 
 !!! note
     In some UI elements and API endpoints, the class name is displayed in addition to or in place of this attribute, so even if defining this attribute, you should still choose an appropriately explanatory class name as well.
 
 #### `description`
 
-An optional human-friendly description of what this job does.
+An optional human-friendly description of what this Job does.
 This can accept either plain text, Markdown-formatted text, or [a limited subset of HTML](../../user-guide/platform-functionality/template-filters.md#render_markdown). It can also be multiple lines:
 
 ```python
@@ -207,22 +216,23 @@ class ExampleJob(Job):
         """
 ```
 
-If you code a multi-line description, the first line only will be used in the description column of the jobs list, while the full description will be rendered in the job detail view, submission, approval, and results pages.
+If you code a multi-line description, the first line only will be used in the description column of the Jobs list, while the full description will be rendered in the Job detail view, submission, approval, and results pages.
 
 #### `approval_required`
 
 Default: `False`
 
-A boolean that will mark this job as requiring approval from another user to be run. For more details on approvals, [please refer to the section on scheduling and approvals](../../user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md).
+A boolean that will mark this Job as requiring approval from another user to be run. For more details on approvals, [please refer to the section on scheduling and approvals](../../user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md).
 
 #### `dryrun_default`
 
-+/- 2.0.0
-    The `commit_default` field was renamed to `dryrun_default` and the default value was changed from `True` to `False`. The `commit` functionality that provided an automatic rollback of database changes if the job failed was removed. The `dryrun` functionality was added to provide a way to bypass job approval if a job implements a [`DryRunVar`](#dryrunvar).
++/- 2.0.0 "Replacement for `commit_default`"
+    The `commit_default` field was renamed to `dryrun_default` and the default value was changed from `True` to `False`. The `commit` functionality that provided an automatic rollback of database changes if the Job failed was removed.
 
 Default: `False`
 
-The checkbox to enable dryrun when executing a job is unchecked by default in the Nautobot UI. You can set `dryrun_default` to `True` under the `Meta` class if you want this option to instead be checked by default.
+If the Job implements a [`DryRunVar`](#dryrunvar), what its default value should be.
+The checkbox to enable dryrun when executing a Job is unchecked by default in the Nautobot UI. You can set `dryrun_default` to `True` under the `Meta` class if you want this option to instead be checked by default.
 
 ```python
 class MyJob(Job):
@@ -234,7 +244,7 @@ class MyJob(Job):
 
 Default: `[]`
 
-A list of strings (field names) representing the order your job [variables](#variables) should be rendered as form fields in the job submission UI. If not defined, the variables will be listed in order of their definition in the code. If variables are defined on a parent class and no field order is defined, the parent class variables will appear before the subclass variables.
+A list of strings (field names) representing the order your Job [variables](#variables) should be rendered as form fields in the Job submission UI. If not defined, the variables will be listed in order of their definition in the code. If variables are defined on a parent class and no field order is defined, the parent class variables will appear before the subclass variables.
 
 #### `has_sensitive_variables`
 
@@ -242,47 +252,47 @@ A list of strings (field names) representing the order your job [variables](#var
 
 Default: `True`
 
-Unless set to False, it prevents the job's input parameters from being saved to the database. This defaults to True so as to protect against inadvertent database exposure of input parameters that may include sensitive data such as passwords or other user credentials. Review whether each job's inputs contain any such variables before setting this to False; if a job *does* contain sensitive inputs, if possible you should consider whether the job could be re-implemented using Nautobot's [`Secrets`](../../user-guide/platform-functionality/secret.md) feature as a way to ensure that the sensitive data is not directly provided as a job variable at all.
+Unless set to False, it prevents the Job's input parameters from being saved to the database. This defaults to True so as to protect against inadvertent database exposure of input parameters that may include sensitive data such as passwords or other user credentials. Review whether each Job's inputs contain any such variables before setting this to False; if a Job *does* contain sensitive inputs, if possible you should consider whether the Job could be re-implemented using Nautobot's [`Secrets`](../../user-guide/platform-functionality/secret.md) feature as a way to ensure that the sensitive data is not directly provided as a Job variable at all.
 
-Important notes about jobs with sensitive variables:
+Important notes about Jobs with sensitive variables:
 
-* Such jobs cannot be scheduled to run in the future or on a recurring schedule (as scheduled jobs must by necessity store their variables in the database for future reference).
-* Jobs with sensitive variables cannot be marked as requiring approval (as jobs pending approval must store their variables in the database until approved).
+* Such Jobs cannot be scheduled to run in the future or on a recurring schedule (as Scheduled Jobs must by necessity store their variables in the database for future reference).
+* Jobs with sensitive variables cannot be marked as requiring approval (as Jobs pending approval must store their variables in the database until approved).
 
 #### `hidden`
 
 Default: `False`
 
-A Boolean that if set to `True` prevents the job from being displayed by default in the list of Jobs in the Nautobot UI.
+A Boolean that if set to `True` prevents the Job from being displayed by default in the list of Jobs in the Nautobot UI.
 
-Since the jobs execution framework is designed to be generic, there may be several technical jobs defined by users which interact with or are invoked by external systems. In such cases, these jobs are not meant to be executed by a human and likely do not make sense to expose to end users for execution, and thus having them exposed in the UI at all is extraneous.
+Since the Job execution framework is designed to be generic, there may be several technical Jobs defined by users which interact with or are invoked by external systems. In such cases, these Jobs are not meant to be executed by a human and likely do not make sense to expose to end users for execution, and thus having them exposed in the UI at all is extraneous.
 
-Important notes about hidden jobs:
+Important notes about hidden Jobs:
 
 * This is merely hiding them by default from the web interface. It is NOT a security feature.
-* In the Jobs list view it is possible to filter to "Hidden: (no selection)" or even "Hidden: Yes" to list the hidden jobs.
-* All Job UI and REST API endpoints still exist for hidden jobs and can be accessed by any user who is aware of their existence.
-* Hidden jobs can still be executed through the UI or the REST API given the appropriate URL.
-* Results for hidden jobs will still appear in the Job Results list after they are run.
+* In the Jobs list view it is possible to filter to "Hidden: (no selection)" or even "Hidden: Yes" to list the hidden Jobs.
+* All Job UI and REST API endpoints still exist for hidden Jobs and can be accessed by any user who is aware of their existence.
+* Hidden Jobs can still be executed through the UI or the REST API given the appropriate URL.
+* Results for hidden Jobs will still appear in the Job Results list after they are run.
 
 #### `read_only`
 
 +++ 1.1.0
 
-+/- 2.0.0
-    The `read_only` flag no longer changes the behavior of Nautobot core and is up to the job author to decide whether their job should be considered read only.
++/- 2.0.0 "No automatic functionality"
+    The `read_only` flag no longer changes the behavior of Nautobot core and is up to the Job author to decide whether their Job should be considered read only.
 
 Default: `False`
 
-A boolean that can be set by the job author to indicate that the job does not make any changes to the environment. What behavior makes each job "read only" is up to the individual job author to decide. Note that user input may still be optionally collected with read-only jobs via job variables, as described below.
+A boolean that can be set by the Job author to indicate that the Job does not make any changes to the environment. What behavior makes each Job "read only" is up to the individual Job author to decide. Note that user input may still be optionally collected with read-only Jobs via Job variables, as described below.
 
 #### `soft_time_limit`
 
 +++ 1.3.0
 
-An int or float value, in seconds, which can be used to override the default [soft time limit](../../user-guide/administration/configuration/settings.md#celery_task_soft_time_limit) for a job task to complete.
+An int or float value, in seconds, which can be used to override the default [soft time limit](../../user-guide/administration/configuration/settings.md#celery_task_soft_time_limit) for a Job task to complete.
 
-The `celery.exceptions.SoftTimeLimitExceeded` exception will be raised when this soft time limit is exceeded. The job task can catch this to clean up before the [hard time limit](../../user-guide/administration/configuration/settings.md#celery_task_time_limit) (10 minutes by default) is reached:
+The `celery.exceptions.SoftTimeLimitExceeded` exception will be raised when this soft time limit is exceeded. The Job task can catch this to clean up before the [hard time limit](../../user-guide/administration/configuration/settings.md#celery_task_time_limit) (10 minutes by default) is reached:
 
 ```python
 from celery.exceptions import SoftTimeLimitExceeded
@@ -309,16 +319,16 @@ class ExampleJobWithSoftTimeLimit(Job):
 
 Default: `[]`
 
-A list of task queue names that the job can be routed to. An empty list will default to only allowing the user to select the [default queue](../../user-guide/administration/configuration/settings.md#celery_task_default_queue) (`default` unless changed by an administrator). The first queue in the list will be used if a queue is not specified in a job run API call.
+A list of task queue names that the Job can be routed to. An empty list will default to only allowing the user to select the [default queue](../../user-guide/administration/configuration/settings.md#celery_task_default_queue) (`default` unless changed by an administrator). The first queue in the list will be used if a queue is not specified in a Job run API call.
 
 !!! note
-    A worker must be listening on the requested queue or the job will not run. See the documentation on [task queues](../../user-guide/administration/guides/celery-queues.md) for more information.
+    A worker must be listening on the requested queue or the Job will not run. See the documentation on [task queues](../../user-guide/administration/guides/celery-queues.md) for more information.
 
 #### `template_name`
 
 +++ 1.4.0
 
-A path relative to the job source code containing a Django template which provides additional code to customize the Job's submission form. This template should extend the existing job template, `extras/job.html`, otherwise the base form and functionality may not be available.
+A path relative to the Job source code containing a Django template which provides additional code to customize the Job's submission form. This template should extend the existing Job template, `extras/job.html`, otherwise the base form and functionality may not be available.
 
 A template can provide additional JavaScript, CSS, or even display HTML. A good starting template would be:
 
@@ -339,7 +349,7 @@ A template can provide additional JavaScript, CSS, or even display HTML. A good 
 {% endblock javascript %}
 ```
 
-+++ 2.2.0
++++ 2.2.0 "Additional blocks"
     Added the `job_form` and `schedule_form` sub-blocks to `extras/job.html`, for use by Jobs that just want to override the rendered forms without replacing all of `{% block content %}`.
 
 For another example checkout [the template used in the Example App](https://github.com/nautobot/nautobot/blob/main/examples/example_app/example_app/templates/example_app/example_with_custom_template.html) in the GitHub repo.
@@ -349,7 +359,7 @@ For another example checkout [the template used in the Example App](https://gith
 +++ 1.3.0
 
 An int or float value, in seconds, which can be used to override the
-default [hard time limit](../../user-guide/administration/configuration/settings.md#celery_task_time_limit) (10 minutes by default) for a job task to complete.
+default [hard time limit](../../user-guide/administration/configuration/settings.md#celery_task_time_limit) (10 minutes by default) for a Job task to complete.
 
 Unlike the `soft_time_limit` above, no exceptions are raised when a `time_limit` is exceeded. The task will just terminate silently:
 
@@ -368,12 +378,12 @@ class ExampleJobWithHardTimeLimit(Job):
         job_code()
 ```
 
-!!! note
-    If the `time_limit` is set to a value less than or equal to the `soft_time_limit`, a warning log is generated to inform the user that this job will fail silently after the `time_limit` as the `soft_time_limit` will never be reached.
+!!! note "`time_limit` versus `soft_time_limit`"
+    If the `time_limit` is set to a value less than or equal to the `soft_time_limit`, a warning log is generated to inform the user that this Job will fail silently after the `time_limit` as the `soft_time_limit` will never be reached.
 
 ### Variables
 
-Variables allow your job to accept user input via the Nautobot UI, but they are optional; if your job does not require any user input, there is no need to define any variables. Conversely, if you are making use of user input in your job, you *must* also implement the `run()` method, as it is the only entry point to your job that has visibility into the variable values provided by the user.
+Variables allow your Job to accept user input via the Nautobot UI, but they are optional; if your Job does not require any user input, there is no need to define any variables. Conversely, if you are making use of user input in your Job, you *must* also implement the `run()` method, as it is the only entry point to your Job that has visibility into the variable values provided by the user.
 
 ```python
 from nautobot.apps.jobs import Job, StringVar, IntegerVar, ObjectVar
@@ -391,7 +401,7 @@ The remainder of this section documents the various supported variable types and
 
 #### Default Variable Options
 
-All job variables support the following default options:
+All Job variables support the following default options:
 
 * `default` - The field's default value
 * `description` - A brief user-friendly description of the field
@@ -417,7 +427,7 @@ Arbitrary text of any length. Renders as a multi-line text input field.
 
 +++ 2.1.0
 
-Accepts JSON-formatted data of any length. Renders as a multi-line text input field. The variable passed to `run()` method on the job has been serialized to the appropriate Python objects.
+Accepts JSON-formatted data of any length. Renders as a multi-line text input field. The variable passed to `run()` method on the Job has been serialized to the appropriate Python objects.
 
 ```python
 class ExampleJSONVarJob(Job):
@@ -428,7 +438,7 @@ class ExampleJSONVarJob(Job):
         self.logger.info("The value of key1 is: %s", var1["key1"])
 ```
 
-In the above example `{"key1": "value1"}` is provided to the job form, on submission first the field is validated to be JSON-formatted data then is serialized and passed to the `run()` method as a dictionary without any need for the job developer to post-process the variable into a Python dictionary.
+In the above example `{"key1": "value1"}` is provided to the Job form, on submission first the field is validated to be JSON-formatted data then is serialized and passed to the `run()` method as a dictionary without any need for the Job developer to post-process the variable into a Python dictionary.
 
 #### `IntegerVar`
 
@@ -443,7 +453,7 @@ A true/false flag. This field has no options beyond the defaults listed above.
 
 #### `DryRunVar`
 
-A true/false flag with special handling for jobs that require approval. If `dryrun = DryRunVar()` is declared on a job class, approval may be bypassed if `dryrun` is set to `True` on job execution.
+A true/false flag with special handling for Jobs that require approval. If `dryrun = DryRunVar()` is declared on a Job class, approval may be bypassed if `dryrun` is set to `True` on Job execution.
 
 #### `ChoiceVar`
 
@@ -546,7 +556,7 @@ Similar to `ObjectVar`, but allows for the selection of multiple objects.
 
 #### `FileVar`
 
-An uploaded file. Note that uploaded files are present in memory only for the duration of the job's execution: They will not be automatically saved for future use. The job is responsible for writing file contents to disk where necessary.
+An uploaded file. Note that uploaded files are present in memory only for the duration of the Job's execution: They will not be automatically saved for future use. The Job is responsible for writing file contents to disk where necessary.
 
 #### `IPAddressVar`
 
@@ -569,7 +579,7 @@ Nautobot Jobs when executed will be instantiated by Nautobot, then Nautobot will
 
 As Jobs are Python classes, you are of course free to define any number of other helper methods or functions that you call yourself from within any of the above special methods, but the above are the only ones that will be automatically called.
 
---- 2.0.0
+--- 2.0.0 "Removal of `test` and `post_run` special methods"
     The NetBox backwards compatible `test_*()` and `post_run()` special methods have been removed.
 
 #### The `before_start()` Method
@@ -580,7 +590,7 @@ The return value from `before_start()` is ignored, but if it raises any exceptio
 
 #### The `run()` Method
 
-The `run()` method is the primary worker of any Job, and must be implemented. After the `self` argument, it should accept keyword arguments for any variables defined on the job:
+The `run()` method is the primary worker of any Job, and must be implemented. After the `self` argument, it should accept keyword arguments for any variables defined on the Job:
 
 ```python
 from nautobot.apps.jobs import Job, StringVar, IntegerVar, ObjectVar
@@ -594,12 +604,12 @@ class CreateDevices(Job):
         ...
 ```
 
-Again, defining user variables is totally optional; you may create a job with a `run()` method with only the `self` argument if no user input is needed.
+Again, defining user variables is totally optional; you may create a Job with a `run()` method with only the `self` argument if no user input is needed.
 
-!!! warning
+!!! warning "Use `validated_save()` where applicable"
     When writing Jobs that create and manipulate data it is recommended to make use of the `validated_save()` convenience method which exists on all core models. This method saves the instance data but first enforces model validation logic. Simply calling `save()` on the model instance **does not** enforce validation automatically and may lead to bad data. See the development [best practices](../core/best-practices.md).
 
-!!! warning
+!!! warning "Be cautious around bulk operations"
     The Django ORM provides methods to create/edit many objects at once, namely `bulk_create()` and `update()`. These are best avoided in most cases as they bypass a model's built-in validation and can easily lead to database corruption if not used carefully.
 
 If `run()` returns any value (even the implicit `None`), the Job execution will be marked as a success and the returned value will be stored in the associated JobResult database record. Conversely, if `run()` raises any exception, the Job execution will be marked as a failure and the traceback will be stored in the JobResult.
@@ -620,9 +630,9 @@ Regardless of the overall Job execution success or failure, the `after_return()`
 
 +/- 2.0.0
 
-Messages logged from a job's logger will be stored in [`JobLogEntry`](../../user-guide/platform-functionality/jobs/models.md#job-log-entry) records associated with the current [`JobResult`](../../user-guide/platform-functionality/jobs/models.md#job-results).
+Messages logged from a Job's logger will be stored in [`JobLogEntry`](../../user-guide/platform-functionality/jobs/models.md#job-log-entry) records associated with the current [`JobResult`](../../user-guide/platform-functionality/jobs/models.md#job-results).
 
-The logger can be accessed either by using the `logger` property on the job class or `nautobot.extras.jobs.get_task_logger(__name__)`. Both will return the same logger instance. For more information on the standard Python logging module, see the [Python documentation](https://docs.python.org/3/library/logging.html).
+The logger can be accessed either by using the `logger` property on the Job class or `nautobot.extras.jobs.get_task_logger(__name__)`. Both will return the same logger instance. For more information on the standard Python logging module, see the [Python documentation](https://docs.python.org/3/library/logging.html).
 
 The logger accepts an `extra` kwarg that you can optionally set for the following features:
 
@@ -654,14 +664,14 @@ To skip writing a log entry to the database, set the `skip_db_logging` key in th
 
 Markdown rendering is supported for log messages, as well as [a limited subset of HTML](../../user-guide/platform-functionality/template-filters.md#render_markdown).
 
-+/- 1.3.4
-    As a security measure, the `message` passed to any of these methods will be passed through the `nautobot.core.utils.logging.sanitize()` function in an attempt to strip out information such as usernames/passwords that should not be saved to the logs. This is of course best-effort only, and Job authors should take pains to ensure that such information is not passed to the logging APIs in the first place. The set of redaction rules used by the `sanitize()` function can be configured as [settings.SANITIZER_PATTERNS](../../user-guide/administration/configuration/settings.md#sanitizer_patterns).
++/- 1.3.4 "Log entry sanitization"
+    As a security measure, the `message` passed to any of these methods will be passed through the `nautobot.core.utils.logging.sanitize()` function in an attempt to strip out information such as usernames/passwords that should not be saved to the logs. This is of course best-effort only, and Job authors should take pains to ensure that such information is not passed to the logging APIs in the first place. The set of redaction rules used by the `sanitize()` function can be configured as [`settings.SANITIZER_PATTERNS`](../../user-guide/administration/configuration/settings.md#sanitizer_patterns).
+
++/- 2.0.0 "Significant API changes"
+    The Job class logging functions (example: `self.log(message)`, `self.log_success(obj=None, message=message)`, etc) have been removed. Also, the convenience method to mark a Job as failed, `log_failure()`, has been removed. To replace the functionality of this method, you can log an error message with `self.logger.error()` and then raise an exception to fail the Job. Note that it is no longer possible to manually set the Job Result status as failed without raising an exception in the Job.
 
 +/- 2.0.0
-    The Job class logging functions (example: `self.log(message)`, `self.log_success(obj=None, message=message)`, etc) have been removed. Also, the convenience method to mark a job as failed, `log_failure()`, has been removed. To replace the functionality of this method, you can log an error message with `self.logger.error()` and then raise an exception to fail the job. Note that it is no longer possible to manually set the job result status as failed without raising an exception in the job.
-
-+/- 2.0.0
-    The `AbortTransaction` class was moved from the `nautobot.utilities.exceptions` module to `nautobot.core.exceptions`.
+    The `AbortTransaction` class was moved from the `nautobot.utilities.exceptions` module to `nautobot.core.exceptions`. Jobs should generally import it from `nautobot.apps.exceptions` if needed.
 
 ### File Output
 
@@ -684,9 +694,9 @@ The maximum size of any single created file (or in other words, the maximum numb
 
 ### Marking a Job as Failed
 
-To mark a job as failed, raise an exception from within the `run()` method. The exception message will be logged to the traceback of the job result. The job result status will be set to `failed`. To output a job log message you can use the `self.logger.error()` method.
+To mark a Job as failed, raise an exception from within the `run()` method. The exception message will be logged to the traceback of the Job Result. The Job Result status will be set to `failed`. To output a Job log message you can use the `self.logger.error()` method.
 
-As an example, the following job will fail if the user does not put the word "Taco" in `var1`:
+As an example, the following Job will fail if the user does not put the word "Taco" in `var1`:
 
 ```python
 from nautobot.apps.jobs import Job, StringVar
@@ -702,10 +712,10 @@ class MyJob(Job):
 
 ### Accessing User and Job Result
 
-+/- 2.0.0
++/- 2.0.0 "Significant API change"
     The `request` property has been changed to a Celery request instead of a Django web request and no longer includes the information from the web request that initiated the Job. The `user` object is now available as `self.user` instead of `self.request.user`.
 
-The user that initiated the job and the job result associated to the job can be accessed through properties on the job class:
+The user that initiated the Job and the Job Result associated to the Job can be accessed through properties on the Job class:
 
 ```py
 username = self.user.username
@@ -736,7 +746,7 @@ The simplest way to test the entire execution of Jobs is via calling the `nautob
 
 Because of the way `run_job_for_testing` and more specifically Celery tasks work, which is somewhat complex behind the scenes, you need to inherit from `nautobot.apps.testing.TransactionTestCase` instead of `django.test.TestCase` (Refer to the [Django documentation](https://docs.djangoproject.com/en/stable/topics/testing/tools/#provided-test-case-classes) if you're interested in the differences between these classes - `TransactionTestCase` from Nautobot is a small wrapper around Django's `TransactionTestCase`).
 
-When using `TransactionTestCase` (whether from Django or from Nautobot) each tests runs on a completely empty database. Furthermore, Nautobot requires new jobs to be enabled before they can run. Therefore, we need to make sure the job is enabled before each run which `run_job_for_testing` handles for us.
+When using `TransactionTestCase` (whether from Django or from Nautobot) each tests runs on a completely empty database. Furthermore, Nautobot requires new Jobs to be enabled before they can run. Therefore, we need to make sure the Job is enabled before each run which `run_job_for_testing` handles for us.
 
 A simple example of a Job test case might look like the following:
 
@@ -761,16 +771,16 @@ class MyJobTestCase(TransactionTestCase):
 !!! tip
     For more advanced examples refer to the Nautobot source code, specifically `nautobot/extras/tests/test_jobs.py`.
 
-## Debugging job performance
+## Debugging Job Performance
 
 +++ 1.5.17
 
-Debugging the performance of Nautobot jobs can be tricky, because they are executed in the worker context. In order to gain extra visibility, [cProfile](https://docs.python.org/3/library/profile.html) can be used to profile the job execution.
+Debugging the performance of Nautobot Jobs can be tricky, because they are executed in the worker context. In order to gain extra visibility, [cProfile](https://docs.python.org/3/library/profile.html) can be used to profile the Job execution.
 
-The 'profile' form field on jobs is automatically available when the `DEBUG` settings is `True`. When you select that checkbox, a profiling report in the pstats format will be written to the file system of the environment where the job runs. Normally, this is on the file system of the worker process, but if you are using the `nautobot-server runjob` command with `--local`, it will end up in the file system of the web application itself. The path of the written file will be logged in the job.
+The 'profile' form field on Jobs is automatically available when the `DEBUG` settings is `True`. When you select that checkbox, a profiling report in the pstats format will be written to the file system of the environment where the Job runs. Normally, this is on the file system of the worker process, but if you are using the `nautobot-server runjob` command with `--local`, it will end up in the file system of the web application itself. The path of the written file will be logged in the Job.
 
 !!! note
-    If you need to run this in an environment where `DEBUG` is `False`, you have the option of using `nautobot-server runjob` with the `--profile` flag. According to the docs, `cProfile` should have minimal impact on the performance of the job; still, proceed with caution when using this in a production environment.
+    If you need to run this in an environment where `DEBUG` is `False`, you have the option of using `nautobot-server runjob` with the `--profile` flag. According to the docs, `cProfile` should have minimal impact on the performance of the Job; still, proceed with caution when using this in a production environment.
 
 ### Reading profiling reports
 
@@ -783,19 +793,23 @@ stats = pstats.Stats(f"/tmp/nautobot-jobresult-{job_result_uuid}.pstats")
 stats.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(10)
 ```
 
-This will print the 10 functions that the job execution spent the most time in - adapt this to your needs!
+This will print the 10 functions that the Job execution spent the most time in - adapt this to your needs!
 
 ## Example Jobs
 
+### Example "Everything" Job
+
+The "Example App" included with the Nautobot source code [includes a number of simple sample Jobs](https://github.com/nautobot/nautobot/blob/main/examples/example_app/example_app/jobs.py), including an `ExampleEverythingJob` class that demonstrates and documents the usage of the various metadata attributes, input variable types, and magic methods that a Job can support. As Job functionality will continue to evolve over time, if using this file as a reference, please make sure that you're viewing the version of this Job that corresponds to your target Nautobot version.
+
 ### Creating objects for a planned location
 
-This job prompts the user for three variables:
+This Job prompts the user for three variables:
 
 * The name of the new location
 * The device model (a filtered list of defined device types)
 * The number of access switches to create
 
-These variables are presented as a web form to be completed by the user. Once submitted, the job's `run()` method is called to create the appropriate objects, and it returns simple CSV output to the user summarizing the created objects.
+These variables are presented as a web form to be completed by the user. Once submitted, the Job's `run()` method is called to create the appropriate objects, and it returns simple CSV output to the user summarizing the created objects.
 
 ```python
 from django.contrib.contenttypes.models import ContentType
@@ -859,7 +873,7 @@ register_jobs(NewBranch)
 
 ### Device validation
 
-A job to perform various validation of Device data in Nautobot. As this job does not require any user input, it does not define any variables.
+A Job to perform various validation of Device data in Nautobot. As this Job does not require any user input, it does not define any variables.
 
 ```python
 from nautobot.apps.jobs import Job, register_jobs
@@ -916,9 +930,9 @@ register_jobs(DeviceConnectionsReport)
 
 ## Job Button Receivers
 
-Job Buttons are only able to initiate a specific type of job called a **Job Button Receiver**. These are jobs that subclass the `nautobot.apps.jobs.JobButtonReceiver` class. Job Button Receivers are similar to normal jobs except they are hard coded to accept only `object_pk` and `object_model_name` [variables](#variables). Job Button Receivers are hidden from the jobs listing UI by default but otherwise function similarly to other jobs. The `JobButtonReceiver` class only implements one method called `receive_job_button`.
+Job Buttons are only able to initiate a specific type of Job called a **Job Button Receiver**. These are Jobs that subclass the `nautobot.apps.jobs.JobButtonReceiver` class. Job Button Receivers are similar to normal Jobs except they are hard coded to accept only `object_pk` and `object_model_name` [variables](#variables). The `JobButtonReceiver` class only implements one method called `receive_job_button`.
 
-!!! note
+!!! note "Disabled by default just like other Jobs"
     Job Button Receivers still need to be [enabled through the web UI](../../user-guide/platform-functionality/jobs/index.md#enabling-jobs-for-running) before they can be used just like other Jobs.
 
 ### The `receive_job_button()` Method
@@ -990,13 +1004,13 @@ register_jobs(ExampleComplexJobButtonReceiver)
 
 ## Job Hook Receivers
 
-Job Hooks are only able to initiate a specific type of job called a **Job Hook Receiver**. These are jobs that subclass the `nautobot.apps.jobs.JobHookReceiver` class. Job hook receivers are similar to normal jobs except they are hard coded to accept only an `object_change` [variable](#variables). Job Hook Receivers are hidden from the jobs listing UI by default but otherwise function similarly to other jobs. The `JobHookReceiver` class only implements one method called `receive_job_hook`.
+Job Hooks are only able to initiate a specific type of Job called a **Job Hook Receiver**. These are Jobs that subclass the `nautobot.apps.jobs.JobHookReceiver` class. Job Hook Receivers are similar to normal Jobs except they are hard coded to accept only an `object_change` [variable](#variables). The `JobHookReceiver` class only implements one method called `receive_job_hook`.
 
-!!! warning
+!!! warning "No support for `approval_required` at this time"
     Requiring approval for execution of Job Hooks by setting the `Meta.approval_required` attribute to `True` on your `JobHookReceiver` subclass is not supported. The value of this attribute will be ignored. Support for requiring approval of Job Hooks will be added in a future release.
 
-!!! important
-    To prevent negatively impacting system performance through an infinite loop, a change that was made by a `JobHookReceiver` job will not trigger another `JobHookReceiver` job to run.
+!!! important "No recursive JobHookReceivers"
+    To prevent negatively impacting system performance through an infinite loop, a change that was made by a `JobHookReceiver` Job will not trigger another `JobHookReceiver` Job to run.
 
 ### Example Job Hook Receiver
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -98,13 +98,15 @@ class BaseJob:
 
         - name (str)
         - description (str)
-        - hidden (bool)
-        - field_order (list)
         - approval_required (bool)
-        - soft_time_limit (int)
-        - time_limit (int)
+        - dryrun_default (bool)
+        - field_order (list)
         - has_sensitive_variables (bool)
+        - hidden (bool)
+        - soft_time_limit (int)
         - task_queues (list)
+        - template_name (str)
+        - time_limit (int)
         """
 
     def __init__(self):


### PR DESCRIPTION
# Closes #6590 
# What's Changed

- Add `ExampleEverythingJob` to the Example App to demonstrate the full set of built-in features that a Job can take advantage of.
- Update Job developer documentation to reference this example; plus other various improvements to this file.

# Screenshots

![Screenshot 2024-12-10 at 09-14-35 Example Job of Everything - Nautobot](https://github.com/user-attachments/assets/f637562b-5316-4613-bcd4-55501c20479d)

![Screenshot 2024-12-10 at 09-13-53 Job Result Example Job of Everything - Nautobot](https://github.com/user-attachments/assets/7e8d9c31-78f6-4282-8c8b-7c207c3ea0c3)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design

**note: when this is merged up into `next`, we should update the ExampleEverythingJob to take advantage of #6541**