### PR TITLE
Add default admin and read only roles

### DIFF
--- a/changes/6765.added
+++ b/changes/6765.added
@@ -1,0 +1,1 @@
+Create default read/write and read only roles

--- a/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
+++ b/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
@@ -1,0 +1,51 @@
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db import migrations
+
+from nautobot.users.models import ObjectPermission
+
+
+def add_default_groups(apps, schema_editor):
+    read_only, _ = Group.objects.get_or_create(name="Read Only")
+    admin, _ = Group.objects.get_or_create(name="Admins")
+
+    ro_obj_permission, created = ObjectPermission.objects.get_or_create(
+        name="Default: Global Read Only",
+        actions=["view"],
+    )
+
+    if not created:
+        # Only exit if it didn't exist before
+        return
+
+    rw_obj_permission, created = ObjectPermission.objects.get_or_create(
+        name="Default: Global Read/Write",
+        actions=["read", "view", "modify", "delete"],
+    )
+
+    if not created:
+        return
+
+    ro_obj_permission.groups.add(read_only)
+    rw_obj_permission.groups.add(admin)
+
+    # Get all ContentTypes and add them to Permissions
+    for x in ContentType.objects.all():
+        ro_obj_permission.object_types.add(x)
+        rw_obj_permission.object_types.add(x)
+
+
+def remove_default_groups(apps, schema_editor):
+    read_only, _ = Group.objects.get_or_create(name="Default: Global Read Only")
+    admin, _ = Group.objects.get_or_create(name="Default: Global Read/Write")
+
+    read_only.delete()
+    admin.delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0010_user_default_saved_views"),
+    ]
+
+    operations = [migrations.RunPython(add_default_groups, remove_default_groups)]

--- a/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
+++ b/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
-from django.db import migrations
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import migrations
 
 from nautobot.users.models import ObjectPermission
 

--- a/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
+++ b/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
@@ -20,7 +20,7 @@ def add_default_groups(apps, schema_editor):
 
     rw_obj_permission, created = ObjectPermission.objects.get_or_create(
         name="Default: Global Read/Write",
-        actions=["read", "view", "modify", "delete"],
+        actions=["view", "add", "change", "delete"],
     )
 
     if not created:

--- a/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
+++ b/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.db import migrations
+from django.core.exceptions import ObjectDoesNotExist
 
 from nautobot.users.models import ObjectPermission
 
@@ -36,11 +37,29 @@ def add_default_groups(apps, schema_editor):
 
 
 def remove_default_groups(apps, schema_editor):
-    read_only, _ = Group.objects.get_or_create(name="Default: Global Read Only")
-    admin, _ = Group.objects.get_or_create(name="Default: Global Read/Write")
+    try:
+        read_only = Group.objects.get(name="Default: Global Read Only")
+        read_only.delete()
+    except ObjectDoesNotExist:
+        pass
 
-    read_only.delete()
-    admin.delete()
+    try:
+        admin = Group.objects.get(name="Default: Global Read/Write")
+        admin.delete()
+    except ObjectDoesNotExist:
+        pass
+
+    try:
+        read_only = ObjectPermission.objects.get(name="Default: Global Read Only")
+        read_only.delete()
+    except ObjectDoesNotExist:
+        pass
+
+    try:
+        admin = ObjectPermission.objects.get_or_create(name="Default: Global Read/Write")
+        admin.delete()
+    except ObjectDoesNotExist:
+        pass
 
 
 class Migration(migrations.Migration):

--- a/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
+++ b/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.db import migrations
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6765
# What's Changed
Added two default Permission roles and relative Groups for read/write and read only access to all content types
# Screenshots
Not relevant
# TODO
- [X] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [X] Example App Updates (when adding/changing features)
- [] Outline Remaining Work, Constraints from Design
