### PR TITLE
fix: passing pk for JobButton job_queue variable

### DIFF
--- a/changes/6770.fixed
+++ b/changes/6770.fixed
@@ -1,0 +1,1 @@
+Fixed JobButtons to now trigger jobs on click

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -8,7 +8,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
 from nautobot.core.utils.data import render_jinja2
-from nautobot.extras.models import Job, JobButton
+from nautobot.extras.models import Job, JobButton, JobQueue
 
 register = template.Library()
 

--- a/nautobot/extras/templatetags/job_buttons.py
+++ b/nautobot/extras/templatetags/job_buttons.py
@@ -108,17 +108,17 @@ def _render_job_button_for_obj(job_button, obj, context, content_type):
     # Disable buttons if the user doesn't have permission to run the underlying Job.
     has_run_perm = Job.objects.check_perms(context["user"], instance=job_button.job, action="run")
     try:
-        job_queues = list(job_button.job.job_queues.all().values_list("name", flat=True))
+        job_queues = job_button.job.job_queues.all()
         _job_queue = job_queues[0]
     except IndexError:
-        _job_queue = settings.CELERY_TASK_DEFAULT_QUEUE
+        _job_queue = JobQueue.objects.get(name=settings.CELERY_TASK_DEFAULT_QUEUE)
     hidden_inputs = format_html(
         HIDDEN_INPUTS,
         csrf_token=context["csrf_token"],
         object_pk=obj.pk,
         object_model_name=f"{content_type.app_label}.{content_type.model}",
         redirect_path=context["request"].path,
-        job_queue=_job_queue,
+        job_queue=_job_queue.pk,
     )
     template_args = {
         "button_id": job_button.pk,

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2955,8 +2955,9 @@ class JobButtonRenderingTestCase(TestCase):
         response = self.client.get(self.location_type.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
-        job_queues = self.job.job_queues.all().values_list("name", flat=True)
-        self.assertIn(f'<input type="hidden" name="_job_queue" value="{job_queues[0]}">', content, content)
+        job_queues = self.job.job_queues.all()
+        _job_queue = job_queues[0]
+        self.assertIn(f'<input type="hidden" name="_job_queue" value="{_job_queue.pk}">', content, content)
 
         self.job.job_queues_override = False
         self.job.save()
@@ -2965,7 +2966,7 @@ class JobButtonRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         content = extract_page_body(response.content.decode(response.charset))
         self.assertIn(
-            f'<input type="hidden" name="_job_queue" value="{self.job.default_job_queue.name}">', content, content
+            f'<input type="hidden" name="_job_queue" value="{self.job.default_job_queue.pk}">', content, content
         )
 
     def test_view_object_with_unsafe_text(self):


### PR DESCRIPTION
Original implemenation was passing the string name of the job_queue to be used. This was creating a payload that would not run the job on click as what is required is the UUID (pk) of the JobQueue object instead.

# Closes #6770 
# What's Changed

Fixed populating the hidden job queue variable associated to JobButtons, changing from the 'name' field of the JobQueue object being stored to the UUID primary key.

I have just made modifications to the job_buttons.py file under the function _render_job_button_for_obj().

# Screenshots
Before:
![image](https://github.com/user-attachments/assets/9e9e5022-42d6-4266-a1f0-e4a8353cc2ff)

Intended After:
![image](https://github.com/user-attachments/assets/a6fcec09-24f2-4bdc-8207-9f33c04acd1b)

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
