### PR TITLE
Fix #6910 - add UTF-8 BOM in CSV exports

### DIFF
--- a/changes/6910.fixed
+++ b/changes/6910.fixed
@@ -1,0 +1,1 @@
+Fixed CSV export job to add a UTF-8 BOM (byte order mark) to the created file to ensure Excel will correctly handle any Unicode data.

--- a/nautobot/core/jobs/__init__.py
+++ b/nautobot/core/jobs/__init__.py
@@ -229,7 +229,8 @@ class ExportObjectList(Job):
             # The force_csv=True attribute is a hack, but much easier than trying to construct a valid HttpRequest
             # object from scratch that passes all implicit and explicit assumptions in Django and DRF.
             serializer = serializer_class(queryset, many=True, context={"request": None}, force_csv=True)
-            csv_data = renderer.render(serializer.data)
+            # Explicitly add UTF-8 BOM to the data so that Excel will understand non-ASCII characters correctly...
+            csv_data = codecs.BOM_UTF8 + renderer.render(serializer.data).encode("utf-8")
             self.create_file(filename + ".csv", csv_data)
 
 

--- a/nautobot/core/tests/test_jobs.py
+++ b/nautobot/core/tests/test_jobs.py
@@ -1,3 +1,4 @@
+import codecs
 from datetime import timedelta
 import json
 from pathlib import Path
@@ -72,7 +73,9 @@ class ExportObjectListTest(TransactionTestCase):
         self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertTrue(job_result.files.exists())
         self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_statuses.csv")
-        csv_data = job_result.files.first().file.read().decode("utf-8")
+        csv_bytes = job_result.files.first().file.read()
+        self.assertTrue(csv_bytes.startswith(codecs.BOM_UTF8), csv_bytes)
+        csv_data = csv_bytes.decode("utf-8")
         self.assertIn(str(instance1.pk), csv_data)
         self.assertNotIn(str(instance2.pk), csv_data)
 


### PR DESCRIPTION
# Closes #6910
# What's Changed

- Add UTF-8 BOM explicitly to CSV file exports to make MS Excel happier
- Add unit test

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
