### PR TITLE
Feature: Download button added to download cable trace diagram as SVG

### DIFF
--- a/nautobot/dcim/templates/dcim/cable_trace.html
+++ b/nautobot/dcim/templates/dcim/cable_trace.html
@@ -1,130 +1,221 @@
 {% extends 'base.html' %}
 {% load helpers %}
-
 {% block header %}
-    <h1>{% block title %}Cable Trace for {{ object|meta:"verbose_name"|bettertitle }} {{ object }}{% endblock %}</h1>
+<h1>{% block title %}Cable Trace for {{ object|meta:"verbose_name"|bettertitle }} {{ object }}{% endblock %}</h1>
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col-md-5 col-sm-12">
-            <div class="cable-trace">
-                {% with traced_path=path.origin.trace %}
-                    {% for near_end, cable, far_end in traced_path %}
+<div class="row">
+    <div class="col-md-5 col-sm-12">
+        <div class="cable-trace" id="cable-trace">
+            {% with traced_path=path.origin.trace %}
+            {% for near_end, cable, far_end in traced_path %}
 
-                        {# Near end #}
-                        {% if near_end.device %}
-                            {% include 'dcim/trace/device.html' with device=near_end.device %}
-                            {% include 'dcim/trace/termination.html' with termination=near_end %}
-                        {% elif near_end.power_panel %}
-                            {% include 'dcim/trace/powerpanel.html' with powerpanel=near_end.power_panel %}
-                            {% include 'dcim/trace/termination.html' with termination=far_end %}
-                        {% elif near_end.circuit %}
-                            {% include 'dcim/trace/circuit.html' with circuit=near_end.circuit %}
-                            {% include 'dcim/trace/termination.html' with termination=near_end %}
-                        {% endif %}
+            {# Near end #}
+            {% if near_end.device %}
+            {% include 'dcim/trace/device.html' with device=near_end.device %}
+            {% include 'dcim/trace/termination.html' with termination=near_end %}
+            {% elif near_end.power_panel %}
+            {% include 'dcim/trace/powerpanel.html' with powerpanel=near_end.power_panel %}
+            {% include 'dcim/trace/termination.html' with termination=far_end %}
+            {% elif near_end.circuit %}
+            {% include 'dcim/trace/circuit.html' with circuit=near_end.circuit %}
+            {% include 'dcim/trace/termination.html' with termination=near_end %}
+            {% endif %}
 
-                        {# Cable #}
-                        {% if cable %}
-                            {% include 'dcim/trace/cable.html' %}
-                        {% endif %}
+            {# Cable #}
+            {% if cable %}
+            {% include 'dcim/trace/cable.html' %}
+            {% endif %}
 
-                        {# Far end #}
-                        {% if far_end.device %}
-                            {% include 'dcim/trace/termination.html' with termination=far_end %}
-                            {% if forloop.last %}
-                                {% include 'dcim/trace/device.html' with device=far_end.device %}
-                            {% endif %}
-                        {% elif far_end.power_panel %}
-                            {% include 'dcim/trace/termination.html' with termination=far_end %}
-                            {% include 'dcim/trace/powerpanel.html' with powerpanel=far_end.power_panel %}
-                        {% elif far_end.circuit %}
-                            {% include 'dcim/trace/termination.html' with termination=far_end %}
-                            {% if forloop.last %}
-                                {% include 'dcim/trace/circuit.html' with circuit=far_end.circuit %}
-                            {% endif %}
-                        {% endif %}
+            {# Far end #}
+            {% if far_end.device %}
+            {% include 'dcim/trace/termination.html' with termination=far_end %}
+            {% if forloop.last %}
+            {% include 'dcim/trace/device.html' with device=far_end.device %}
+            {% endif %}
+            {% elif far_end.power_panel %}
+            {% include 'dcim/trace/termination.html' with termination=far_end %}
+            {% include 'dcim/trace/powerpanel.html' with powerpanel=far_end.power_panel %}
+            {% elif far_end.circuit %}
+            {% include 'dcim/trace/termination.html' with termination=far_end %}
+            {% if forloop.last %}
+            {% include 'dcim/trace/circuit.html' with circuit=far_end.circuit %}
+            {% endif %}
+            {% endif %}
 
-                        {% if forloop.last %}
-                            {% if path.is_split %}
-                                <div class="trace-end">
-                                    <h3 class="text-danger">Path split!</h3>
-                                    <p>Select a node below to continue:</p>
-                                    <ul class="text-left">
-                                        {% for next_node in path.get_split_nodes %}
-                                            {% if next_node.cable %}
-                                                <li>
-                                                    <a href="{% url 'dcim:frontport_trace' pk=next_node.pk %}">{{ next_node }}</a>
-                                                    (Cable {{ next_node.cable|hyperlinked_object }})
-                                                </li>
-                                            {% else %}
-                                                <li class="text-muted">{{ next_node }}</li>
-                                            {% endif %}
-                                        {% endfor %}
-                                    </ul>
-                                </div>
-                            {% else %}
-                                <div class="trace-end">
-                                    <h3{% if far_end %} class="text-success"{% endif %}>Trace completed</h3>
-                                    <h5>Total segments: {{ traced_path|length }}</h5>
-                                    <h5>Total length:
-                                        {% if total_length %}
-                                            {{ total_length|floatformat:"-2" }} Meters /
-                                            {{ total_length|meters_to_feet|floatformat:"-2" }} Feet
-                                        {% else %}
-                                            <span class="text-muted">N/A</span>
-                                        {% endif %}
-                                    </h5>
-                                </div>
-                            {% endif %}
-                        {% endif %}
-
+            {% if forloop.last %}
+            {% if path.is_split %}
+            <div class="trace-end">
+                <h3 class="text-danger">Path split!</h3>
+                <p>Select a node below to continue:</p>
+                <ul class="text-left">
+                    {% for next_node in path.get_split_nodes %}
+                    {% if next_node.cable %}
+                    <li>
+                        <a href="{% url 'dcim:frontport_trace' pk=next_node.pk %}">{{ next_node }}</a>
+                        (Cable {{ next_node.cable|hyperlinked_object }})
+                    </li>
+                    {% else %}
+                    <li class="text-muted">{{ next_node }}</li>
+                    {% endif %}
                     {% endfor %}
-                {% endwith %}
+                </ul>
             </div>
-        </div>
-        <div class="col-md-7 col-sm-12">
+            {% else %}
+            <div class="trace-end">
+                <button type="button" id="download-btn" class="btn btn-default">Download SVG</button>
+                <script>
+                    document.getElementById("download-btn").addEventListener("click", function () {
+                        const traceElement = document.getElementById("cable-trace");
+                        const downloadButton = document.getElementById("download-btn");
+                        const serializer = new XMLSerializer();
+                        const svgNS = "http://www.w3.org/2000/svg";
+                    
+                        
+                        downloadButton.style.visibility = "hidden";
+                    
+                        
+                        const clonedTrace = traceElement.cloneNode(true);
+                        const clonedButton = clonedTrace.querySelector("#download-btn");
+                        if (clonedButton) {
+                            clonedButton.remove();
+                        }
+                        downloadButton.style.visibility = "visible";
 
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                  <strong>Related Paths</strong>
-                </div>
-                <table class="table table-hover panel-body">
-                    <thead>
-                        <tr>
-                            <th>Origin</th>
-                            <th>Destination</th>
-                            <th>Segments</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for cablepath in related_paths %}
-                            <tr{% if cablepath.pk == path.pk %} class="info"{% endif %}>
-                                <td>
-                                    <a href="?cablepath_id={{ cablepath.pk }}">
-                                        {{ cablepath.origin.parent }} / {{ cablepath.origin }}
-                                    </a>
-                                </td>
-                                <td>
-                                    {% if cablepath.destination %}
-                                        {{ cablepath.destination }} ({{ cablepath.destination.parent }})
-                                    {% else %}
-                                        <span class="text-muted">Incomplete</span>
-                                    {% endif %}
-                                </td>
-                                <td class="text-right">
-                                    {{ cablepath.segment_count }}
-                                </td>
-                            </tr>
-                        {% empty %}
-                            <td colspan="3" class="text-muted">
-                                None found
-                            </td>
-                        {% endfor %}
-                    </tbody>
-                </table>
+                        function inlineStyles(element) {
+                            const computedStyles = window.getComputedStyle(element);
+                            element.setAttribute("style", `
+                                font-family: ${computedStyles.fontFamily};
+                                font-size: ${computedStyles.fontSize};
+                                font-style: ${computedStyles.fontStyle};
+                                font-weight: ${computedStyles.fontWeight};
+                                line-height: ${computedStyles.lineHeight};
+                                letter-spacing: ${computedStyles.letterSpacing};
+                                text-align: ${computedStyles.textAlign};
+                                white-space: ${computedStyles.whiteSpace};
+                                word-spacing: ${computedStyles.wordSpacing};
+                            `);
+                    
+                            
+                            Array.from(element.children).forEach((child) => {
+                                inlineStyles(child);
+                                if (child.tagName.toLowerCase() === "a") {
+                                    const href = child.getAttribute("href");
+                                    if (href && !href.startsWith("http")) {
+                                        child.setAttribute(
+                                            "href",
+                                            new URL(href, window.location.href).href 
+                                        );
+                                    }
+                                    child.setAttribute("target", "_blank"); 
+                                }
+                            });
+                        }
+                    
+                        inlineStyles(clonedTrace);
+                        const svgElement = document.createElementNS(svgNS, "svg");
+                        const boundingBox = traceElement.getBoundingClientRect();
+                    
+                        svgElement.setAttribute("width", boundingBox.width);
+                        svgElement.setAttribute("height", boundingBox.height);
+                        svgElement.setAttribute("xmlns", svgNS);
+                        svgElement.setAttribute("version", "1.1");
+                        svgElement.setAttribute("viewBox", `0 0 ${boundingBox.width} ${boundingBox.height}`);
+                    
+                        const styleElement = document.createElementNS(svgNS, "style");
+                        const cssRules = Array.from(document.styleSheets)
+                            .filter((sheet) => sheet.cssRules)
+                            .flatMap((sheet) => Array.from(sheet.cssRules || []))
+                            .map((rule) => rule.cssText)
+                            .join("\n");
+                    
+                        styleElement.textContent = `
+                            ${cssRules}
+                            svg * {
+                                font-family: 'YourFontFamily', sans-serif;
+                                font-size: 14px;
+                            }
+                        `;
+                        svgElement.appendChild(styleElement);
+
+                        const foreignObject = document.createElementNS(svgNS, "foreignObject");
+                        foreignObject.setAttribute("width", "100%");
+                        foreignObject.setAttribute("height", "100%");
+                        foreignObject.appendChild(clonedTrace);
+                        svgElement.appendChild(foreignObject);
+                    
+                        // Serialize SVG
+                        const svgData = serializer.serializeToString(svgElement);
+                        const blob = new Blob([svgData], { type: "image/svg+xml;charset=utf-8" });
+                        const url = URL.createObjectURL(blob);
+                    
+                        // Download SVG
+                        const link = document.createElement("a");
+                        link.href = url;
+                        link.download = "cable_trace.svg";
+                        link.click();
+                    });                    
+
+                </script>
+                <h3{% if far_end %} class="text-success"{% endif %}>Trace completed</h3>
+                <h5>Total segments: {{ traced_path|length }}</h5>
+                <h5>Total length:
+                    {% if total_length %}
+                    {{ total_length|floatformat:"-2" }} Meters /
+                    {{ total_length|meters_to_feet|floatformat:"-2" }} Feet
+                    {% else %}
+                    <span class="text-muted">N/A</span>
+                    {% endif %}
+                </h5>
             </div>
+            {% endif %}
+            {% endif %}
 
+            {% endfor %}
+            {% endwith %}
         </div>
     </div>
+    <div class="col-md-7 col-sm-12">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <strong>Related Paths</strong>
+            </div>
+            <table class="table table-hover panel-body">
+                <thead>
+                    <tr>
+                        <th>Origin</th>
+                        <th>Destination</th>
+                        <th>Segments</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for cablepath in related_paths %}
+                    <tr{% if cablepath.pk == path.pk %} class="info"{% endif %}>
+                        <td>
+                            <a href="?cablepath_id={{ cablepath.pk }}">
+                                {{ cablepath.origin.parent }} / {{ cablepath.origin }}
+                            </a>
+                        </td>
+                        <td>
+                            {% if cablepath.destination %}
+                            {{ cablepath.destination }} ({{ cablepath.destination.parent }})
+                            {% else %}
+                            <span class="text-muted">Incomplete</span>
+                            {% endif %}
+                        </td>
+                        <td class="text-right">
+                            {{ cablepath.segment_count }}
+                        </td>
+                    </tr>
+                    {% empty %}
+                    <td colspan="3" class="text-muted">
+                        None found
+                    </td>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
<img width="943" alt="download_svg" src="https://github.com/user-attachments/assets/1d2beff9-3f24-4809-8e5b-57e9ebb17422" />
<img width="407" alt="downloaded_svg" src="https://github.com/user-attachments/assets/bf578c7c-973b-414b-a2d2-82bccca7cdb7" />
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #<ISSUE NUMBER GOES HERE>
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
I've added Download SVG button in cable_trace.html that downloads the SVG format of the path generated. The SVG image contains clickable links of every segment of the path just like the generated path

The above feature involves minimal code changes, just a small script written in JS, which is triggered when the Download SVG button is clicked
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
