### PR TITLE
Fix exception when cleaning a Prefix with network/prefix_length

### DIFF
--- a/changes/6738.fixed
+++ b/changes/6738.fixed
@@ -1,0 +1,1 @@
+Fixed an exception when cleaning a Prefix that was defined by specifying `network` and `prefix_length`.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -648,19 +648,18 @@ class Prefix(PrimaryModel):
         return None
 
     def clean(self):
-        if self.prefix:
-            # self.parent depends on self.prefix having a value
-            self.parent = self.get_parent()
-        super().clean()
-
-    def save(self, *args, **kwargs):
-        if isinstance(self.prefix, netaddr.IPNetwork):
+        if self.prefix is not None:  # missing network/prefix_length will be caught by super().clean()
             # Clear host bits from prefix
             # This also has the subtle side effect of calling self._deconstruct_prefix(),
             # which will (re)set the broadcast and ip_version values of this instance to their correct values.
             self.prefix = self.prefix.cidr
 
-        self.parent = self.get_parent()
+            self.parent = self.get_parent()
+
+        super().clean()
+
+    def save(self, *args, **kwargs):
+        self.clean()
 
         # Validate that creation of this prefix does not create an invalid parent/child relationship
         # 3.0 TODO: uncomment this to enforce this constraint


### PR DESCRIPTION
# Closes #6738 
# What's Changed

- Rework Prefix clean/save logic to avoid an exception case when instantiating a Prefix with specified `network` and `prefix_length` but not specified `broadcast` or `ip_version` and then attempting to clean it.
- Improve test case to cover this scenario.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
