### PR TITLE
Improved returned data when syncing a Git repo via the REST API (#6808)

### DIFF
--- a/changes/6808.changed
+++ b/changes/6808.changed
@@ -1,0 +1,1 @@
+Improved returned data when syncing a Git repository via the REST API.

--- a/nautobot/docs/user-guide/platform-functionality/gitrepository.md
+++ b/nautobot/docs/user-guide/platform-functionality/gitrepository.md
@@ -437,14 +437,50 @@ curl -s -X POST \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; version=2.4" \
-http://nautobot/api/extras/git-repositories/2ecb8556-db58-466d-8278-860b8fd74627/sync/
+http://nautobot/api/extras/git-repositories/2ecb8556-db58-466d-8278-860b8fd74627/sync/ | jq '.'
 ```
 
 Which returns, for example:
 
 ```no-highlight
 {
-  "message": "Repository demo-git-datasource sync job added to queue."
+  "message": "Repository demo-git-datasource sync job added to queue.",
+  "job_result": {
+    "id": "68500ca5-27c3-488c-a24a-e98858bf52a1",
+    "object_type": "extras.jobresult",
+    "display": "Git Repository: Sync started at 2025-01-30 19:35:14.120625+00:00 (PENDING)",
+    "url": "http://nautobot/api/extras/job-results/68500ca5-27c3-488c-a24a-e98858bf52a1/",
+    "natural_slug": "68500ca5-27c3-488c-a24a-e98858bf52a1_6850",
+    "status": {
+      "value": "PENDING",
+      "label": "PENDING"
+    },
+    "name": "Git Repository: Sync",
+    "task_name": null,
+    "date_created": "2025-01-30T19:35:14.120625Z",
+    "date_done": null,
+    "result": null,
+    "worker": null,
+    "task_args": [],
+    "task_kwargs": {},
+    "celery_kwargs": {},
+    "traceback": null,
+    "meta": null,
+    "job_model": {
+      "id": "ad2b27c8-adf0-4e23-a4d3-a37fe3c42abd",
+      "object_type": "extras.job",
+      "url": "http://nautobot/api/extras/jobs/ad2b27c8-adf0-4e23-a4d3-a37fe3c42abd/"
+    },
+    "user": {
+      "id": "569138fe-f0b9-4abf-9812-c85a7ec73bbd",
+      "object_type": "users.user",
+      "url": "http://nautobot/api/users/users/569138fe-f0b9-4abf-9812-c85a7ec73bbd/"
+    },
+    "scheduled_job": null,
+    "custom_fields": {},
+    "computed_fields": {},
+    "files": []
+  }
 }
 ```
 
@@ -457,7 +493,7 @@ curl -s -X GET \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; version=2.4" \
-http://nautobot/api/extras/jobs/?module_name__isw=demo_git_datasource. | jq .
+http://nautobot/api/extras/jobs/?module_name__isw=demo_git_datasource. | jq '.'
 ```
 
 Here are the first 20 lines of JSON returned:
@@ -527,7 +563,7 @@ curl -s -X GET \
 -H "Authorization: Token $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; version=2.4" \
-http://nautobot/api/extras/config-contexts/?owner_object_id=2ecb8556-db58-466d-8278-860b8fd74627 | jq .
+http://nautobot/api/extras/config-contexts/?owner_object_id=2ecb8556-db58-466d-8278-860b8fd74627 | jq '.'
 ```
 
 Here's the first part of the output:

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -1169,3 +1169,15 @@ class WebhookSerializer(ValidatedModelSerializer, NotesSerializerMixin):
             raise serializers.ValidationError(conflicts)
 
         return validated_attrs
+
+
+#
+# More Git repositories
+#
+
+
+class GitRepositorySyncResponseSerializer(serializers.Serializer):
+    """Serializer representing responses from the GitRepository.sync() POST endpoint."""
+
+    message = serializers.CharField(read_only=True)
+    job_result = JobResultSerializer(read_only=True)

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1207,6 +1207,10 @@ class GitRepositoryTest(APIViewTestCases.APIViewTestCase):
         url = reverse("extras-api:gitrepository-sync", kwargs={"pk": self.repos[0].id})
         response = self.client.post(url, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertIn("message", response.data)
+        self.assertIn("job_result", response.data)
+        self.assertEqual(response.data["message"], f"Repository {self.repos[0].name} sync job added to queue.")
+        self.assertIsInstance(response.data["job_result"], dict)
 
     def test_create_with_app_provided_contents(self):
         """Test that `provided_contents` published by an App works."""


### PR DESCRIPTION
# Closes #6808
# What's Changed
- Added extra detail to returned data when syncing a Git repo via the REST API, to resolve #6808.
- Instead of including the proposed `selected job queue` and `worker ID`, I included the serialised `JobResult`, from which the above and more can be easily derived.
- I've left `message` untouched to avoid breaking any existing integrations.
- Also left the HTTP response code at `200` for now to avoid breaking changes. `201` would be more appropriate in future.

# Screenshots
**BEFORE (REST)**
```
curl -s -X POST -H "Authorization: Token <SNIPPED>" -H "Content-Type: application/json" -H "Accept: application/json; version=2.4" http://nautobot:8080/api/extras/git-repositories/35c54754-3a8e-49f5-ae65-2c16202b17e4/sync/ | jq '.'
{
  "message": "Repository demo-git-datasource sync job added to queue."
}
```
**BEFORE (Swagger)**
![Screenshot 2025-01-30 095658](https://github.com/user-attachments/assets/93a0f84f-b129-4b20-9617-001ad9df68ac)

**AFTER (REST)**
```
curl -s -X POST -H "Authorization: Token <SNIPPED>" -H "Content-Type: application/json" -H "Accept: application/json; version=2.4" http://nautobot:8080/api/extras/git-repositories/35c54754-3a8e-49f5-ae65-2c16202b17e4/sync/ | jq '.'
{
  "message": "Repository demo-git-datasource sync job added to queue.",
  "job_result": {
    "id": "68500ca5-27c3-488c-a24a-e98858bf52a1",
    "object_type": "extras.jobresult",
    "display": "Git Repository: Sync started at 2025-01-30 19:35:14.120625+00:00 (PENDING)",
    "url": "http://nautobot/api/extras/job-results/68500ca5-27c3-488c-a24a-e98858bf52a1/",
    "natural_slug": "68500ca5-27c3-488c-a24a-e98858bf52a1_6850",
    "status": {
      "value": "PENDING",
      "label": "PENDING"
    },
    "name": "Git Repository: Sync",
    "task_name": null,
    "date_created": "2025-01-30T19:35:14.120625Z",
    "date_done": null,
    "result": null,
    "worker": null,
    "task_args": [],
    "task_kwargs": {},
    "celery_kwargs": {},
    "traceback": null,
    "meta": null,
    "job_model": {
      "id": "ad2b27c8-adf0-4e23-a4d3-a37fe3c42abd",
      "object_type": "extras.job",
      "url": "http://nautobot/api/extras/jobs/ad2b27c8-adf0-4e23-a4d3-a37fe3c42abd/"
    },
    "user": {
      "id": "569138fe-f0b9-4abf-9812-c85a7ec73bbd",
      "object_type": "users.user",
      "url": "http://nautobot/api/users/users/569138fe-f0b9-4abf-9812-c85a7ec73bbd/"
    },
    "scheduled_job": null,
    "custom_fields": {},
    "computed_fields": {},
    "files": []
  }
}
```
**AFTER (Swagger)**
![Screenshot 2025-01-31 090015](https://github.com/user-attachments/assets/1b82bd80-8aef-4c06-b1a0-20f59925aca4)

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
