### PR TITLE
Fix #6602 - correct wireless filter names

### DIFF
--- a/changes/6602.fixed
+++ b/changes/6602.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect naming of `controller_managed_device_groups` filter on the RadioProfile and WirelessNetwork filtersets.

--- a/nautobot/wireless/filters.py
+++ b/nautobot/wireless/filters.py
@@ -63,7 +63,7 @@ class RadioProfileFilterSet(NautobotFilterSet):
         choices=choices.RadioProfileFrequencyChoices,
         null_value=None,
     )
-    controller_managed_device_group = NaturalKeyOrPKMultipleChoiceFilter(
+    controller_managed_device_groups = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=ControllerManagedDeviceGroup.objects.all(),
         to_field_name="name",
         label="Controller Managed Device Groups (name or ID)",
@@ -101,7 +101,7 @@ class WirelessNetworkFilterSet(NautobotFilterSet, TenancyModelFilterSetMixin):
         to_field_name="name",
         label="Secrets group (name or ID)",
     )
-    controller_managed_device_group = NaturalKeyOrPKMultipleChoiceFilter(
+    controller_managed_device_groups = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=ControllerManagedDeviceGroup.objects.all(),
         to_field_name="name",
         label="Controller Managed Device Groups (name or ID)",

--- a/nautobot/wireless/tests/test_filters.py
+++ b/nautobot/wireless/tests/test_filters.py
@@ -1,4 +1,5 @@
 from nautobot.core.testing import FilterTestCases
+from nautobot.extras.models import SecretsGroup
 from nautobot.wireless import filters, models
 
 
@@ -7,6 +8,8 @@ class SupportedDataRateTestCase(FilterTestCases.FilterTestCase):
     filterset = filters.SupportedDataRateFilterSet
     generic_filter_tests = [
         ("mcs_index",),
+        ("radio_profiles", "radio_profiles__id"),
+        ("radio_profiles", "radio_profiles__name"),
         ("rate",),
         ("standard",),
     ]
@@ -17,19 +20,44 @@ class RadioProfileTestCase(FilterTestCases.FilterTestCase):
     filterset = filters.RadioProfileFilterSet
     generic_filter_tests = [
         ("name",),
-        ("regulatory_domain",),
+        ("controller_managed_device_groups", "controller_managed_device_groups__id"),
+        ("controller_managed_device_groups", "controller_managed_device_groups__name"),
         ("frequency",),
+        ("regulatory_domain",),
     ]
+
+    def test_channel_width(self):
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset({"channel_width": "80"}, self.queryset).qs,
+            self.queryset.filter(channel_width__contains=[80])
+        )
 
 
 class WirelessNetworkTestCase(FilterTestCases.FilterTestCase):
     queryset = models.WirelessNetwork.objects.all()
     filterset = filters.WirelessNetworkFilterSet
     generic_filter_tests = [
+        ("authentication",),
+        ("controller_managed_device_groups", "controller_managed_device_groups__id"),
+        ("controller_managed_device_groups", "controller_managed_device_groups__name"),
         ("description",),
+        ("mode",),
         ("name",),
+        ("secrets_group", "secrets_group__id"),
+        ("secrets_group", "secrets_group__name"),
         ("ssid",),
     ]
+
+    @classmethod
+    def setUpTestData(cls):
+        secrets_groups = (
+            SecretsGroup.objects.create(name="Secrets Group 1"),
+            SecretsGroup.objects.create(name="Secrets Group 2"),
+            SecretsGroup.objects.create(name="Secrets Group 3"),
+        )
+        for i, wireless_network in enumerate(models.WirelessNetwork.objects.all()[:3]):
+            wireless_network.secrets_group = secrets_groups[i]
+            wireless_network.validated_save()
 
 
 class ControllerManagedDeviceGroupWirelessNetworkAssignmentTestCase(FilterTestCases.FilterTestCase):


### PR DESCRIPTION
# Closes #6602 
# What's Changed

- Correct wireless filter names (since these two models have a M2M to ControllerManagedDeviceGroup, the correct filter name is `controller_managed_device_groups` not `controller_managed_device_group`
- Add missing tests to `wireless/tests/test_filters.py`.

# Screenshots

![image](https://github.com/user-attachments/assets/cdae3cfc-dd87-46e0-91ce-9f49d91f4713)

![image](https://github.com/user-attachments/assets/d506efb0-e54c-4763-a170-b7216c45797d)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
