### PR TITLE
Fix natural_key_field_lookups for Proxy Models

### DIFF
--- a/changes/6792.fixed
+++ b/changes/6792.fixed
@@ -1,0 +1,1 @@
+Fix `natural_key_field_lookups` for proxy models

--- a/changes/6792.fixed
+++ b/changes/6792.fixed
@@ -1,1 +1,1 @@
-Fix `natural_key_field_lookups` for proxy models
+Fixed `natural_key_field_lookups` for proxy models.

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -248,7 +248,8 @@ class BaseModel(models.Model):
         Unlike `get_natural_key_def()`, this doesn't auto-exclude all AutoField and BigAutoField fields,
         but instead explicitly discounts the `id` field (only) as a candidate.
         """
-        cls = cls._meta.concrete_model
+        if cls != cls._meta.concrete_model:
+            return cls._meta.concrete_model.natural_key_field_lookups
         # First, figure out which local fields comprise the natural key:
         natural_key_field_names = []
         if hasattr(cls, "natural_key_field_names"):

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -248,6 +248,7 @@ class BaseModel(models.Model):
         Unlike `get_natural_key_def()`, this doesn't auto-exclude all AutoField and BigAutoField fields,
         but instead explicitly discounts the `id` field (only) as a candidate.
         """
+        # cls = cls._meta.concrete_model
         # First, figure out which local fields comprise the natural key:
         natural_key_field_names = []
         if hasattr(cls, "natural_key_field_names"):

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -248,7 +248,7 @@ class BaseModel(models.Model):
         Unlike `get_natural_key_def()`, this doesn't auto-exclude all AutoField and BigAutoField fields,
         but instead explicitly discounts the `id` field (only) as a candidate.
         """
-        # cls = cls._meta.concrete_model
+        cls = cls._meta.concrete_model
         # First, figure out which local fields comprise the natural key:
         natural_key_field_names = []
         if hasattr(cls, "natural_key_field_names"):

--- a/nautobot/core/tests/test_models.py
+++ b/nautobot/core/tests/test_models.py
@@ -72,6 +72,15 @@ class NaturalKeyTestCase(BaseModelTest):
         dt = DeviceType.objects.first()
         self.assertEqual(dt.natural_key(), [dt.manufacturer.name, dt.model])
 
+    def test_natural_key_with_proxy_model(self):
+        """Test that natural_key_field_lookups function returns the same value as its base class."""
+
+        class ProxyManufacturer(Manufacturer):
+            class Meta:
+                proxy = True
+
+        self.assertEqual(ProxyManufacturer.natural_key_field_lookups, Manufacturer.natural_key_field_lookups)
+
     @skip("Composite keys aren't being supported at this time")
     def test_composite_key(self):
         """Test the composite_key default implementation with some representative models."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #DNE

### Environment
* Nautobot version (Docker tag too if applicable): 2.3.15
* Python version: 3.11
* Database platform, version: N/A
* Middleware(s): N/A

<!--
    Describe in detail the exact steps that someone else can take to reproduce
    this bug using the current stable release of Nautobot. Begin with the
    creation of any necessary database objects and call out every operation
    being performed explicitly. If reporting a bug in the REST API, be sure to
    reconstruct the raw HTTP request(s) being made: Don't rely on a client
    library such as pynautobot.
-->
### Steps to Reproduce
1. Create a proxy model:

```
class ProxyCircuitModel(Circuit):
    class Meta:
        proxy = True
        verbose_name = "Circuit"
        verbose_name_plural = "Circuits"

    def __str__(self):
        return "I am a proxy model for Circuit"
```

2. Create a ViewSet and Route that leverages the proxy model
3. Navigate to a detail view provided by the ViewSet

<!-- What did you expect to happen? -->
### Expected Behavior

Page loads as desired, fetching data from the base model

<!-- What happened instead? -->
### Observed Behavior

AttributeError is thrown:

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/4143454a-717e-4f69-afca-7956b593d4ce" />

(this is a proof of concept where I updated the existing Core-provided CircuitUIViewSet but is experienced with creating a new ViewSet as well)

# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

- When accessing `natural_key_field_lookups`, the concrete class is fetched as opposed to using the proxy class for property definitions.
- Test case added to ensure the proxy class has the same output as the concrete class's `natural_key_field_lookups` 

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Fix applied with example above: 

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/9c3f13f5-6b59-4c7e-aaec-49b6548399de" />

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] ~Documentation Updates (when adding/changing features)~
- [ ] ~Example App Updates (when adding/changing features)~
- [ ] ~Outline Remaining Work, Constraints from Design~
