### PR TITLE
#5006 Prevent removal of ContentType from LocationType if in use by r…

### DIFF
--- a/changes/5006.fixed
+++ b/changes/5006.fixed
@@ -1,0 +1,1 @@
+A validation check is added to prevent removing content types from LocationType if it's in use by any models associated with the locations

--- a/nautobot/circuits/tests/test_models.py
+++ b/nautobot/circuits/tests/test_models.py
@@ -17,8 +17,7 @@ class CircuitTerminationModelTestCase(ModelTestCases.BaseModelTestCase):
         provider = Provider.objects.first()
         circuit_type = CircuitType.objects.first()
 
-        location_type_1 = LocationType.objects.get(name="Campus")
-        location_type_1.content_types.set([])
+        location_type_1 = LocationType.objects.create(name="University")
         location_type_2 = LocationType.objects.get(name="Building")
         location_type_2.content_types.add(ContentType.objects.get_for_model(CircuitTermination))
         status = Status.objects.get_for_model(Circuit).first()
@@ -26,7 +25,7 @@ class CircuitTerminationModelTestCase(ModelTestCases.BaseModelTestCase):
             cid="Circuit 1", provider=provider, circuit_type=circuit_type, status=status
         )
         cls.provider_network = ProviderNetwork.objects.create(name="Provider Network 1", provider=provider)
-        cls.location_1 = Location.objects.filter(location_type=location_type_1)[0]
+        cls.location_1 = Location.objects.create(name="Department", location_type=location_type_1, status=status)
         cls.location_2 = Location.objects.filter(location_type=location_type_2)[0]
 
         cloud_resource_type = CloudResourceType.objects.get_for_model(CloudNetwork).first()

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -609,7 +609,7 @@ class WritableNestedSerializerTest(testing.APITestCase):
             dcim_models.LocationType.objects.get(name="Building"),
         ]
         for location_type in self.locations_types:
-            location_type.content_types.set([vlan_group_ct, vlan_ct])
+            location_type.content_types.add(vlan_group_ct, vlan_ct)
 
         self.statuses = extras_models.Status.objects.get_for_model(dcim_models.Location)
         self.location1 = dcim_models.Location.objects.create(


### PR DESCRIPTION
…elated models

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #5006 
# What's Changed
Preventing the removal of a ContentType from a LocationType if that ContentType is still in use by any models associated with locations of that LocationType
# Screenshots
![image](https://github.com/user-attachments/assets/774df930-2c3b-4b0e-8ce1-f630dad3c125)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
