### PR TITLE
6496 available ips endpoint fix

### DIFF
--- a/changes/6496.fixed
+++ b/changes/6496.fixed
@@ -1,0 +1,2 @@
+Fixed `/ipam/prefixes/<UUID>/available-ips` to calculate IP's with IP's from Child Prefixes.
+Fixed `Prefix.get_first_available_ip` method to not return IP taken by IP's from Child Prefixes.

--- a/changes/6496.fixed
+++ b/changes/6496.fixed
@@ -1,2 +1,2 @@
 Fixed `/ipam/prefixes/<UUID>/available-ips` to calculate IP's with IP's from Child Prefixes.
-Fixed `Prefix.get_first_available_ip` method to not return IP taken by IP's from Child Prefixes.
+Fixed `Prefix.get_first_available_ip` method to not return IP taken by Child Prefixes.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -918,7 +918,7 @@ class Prefix(PrimaryModel):
         Return all available IPs within this prefix as an IPSet.
         """
         prefix = netaddr.IPSet(self.prefix)
-        child_ips = netaddr.IPSet([ip.address.ip for ip in self.ip_addresses.all()])
+        child_ips = netaddr.IPSet([ip.address.ip for ip in self.get_all_ips()])
         available_ips = prefix - child_ips
 
         # IPv6, pool, or IPv4 /31-32 sets are fully usable

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -622,7 +622,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
 
         # Retrieve all available IPs
         response = self.client.get(url, **self.header)
-        self.assertEqual(len(response.data), 7)  # 8 because prefix.type = pool and one children IP
+        self.assertEqual(len(response.data), 7)  # 7 because prefix.type = pool got 8 IP's minus one children IP
 
     def test_create_single_available_ip_calculate_child_ips(self):
         """

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -594,9 +594,76 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
         response = self.client.get(url, **self.header)
         self.assertEqual(len(response.data), 6)  # 8 - 2 because prefix.type = network
 
+    def test_list_available_ips_calculate_child_ips(self):
+        """
+        Test retrieval of all available IP addresses when child IP's exists.
+        """
+        ip_status = Status.objects.get_for_model(IPAddress).first()
+        prefix = Prefix.objects.create(
+            prefix="192.0.3.0/29",
+            type=choices.PrefixTypeChoices.TYPE_POOL,
+            namespace=self.namespace,
+            status=self.status,
+        )
+        Prefix.objects.create(
+            prefix="192.0.3.0/30",
+            type=choices.PrefixTypeChoices.TYPE_POOL,
+            namespace=self.namespace,
+            status=self.status,
+        )
+        IPAddress.objects.create(
+            address="192.0.3.1/30",
+            status=ip_status,
+            namespace=self.namespace,
+        )
+
+        url = reverse("ipam-api:prefix-available-ips", kwargs={"pk": prefix.pk})
+        self.add_permissions("ipam.view_prefix", "ipam.view_ipaddress")
+
+        # Retrieve all available IPs
+        response = self.client.get(url, **self.header)
+        self.assertEqual(len(response.data), 7)  # 8 because prefix.type = pool and one children IP
+
+    def test_create_single_available_ip_calculate_child_ips(self):
+        """
+        Test creating a single IP when child IP's exists.
+        """
+        ip_status = Status.objects.get_for_model(IPAddress).first()
+        prefix = Prefix.objects.create(
+            prefix="192.0.4.0/31",
+            namespace=self.namespace,
+            type=choices.PrefixTypeChoices.TYPE_NETWORK,
+            status=self.status,
+        )
+        Prefix.objects.create(
+            prefix="192.0.4.0/32",
+            type=choices.PrefixTypeChoices.TYPE_POOL,
+            namespace=self.namespace,
+            status=self.status,
+        )
+        IPAddress.objects.create(
+            address="192.0.4.0/32",
+            status=ip_status,
+            namespace=self.namespace,
+        )
+        url = reverse("ipam-api:prefix-available-ips", kwargs={"pk": prefix.pk})
+        self.add_permissions("ipam.view_prefix", "ipam.add_ipaddress", "extras.view_status")
+
+        data = {
+            "status": self.status.pk,
+        }
+
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(str(response.data["parent"]["url"]), self.absolute_api_url(prefix))
+
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_204_NO_CONTENT)
+        self.assertIn("detail", response.data)
+
     def test_create_single_available_ip(self):
         """
-        Test retrieval of the first available IP address within a parent prefix.
+        Test creating single IP will return 204 No content when pool is fully filled.
         """
         prefix = Prefix.objects.create(
             prefix="192.0.2.0/29",

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -800,6 +800,13 @@ class TestPrefix(ModelTestCases.BaseModelTestCase):
         IPAddress.objects.create(address="10.0.0.4/24", status=self.status, namespace=self.namespace)
         self.assertEqual(parent_prefix.get_first_available_ip(), "10.0.0.5/24")
 
+    def test_get_first_available_ip_calculate_child_ips(self):
+        parent_prefix = Prefix.objects.create(prefix="10.0.3.0/29", status=self.status, namespace=self.namespace)
+        Prefix.objects.create(prefix="10.0.3.0/30", status=self.status, namespace=self.namespace)
+        IPAddress(address="10.0.3.1/30", status=self.status, namespace=self.namespace).save()
+
+        self.assertEqual(parent_prefix.get_first_available_ip(), "10.0.3.2/29")
+
     def test_get_utilization(self):
         # Container Prefix
         prefix = Prefix.objects.create(


### PR DESCRIPTION
# Closes #6496
# What's Changed
Fixed 3 places where calculating `available-ips` was wrong:
- Fixed `/ipam/prefixes/<UUID>/available-ips` returning taken IP's as free
- Fixed top table "Add an IP Address" to fill with real first available IP
- Fixed validation when creating an IP Address through POST /available-ips
- 
# Screenshots
`invoke unittest --parallel-workers 10 --pattern test_list_available_ips_calculate_children_ips --pattern test_get_first_available_ip_calculate_children_ips --pattern test_create_single_available_ip_calculate_children_ips`
Before:
![image](https://github.com/user-attachments/assets/e98d7352-8bb1-48a6-a60d-81af7916df1d)

After:
![image](https://github.com/user-attachments/assets/ad16b1ae-8de6-427d-83fe-7e735539a82f)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
