### PR TITLE
Release 1.6.30

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: "Install Python Packages"
-        run: "pip install poetry"
+        run: "pip install poetry==1.8.4"
       - name: "Configure Poetry"
         run: "poetry config virtualenvs.create false && poetry config installer.parallel false"
       - name: "Install Dependencies (needed for mkdocs)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: "Install Python Packages"
-        run: "pip install poetry"
+        run: "pip install poetry==1.8.4"
       - name: "Configure Poetry"
         run: "poetry config virtualenvs.create false && poetry config installer.parallel false"
       - name: "Install Dependencies (needed for mkdocs)"

--- a/changes/6659.housekeeping
+++ b/changes/6659.housekeeping
@@ -1,1 +1,0 @@
-Enhanced development environment and associated `invoke` tasks to be Nautobot major/minor version aware, such that a different Docker compose `project-name` (and different local Docker image label) will be used for containers in a `develop`-based branch versus a `next`-based branch versus an `ltm`-based branch.

--- a/changes/6695.security
+++ b/changes/6695.security
@@ -1,1 +1,0 @@
-Updated dependency `Jinja2` to `~3.1.5` to address `CVE-2024-56201` and `CVE-2024-56326`.

--- a/nautobot/docs/release-notes/version-1.6.md
+++ b/nautobot/docs/release-notes/version-1.6.md
@@ -72,6 +72,16 @@ The default Python version for Nautobot Docker images has been changed from 3.7 
 As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support installation or operation under Python 3.7.
 
 <!-- towncrier release notes start -->
+## v1.6.30 (2025-01-06)
+
+### Security
+
+- [#6695](https://github.com/nautobot/nautobot/issues/6695) - Updated dependency `Jinja2` to `~3.1.5` to address `CVE-2024-56201` and `CVE-2024-56326`.
+
+### Housekeeping
+
+- [#6659](https://github.com/nautobot/nautobot/issues/6659) - Enhanced development environment and associated `invoke` tasks to be Nautobot major/minor version aware, such that a different Docker compose `project-name` (and different local Docker image label) will be used for containers in a `develop`-based branch versus a `next`-based branch versus an `ltm`-based branch.
+
 ## v1.6.29 (2024-12-10)
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "1.6.29"
+version = "1.6.30"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
- [x] towncrier
- [x] version bump

## v1.6.30 (2025-01-06)

### Security

- [#6695](https://github.com/nautobot/nautobot/issues/6695) - Updated dependency `Jinja2` to `~3.1.5` to address `CVE-2024-56201` and `CVE-2024-56326`.

### Housekeeping

- [#6659](https://github.com/nautobot/nautobot/issues/6659) - Enhanced development environment and associated `invoke` tasks to be Nautobot major/minor version aware, such that a different Docker compose `project-name` (and different local Docker image label) will be used for containers in a `develop`-based branch versus a `next`-based branch versus an `ltm`-based branch.
