### PR TITLE
Optional development setting to utilize dynamic docker ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ development/kind-kube-config
 development/pod.yaml
 node_modules
 .yarn
+.service_ports.json

--- a/changes/6893.housekeeping
+++ b/changes/6893.housekeeping
@@ -1,0 +1,1 @@
+Adds ephemeral ports, streamlines debug settings for VSCode developers.

--- a/development/docker-compose.ephemeral-ports.yml
+++ b/development/docker-compose.ephemeral-ports.yml
@@ -1,0 +1,18 @@
+# Set all ports to ephemeral to avoid conflicts with other services.
+---
+services:
+  nautobot:
+    ports:
+      - "8080"
+      - "6899"
+  celery_worker:
+    ports:
+      - "8080"
+      - "6898"
+  mkdocs:
+    ports:
+      - "8001"
+  selenium:
+    ports:
+        - "4444"
+        - "15900"

--- a/development/docker-compose.static-ports.yml
+++ b/development/docker-compose.static-ports.yml
@@ -1,0 +1,18 @@
+# Set all ports to ephemeral to avoid conflicts with other services.
+---
+services:
+  nautobot:
+    ports:
+      - "8080:8080"
+      - "6899:6899"
+  celery_worker:
+    ports:
+      - "8081:8080"
+      - "6898:6898"
+  mkdocs:
+    ports:
+      - "8001:8001"
+  selenium:
+    ports:
+        - "4444:4444"
+        - "15900:15900"

--- a/development/docker-compose.vscode-rdb.yml
+++ b/development/docker-compose.vscode-rdb.yml
@@ -2,17 +2,12 @@
 ---
 services:
   nautobot:
-    ports:
-      - "8080:8080"
-      - "6899:6899"
     entrypoint: ""
     command: sh -c "
       pip install debugpy &&
       /docker-entrypoint.sh &&
       python -m debugpy --listen 0.0.0.0:6899 -m nautobot.core.cli runserver 0.0.0.0:8080 --insecure"
   celery_worker:
-    ports:
-      - "6898:6898"
     entrypoint: ""
     command: sh -c "
       pip install debugpy &&

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -12,8 +12,6 @@ services:
     healthcheck:
       start_period: 10m
     image: "local/nautobot-dev:local-${NAUTOBOT_VER}-py${PYTHON_VER}"
-    ports:
-      - "8080:8080"
     volumes:
       - media_root:/opt/nautobot/media
     depends_on:
@@ -28,8 +26,6 @@ services:
     tty: true
   celery_worker:
     image: "local/nautobot-dev:local-${NAUTOBOT_VER}-py${PYTHON_VER}"
-    ports:
-      - "8081:8080"
     volumes:
       - media_root:/opt/nautobot/media
     entrypoint: "watchmedo auto-restart --directory './' --pattern '*.py' --recursive -- nautobot-server celery worker -l INFO --events"
@@ -80,9 +76,6 @@ services:
       - ./dev.env
   selenium:
     image: selenium/standalone-firefox:4.27
-    ports:
-        - "4444:4444"
-        - "15900:5900"
     shm_size: 2g
   mkdocs:
     profiles:
@@ -92,5 +85,3 @@ services:
     healthcheck:
       disable: true
     tty: true
-    ports:
-      - "8001:8001"

--- a/nautobot.code-workspace
+++ b/nautobot.code-workspace
@@ -7,7 +7,8 @@
 	"extensions": {
 		"recommendations": [
 			"ms-python.python",
-			"charliermarsh.ruff"
+			"charliermarsh.ruff",
+			"rioj7.command-variable"
 		]
 	},
 	"settings": {
@@ -19,8 +20,49 @@
 			"editor.formatOnSave": true
 		}
 	},
+	"tasks": {
+		"version": "2.0.0",
+		"tasks": [
+			{
+				"label": "Inject debugpy docker settings on startup",
+				"command": "poetry run inv vscode",
+				"type": "shell",
+				"presentation": {
+					"reveal": "silent",
+					"close": true,
+					"echo": false,
+					"clear": true,
+				},
+				"runOptions": {
+					"runOn": "folderOpen"
+				}
+			}
+		]
+	},
 	"launch": {
 		"version": "0.2.0",
+		"inputs": [
+			{
+				"id": "celeryport",
+				"type": "command",
+				"command": "extension.commandvariable.file.content",
+				"args": {
+					"fileName": "${workspaceFolder}/.service_ports.json",
+					"json": "content.celery_worker['6898']",
+					"default": "6898",
+				}
+			},
+			{
+				"id": "nautobotport",
+				"type": "command",
+				"command": "extension.commandvariable.file.content",
+				"args": {
+					"fileName": "${workspaceFolder}/.service_ports.json",
+					"json": "content.nautobot['6899']",
+					"default": "6899",
+				}
+			}
+		],
 		"configurations": [
 			{
 				"name": "Python: Nautobot (Local)",
@@ -45,13 +87,15 @@
 				"request": "attach",
 				"connect": {
 					"host": "127.0.0.1",
-					"port": 6899
+					"port": "${input:nautobotport}"
 				},
-				"pathMappings": [{
-					"localRoot": "${workspaceFolder}",
-					"remoteRoot": "/source"
-				}],
-				"django": true
+				"django": true,
+				"pathMappings": [
+					{
+						"localRoot": "${workspaceFolder}",
+						"remoteRoot": "/source"
+					}
+				],
 			},
 			{
 				"name": "Python: Nautobot-Celery (Remote)",
@@ -59,12 +103,14 @@
 				"request": "attach",
 				"connect": {
 					"host": "127.0.0.1",
-					"port": 6898
+					"port": "${input:celeryport}"
 				},
-				"pathMappings": [{
-					"localRoot": "${workspaceFolder}",
-					"remoteRoot": "/source"
-				}],
+				"pathMappings": [
+					{
+						"localRoot": "${workspaceFolder}",
+						"remoteRoot": "/source"
+					}
+				],
 				"django": true
 			}
 		]

--- a/nautobot/docs/development/core/docker-compose-advanced-use-cases.md
+++ b/nautobot/docs/development/core/docker-compose-advanced-use-cases.md
@@ -12,6 +12,7 @@ The Invoke tasks have some default [configuration](http://docs.pyinvoke.org/en/s
 - `compose_dir`: the full path to the directory containing the Docker Compose YAML files (default: `"<nautobot source directory>/development"`)
 - `compose_files`: the Docker Compose YAML file(s) to use (default: `["docker-compose.yml", "docker-compose.postgres.yml", "docker-compose.dev.yml"]`)
 - `docker_image_names_main` and `docker_image_names_develop`: Used when [building Docker images for publication](release-checklist.md#publish-docker-images); you shouldn't generally need to change these.
+- `ephemeral_ports`: Setting this value to `True` will make all Nautobot containers with published ports expose themselves with dynamic ports. This is useful when running multiple Nautobot versions at the same time on the same machine so you won't experience system port conflicts.
 
 These setting may be overridden several different ways (from highest to lowest precedence):
 
@@ -195,9 +196,17 @@ docker compose -f docker-compose.yml -f docker-compose.debug.yml up
 
 ### Remote Debugging Configuration
 
-Using the Remote-Attach functionality of VS Code debugger is an alternative to debugging in a development container. This allows a local VS Code instance to connect to a remote container and debug the code running in the container the same way as when debugging locally.
+Using the [Remote-Attach functionality of VS Code](https://code.visualstudio.com/docs/python/debugging#_debugging-by-attaching-over-a-network-connection) debugger is an alternative to debugging in a development container. This allows a local VS Code instance to connect to a remote container and debug the code running in the container the same way as when debugging locally. To learn more about debugging in VSCode, please [follow the official docs](https://code.visualstudio.com/docs/editor/debugging).
 
-Follow the steps below to configure VS Code to debug Nautobot and Celery Worker running in a remote container:
+Follow either of the options below to configure VS Code to debug Nautobot and Celery Worker running in a remote container:
+
+#### Running inside the Nautobot workspace
+
+If you have opened the project via the workspace file `nautobot.code-workspace` then there are two debug configurations for remote debugging available. These can be run via one of the debug tasks:
+- `Python: Nautobot (Remote)` or
+- `Python: Nautobot-Celery (Remote)`
+
+#### Adding Nautobot folder to an existing workspace
 
 1. **Configure `invoke.yml` to use the `docker-compose.vscode-rdb.yml` file.**
 
@@ -245,6 +254,6 @@ Follow the steps below to configure VS Code to debug Nautobot and Celery Worker 
       }
       ```
 
-It is now possible to debug the containerized Nautobot and Celery Worker using the VS Code debugger.
+    It is now possible to debug the containerized Nautobot and Celery Worker using the VS Code debugger.
 
-After restarting the Celery-Worker container you need to restart the debug session.
+    After restarting the Celery-Worker container you need to restart the debug session.

--- a/nautobot/docs/development/core/getting-started.md
+++ b/nautobot/docs/development/core/getting-started.md
@@ -511,7 +511,7 @@ Quit the server with CONTROL-C.
 
 Please see the [official Django documentation on `runserver`](https://docs.djangoproject.com/en/stable/ref/django-admin/#runserver) for more information.
 
-You can connect to the development server at `localhost:8080`.
+You can connect to the development server in your local web browser at `http://localhost:8080`. If you are using the ephemeral ports feature (disabled by default), you can make use of the command, `invoke open-nautobot-web`. This will open up the default web-browser on your system pointing to the correct Nautobot admin port. Note that this command can be used regardless of ephemeral port mode.
 
 ### Starting the Worker Server
 

--- a/tasks.py
+++ b/tasks.py
@@ -12,11 +12,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import json
 import os
+import platform
 import re
 
 from invoke import Collection, task as invoke_task
-from invoke.exceptions import Exit
+from invoke.exceptions import Exit, Failure
+import yaml
 
 try:
     # Override built-in print function with rich's pretty-printer function, if available
@@ -68,6 +71,7 @@ namespace.configure(
             "project_name": "nautobot",  # extended automatically with Nautobot major/minor ver, see docker_compose()
             "python_ver": "3.12",
             "local": False,
+            "ephemeral_ports": False,
             "compose_dir": os.path.join(BASE_DIR, "development/"),
             "compose_files": [
                 "docker-compose.yml",
@@ -166,6 +170,15 @@ def docker_compose(context, command, **kwargs):
         compose_file_path = os.path.join(context.nautobot.compose_dir, compose_file)
         compose_command_tokens.append(f'-f "{compose_file_path}"')
 
+    # Determine which ports mapping strategy to use
+    if context.nautobot.ephemeral_ports:
+        ports_type = "ephemeral"
+    else:
+        ports_type = "static"
+    compose_command_tokens.append(
+        f'-f "{os.path.join(context.nautobot.compose_dir, f"docker-compose.{ports_type}-ports.yml")}"'
+    )
+
     compose_command_tokens.append(command)
 
     # If `service` was passed as a kwarg, add it to the end.
@@ -173,7 +186,8 @@ def docker_compose(context, command, **kwargs):
     if service is not None:
         compose_command_tokens.append(service)
 
-    print(f'Running docker compose command "{command}"')
+    if "hide" not in kwargs:
+        print(f'Running docker compose command "{command}"')
     compose_command = " ".join(compose_command_tokens)
     env = kwargs.pop("env", {})
     env.update({"PYTHON_VER": context.nautobot.python_ver, "NAUTOBOT_VER": NAUTOBOT_VER})
@@ -371,6 +385,32 @@ def get_dependency_version(dependency_name):
     return version_match.group(1)
 
 
+def dump_service_ports_to_disk(context):
+    """Useful for downstream utilities without direct docker access to determine ports."""
+    service_ports = {}
+
+    result = docker_compose(context, "ps --format json", hide=True)
+    for line in result.stdout.splitlines():
+        try:
+            service_def = json.loads(line)
+            service_name = re.search(r"com\.docker\.compose\.service=(?P<service>\w+)", service_def["Labels"]).group(
+                "service"
+            )
+
+            ports_found = {}
+            for port in service_def["Publishers"]:
+                if port.get("PublishedPort", 0):
+                    ports_found[port["TargetPort"]] = port["PublishedPort"]
+
+            if ports_found:
+                service_ports[service_name] = ports_found
+        except (json.decoder.JSONDecodeError, AttributeError, IndexError, KeyError):
+            continue
+
+    with open(".service_ports.json", "w") as f:
+        json.dump(service_ports, f, indent=4)
+
+
 @task(
     help={
         "branch": "Source branch used to push.",
@@ -429,7 +469,9 @@ def docker_push(context, branch, commit="", datestamp=""):  # pylint: disable=re
 def debug(context, service=None):
     """Start Nautobot and its dependencies in debug mode."""
     print("Starting Nautobot in debug mode...")
-    docker_compose(context, "up", service=service)
+    docker_compose(context, "up --detach --force-recreate", service=service)
+    dump_service_ports_to_disk(context)
+    docker_compose(context, "logs --follow", service=service)
 
 
 @task(help={"service": "If specified, only affect this service."})
@@ -437,6 +479,7 @@ def start(context, service=None):
     """Start Nautobot and its dependencies in detached mode."""
     print("Starting Nautobot in detached mode...")
     docker_compose(context, "up --detach", service=service)
+    dump_service_ports_to_disk(context)
 
 
 @task(help={"service": "If specified, only affect this service."})
@@ -468,11 +511,28 @@ def vscode(context):
     """Launch Visual Studio Code with the appropriate Environment variables to run in a container."""
     command = "code nautobot.code-workspace"
 
-    # Setup PYTHON
+    # Setup PYTHON version if using docker dev containers
     env_file_path = os.path.join(BASE_DIR, "development/.env")
     if not os.path.exists(env_file_path):
         with open(env_file_path, "w") as env_file_obj:
             env_file_obj.write(f"PYTHON_VER={context.nautobot.python_ver}")
+
+    # Start nautobot services with debugpy enabled
+    try:
+        with open("invoke.yml", "r") as f:
+            invoke_settings = yaml.safe_load(f)
+    except FileNotFoundError:
+        invoke_settings = {"nautobot": {}}
+
+    # Dont clobber someones existing compose_files settings arrangement
+    # But otherwise, make sure docker compose has the debugpy settings
+    if not invoke_settings.get("nautobot", {}).get("compose_files", None):
+        invoke_settings["nautobot"]["compose_files"] = [
+            f"docker-compose.{pattern}yml" for pattern in ["", "postgres.", "dev.", "vscode-rdb."]
+        ]
+
+        with open("invoke.yml", "w") as f:
+            yaml.dump(invoke_settings, f)
 
     context.run(command, env={"PYTHON_VER": context.nautobot.python_ver})
 
@@ -633,6 +693,34 @@ def build_example_app_docs(context):
     else:
         docker_command = f"run --rm --workdir='/source/examples/example_app' --entrypoint '{command}' nautobot"
         docker_compose(context, docker_command, pty=True)
+
+
+def task_navigate_to_web_port(context, service: str, internal_port: str):
+    """Navigate to the web interface in your web browser."""
+    nautobot_raw_uri = docker_compose(context, f"port {service} {internal_port}").stdout.rstrip()
+    # nautobot_raw_uri = docker_compose(context, "port nautobot 8080", hide=True).stdout.rstrip()
+    nautobot_url = f"http://{nautobot_raw_uri}".replace("0.0.0.0", "127.0.0.1")  # noqa: S104
+
+    if platform.system().lower() == "darwin":
+        open_cmd = "open"
+    else:
+        open_cmd = "xdg-open"
+    try:
+        context.run(f"{open_cmd} {nautobot_url}", hide="err")
+    except Failure:
+        print(f"Unable to open browser. {service} interface available at {nautobot_url}")
+
+
+@task
+def open_nautobot_web(context):
+    """Navigate to the Nautobot interface in your web browser."""
+    task_navigate_to_web_port(context, "nautobot", "8080")
+
+
+@task
+def open_docs_web(context):
+    """Navigate to the mkdocs interface in your web browser."""
+    task_navigate_to_web_port(context, "mkdocs", "8001")
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6893
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

* Adds optional setting to utilize ephemeral docker ports for all nautobot docker containers. This is controlled via invoke configuration so can either be overwritten in `invoke.yml` file locally, or an env var *(`INVOKE_NAUTOBOT_EPHEMERAL_PORTS=True`)
* Updates the VSCode workspace launch configs to be able to hit the ephemeral `debugpy` ports. This requires a new VSCode extension [rioj7.command-variable](https://marketplace.visualstudio.com/items?itemName=rioj7.command-variable)
* Adds a task that launches upon first entering the VSCode workspace to make sure that these users have the `docker-compose.vscode-rdb.yml` over-ride configured.
* Adds invoke commands to drive a web-browser to the `mkdocs` and `nautobot` web interfaces

# Discussion points
Notice that this feature is disabled by default to not ruffle feathers of users whom prefer static ports. The only potential controversial change is that if you are a VSCode user of the workspace file, this new extension `rioj7.command-variable` is required in order to run the launch configurations because of the potential for dynamic ports on the debugpy process. Since I added it to the recommended extensions, it should prompt users to install it AND it's ONLY required for VSCode users that want to utilize the remote debug launch commands. I didn't see a great way around this but willing to do some more research if that's going to be a tough pill for us to require this new extension in this scenario.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
