### PR TITLE
Fixed untagged VLAN dropdown options mismatch in InterfaceEditForm and in InterfaceBulkEditForm.

### DIFF
--- a/changes/6470.fixed
+++ b/changes/6470.fixed
@@ -1,0 +1,1 @@
+Fixed untagged VLAN dropdown options mismatch in InterfaceEditForm and in InterfaceBulkEditForm.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -3239,6 +3239,8 @@ class InterfaceBulkEditForm(
                 self.fields["tagged_vlans"].widget.add_query_param("locations", location.pk)
             else:
                 self.fields["untagged_vlan"].widget.add_query_param("locations", "null")
+                if locations.count() > 1:
+                    self.fields["untagged_vlans"].widget.add_query_param("locations", list(locations.values_list("pk", flat=True)))
 
         # Restrict parent/bridge/LAG interface assignment by device (or VC master)
         if device_count == 1:

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -3183,6 +3183,9 @@ class InterfaceBulkEditForm(
     untagged_vlan = DynamicModelChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
+        query_params={
+            "locations": "null",
+        },
     )
     tagged_vlans = DynamicModelMultipleChoiceField(
         queryset=VLAN.objects.all(),
@@ -3234,15 +3237,8 @@ class InterfaceBulkEditForm(
                 location = locations.first()
                 # In the case of a single location, use the available_on_device query param to limit untagged VLAN choices
                 # to those available on the devices in that location and in the ancestors of the location.
-                device_pks = [device.pk for device in devices]
-                self.fields["untagged_vlan"].widget.add_query_param("available_on_device", device_pks)
+                self.fields["untagged_vlan"].widget.add_query_param("available_on_device", device.pk)
                 self.fields["tagged_vlans"].widget.add_query_param("locations", location.pk)
-            else:
-                self.fields["untagged_vlan"].widget.add_query_param("locations", "null")
-                if locations.count() > 1:
-                    self.fields["untagged_vlans"].widget.add_query_param(
-                        "locations", list(locations.values_list("pk", flat=True))
-                    )
 
         # Restrict parent/bridge/LAG interface assignment by device (or VC master)
         if device_count == 1:

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -3240,7 +3240,9 @@ class InterfaceBulkEditForm(
             else:
                 self.fields["untagged_vlan"].widget.add_query_param("locations", "null")
                 if locations.count() > 1:
-                    self.fields["untagged_vlans"].widget.add_query_param("locations", list(locations.values_list("pk", flat=True)))
+                    self.fields["untagged_vlans"].widget.add_query_param(
+                        "locations", list(locations.values_list("pk", flat=True))
+                    )
 
         # Restrict parent/bridge/LAG interface assignment by device (or VC master)
         if device_count == 1:

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -3183,9 +3183,6 @@ class InterfaceBulkEditForm(
     untagged_vlan = DynamicModelChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
-        query_params={
-            "locations": "null",
-        },
     )
     tagged_vlans = DynamicModelMultipleChoiceField(
         queryset=VLAN.objects.all(),
@@ -3239,6 +3236,8 @@ class InterfaceBulkEditForm(
                 # to those available on the devices in that location and in the ancestors of the location.
                 self.fields["untagged_vlan"].widget.add_query_param("available_on_device", device.pk)
                 self.fields["tagged_vlans"].widget.add_query_param("locations", location.pk)
+            else:
+                self.fields["tagged_vlans"].widget.add_query_param("locations", "null")
 
         # Restrict parent/bridge/LAG interface assignment by device (or VC master)
         if device_count == 1:

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -3183,9 +3183,6 @@ class InterfaceBulkEditForm(
     untagged_vlan = DynamicModelChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
-        query_params={
-            "locations": "null",
-        },
     )
     tagged_vlans = DynamicModelMultipleChoiceField(
         queryset=VLAN.objects.all(),
@@ -3235,8 +3232,13 @@ class InterfaceBulkEditForm(
             # Limit VLAN choices by Location
             if locations.count() == 1:
                 location = locations.first()
-                self.fields["untagged_vlan"].widget.add_query_param("locations", location.pk)
+                # In the case of a single location, use the available_on_device query param to limit untagged VLAN choices
+                # to those available on the devices in that location and in the ancestors of the location.
+                device_pks = [device.pk for device in devices]
+                self.fields["untagged_vlan"].widget.add_query_param("available_on_device", device_pks)
                 self.fields["tagged_vlans"].widget.add_query_param("locations", location.pk)
+            else:
+                self.fields["untagged_vlan"].widget.add_query_param("locations", "null")
 
         # Restrict parent/bridge/LAG interface assignment by device (or VC master)
         if device_count == 1:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6470 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
In the case of InterfaceBulkEdit:
1. In the case of a single location, use the `available_on_device` query param to limit untagged VLAN choices to those available on the devices in that location and in the ancestors of the location.
2. In the case of multiple locations, we use the old query params with locations=null and locations=[list of location pks].

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
N/A
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
