### PR TITLE
Fixed missing Linkify for manufacturer on platform table.

### DIFF
--- a/changes/6825.fixed
+++ b/changes/6825.fixed
@@ -1,1 +1,1 @@
-Fixed missing Linkify for manufacturer on platform table.
+Added links to the `manufacturer` column of the Platform table.

--- a/changes/6825.fixed
+++ b/changes/6825.fixed
@@ -1,0 +1,1 @@
+Fixed missing Linkify for manufacturer on platform table.

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -106,7 +106,8 @@ __all__ = (
 
 class PlatformTable(BaseTable):
     pk = ToggleColumn()
-    name = tables.LinkColumn()
+    name = tables.Column(linkify=True)
+    manufacturer = tables.Column(linkify=True)
     device_count = LinkedCountColumn(
         viewname="dcim:device_list",
         url_params={"platform": "pk"},


### PR DESCRIPTION
Didn't test locally, but seems to make sense to me :) 