### PR TITLE
#5539 Fixed Typo in controller clean method

### DIFF
--- a/changes/5539.fixed
+++ b/changes/5539.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect error message in Controller clean() method.

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -1419,11 +1419,10 @@ class Controller(PrimaryModel):
                     "controller_device": ("Cannot assign both a device and a device redundancy group to a controller."),
                 },
             )
-
         if self.location:
             if ContentType.objects.get_for_model(self) not in self.location.location_type.content_types.all():
                 raise ValidationError(
-                    {"location": f'Devices may not associate to locations of type "{self.location.location_type}".'}
+                    {"location": f'Controllers may not associate to locations of type "{self.location.location_type}".'}
                 )
 
     def get_capabilities_display(self):

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -2790,7 +2790,7 @@ class ControllerTestCase(ModelTestCases.BaseModelTestCase):
             controller.validated_save()
         self.assertEqual(
             error.exception.message_dict["location"][0],
-            f'Devices may not associate to locations of type "{location_type}".',
+            f'Controllers may not associate to locations of type "{location_type}".',
         )
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5539 
# What's Changed
The typo where 'devices' was incorrectly used has been corrected to 'controllers'
# Screenshots
![Screenshot 2025-02-14 174413](https://github.com/user-attachments/assets/ea93788a-fb53-49e4-8676-6fb728056320)
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
