### PR TITLE
Fixed `circuit_type` column not included correctly in CircuitTable default columns

### DIFF
--- a/changes/6664.fixed
+++ b/changes/6664.fixed
@@ -1,0 +1,1 @@
+Fixed `circuit_type` column not included correctly in CircuitTable default columns.

--- a/nautobot/circuits/tables.py
+++ b/nautobot/circuits/tables.py
@@ -146,7 +146,7 @@ class CircuitTable(StatusTableMixin, BaseTable):
             "pk",
             "cid",
             "provider",
-            "type",
+            "circuit_type",
             "status",
             "tenant",
             "circuit_termination_a",

--- a/nautobot/circuits/tables.py
+++ b/nautobot/circuits/tables.py
@@ -110,6 +110,7 @@ class CircuitTable(StatusTableMixin, BaseTable):
     pk = ToggleColumn()
     cid = tables.LinkColumn(verbose_name="ID")
     provider = tables.Column(linkify=True)
+    circuit_type = tables.Column(linkify=True)
     tenant = TenantColumn()
     tags = TagColumn(url_name="circuits:circuit_list")
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6664 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Fixed `circuit_type` column not included correctly in CircuitTable default columns
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
![Screenshot 2024-12-16 at 11 49 39 AM](https://github.com/user-attachments/assets/9f92c66f-dd68-4912-bc40-a14c8d15215c)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
