### PR TITLE
Ensure test pattern match includes integration tests

### DIFF
--- a/changes/6846.housekeeping
+++ b/changes/6846.housekeeping
@@ -1,0 +1,1 @@
+Fixed integration test task to allow passing in pattern match.

--- a/tasks.py
+++ b/tasks.py
@@ -880,7 +880,7 @@ def unittest_coverage(context):
         "performance_report": "Generate Performance Testing report in the terminal. Set GENERATE_PERFORMANCE_REPORT=True in settings.py before using this flag",
         "performance_snapshot": "Generate a new performance testing report to report.yml. Set GENERATE_PERFORMANCE_REPORT=True in settings.py before using this flag",
     },
-    iterable=["tag", "exclude_tag"],
+    iterable=["tag", "exclude_tag", "pattern"],
 )
 def integration_test(
     context,
@@ -897,6 +897,7 @@ def integration_test(
     skip_docs_build=False,
     performance_report=False,
     performance_snapshot=False,
+    pattern=None,
 ):
     """Run Nautobot integration tests."""
 
@@ -919,6 +920,7 @@ def integration_test(
         performance_report=performance_report,
         performance_snapshot=performance_snapshot,
         parallel=False,
+        pattern=pattern,
     )
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6846 

# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
* Adds a slight tweak to the integration test task to allow passing thru a `--pattern` argument


# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## Before:
* Trying to target an integration test, [PluginBannerTestCase](https://github.com/nautobot/nautobot/blob/5476e2e3322298139d1943f6df6950c7c1f88316/nautobot/extras/tests/integration/test_plugin_banner.py#L4):

```
inv integration-test --skip-docs-build --no-buffer --pattern PluginBannerTestCase --no-parallel           

[...]

Using NautobotPerformanceTestRunner to run tests ...
Found 0 test(s).
System check identified some issues:
----------------------------------------------------------------------
Ran 0 tests in 0.000s
```

## After:
* Trying to target that same test but with this code change:

```
inv integration-test --skip-docs-build --no-buffer --pattern PluginBannerTestCase --no-parallel

Using NautobotPerformanceTestRunner to run tests ...
Found 2 test(s).
Using existing test database for alias 'default'...
Flushing all existing data from the database "default"...

.
.
----------------------------------------------------------------------
Ran 2 tests in 9.218s
```





# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
