### PR TITLE
6113 Fix menu inside of tables not showing properly

### DIFF
--- a/changes/6113.fixed
+++ b/changes/6113.fixed
@@ -1,0 +1,1 @@
+Menus inside responsive tables are fixed to be visible by dynamically mounting them to the body and positioning them absolutely.

--- a/nautobot/core/templates/inc/javascript.html
+++ b/nautobot/core/templates/inc/javascript.html
@@ -24,6 +24,8 @@
         onerror="window.location='{% url 'media_failure' %}?filename=js/theme.js'"></script>
 <script src="{% versioned_static 'js/table_sorting_indicator.js' %}"
         onerror="window.location='{% url 'media_failure' %}?filename=js/table_sorting_indicator.js'"></script>
+<script src="{% versioned_static 'js/dropdown.js' %}"
+        onerror="window.location='{% url 'media_failure' %}?filename=js/dropdown.js'"></script>
 <script type="text/javascript">
     var nautobot_api_path = "{% url 'api-root' %}";
     var nautobot_csrf_token = "{{ csrf_token }}";

--- a/nautobot/project-static/js/dropdown.js
+++ b/nautobot/project-static/js/dropdown.js
@@ -15,17 +15,14 @@ $(document).on('show.bs.dropdown', '.table-responsive .dropdown', function() {
         display: 'table', // required, because we're outside any container
     });
 
-    const hideMenu = function () {
+    // move dropdown back and hide
+    $dropdown.one('hidden.bs.dropdown', function () {
         $menu.appendTo($dropdown);
         $menu.removeAttr('style');
-    }
-
-    // move dropdown back and hide
-    $dropdown.one('hidden.bs.dropdown', hideMenu);
+    });
 
     // hide dropdown when scrolling vertically to avoid recalculating position
     $('.table-responsive').one('scroll', function() {
-        hideMenu();
         $toggle.trigger("click");
     });
 });

--- a/nautobot/project-static/js/dropdown.js
+++ b/nautobot/project-static/js/dropdown.js
@@ -1,0 +1,24 @@
+$(document).on('show.bs.dropdown', '.table-responsive .dropdown', function() {
+    const $dropdown = $(this);
+    const $toggle = $dropdown.find('.dropdown-toggle');
+    const $menu = $dropdown.find('.dropdown-menu');
+
+    const toggleOffset = $toggle.offset();
+    const topOffset = toggleOffset.top + $toggle.outerHeight()
+    // calculate left offset to match right side edges of dropdown and toggle button
+    const leftOffset = toggleOffset.left + $toggle.outerWidth() - $menu.outerWidth()
+
+    $menu.appendTo('body').css({
+        position: 'absolute',
+        top: topOffset,
+        left: leftOffset,
+        display: 'table', // required, because we're outside any container
+    });
+
+    // move dropdown back and hide
+    $dropdown.one('hidden.bs.dropdown', function() {
+        $menu.appendTo($dropdown);
+        $menu.removeAttr('style');
+    });
+});
+

--- a/nautobot/project-static/js/dropdown.js
+++ b/nautobot/project-static/js/dropdown.js
@@ -15,10 +15,17 @@ $(document).on('show.bs.dropdown', '.table-responsive .dropdown', function() {
         display: 'table', // required, because we're outside any container
     });
 
-    // move dropdown back and hide
-    $dropdown.one('hidden.bs.dropdown', function() {
+    const hideMenu = function () {
         $menu.appendTo($dropdown);
         $menu.removeAttr('style');
+    }
+
+    // move dropdown back and hide
+    $dropdown.one('hidden.bs.dropdown', hideMenu);
+
+    // hide dropdown when scrolling vertically to avoid recalculating position
+    $('.table-responsive').one('scroll', function() {
+        hideMenu();
+        $toggle.trigger("click");
     });
 });
-


### PR DESCRIPTION
# Closes #6113 
# What's Changed
Added custom js code to dynamically attach current dropdown to the body, to override browser behavior when custom overflow is set for `.table-responsive`. Then absolute position is calculated to match the clicked `.dropdown-toggle` button and match right side edges.

# Screenshots
Before:
![image](https://github.com/user-attachments/assets/70382959-e403-4e89-b5c4-aa9a33efc1f1)
![image](https://github.com/user-attachments/assets/6a5b1e6a-7033-4802-b2cb-d97e69a4a6a9)

After:
![image](https://github.com/user-attachments/assets/311e2b3e-f8e1-43b7-8dfe-1d782e54a73a)
![image](https://github.com/user-attachments/assets/7a098bf1-a237-471d-b16a-afa5a94e6449)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
