### PR TITLE
Introduce rack CSV graphical export

### DIFF
--- a/changes/6750.added
+++ b/changes/6750.added
@@ -1,0 +1,1 @@
+Add Export to CSV option for rack elevations

--- a/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
+++ b/nautobot/users/migrations/0011_create_default_groups_and_permissions.py
@@ -1,0 +1,70 @@
+from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import migrations
+
+from nautobot.users.models import ObjectPermission
+
+
+def add_default_groups(apps, schema_editor):
+    read_only, _ = Group.objects.get_or_create(name="Read Only")
+    admin, _ = Group.objects.get_or_create(name="Admins")
+
+    ro_obj_permission, created = ObjectPermission.objects.get_or_create(
+        name="Default: Global Read Only",
+        actions=["view"],
+    )
+
+    if not created:
+        # Only exit if it didn't exist before
+        return
+
+    rw_obj_permission, created = ObjectPermission.objects.get_or_create(
+        name="Default: Global Read/Write",
+        actions=["view", "add", "change", "delete"],
+    )
+
+    if not created:
+        return
+
+    ro_obj_permission.groups.add(read_only)
+    rw_obj_permission.groups.add(admin)
+
+    # Get all ContentTypes and add them to Permissions
+    for x in ContentType.objects.all():
+        ro_obj_permission.object_types.add(x)
+        rw_obj_permission.object_types.add(x)
+
+
+def remove_default_groups(apps, schema_editor):
+    try:
+        read_only = Group.objects.get(name="Default: Global Read Only")
+        read_only.delete()
+    except ObjectDoesNotExist:
+        pass
+
+    try:
+        admin = Group.objects.get(name="Default: Global Read/Write")
+        admin.delete()
+    except ObjectDoesNotExist:
+        pass
+
+    try:
+        read_only = ObjectPermission.objects.get(name="Default: Global Read Only")
+        read_only.delete()
+    except ObjectDoesNotExist:
+        pass
+
+    try:
+        admin = ObjectPermission.objects.get_or_create(name="Default: Global Read/Write")
+        admin.delete()
+    except ObjectDoesNotExist:
+        pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0010_user_default_saved_views"),
+    ]
+
+    operations = [migrations.RunPython(add_default_groups, remove_default_groups)]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #4141 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
New "Save CSV" file under the graphical representation of racks to get a quasi-graphical representation of a rack to be used in spreadsheet editors.

Output is as follows:

```csv
unit,name
FrontU1,coresw-01
FrontU2,
RearU1,coresw-01 (Rear)
RearU2,
```

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [X] Example App Updates (when adding/changing features)
- [X] Outline Remaining Work, Constraints from Design
