### PR TITLE
Fixed an AttributeError that occurred in the UI when editing a `DynamicGroup` with `ipam|prefix` as its content-type and changing the value of the "Present in VRF" field.

### DIFF
--- a/changes/6526.fixed
+++ b/changes/6526.fixed
@@ -1,0 +1,1 @@
+Fixed an AttributeError that occurred in the UI when editing a `DynamicGroup` with `ipam|prefix` as its content-type and changing the value of the "Present in VRF" field.

--- a/nautobot/core/testing/views.py
+++ b/nautobot/core/testing/views.py
@@ -487,8 +487,8 @@ class ViewTestCases:
                 self.assertHttpStatus(self.client.post(**request), [403, 404])
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
-        def test_edit_object_with_permission(self):
-            instance = self._get_queryset().first()
+        def test_edit_object_with_permission(self, instance=None):
+            instance = instance or self._get_queryset().first()
 
             # Assign model-level permission
             obj_perm = users_models.ObjectPermission(name="Test permission", actions=["change"])

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -83,7 +83,7 @@ from nautobot.extras.templatetags.job_buttons import NO_CONFIRM_BUTTON
 from nautobot.extras.tests.constants import BIG_GRAPHQL_DEVICE_QUERY
 from nautobot.extras.tests.test_relationships import RequiredRelationshipTestMixin
 from nautobot.extras.utils import RoleModelsQuery, TaggableClassesQuery
-from nautobot.ipam.models import IPAddress, Prefix, VLAN, VLANGroup
+from nautobot.ipam.models import IPAddress, Prefix, VLAN, VLANGroup, VRF
 from nautobot.tenancy.models import Tenant
 from nautobot.users.models import ObjectPermission
 
@@ -907,6 +907,22 @@ class DynamicGroupTestCase(
         instance = self._get_queryset().first()
         self.form_data["content_type"] = instance.content_type.pk  # Content-type is not editable after creation
         super().test_edit_object_with_constrained_permission()
+
+    def test_edit_object_with_content_type_ipam_prefix(self):
+        """Assert bug fix #6526: `Error when defining Dynamic Group of Prefixes using `present_in_vrf_id` filter`"""
+        content_type = ContentType.objects.get_for_model(Prefix)
+        instance = DynamicGroup.objects.create(name="DG Ipam|Prefix", content_type=content_type)
+        vrf_instance = VRF.objects.first()
+        self.form_data["content_type"] = content_type.pk
+        self.form_data.update(
+            {
+                "name": "DG Ipam|Prefix",
+                "filter-present_in_vrf_id": vrf_instance.id,
+            }
+        )
+        super().test_edit_object_with_permission(instance)
+        instance.refresh_from_db()
+        self.assertEqual(instance.filter["present_in_vrf_id"], str(vrf_instance.id))
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_edit_saved_filter(self):

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -1,4 +1,5 @@
 import contextlib
+import uuid
 
 from django.core.exceptions import ValidationError
 from django.db.models import Q
@@ -323,7 +324,7 @@ class PrefixFilterSet(
         return prefixes_queryset
 
     def generate_query_filter_present_in_vrf(self, value):
-        if isinstance(value, str):
+        if isinstance(value, (str, uuid.UUID)):
             value = VRF.objects.get(pk=value)
 
         query = Q(vrfs=value) | Q(vrfs__export_targets__in=value.import_targets.all())


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6526 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
