### PR TITLE
Fix #6786 - mark capabilities field as non-required

### DIFF
--- a/changes/6786.fixed
+++ b/changes/6786.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect marking of `capabilities` field as required on Controller and ControllerManagedDeviceGroup REST APIs.

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -981,7 +981,7 @@ class DeviceTypeToSoftwareImageFileSerializer(ValidatedModelSerializer):
 
 class ControllerSerializer(TaggedModelSerializerMixin, NautobotModelSerializer):
     capabilities = serializers.ListField(
-        child=ChoiceField(choices=ControllerCapabilitiesChoices, required=False), allow_empty=True
+        child=ChoiceField(choices=ControllerCapabilitiesChoices, required=False), allow_empty=True, required=False
     )
 
     class Meta:
@@ -991,7 +991,7 @@ class ControllerSerializer(TaggedModelSerializerMixin, NautobotModelSerializer):
 
 class ControllerManagedDeviceGroupSerializer(TaggedModelSerializerMixin, NautobotModelSerializer):
     capabilities = serializers.ListField(
-        child=ChoiceField(choices=ControllerCapabilitiesChoices, required=False), allow_empty=True
+        child=ChoiceField(choices=ControllerCapabilitiesChoices, required=False), allow_empty=True, required=False
     )
 
     class Meta:

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -3366,7 +3366,6 @@ class ControllerTestCase(APIViewTestCases.APIViewTestCase):
                 "status": statuses[1].pk,
                 "role": roles[1].pk,
                 "location": locations[1].pk,
-                "capabilities": [],
             },
             {
                 "name": "Controller 3",
@@ -3402,7 +3401,6 @@ class ControllerManagedDeviceGroupTestCase(APIViewTestCases.APIViewTestCase):
                 "name": "ControllerManagedDeviceGroup 2",
                 "controller": controllers[1].pk,
                 "weight": 150,
-                "capabilities": [],
             },
             {
                 "name": "ControllerManagedDeviceGroup 3",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6786
# What's Changed

Add `required=False` to `capabilities` field on `ControllerSerializer` and `ControllerManagedDeviceGroupSerializer`. Update API tests to exercise this case.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
