### PR TITLE
Fix #6860 - wireless radio profile REST API

### DIFF
--- a/changes/6860.fixed
+++ b/changes/6860.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect marking of `channel_width` and `allowed_channel_list` as required fields in the Wireless Radio Profile REST API.

--- a/nautobot/wireless/api/serializers.py
+++ b/nautobot/wireless/api/serializers.py
@@ -15,10 +15,15 @@ class SupportedDataRateSerializer(TaggedModelSerializerMixin, NautobotModelSeria
 
 
 class RadioProfileSerializer(TaggedModelSerializerMixin, NautobotModelSerializer):
-    channel_width = serializers.ListField(child=ChoiceField(choices=RadioProfileChannelWidthChoices), allow_empty=True)
+    channel_width = serializers.ListField(
+        child=ChoiceField(choices=RadioProfileChannelWidthChoices),
+        allow_empty=True,
+        required=False,
+    )
     allowed_channel_list = serializers.ListField(
         child=serializers.IntegerField(required=False),
         allow_empty=True,
+        required=False,
     )
 
     class Meta:

--- a/nautobot/wireless/tests/test_api.py
+++ b/nautobot/wireless/tests/test_api.py
@@ -107,6 +107,11 @@ class RadioProfileTest(APIViewTestCases.APIViewTestCase):
                 "tx_power_min": 20,
                 "allowed_channel_list": [],
             },
+            {
+                "name": "Radio Profile 7",
+                "frequency": "6GHz",
+                "regulatory_domain": "US",
+            },
         ]
         cls.bulk_update_data = {
             "frequency": "5GHz",


### PR DESCRIPTION
# Closes #6860
# What's Changed

Add missing `required=False` to serializer fields.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
