### PR TITLE
Closes #6848: Fixed DoesNotExist in GUI at /extras/git-repositories/X/result/ if git repository created via API and not yet synced

### DIFF
--- a/changes/6848.fixed
+++ b/changes/6848.fixed
@@ -1,0 +1,1 @@
+Fixed a `DoesNotExist` error in the GUI at `/extras/git-repositories/X/result/` when a Git repository was created via API and not yet synced.

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -642,7 +642,7 @@ class JobViewSetBase(
             ):
                 raise ValidationError(
                     {
-                        "_task_queue": "_task_queue and _job_queue are both specified. Please specifiy only one or another."
+                        "_task_queue": "_task_queue and _job_queue are both specified. Please specify only one or another."
                     }
                 )
 
@@ -685,7 +685,7 @@ class JobViewSetBase(
                 "job_queue", None
             ):
                 raise ValidationError(
-                    {"task_queue": "task_queue and job_queue are both specified. Please specifiy only one or another."}
+                    {"task_queue": "task_queue and job_queue are both specified. Please specify only one or another."}
                 )
             schedule_data = input_serializer.validated_data.get("schedule", None)
 

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -131,16 +131,20 @@ class GitRepository(PrimaryModel):
 
     def get_latest_sync(self):
         """
-        Return a `JobResult` for the latest sync operation.
+        Return a `JobResult` for the latest sync operation if one has occurred.
 
         Returns:
-            JobResult
+            Returns a `JobResult` if the repo has been synced before, otherwise returns None.
         """
         from nautobot.extras.models import JobResult
 
         # This will match all "GitRepository" jobs (pull/refresh, dry-run, etc.)
         prefix = "nautobot.core.jobs.GitRepository"
-        return JobResult.objects.filter(task_name__startswith=prefix, task_kwargs__repository=self.pk).latest()
+
+        if JobResult.objects.filter(task_name__startswith=prefix, task_kwargs__repository=self.pk).exists():
+            return JobResult.objects.filter(task_name__startswith=prefix, task_kwargs__repository=self.pk).latest()
+        else:
+            return None
 
     def to_csv(self):
         return (

--- a/nautobot/extras/templates/extras/inc/jobresult.html
+++ b/nautobot/extras/templates/extras/inc/jobresult.html
@@ -12,45 +12,43 @@
         <strong>Summary of Results</strong>
     </div>
     <table class="table table-hover panel-body">
-        {% if result.job_model is not None %}
             <tr>
                 <td>Job Description</td>
-                <td>{{ result.job_model.description | render_markdown }}</td>
+                <td>{{ result.job_model.description | render_markdown | placeholder }}</td>
             </tr>
-        {% endif %}
         <tr>
             <td>Status</td>
             <td><span id="pending-result-label">{% include 'extras/inc/job_label.html' with result=result %}</span></td>
         </tr>
         <tr>
             <td>Started at</td>
-            <td>{{ result.date_created }}</td>
+            <td>{{ result.date_created | placeholder }}</td>
         </tr>
         <tr>
             <td>User</td>
-            <td>{{ result.user }}</td>
+            <td>{{ result.user | placeholder }}</td>
         </tr>
         <tr>
             <td>Duration</td>
             <td>
-            {% if result.date_done %}
-                {{ result.duration }}
-            {% else %}
+            {% if result.date_created and not result.date_done %}
                 <img src="{% static 'img/ajax-loader.gif' %}">
+            {% else %}
+                {{ result.duration | placeholder}}
             {% endif %}
             </td>
         </tr>
         <tr>
             <td>Return Value</td>
             <td>
-            {% if result.date_done %}
+            {% if result.date_created and not result.date_done %}
+                <img src="{% static 'img/ajax-loader.gif' %}">
+            {% else %}
                 {% if result.result %}
                     <pre>{{ result.result | render_json }}</pre>
                 {% else %}
                     {{ result.result | placeholder }}
                 {% endif %}
-            {% else %}
-                <img src="{% static 'img/ajax-loader.gif' %}">
             {% endif %}
             </td>
         </tr>
@@ -89,6 +87,7 @@
             <input class="form-control" id="log-filter" type="text" placeholder="Filter log level or message" title="Filter log level or message" style="height: 23px" />
         </div>
     </div>
-    {% ajax_table "log_table" "extras:jobresult_log-table" pk=result.pk %}
+    {% if result and result.pk %}
+        {% ajax_table "log_table" "extras:jobresult_log-table" pk=result.pk %}
+    {% endif %}
 </div>
-

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1797,7 +1797,7 @@ class JobTest(
         )
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
         self.assertIn(
-            "task_queue and job_queue are both specified. Please specifiy only one or another.", str(response.content)
+            "task_queue and job_queue are both specified. Please specify only one or another.", str(response.content)
         )
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -1177,6 +1177,13 @@ class GitRepositoryTestCase(
         self.form_data = form_data
         super().test_edit_object_with_constrained_permission()
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_view_when_no_sync_job_result_exists(self):
+        instance = self._get_queryset().first()
+        response = self.client.get(reverse("extras:gitrepository_result", kwargs={"pk": instance.pk}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["result"], {})
+
     def test_post_sync_repo_anonymous(self):
         self.client.logout()
         url = reverse("extras:gitrepository_sync", kwargs={"pk": self._get_queryset().first().pk})

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1165,6 +1165,9 @@ class GitRepositoryResultView(generic.ObjectView):
     def get_extra_context(self, request, instance):
         job_result = instance.get_latest_sync()
 
+        if job_result is None:
+            job_result = {}
+
         return {
             "result": job_result,
             "base_template": "extras/gitrepository.html",


### PR DESCRIPTION
# Closes #6848 
# What's Changed
- If a git repository is created via the API and has not yet synced but someone tries to view the `Synchronization Status`, a `DoesNotExist` error no longer occurs.
- Also as flagged by Glenn, given that JobResults are generally deletable, this fix would apply to the case of all results associated with a given GitRepository being deleted as well.
- Fixed cosmetic typo `"specifiy"` elsewhere in code and a UT.

# Screenshots
# Successful view of the page that would previously have errored:
![Screenshot 2025-02-21 145913](https://github.com/user-attachments/assets/40595c97-39ca-4e7d-9aa5-1cbfaf40ddf9)

# Normal view still unaffected after a sync:
![Screenshot 2025-02-20 143039](https://github.com/user-attachments/assets/5c744890-9e18-435d-8143-86418ca8fcd2)

-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests