### PR TITLE
Improve REST API documentation around query parameters

### DIFF
--- a/changes/6654.documentation
+++ b/changes/6654.documentation
@@ -1,0 +1,1 @@
+Improved REST API documentation about query parameters and filtering of fields.

--- a/nautobot/docs/user-guide/core-data-model/extras/configcontext.md
+++ b/nautobot/docs/user-guide/core-data-model/extras/configcontext.md
@@ -5,18 +5,18 @@ Sometimes it is desirable to associate additional data with a group of devices o
 * Location
 * Role
 * Device type
+* Device redundancy group
 * Platform
 * Cluster group
 * Cluster
 * Tenant group
 * Tenant
 * Tag
+* Dynamic group - Need to set `settings.CONFIG_CONTEXT_DYNAMIC_GROUPS_ENABLED` to `True`. [See notes here](../../administration/configuration/settings.md#config_context_dynamic_groups_enabled)
 
-+++ 1.5.0
-    * Device redundancy group
++++ 1.5.0 "Added support for filtering by device redundancy group"
 
-+++ 1.5.12
-    * Dynamic group - Need to set `settings.CONFIG_CONTEXT_DYNAMIC_GROUPS_ENABLED` to `True`. [See notes here](../../administration/configuration/settings.md#config_context_dynamic_groups_enabled)
++++ 1.5.12 "Added support for filtering by dynamic group"
 
 Context data not specifically assigned to one or more of the above groups is by default associated with **all** devices and virtual machines.
 

--- a/nautobot/docs/user-guide/platform-functionality/computedfield.md
+++ b/nautobot/docs/user-guide/platform-functionality/computedfield.md
@@ -63,7 +63,7 @@ See the documentation on [built-in filters](./template-filters.md) or [registeri
 
 ## Computed Fields and the REST API
 
-When retrieving an object via the REST API, computed field data is not included by default in order to prevent potentially computationally expensive rendering operations that degrade the user experience. In order to retrieve computed field data, you must use the `include` query parameter.
+When retrieving an object via the REST API, computed field data is not included by default in order to prevent potentially computationally expensive rendering operations that degrade the user experience. In order to retrieve computed field data, you must use the [`include` query parameter](rest-api/filtering.md#filtering-included-fields).
 
 Take a look at an example URL that includes computed field data:
 
@@ -75,9 +75,9 @@ When explicitly requested as such, computed field data will be included in the `
 
 ```json
 {
-    "id": 123,
-    "url": "http://localhost:8080/api/dcim/locations/123/",
-    "name": "Raleigh 42",
+    "id": 9cd6092d-a4df-4708-94a5-349e845e2f79,
+    "url": "http://localhost:8080/api/dcim/locations/9cd6092d-a4df-4708-94a5-349e845e2f79/",
+    "name": "Raleigh",
     ...
     "computed_fields": {
         "location_name_uppercase": "RALEIGH"

--- a/nautobot/docs/user-guide/platform-functionality/computedfield.md
+++ b/nautobot/docs/user-guide/platform-functionality/computedfield.md
@@ -75,7 +75,7 @@ When explicitly requested as such, computed field data will be included in the `
 
 ```json
 {
-    "id": 9cd6092d-a4df-4708-94a5-349e845e2f79,
+    "id": "9cd6092d-a4df-4708-94a5-349e845e2f79",
     "url": "http://localhost:8080/api/dcim/locations/9cd6092d-a4df-4708-94a5-349e845e2f79/",
     "name": "Raleigh",
     ...

--- a/nautobot/docs/user-guide/platform-functionality/relationship.md
+++ b/nautobot/docs/user-guide/platform-functionality/relationship.md
@@ -121,7 +121,7 @@ From our many to many example above, we would use the following data to create t
 
 +++ 1.4.0
 
-To get object relationships and associations from the REST API, you can query any object endpoint with the `?include=relationships` query parameter included, for example `GET /api/dcim/devices/f472bb77-7f56-4e79-ac25-2dc73eb63924/?include=relationships`. The API response will include a nested dictionary of relationships and associations applicable to the object(s) retrieved.
+To get object relationships and associations from the REST API, you can query any object endpoint with the [`?include=relationships` query parameter](rest-api/filtering.md#filtering-included-fields) included, for example `GET /api/dcim/devices/f472bb77-7f56-4e79-ac25-2dc73eb63924/?include=relationships`. The API response will include a nested dictionary of relationships and associations applicable to the object(s) retrieved.
 
 Similarly, you can update the relationship associations for a given object via an HTTP `POST` or `PATCH` request, generally by including the nested key `["relationships"][<relationship_key>]["source"|"destination"|"peer"]["objects"]` with a list of objects to associate.
 

--- a/nautobot/docs/user-guide/platform-functionality/rest-api/filtering.md
+++ b/nautobot/docs/user-guide/platform-functionality/rest-api/filtering.md
@@ -1,5 +1,20 @@
 # REST API Filtering
 
+## Filtering Included Fields
+
+Certain REST API fields can be expensive to look up or render, so Nautobot provides some capabilities to specify via query parameters whether to include or exclude such fields. Specifically, at this time, the following capabilities exist:
+
+- `?include=config_context` - Device and Virtual Machine APIs only. Rendered [configuration context data](../../core-data-model/extras/configcontext.md) is not included by default, but can be added to these API responses by specifying this query parameter.
+- `?include=relationships` - Any object supporting [Relationships](../relationship.md). Relationship data is not included by default, but can be added by specifying this query parameter.
+- `?include=computed_fields` - Any object supporting [Computed Fields](../computedfield.md). Computed field values are not included by default, but can be added by specifying this query parameter.
+- `?exclude_m2m=true` - Any object with many-to-many relations to another type of object. These related objects are included by default, but can be excluded (in many cases improving the REST API performance) by specifying this query parameter.
+
++++ 1.4.0 "Added `include=relationships` and `include=computed_fields` support"
+
++/- 2.0.0 "Changed config contexts to excluded by default, added `include=config_context` support"
+
++++ 2.4.0 "Added `exclude_m2m` support"
+
 ## Filtering Objects
 
 The objects returned by an API list endpoint can be filtered by attaching one or more query parameters to the request URL. For example, `GET /api/dcim/locations/?status=active` will return only locations with a status of "active."
@@ -8,7 +23,7 @@ Multiple parameters can be joined to further narrow results. For example, `GET /
 
 Generally, passing multiple values for a single parameter will result in a logical OR operation. For example, `GET /api/dcim/locations/?parent=north-america&parent=south-america&location_type=country` will return "country" type locations in North America _or_ South America. However, a logical AND operation will be used in instances where a field may have multiple values, such as tags. For example, `GET /api/dcim/locations/?tag=foo&tag=bar` will return only locations which have both the "foo" _and_ "bar" tags applied.
 
-+/- 1.4.0
++/- 1.4.0 "`STRICT_FILTERING` by default"
     If [`STRICT_FILTERING`](../../administration/configuration/settings.md#strict_filtering) is True (its default value), unrecognized filter parameters now result in a 400 Bad Request response instead of being silently ignored.
 
 ### Filtering by Choice Field
@@ -65,11 +80,11 @@ GET /api/dcim/locations/?cf_foo=123
 
 Custom fields can be mixed with built-in fields to further narrow results. When creating a custom string field, the type of filtering selected (loose versus exact) determines whether partial or full matching is used.
 
-+++ 1.4.0
-    Custom fields can use the lookup expressions listed in the next section by prepending `cf_` to the custom field `name` (not the `slug`) followed by the required lookup type (see below).
++++ 1.4.0 "Custom field support for lookup expressions"
+    Custom fields can now use the [lookup expressions](#lookup-expressions) listed in the next section.
 
-+/- 2.0.0
-    Custom field filters are now based on the custom field `key` string.
++/- 2.0.0 "Custom field filters changed from `name` to `key` based"
+    Custom field filters are now based on the custom field `key` string (in 1.x they used the field's `name`).
 
 ## Lookup Expressions
 
@@ -94,9 +109,9 @@ Numeric-based fields (ASN, VLAN ID, etc.) as well as date/time fields (`created`
 - `__lte` - less than or equal
 - `__gt` - greater than
 - `__gte` - greater than or equal
+- `__isnull` - is null (only if this field is nullable, which most numeric fields in Nautobot are not)
 
-+++ 2.1.0
-    - `__isnull` - as above, only if this field is nullable (most numeric fields in Nautobot are not)
++++ 2.1.0 "Added `__isnull` support"
 
 ### String Fields
 
@@ -111,24 +126,24 @@ String-based (char) fields (Name, Address, etc.) support these lookup expression
 - `__niew` - negated case-insensitive ends-with
 - `__ie` - case-insensitive exact match
 - `__nie` - negated case-insensitive exact match
+- `__re` - case-sensitive regular expression match
+- `__nre` - negated case-sensitive regular expression match
+- `__ire` - case-insensitive regular expression match
+- `__nire` - negated case-insensitive regular expression match
+- `__isnull` - is null (only if this field is nullable, which most string fields in Nautobot are not)
 
-+++ 1.3.0
-    - `__re` - case-sensitive regular expression match
-    - `__nre` - negated case-sensitive regular expression match
-    - `__ire` - case-insensitive regular expression match
-    - `__nire` - negated case-insensitive regular expression match
++++ 1.3.0 "Added regular expression lookup expressions"
 
-+++ 2.1.0
-    - `__isnull` - as above, only if this field is nullable (most string fields in Nautobot are not)
++++ 2.1.0 "Added `__isnull` lookup expression"
 
 ### Foreign Keys & Other Fields
 
 Certain other fields, namely foreign key relationships support the lookup expression:
 
 - `__n` - not equal to (negation)
+- `__isnull` - is null, only if this field is nullable
 
-+++ 2.1.0
-    - `__isnull` - as above, only if this field is nullable
++++ 2.1.0 "Added `__isnull` lookup expression"
 
 ### Network and Host Fields
 

--- a/nautobot/docs/user-guide/platform-functionality/rest-api/overview.md
+++ b/nautobot/docs/user-guide/platform-functionality/rest-api/overview.md
@@ -331,10 +331,13 @@ In many (but not necessarily all) cases, as a convenience for users, the REST AP
 !!! warning "Many-to-many at scale"
     When Nautobot contains a substantial number of related records, the inclusion of many-to-many related objects in the REST API may impose a significant amount of performance overhead in terms of processing time and memory usage. For example, if you have many VRFs, each of which is associated to 1000 Prefixes, listing VRFs in the REST API would also by default retrieve, serialize, and list the 1000 Prefix records _per VRF retrieved_.
 
-+++ 2.4.0 "The `exclude_m2m` query parameter"
-    To address the aforementioned performance/scalability concern, Nautobot 2.4.0 introduced support for the REST API query parameter `exclude_m2m`. When this parameter is specified (for example `GET /api/ipam/vrfs/?exclude_m2m=true`), many-to-many related objects will **not** be included in the REST API response, and in most cases will not even be retrieved from the database.
+To address the aforementioned performance/scalability concern, Nautobot supports the REST API query parameter `exclude_m2m`. When this parameter is specified (for example `GET /api/ipam/vrfs/?exclude_m2m=true`), many-to-many related objects will **not** be included in the REST API response, and in most cases will not even be retrieved from the database.
 
-    In a future Nautobot major release, a change in the REST API may make `exclude_m2m=true` the default behavior.
++++ 2.4.0 "Added support for the `exclude_m2m` query parameter"
+
+In a future Nautobot major release, a change in the REST API may make `exclude_m2m=true` the default behavior.
+
+See also [Filtering Included Fields](filtering.md#filtering-included-fields).
 
 ## Pagination
 
@@ -819,12 +822,16 @@ GET /api/dcim/locations/f472bb77-7f56-4e79-ac25-2dc73eb63924/?include=relationsh
 
 In the example above we can see that a single VRF, `green`, is a destination for the `site-to-vrf` Relationship from this Site, while there are currently no VRFs associated as sources for the `vrfs-to-locations` Relationship to this Site.
 
+See also [Filtering Included Fields](filtering.md#filtering-included-fields).
+
 ### Including Config Contexts
 
 When retrieving Devices and Virtual Machines via the REST API, it is possible to also retrive the rendered [configuration context data](../../core-data-model/extras/configcontext.md) for each such object if desired. Because rendering this data can be time consuming, it is _not_ included in the REST API responses by default. If you wish to include config context data in the response, you must opt in by specifying the query parameter `include=config_context` as a part of your request.
 
 +/- 2.0.0
     In Nautobot 1.x, the rendered configuration context was included by default in the REST API response unless specifically excluded with the query parameter `exclude=config_context`. This behavior has been reversed in Nautobot 2.0 and the `exclude` query parameter is no longer supported.
+
+See also [Filtering Included Fields](filtering.md#filtering-included-fields).
 
 ### Creating a New Object
 


### PR DESCRIPTION
# What's Changed

Initial goal was to make the `exclude_m2m` REST API query parameter more discoverable in the documentation,  but I ended up making a number of additional enhancements as well.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
