### PR TITLE
Closes #6427: Fixed a bug which allowed several wireless interface types to accept cables.

### DIFF
--- a/changes/6427.fixed
+++ b/changes/6427.fixed
@@ -1,0 +1,1 @@
+Fixed a bug which allowed several wireless interface types to accept cables.

--- a/nautobot/dcim/constants.py
+++ b/nautobot/dcim/constants.py
@@ -27,19 +27,12 @@ REARPORT_POSITIONS_MAX = 1024
 INTERFACE_MTU_MIN = 1
 INTERFACE_MTU_MAX = 32767  # Max value of a signed 16-bit integer
 
-VIRTUAL_IFACE_TYPES = [
-    InterfaceTypeChoices.TYPE_VIRTUAL,
-    InterfaceTypeChoices.TYPE_BRIDGE,
-    InterfaceTypeChoices.TYPE_LAG,
-]
+interface_type_by_category = {}
+for category_name, category_item_tuples in InterfaceTypeChoices.CHOICES:
+    interface_type_by_category[category_name] = [item_tuple[0] for item_tuple in category_item_tuples]
 
-WIRELESS_IFACE_TYPES = [
-    InterfaceTypeChoices.TYPE_80211A,
-    InterfaceTypeChoices.TYPE_80211G,
-    InterfaceTypeChoices.TYPE_80211N,
-    InterfaceTypeChoices.TYPE_80211AC,
-    InterfaceTypeChoices.TYPE_80211AD,
-]
+WIRELESS_IFACE_TYPES = interface_type_by_category["Wireless"]
+VIRTUAL_IFACE_TYPES = interface_type_by_category["Virtual interfaces"]
 
 NONCONNECTABLE_IFACE_TYPES = VIRTUAL_IFACE_TYPES + WIRELESS_IFACE_TYPES
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6427 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Issue was that `WIRELESS_IFACE_TYPES` was populated statically and was out of step with `InterfaceTypeChoices.CHOICES`. Rather than have most those structures populated manually, this patch builds the former from the latter. In the interest of future-proofing, I also added this logic for `VIRTUAL_IFACE_TYPES`.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Screenshot of the Interfaces UI before; note that 802.11ax interfaces allowed cables:
![Screenshot 2025-01-12 at 5 33 21 PM](https://github.com/user-attachments/assets/9a47baee-175d-493e-8539-7ef64c0c7d0d)

Screenshot of the same after:
![Screenshot 2025-01-12 at 5 34 19 PM](https://github.com/user-attachments/assets/e8ca5bf0-756f-4d10-9e35-5983af283ee3)

Similarly, here are captures of debugging info of `WIRELESS_IFACE_TYPES` before/after:

```
Before:
========================
nautobot-1  | WIRELESS TYPES:
nautobot-1  |   * ieee802.11a
nautobot-1  |   * ieee802.11g
nautobot-1  |   * ieee802.11n
nautobot-1  |   * ieee802.11ac
nautobot-1  |   * ieee802.11ad


After:
========================
nautobot-1  | WIRELESS TYPES:
nautobot-1  |   * ieee802.11a
nautobot-1  |   * ieee802.11g
nautobot-1  |   * ieee802.11n
nautobot-1  |   * ieee802.11ac
nautobot-1  |   * ieee802.11ad
nautobot-1  |   * ieee802.11ax
nautobot-1  |   * ieee802.11ay
nautobot-1  |   * ieee802.15.1
nautobot-1  |   * other-wireless
```

Finally, I updated the test harness so that all wireless/virtual interface types are now checked to ensure that cables can't be run, rather than simply having a single example.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
