### PR TITLE
Fix factory to ensure software-image-files for a device are valid

### DIFF
--- a/changes/6794.housekeeping
+++ b/changes/6794.housekeeping
@@ -1,0 +1,1 @@
+Fixed Device factory to ensure that it only selects SoftwareImageFiles that are permitted for a given Device.

--- a/nautobot/dcim/factory.py
+++ b/nautobot/dcim/factory.py
@@ -201,7 +201,12 @@ class DeviceFactory(PrimaryModelFactory):
         if extracted:
             self.software_image_files.set(extracted)
         else:
-            self.software_image_files.set(get_random_instances(SoftwareImageFile))
+            self.software_image_files.set(
+                get_random_instances(
+                    SoftwareImageFile.objects.filter(default_image=True)
+                    | SoftwareImageFile.objects.filter(device_types=self.device_type)
+                )
+            )
 
     # TODO to be done after these model factories are done.
     # has_cluster = NautobotBoolIterator()


### PR DESCRIPTION
# What's Changed

Ensure that the Device factory only selects software-image-files that are valid for the given device and device-type.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
