### PR TITLE
[v2.4.0]Fixed NautobotDatabaseScheduler unable to run Scheduled Jobs without job queues assigned

### DIFF
--- a/changes/6783.fixed
+++ b/changes/6783.fixed
@@ -1,0 +1,1 @@
+Fixed `NautobotDataBaseScheduler` unable to run Scheduled Jobs without job queues assigned.

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -13,7 +13,7 @@ from django_celery_beat.schedulers import DatabaseScheduler, ModelEntry
 from kombu.utils.json import loads
 
 from nautobot.extras.choices import JobQueueTypeChoices
-from nautobot.extras.models import JobQueue, JobResult, ScheduledJob, ScheduledJobs
+from nautobot.extras.models import JobResult, ScheduledJob, ScheduledJobs
 from nautobot.extras.utils import run_kubernetes_job_and_return_job_result
 
 logger = logging.getLogger(__name__)

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -13,7 +13,7 @@ from django_celery_beat.schedulers import DatabaseScheduler, ModelEntry
 from kombu.utils.json import loads
 
 from nautobot.extras.choices import JobQueueTypeChoices
-from nautobot.extras.models import JobResult, ScheduledJob, ScheduledJobs, JobQueue
+from nautobot.extras.models import JobQueue, JobResult, ScheduledJob, ScheduledJobs
 from nautobot.extras.utils import run_kubernetes_job_and_return_job_result
 
 logger = logging.getLogger(__name__)
@@ -128,7 +128,10 @@ class NautobotDatabaseScheduler(DatabaseScheduler):
                 scheduled_job = entry.model
                 job_queue = scheduled_job.job_queue
                 if job_queue is None:
-                    job_queue, _ = JobQueue.objects.get_or_create(name=settings.CELERY_TASK_DEFAULT_QUEUE, defaults={"queue_type": JobQueueTypeChoices.TYPE_CELERY})
+                    job_queue, _ = JobQueue.objects.get_or_create(
+                        name=settings.CELERY_TASK_DEFAULT_QUEUE,
+                        defaults={"queue_type": JobQueueTypeChoices.TYPE_CELERY},
+                    )
                 # Distinguish between Celery and Kubernetes job queues
                 if job_queue.queue_type == JobQueueTypeChoices.TYPE_KUBERNETES:
                     job_result = JobResult.objects.create(

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -127,13 +127,8 @@ class NautobotDatabaseScheduler(DatabaseScheduler):
             if task:
                 scheduled_job = entry.model
                 job_queue = scheduled_job.job_queue
-                if job_queue is None:
-                    job_queue, _ = JobQueue.objects.get_or_create(
-                        name=settings.CELERY_TASK_DEFAULT_QUEUE,
-                        defaults={"queue_type": JobQueueTypeChoices.TYPE_CELERY},
-                    )
                 # Distinguish between Celery and Kubernetes job queues
-                if job_queue.queue_type == JobQueueTypeChoices.TYPE_KUBERNETES:
+                if job_queue is not None and job_queue.queue_type == JobQueueTypeChoices.TYPE_KUBERNETES:
                     job_result = JobResult.objects.create(
                         name=scheduled_job.job_model.name,
                         job_model=scheduled_job.job_model,

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -13,7 +13,7 @@ from django_celery_beat.schedulers import DatabaseScheduler, ModelEntry
 from kombu.utils.json import loads
 
 from nautobot.extras.choices import JobQueueTypeChoices
-from nautobot.extras.models import JobResult, ScheduledJob, ScheduledJobs
+from nautobot.extras.models import JobResult, ScheduledJob, ScheduledJobs, JobQueue
 from nautobot.extras.utils import run_kubernetes_job_and_return_job_result
 
 logger = logging.getLogger(__name__)
@@ -127,6 +127,8 @@ class NautobotDatabaseScheduler(DatabaseScheduler):
             if task:
                 scheduled_job = entry.model
                 job_queue = scheduled_job.job_queue
+                if job_queue is None:
+                    job_queue, _ = JobQueue.objects.get_or_create(name=settings.CELERY_TASK_DEFAULT_QUEUE, defaults={"queue_type": JobQueueTypeChoices.TYPE_CELERY})
                 # Distinguish between Celery and Kubernetes job queues
                 if job_queue.queue_type == JobQueueTypeChoices.TYPE_KUBERNETES:
                     job_result = JobResult.objects.create(

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -2146,6 +2146,12 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
     #     entry = NautobotScheduleEntry(model=sj)
     #     scheduler = NautobotDatabaseScheduler(app=entry.app)
     #     scheduler.apply_async(entry=entry, producer=None, advance=False)
+    #     Check scheduled job runs correctly with no job queue
+    #     sj.job_queue = None
+    #     sj.save()
+    #     entry = NautobotScheduleEntry(model=sj)
+    #     scheduler = NautobotDatabaseScheduler(app=entry.app)
+    #     scheduler.apply_async(entry=entry, producer=None, advance=False)
 
 
 class SecretTest(ModelTestCases.BaseModelTestCase):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6783 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
1. Added checks in NautobotDatabaseScheduler's apply_async() method to check if the scheduled_job.job_queue is None or not.
```
job_queue = scheduled_job.job_queue
if job_queue is None:
     job_queue, _ = JobQueue.objects.get_or_create(name=settings.CELERY_TASK_DEFAULT_QUEUE, defaults={"queue_type": JobQueueTypeChoices.TYPE_CELERY})
# Rest of the logic ...
```
Tests with:
1. `ScheduledJob` with no `JobQueue` instance assigned --> Default Celery Queue is used and Celery/legacy Code path is executed
2. `ScheduledJob` with `JobQueue` of `TYPE_CELERY` --> Celery/legacy Code path is executed
3. `ScheduledJob` with `JobQueue` of `TYPE_KUBERNETES` --> Kubernetes Code Path is executed

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
N/A
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
