### PR TITLE
Fixes 4056 : filter tags on bulkedit forms

### DIFF
--- a/changes/4056.fixed
+++ b/changes/4056.fixed
@@ -1,0 +1,1 @@
+Fixed filter of add_tags and remove_tags of bulkedit based on content type

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -792,7 +792,7 @@ class DeviceFamilyFilterForm(NautobotFilterForm):
     tags = TagFilterField(model)
 
 
-class DeviceFamilyBulkEditForm(NautobotBulkEditForm, TagsBulkEditFormMixin):
+class DeviceFamilyBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm):
     pk = forms.ModelMultipleChoiceField(queryset=DeviceFamily.objects.all(), widget=forms.MultipleHiddenInput())
     description = forms.CharField(required=False)
 

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -47,6 +47,7 @@ __all__ = (
     "Controller",
     "ControllerManagedDeviceGroup",
     "Device",
+    "DeviceFamily",
     "DeviceRedundancyGroup",
     "DeviceType",
     "Manufacturer",

--- a/nautobot/extras/forms/mixins.py
+++ b/nautobot/extras/forms/mixins.py
@@ -842,8 +842,16 @@ class TagsBulkEditFormMixin(forms.Form):
         super().__init__(*args, **kwargs)
 
         # Add add/remove tags fields
-        self.fields["add_tags"] = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
-        self.fields["remove_tags"] = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
+        self.fields["add_tags"] = DynamicModelMultipleChoiceField(
+            queryset=Tag.objects.all(),
+            query_params={"content_types": self.model._meta.label_lower},
+            required=False,
+        )
+        self.fields["remove_tags"] = DynamicModelMultipleChoiceField(
+            queryset=Tag.objects.all(),
+            query_params={"content_types": self.model._meta.label_lower},
+            required=False,
+        )
 
 
 # 2.2 TODO: Names below are only for backward compatibility with Nautobot 1.3 and earlier. Remove in 2.2


### PR DESCRIPTION
# Closes #4056 
# What's Changed
Fixes the filter on fileds `add_tags` and `remove_tags` of bulkedit form
I did not reinvented the wheel, only took the same logic of Status and Role based on the content type.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
