### PR TITLE
Fix #6650 - change fallback behavior of get_base_template()

### DIFF
--- a/changes/6650.changed
+++ b/changes/6650.changed
@@ -1,0 +1,2 @@
+Changed the `nautobot.apps.utils.get_base_template()` function's fallback behavior to return `"generic/object_retrieve.html"` instead of `"base.html"` in order to more correctly align with its usage throughout Nautobot core.
+Replaced references to `generic/object_detail.html` with `generic/object_retrieve.html` throughout the code and docs, as `generic/object_detail.html` has been a deprecated alias since v1.4.0.

--- a/changes/6650.fixed
+++ b/changes/6650.fixed
@@ -1,0 +1,1 @@
+Fixed rendering of "notes" and "changelog" tabs for object detail views that do not provide a custom HTML template.

--- a/examples/example_app/example_app/templates/example_app/anotherexamplemodel_retrieve.html
+++ b/examples/example_app/example_app/templates/example_app/anotherexamplemodel_retrieve.html
@@ -1,4 +1,4 @@
-<!-- this is a view demonstrating the capabilities of generic/object_detail.thml -->
+<!-- this is a view demonstrating the capabilities of generic/object_retrieve.html -->
 {% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 

--- a/examples/example_app/example_app/templates/example_app/examplemodel_retrieve.html
+++ b/examples/example_app/example_app/templates/example_app/examplemodel_retrieve.html
@@ -1,4 +1,4 @@
-<!-- this is a view demonstrating the capabilities of generic/object_detail.thml -->
+<!-- this is a view demonstrating the capabilities of generic/object_retrieve.html -->
 {% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
@@ -23,4 +23,4 @@
         </a>
 {% endblock panel_buttons %}
 
-<!-- content defined in ExampleModelUIViewSet.object_detail_content -->
+<!-- additional content is defined in ExampleModelUIViewSet.object_detail_content -->

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -1311,10 +1311,14 @@ class ObjectBulkUpdateViewMixin(NautobotViewSetMixin, BulkUpdateModelMixin, Bulk
 
 class ObjectChangeLogViewMixin(NautobotViewSetMixin):
     """
-    UI mixin to list a model's changelog queryset
+    UI mixin to list a model's changelog queryset.
+
+    base_template: Specify to explicitly identify the base object detail template to render.
+        If not provided, "<app>/<model>.html", "<app>/<model>_retrieve.html", or "generic/object_retrieve.html"
+        will be used, as per `get_base_template()`.
     """
 
-    base_template = None
+    base_template: Optional[str] = None
 
     @drf_action(detail=True)
     def changelog(self, request, *args, **kwargs):
@@ -1329,9 +1333,13 @@ class ObjectChangeLogViewMixin(NautobotViewSetMixin):
 class ObjectNotesViewMixin(NautobotViewSetMixin):
     """
     UI Mixin for an Object's Notes.
+
+    base_template: Specify to explicitly identify the base object detail template to render.
+        If not provided, "<app>/<model>.html", "<app>/<model>_retrieve.html", or "generic/object_retrieve.html"
+        will be used, as per `get_base_template()`.
     """
 
-    base_template = None
+    base_template: Optional[str] = None
 
     @drf_action(detail=True)
     def notes(self, request, *args, **kwargs):

--- a/nautobot/dcim/templates/dcim/cable.html
+++ b/nautobot/dcim/templates/dcim/cable.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/dcim/templates/dcim/device/base.html
+++ b/nautobot/dcim/templates/dcim/device/base.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 {% load static %}
 

--- a/nautobot/dcim/templates/dcim/device_component.html
+++ b/nautobot/dcim/templates/dcim/device_component.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block breadcrumbs %}

--- a/nautobot/dcim/templates/dcim/devicetype.html
+++ b/nautobot/dcim/templates/dcim/devicetype.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load buttons %}
 {% load helpers %}
 {% load plugins %}

--- a/nautobot/dcim/templates/dcim/location.html
+++ b/nautobot/dcim/templates/dcim/location.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load buttons %}
 {% load plugins %}
 {% load helpers %}

--- a/nautobot/dcim/templates/dcim/locationtype.html
+++ b/nautobot/dcim/templates/dcim/locationtype.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block extra_breadcrumbs %}

--- a/nautobot/dcim/templates/dcim/locationtype_retrieve.html
+++ b/nautobot/dcim/templates/dcim/locationtype_retrieve.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block extra_breadcrumbs %}

--- a/nautobot/dcim/templates/dcim/manufacturer.html
+++ b/nautobot/dcim/templates/dcim/manufacturer.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/dcim/templates/dcim/platform.html
+++ b/nautobot/dcim/templates/dcim/platform.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/dcim/templates/dcim/powerfeed.html
+++ b/nautobot/dcim/templates/dcim/powerfeed.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block extra_breadcrumbs %}

--- a/nautobot/dcim/templates/dcim/powerpanel.html
+++ b/nautobot/dcim/templates/dcim/powerpanel.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block extra_breadcrumbs %}

--- a/nautobot/dcim/templates/dcim/rack.html
+++ b/nautobot/dcim/templates/dcim/rack.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 {% load static %}
 

--- a/nautobot/dcim/templates/dcim/rackgroup.html
+++ b/nautobot/dcim/templates/dcim/rackgroup.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load buttons %}
 {% load helpers %}
 

--- a/nautobot/dcim/templates/dcim/rackreservation.html
+++ b/nautobot/dcim/templates/dcim/rackreservation.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 {% load static %}
 

--- a/nautobot/dcim/templates/dcim/virtualchassis.html
+++ b/nautobot/dcim/templates/dcim/virtualchassis.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/docs/development/apps/migration/ui-component-framework/index.md
+++ b/nautobot/docs/development/apps/migration/ui-component-framework/index.md
@@ -71,7 +71,7 @@ class SecretBulkDeleteView(generic.BulkDeleteView):
 1. Note the repetition of information such as `queryset` across each distinct view class here. Reducing this repetition is one of the key benefits of moving to use `NautobotUIViewSet`.
 
 ```html title="nautobot/extras/templates/extras/secret.html"
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block extra_buttons %}

--- a/nautobot/docs/development/core/templates.md
+++ b/nautobot/docs/development/core/templates.md
@@ -11,7 +11,7 @@ at the top of your template file.
 
 +++ 1.2.0
 
-The most customizable template is `generic/object_detail.html`, as object detail views have a wide range of specific requirements to be accommodated. It provides the following blocks:
+The most customizable template is `generic/object_retrieve.html`, as object detail views have a wide range of specific requirements to be accommodated. It provides the following blocks:
 
 * `header`: overloading this block allows for changing the entire top row of
   the page, including the title, breadcrumbs, search field, and tabs.

--- a/nautobot/extras/templates/extras/computedfield.html
+++ b/nautobot/extras/templates/extras/computedfield.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/configcontext.html
+++ b/nautobot/extras/templates/extras/configcontext.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/configcontextschema.html
+++ b/nautobot/extras/templates/extras/configcontextschema.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load buttons %}
 {% load plugins %}
 {% load helpers %}

--- a/nautobot/extras/templates/extras/customfield.html
+++ b/nautobot/extras/templates/extras/customfield.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load buttons %}
 {% load helpers %}
 

--- a/nautobot/extras/templates/extras/customlink.html
+++ b/nautobot/extras/templates/extras/customlink.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/dynamicgroup.html
+++ b/nautobot/extras/templates/extras/dynamicgroup.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block extra_nav_tabs %}

--- a/nautobot/extras/templates/extras/exporttemplate.html
+++ b/nautobot/extras/templates/extras/exporttemplate.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/gitrepository.html
+++ b/nautobot/extras/templates/extras/gitrepository.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block extra_buttons %}

--- a/nautobot/extras/templates/extras/graphqlquery.html
+++ b/nautobot/extras/templates/extras/graphqlquery.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/job_detail.html
+++ b/nautobot/extras/templates/extras/job_detail.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 {% load perms %}
 {% load plugins %}

--- a/nautobot/extras/templates/extras/jobbutton_retrieve.html
+++ b/nautobot/extras/templates/extras/jobbutton_retrieve.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/jobhook.html
+++ b/nautobot/extras/templates/extras/jobhook.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/jobresult.html
+++ b/nautobot/extras/templates/extras/jobresult.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 {% load custom_links %}
 {% load form_helpers %}

--- a/nautobot/extras/templates/extras/objectchange.html
+++ b/nautobot/extras/templates/extras/objectchange.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block title %}{{ object }}{% endblock %}

--- a/nautobot/extras/templates/extras/plugin_detail.html
+++ b/nautobot/extras/templates/extras/plugin_detail.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block header %}

--- a/nautobot/extras/templates/extras/relationship.html
+++ b/nautobot/extras/templates/extras/relationship.html
@@ -1,1 +1,1 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}

--- a/nautobot/extras/templates/extras/role_retrieve.html
+++ b/nautobot/extras/templates/extras/role_retrieve.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/scheduledjob.html
+++ b/nautobot/extras/templates/extras/scheduledjob.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load buttons %}
 {% load custom_links %}
 {% load helpers %}

--- a/nautobot/extras/templates/extras/secret.html
+++ b/nautobot/extras/templates/extras/secret.html
@@ -1,1 +1,1 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}

--- a/nautobot/extras/templates/extras/secretsgroup.html
+++ b/nautobot/extras/templates/extras/secretsgroup.html
@@ -1,4 +1,4 @@
-{% extends "generic/object_detail.html" %}
+{% extends "generic/object_retrieve.html" %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/status.html
+++ b/nautobot/extras/templates/extras/status.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/tag.html
+++ b/nautobot/extras/templates/extras/tag.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/templates/extras/webhook.html
+++ b/nautobot/extras/templates/extras/webhook.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -6,6 +6,7 @@ import hmac
 import logging
 import re
 import sys
+from typing import Optional
 
 from django.apps import apps
 from django.conf import settings
@@ -13,7 +14,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.validators import ValidationError
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Model, Q
 from django.template.loader import get_template, TemplateDoesNotExist
 from django.utils.deconstruct import deconstructible
 import kubernetes.client
@@ -36,16 +37,24 @@ from nautobot.extras.registry import registry
 logger = logging.getLogger(__name__)
 
 
-def get_base_template(base_template, model):
+def get_base_template(base_template: Optional[str], model: type[Model]) -> str:
     """
-    Returns the name of the base template, if the base_template is not None
-    Otherwise, default to using "<app>/<model>.html" as the base template, if it exists.
-    Otherwise, check if "<app>/<model>_retrieve.html" used in `NautobotUIViewSet` exists.
-    If both templates do not exist, fall back to "base.html".
+    Attempt to locate the correct base template for an object detail view and related views, if one was not specified.
+
+    Args:
+        base_template (str, optional): If not None, this explicitly specified template will be preferred.
+        model (Model): The model to identify a base template for, if base_template is None.
+
+    Returns the specified `base_template`, if not `None`.
+    Otherwise, if `"<app>/<model_name>.html"` exists (legacy ObjectView pattern), returns that string.
+    Otherwise, if `"<app>/<model_name>_retrieve.html"` exists (as used in `NautobotUIViewSet`), returns that string.
+    If all else fails, returns `"generic/object_retrieve.html"`.
+
+    Note: before Nautobot 2.4.3, this API would default to "base.html" rather than "generic/object_retrieve.html".
+    This behavior was changed to the current behavior to address issue #6550 and similar incorrect behavior.
     """
     if base_template is None:
         base_template = f"{model._meta.app_label}/{model._meta.model_name}.html"
-        # 2.0 TODO(Hanlin): This can be removed once an object view has been established for every model.
         try:
             get_template(base_template)
         except TemplateDoesNotExist:
@@ -53,7 +62,7 @@ def get_base_template(base_template, model):
             try:
                 get_template(base_template)
             except TemplateDoesNotExist:
-                base_template = "base.html"
+                base_template = "generic/object_retrieve.html"
     return base_template
 
 

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -50,7 +50,7 @@ def get_base_template(base_template: Optional[str], model: type[Model]) -> str:
     Otherwise, if `"<app>/<model_name>_retrieve.html"` exists (as used in `NautobotUIViewSet`), returns that string.
     If all else fails, returns `"generic/object_retrieve.html"`.
 
-    Note: before Nautobot 2.4.3, this API would default to "base.html" rather than "generic/object_retrieve.html".
+    Note: before Nautobot 2.4.2, this API would default to "base.html" rather than "generic/object_retrieve.html".
     This behavior was changed to the current behavior to address issue #6550 and similar incorrect behavior.
     """
     if base_template is None:

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 from urllib.parse import parse_qs
 
 from django.contrib import messages
@@ -901,10 +902,13 @@ class DynamicGroupBulkDeleteView(generic.BulkDeleteView):
 class ObjectDynamicGroupsView(generic.GenericView):
     """
     Present a list of dynamic groups associated to a particular object.
-    base_template: The name of the template to extend. If not provided, "<app>/<model>.html" will be used.
+
+    base_template: Specify to explicitly identify the base object detail template to render.
+        If not provided, "<app>/<model>.html", "<app>/<model>_retrieve.html", or "generic/object_retrieve.html"
+        will be used, as per `get_base_template()`.
     """
 
-    base_template = None
+    base_template: Optional[str] = None
 
     def get(self, request, model, **kwargs):
         # Handle QuerySet restriction of parent object if needed
@@ -927,7 +931,7 @@ class ObjectDynamicGroupsView(generic.GenericView):
         }
         RequestConfig(request, paginate).configure(dynamicgroups_table)
 
-        self.base_template = get_base_template(self.base_template, model)
+        base_template = get_base_template(self.base_template, model)
 
         return render(
             request,
@@ -937,7 +941,7 @@ class ObjectDynamicGroupsView(generic.GenericView):
                 "verbose_name": obj._meta.verbose_name,
                 "verbose_name_plural": obj._meta.verbose_name_plural,
                 "table": dynamicgroups_table,
-                "base_template": self.base_template,
+                "base_template": base_template,
                 "active_tab": "dynamic-groups",
             },
         )
@@ -2186,10 +2190,13 @@ class ObjectChangeView(generic.ObjectView):
 class ObjectChangeLogView(generic.GenericView):
     """
     Present a history of changes made to a particular object.
-    base_template: The name of the template to extend. If not provided, "<app>/<model>.html" will be used.
+
+    base_template: Specify to explicitly identify the base object detail template to render.
+        If not provided, "<app>/<model>.html", "<app>/<model>_retrieve.html", or "generic/object_retrieve.html"
+        will be used, as per `get_base_template()`.
     """
 
-    base_template = None
+    base_template: Optional[str] = None
 
     def get(self, request, model, **kwargs):
         # Handle QuerySet restriction of parent object if needed
@@ -2217,7 +2224,7 @@ class ObjectChangeLogView(generic.GenericView):
         }
         RequestConfig(request, paginate).configure(objectchanges_table)
 
-        self.base_template = get_base_template(self.base_template, model)
+        base_template = get_base_template(self.base_template, model)
 
         return render(
             request,
@@ -2227,7 +2234,7 @@ class ObjectChangeLogView(generic.GenericView):
                 "verbose_name": obj._meta.verbose_name,
                 "verbose_name_plural": obj._meta.verbose_name_plural,
                 "table": objectchanges_table,
-                "base_template": self.base_template,
+                "base_template": base_template,
                 "active_tab": "changelog",
             },
         )
@@ -2320,10 +2327,13 @@ class NoteDeleteView(generic.ObjectDeleteView):
 class ObjectNotesView(generic.GenericView):
     """
     Present a list of notes associated to a particular object.
-    base_template: The name of the template to extend. If not provided, "<app>/<model>.html" will be used.
+
+    base_template: Specify to explicitly identify the base object detail template to render.
+        If not provided, "<app>/<model>.html", "<app>/<model>_retrieve.html", or "generic/object_retrieve.html"
+        will be used, as per `get_base_template()`.
     """
 
-    base_template = None
+    base_template: Optional[str] = None
 
     def get(self, request, model, **kwargs):
         # Handle QuerySet restriction of parent object if needed
@@ -2347,7 +2357,7 @@ class ObjectNotesView(generic.GenericView):
         }
         RequestConfig(request, paginate).configure(notes_table)
 
-        self.base_template = get_base_template(self.base_template, model)
+        base_template = get_base_template(self.base_template, model)
 
         return render(
             request,
@@ -2357,7 +2367,7 @@ class ObjectNotesView(generic.GenericView):
                 "verbose_name": obj._meta.verbose_name,
                 "verbose_name_plural": obj._meta.verbose_name_plural,
                 "table": notes_table,
-                "base_template": self.base_template,
+                "base_template": base_template,
                 "active_tab": "notes",
                 "form": notes_form,
             },

--- a/nautobot/ipam/templates/ipam/ipaddress.html
+++ b/nautobot/ipam/templates/ipam/ipaddress.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 {% load render_table from django_tables2 %}
 

--- a/nautobot/ipam/templates/ipam/prefix.html
+++ b/nautobot/ipam/templates/ipam/prefix.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block breadcrumbs %}

--- a/nautobot/ipam/templates/ipam/rir.html
+++ b/nautobot/ipam/templates/ipam/rir.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/ipam/templates/ipam/routetarget.html
+++ b/nautobot/ipam/templates/ipam/routetarget.html
@@ -1,1 +1,1 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}

--- a/nautobot/ipam/templates/ipam/service.html
+++ b/nautobot/ipam/templates/ipam/service.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block extra_breadcrumbs %}

--- a/nautobot/ipam/templates/ipam/vlan.html
+++ b/nautobot/ipam/templates/ipam/vlan.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block extra_breadcrumbs %}

--- a/nautobot/ipam/templates/ipam/vlangroup.html
+++ b/nautobot/ipam/templates/ipam/vlangroup.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load buttons %}
 {% load helpers %}
 {% load plugins %}

--- a/nautobot/ipam/templates/ipam/vrf.html
+++ b/nautobot/ipam/templates/ipam/vrf.html
@@ -1,1 +1,1 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}

--- a/nautobot/tenancy/templates/tenancy/tenant.html
+++ b/nautobot/tenancy/templates/tenancy/tenant.html
@@ -1,6 +1,5 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
-{% load ui_framework %}
 
 {% block extra_breadcrumbs %}
     {% if object.tenant_group %}

--- a/nautobot/tenancy/templates/tenancy/tenantgroup.html
+++ b/nautobot/tenancy/templates/tenancy/tenantgroup.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/virtualization/templates/virtualization/cluster.html
+++ b/nautobot/virtualization/templates/virtualization/cluster.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/virtualization/templates/virtualization/clustergroup.html
+++ b/nautobot/virtualization/templates/virtualization/clustergroup.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}

--- a/nautobot/virtualization/templates/virtualization/clustertype.html
+++ b/nautobot/virtualization/templates/virtualization/clustertype.html
@@ -1,1 +1,1 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}

--- a/nautobot/virtualization/templates/virtualization/virtualmachine.html
+++ b/nautobot/virtualization/templates/virtualization/virtualmachine.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 {% load static %}
 

--- a/nautobot/virtualization/templates/virtualization/vminterface.html
+++ b/nautobot/virtualization/templates/virtualization/vminterface.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_detail.html' %}
+{% extends 'generic/object_retrieve.html' %}
 {% load helpers %}
 
 {% block content_left_page %}


### PR DESCRIPTION
# Closes #6650
# What's Changed

- Change default fallback case of `get_base_template()` to be `generic/object_retrieve.html` instead of `base.html` (fix #6650)
    - Manually tested by deleting `circuits/circuit.html` and `circuits/circuit_retrieve.html` locally and confirming that the circuit detail view, and its associated "Notes" and "Changelog" tabs all still rendered successfully.
    - This is *technically* a breaking change to a `nautobot.apps.utils` API but I think we're in agreement that the old behavior was wrong (a bug). **I do note that both `nautobot-app-bgp-models` and `nautobot-app-data-validation` are calling this API, but based on a quick read of their usage (in both cases, adding additional generic detail tabs, similar to Notes/Changelog tabs) this change should be a net improvement/fix to those apps rather than causing any breakage to current use.**
    - Improved the docstring for this function and code that was using it in various generic views and mixins.
    - Added some basic unit tests for this function
- Because `generic/object_detail.html` has been a mere redirect to `generic/object_retrieve.html` since NautobotUIViewSet was introduced in v1.4, I went on a search-and-replace spree throughout our code and docs to replace lingering references to `generic/object_detail.html`. (I did **not** remove the actual file itself, as that would be a breaking change that would potentially impact Apps, but we should strongly consider doing so as part of the upcoming UI changes in v3.0)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
