### PR TITLE
Fix incorrect annotation logic in IPAddresses list view

### DIFF
--- a/changes/6743.fixed
+++ b/changes/6743.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect rendering of the "Assigned" column in the IPAddress list view.

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -696,7 +696,8 @@ class IPAddressListView(generic.ObjectListView):
             except ObjectDoesNotExist:
                 pass
 
-        if table_columns and "assigned_count" in table_columns:
+        # column name is "assigned", not "assigned_count", and it's shown by default if there is no table config
+        if (table_columns and "assigned" in table_columns) or not table_columns:
             queryset = queryset.annotate(
                 assigned_count=count_related(Interface, "ip_addresses") + count_related(VMInterface, "ip_addresses"),
             )


### PR DESCRIPTION
# Closes #6743 
# What's Changed

#6626 added some incorrect logic to the IPAddress list view; in attempting to optimize the annotation of the queryset with an `assigned_count` value, it made two errors:

1. The column is present by default (when no user config or saved view is applied) but the logic didn't account for that case
2. The column name on the table is `"assigned"` not `"assigned_count"`

Fixing those two errors restores the proper function of this column.

# Screenshots

No table configuration:

![image](https://github.com/user-attachments/assets/57cd3968-82aa-490c-80bb-2bd01f15e3d6)

With table configuration applied:

![image](https://github.com/user-attachments/assets/8a6bdb88-ef7e-404c-aa9f-117e527f89a3)


<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
