### PR TITLE
Fix some UI framework issues (#6920)

### DIFF
--- a/changes/6920.fixed
+++ b/changes/6920.fixed
@@ -1,0 +1,3 @@
+Added log messages to help troubleshoot failures when rendering UI Component Framework `extra_buttons`.
+Fixed logic in UI Component Framework `StatsPanel` that incorrectly disallowed use of FilterSet filters implicitly defined through `fields = "__all__"`.
+Fixed logic in generic `FormTestCase` class that would incorrectly fail if form fields used FilterSet filters implicitly defined through `fields = "__all__"`.

--- a/nautobot/core/templatetags/ui_framework.py
+++ b/nautobot/core/templatetags/ui_framework.py
@@ -1,8 +1,12 @@
+import logging
+
 from django import template
 from django.utils.html import format_html_join
 
 from nautobot.core.utils.lookup import get_view_for_model
 from nautobot.core.views.utils import get_obj_from_context
+
+logger = logging.getLogger(__name__)
 
 register = template.Library()
 
@@ -26,15 +30,27 @@ def render_components(context, components):
 @register.simple_tag(takes_context=True)
 def render_detail_view_extra_buttons(context):
     """
-    Render the "extra_buttons" if any from the base detail view associated with the context object.
+    Render the "extra_buttons" from the context's object_detail_content, or as fallback, from the base detail view.
 
     This makes it possible for "extra" tabs (such as Changelog and Notes, and any added by App TemplateExtensions)
     to automatically still render any `extra_buttons` defined by the base detail view, without the tab-specific views
     needing to explicitly inherit from the base view.
     """
-    obj = get_obj_from_context(context)
-    base_detail_view = get_view_for_model(obj)
-    object_detail_content = getattr(base_detail_view, "object_detail_content", None)
+    object_detail_content = context.get("object_detail_content")
+    if object_detail_content is None:
+        obj = get_obj_from_context(context)
+        if obj is None:
+            logger.error("No 'obj' or 'object' found in the render context!")
+            return ""
+        base_detail_view = get_view_for_model(obj)
+        if base_detail_view is None:
+            logger.warning(
+                "Unable to identify the base detail view - check that it has a valid name, i.e. %sUIViewSet or %sView",
+                type(obj).__name__,
+                type(obj).__name__,
+            )
+            return ""
+        object_detail_content = getattr(base_detail_view, "object_detail_content", None)
     if object_detail_content is not None and object_detail_content.extra_buttons:
         return render_components(context, object_detail_content.extra_buttons)
     return ""

--- a/nautobot/core/testing/forms.py
+++ b/nautobot/core/testing/forms.py
@@ -24,7 +24,7 @@ class FormTestCases:
                         self.skipTest(f"{self.form_class.__name__}.{field_name} has no query_params")
                     field_model = field_class.queryset.model
                     filterset_class = get_filterset_for_model(field_model)
-                    filterset_fields = set(filterset_class.declared_filters.keys())
+                    filterset_fields = set(filterset_class.get_filters().keys())
                     invalid_query_params = query_params_fields - filterset_fields
                     self.assertFalse(
                         invalid_query_params,

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -1372,7 +1372,7 @@ class StatsPanel(Panel):
                 value = [related_object_list_url, related_object_count, related_object_title]
                 stats[related_object_model_class] = value
                 related_object_model_filterset = get_filterset_for_model(related_object_model_class)
-                if self.filter_name not in related_object_model_filterset.declared_filters:
+                if self.filter_name not in related_object_model_filterset.get_filters():
                     raise FieldDoesNotExist(
                         f"{self.filter_name} is not a valid filter field for {related_object_model_class_meta.verbose_name}"
                     )


### PR DESCRIPTION
# Closes #6920
# What's Changed

- When rendering "extra_buttons" in the UI framework:
  - Use the context `object_detail_content` if provided, only fail back to looking up the detail view by name if needed
  - If getting the context `obj`/`object` fails, or if looking up the detail view by name fails, log helpful messages to aid in troubleshooting
- Use `FilterSet.get_filters()` instead of accessing `FilterSet.declared_filters` in a couple of cases, as the latter only includes explicitly declared filter fields, while the former also includes those implicitly generated by `fields = "__all__"`.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
