### PR TITLE
Reintroduce indentation of child prefixes and improve generation of "available" prefixes in Prefix detail view

### DIFF
--- a/changes/6745.fixed
+++ b/changes/6745.fixed
@@ -1,0 +1,2 @@
+Restored indentation of child prefixes in Prefix detail view.
+Improved logic for generation of "available" child prefixes in Prefix detail view.

--- a/nautobot/core/templatetags/helpers.py
+++ b/nautobot/core/templatetags/helpers.py
@@ -1050,12 +1050,13 @@ def versioned_static(file_path):
 
 
 @register.simple_tag
-def tree_hierarchy_ui_representation(tree_depth, hide_hierarchy_ui):
+def tree_hierarchy_ui_representation(tree_depth, hide_hierarchy_ui, base_depth=0):
     """Generates a visual representation of a tree record hierarchy using dots.
 
     Args:
         tree_depth (range): A range representing the depth of the tree nodes.
         hide_hierarchy_ui (bool): Indicates whether to hide the hierarchy UI.
+        base_depth (int, optional): Starting depth (number of dots to skip rendering).
 
     Returns:
         str: A string containing dots (representing hierarchy levels) if `hide_hierarchy_ui` is False,
@@ -1063,6 +1064,8 @@ def tree_hierarchy_ui_representation(tree_depth, hide_hierarchy_ui):
     """
     if hide_hierarchy_ui or tree_depth == 0:
         return ""
+    if isinstance(base_depth, int):  # may be an empty string
+        tree_depth = tree_depth[base_depth:]
     ui_representation = " ".join(['<i class="mdi mdi-circle-small"></i>' for _ in tree_depth])
     return mark_safe(ui_representation)  # noqa: S308 # suspicious-mark-safe-usage, OK here since its just the `i` tag
 

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -43,9 +43,11 @@ UTILIZATION_GRAPH = """
 """
 
 
+# record: the Prefix being rendered in this row
+# object: the base ancestor Prefix, in the case of PrefixDetailTable, else None
 PREFIX_COPY_LINK = """
 {% load helpers %}
-{% tree_hierarchy_ui_representation record.ancestors.count|as_range table.hide_hierarchy_ui%}
+{% tree_hierarchy_ui_representation record.ancestors.count|as_range table.hide_hierarchy_ui base_tree_depth|default:0 %}
 <span class="hover_copy">
   <a href="\
 {% if record.present_in_database %}\

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -437,7 +437,6 @@ class PrefixPrefixesView(generic.ObjectView):
 
         prefix_table = tables.PrefixDetailTable(
             child_prefixes,
-            hide_hierarchy_ui=True,
             exclude=["namespace"],
             data_transform_callback=data_transform_callback,
         )
@@ -461,6 +460,7 @@ class PrefixPrefixesView(generic.ObjectView):
 
         return {
             "first_available_prefix": instance.get_first_available_prefix(),
+            "base_tree_depth": instance.ancestors().count(),
             "prefix_table": prefix_table,
             "permissions": permissions,
             "bulk_querystring": bulk_querystring,


### PR DESCRIPTION
# Closes #6745 
# What's Changed

- Remove `hide_hierarchy_ui=True` mistakenly added to Child Prefixes table in #6072.
- Add `base_depth` optional parameter to Prefix table rendering so that a deeply nested prefix's child prefixes can show indentation relative to the base prefix instead of their global nesting.
- Fix `add_available_prefixes` function logic so that "available" prefixes are assigned to the correct namespace and therefore get the correct nesting depth
- Enhance `add_available_prefixes` to add prefix space available under nested descendant Container prefixes rather than only space directly under this prefix itself.

# Screenshots

## Before #6072 

<img width="633" alt="image" src="https://github.com/user-attachments/assets/8983d770-f2a8-4884-b2ff-a5354f1c4fc2" />

<img width="623" alt="image" src="https://github.com/user-attachments/assets/a400b750-afc6-4df8-b134-2e1e02a3045e" />

## Current `develop`

<img width="469" alt="image" src="https://github.com/user-attachments/assets/1f5d37e8-2def-477f-ab5f-16849347a633" />

<img width="553" alt="image" src="https://github.com/user-attachments/assets/fc7c2fee-b872-4d86-ac7a-bc11082dd20a" />

## After this set of changes

<img width="560" alt="image" src="https://github.com/user-attachments/assets/d6eb1f52-9b9e-40a7-a89f-b0e8e4cda793" />

<img width="562" alt="image" src="https://github.com/user-attachments/assets/75964a8e-a8b7-4366-b1f0-edb82c0cc6aa" />

@cdwchriburg If you have a chance to pull this down and try it out (note that it's based on latest `develop`, which will be the 2.4.0 release shortly, so you'll want to use a test environment and run migrations) I'd really appreciate it!

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
