### PR TITLE
Fix #5851 - add and use PrefixFilter class

### DIFF
--- a/changes/5851.added
+++ b/changes/5851.added
@@ -1,0 +1,6 @@
+Added `PrefixFilter` helper class to `nautobot.apps.filters`.
+Enhanced `prefixes` filter on `CloudNetwork` and `Tenant` filtersets to support filtering by literal prefix string (`10.0.0.0/8`) as an alternative to filtering by primary key.
+Enhanced `prefix` filter on `CloudNetworkPrefixAssignment`, `VRF`, and `VRFPrefixAssignment` filtersets to support filtering by literal prefix string (`10.0.0.0/8`) as an alternative to filtering by primary key.
+Enhanced `parent` filter on `Prefix` filtersets to support filtering by literal prefix string (`10.0.0.0/8`) as an alternative to filtering by primary key.
+Enhanced `prefix` filter on `PrefixLocationAssignment` filtersets to support filtering by primary key as an alternative to filtering by literal prefix string.
+Added `q` search filter to `VRFPrefixAssignment` filterset.

--- a/changes/5851.housekeeping
+++ b/changes/5851.housekeeping
@@ -1,0 +1,1 @@
+Enhanced `PrefixFactory` and `VRFFactory` test helpers to automatically create appropriate `VRFPrefixAssignment` records.

--- a/nautobot/apps/filters.py
+++ b/nautobot/apps/filters.py
@@ -43,6 +43,7 @@ from nautobot.extras.filters.mixins import (
     StatusFilter,
 )
 from nautobot.extras.plugins import FilterExtension
+from nautobot.ipam.filters import PrefixFilter
 from nautobot.tenancy.filters import TenancyModelFilterSetMixin
 
 __all__ = (
@@ -72,6 +73,7 @@ __all__ = (
     "NaturalKeyOrPKMultipleChoiceFilter",
     "NautobotFilterSet",
     "NumericArrayFilter",
+    "PrefixFilter",
     "RelatedMembershipBooleanFilter",
     "RelationshipFilter",
     "RelationshipModelFilterSetMixin",

--- a/nautobot/circuits/filters.py
+++ b/nautobot/circuits/filters.py
@@ -16,7 +16,7 @@ from nautobot.dcim.filters import (
 )
 from nautobot.dcim.models import Location
 from nautobot.extras.filters import NautobotFilterSet, StatusModelFilterSetMixin
-from nautobot.tenancy.filters import TenancyModelFilterSetMixin
+from nautobot.tenancy.filters.mixins import TenancyModelFilterSetMixin
 
 from .models import Circuit, CircuitTermination, CircuitType, Provider, ProviderNetwork
 

--- a/nautobot/cloud/filters.py
+++ b/nautobot/cloud/filters.py
@@ -1,5 +1,3 @@
-import django_filters
-
 from nautobot.cloud import models
 from nautobot.core.filters import (
     BaseFilterSet,
@@ -11,7 +9,7 @@ from nautobot.dcim.models import Manufacturer
 from nautobot.extras.filters import NautobotFilterSet
 from nautobot.extras.models import SecretsGroup
 from nautobot.extras.utils import FeatureQuery
-from nautobot.ipam.models import Prefix
+from nautobot.ipam.filters import PrefixFilter
 
 
 class CloudAccountFilterSet(NautobotFilterSet):
@@ -98,7 +96,7 @@ class CloudNetworkFilterSet(NautobotFilterSet):
         queryset=models.CloudNetwork.objects.all(),
         label="Parent cloud network (name or ID)",
     )
-    prefixes = django_filters.ModelMultipleChoiceFilter(queryset=Prefix.objects.all())
+    prefixes = PrefixFilter()
 
     class Meta:
         model = models.CloudNetwork
@@ -117,8 +115,7 @@ class CloudNetworkPrefixAssignmentFilterSet(BaseFilterSet):
         queryset=models.CloudNetwork.objects.all(),
         label="Cloud network (name or ID)",
     )
-    # Prefix doesn't have an appropriate natural key for NaturalKeyOrPKMultipleChoiceFilter
-    prefix = django_filters.ModelMultipleChoiceFilter(queryset=Prefix.objects.all())
+    prefix = PrefixFilter()
 
     class Meta:
         model = models.CloudNetworkPrefixAssignment

--- a/nautobot/cloud/tests/test_filters.py
+++ b/nautobot/cloud/tests/test_filters.py
@@ -65,6 +65,7 @@ class CloudNetworkTestCase(FilterTestCases.FilterTestCase):
         ("name",),
         ("parent", "parent__id"),
         ("parent", "parent__name"),
+        ("prefixes", "prefixes__id"),
     ]
     exclude_q_filter_predicates = [
         "parent__name",
@@ -79,6 +80,16 @@ class CloudNetworkTestCase(FilterTestCases.FilterTestCase):
             queryset = queryset.filter(children__isnull=True)
         return queryset
 
+    def test_prefixes_filter_by_string(self):
+        """Test filtering by prefix strings as an alternative to pk."""
+        prefix = self.queryset.filter(prefixes__isnull=False).first().prefixes.first()
+        params = {"prefixes": [prefix.prefix]}  # Malkovich malkovich malkovich...
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(prefixes__network=prefix.network, prefixes__prefix_length=prefix.prefix_length),
+            ordered=False,
+        )
+
 
 class CloudNetworkPrefixAssignmentTestCase(FilterTestCases.FilterTestCase):
     queryset = models.CloudNetworkPrefixAssignment.objects.all()
@@ -88,6 +99,16 @@ class CloudNetworkPrefixAssignmentTestCase(FilterTestCases.FilterTestCase):
         ("cloud_network", "cloud_network__name"),
         ("prefix", "prefix__id"),
     ]
+
+    def test_prefix_filter_by_string(self):
+        """Test filtering by prefix strings as an alternative to pk."""
+        prefix = self.queryset.first().prefix
+        params = {"prefix": [prefix.prefix]}  # Malkovich malkovich malkovich...
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(prefix__network=prefix.network, prefix__prefix_length=prefix.prefix_length),
+            ordered=False,
+        )
 
 
 class CloudServiceNetworkAssignmentTestCase(FilterTestCases.FilterTestCase):

--- a/nautobot/dcim/filters/__init__.py
+++ b/nautobot/dcim/filters/__init__.py
@@ -101,7 +101,7 @@ from nautobot.extras.filters import (
 from nautobot.extras.models import ExternalIntegration, SecretsGroup
 from nautobot.extras.utils import FeatureQuery
 from nautobot.ipam.models import IPAddress, VLAN, VLANGroup
-from nautobot.tenancy.filters import TenancyModelFilterSetMixin
+from nautobot.tenancy.filters.mixins import TenancyModelFilterSetMixin
 from nautobot.tenancy.models import Tenant
 from nautobot.virtualization.models import Cluster, VirtualMachine
 from nautobot.wireless.models import RadioProfile, WirelessNetwork

--- a/nautobot/ipam/factory.py
+++ b/nautobot/ipam/factory.py
@@ -127,6 +127,16 @@ class VRFFactory(PrimaryModelFactory):
             else:
                 self.export_targets.set(get_random_instances(RouteTarget))
 
+    @factory.post_generation
+    def prefixes(self, create, extracted, **kwargs):
+        if create:
+            if extracted:
+                self.prefixes.set(extracted)
+            else:
+                self.prefixes.set(
+                    get_random_instances(lambda: Prefix.objects.filter(namespace=self.namespace), minimum=0)
+                )
+
 
 class VLANGroupFactory(OrganizationalModelFactory):
     class Meta:
@@ -295,7 +305,6 @@ class PrefixFactory(PrimaryModelFactory):
         has_role = NautobotBoolIterator()
         has_tenant = NautobotBoolIterator()
         has_vlan = NautobotBoolIterator()
-        # has_vrf = NautobotBoolIterator()
         is_ipv6 = NautobotBoolIterator()
 
     prefix = factory.Maybe(
@@ -321,12 +330,6 @@ class PrefixFactory(PrimaryModelFactory):
         None,
     )
     namespace = random_instance(Namespace, allow_null=False)
-    # TODO: Update for M2M tests
-    # vrf = factory.Maybe(
-    #     "has_vrf",
-    #     factory.SubFactory(VRFGetOrCreateFactory, tenant=factory.SelfAttribute("..tenant")),
-    #     None,
-    # )
     rir = factory.Maybe("has_rir", random_instance(RIR, allow_null=False), None)
     date_allocated = factory.Maybe("has_date_allocated", factory.Faker("date_time", tzinfo=datetime.timezone.utc), None)
 
@@ -342,6 +345,14 @@ class PrefixFactory(PrimaryModelFactory):
                         lambda: Location.objects.filter(location_type__content_types__in=[prefix_ct]), minimum=0
                     )
                 )
+
+    @factory.post_generation
+    def vrfs(self, create, extracted, **kwargs):
+        if create:
+            if extracted:
+                self.vrfs.set(extracted)
+            else:
+                self.vrfs.set(get_random_instances(lambda: VRF.objects.filter(namespace=self.namespace), minimum=0))
 
     @factory.post_generation
     def children(self, create, extracted, **kwargs):

--- a/nautobot/ipam/formfields.py
+++ b/nautobot/ipam/formfields.py
@@ -1,7 +1,11 @@
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_ipv4_address, validate_ipv6_address
+from django.db.models import Q
 from netaddr import AddrFormatError, IPAddress, IPNetwork
+
+from nautobot.core.forms.fields import MultiMatchModelMultipleChoiceField
+from nautobot.core.utils.data import is_uuid
 
 #
 # Form fields
@@ -58,3 +62,50 @@ class IPNetworkFormField(forms.Field):
             return IPNetwork(value)
         except AddrFormatError:
             raise ValidationError("Please specify a valid IPv4 or IPv6 address.")
+
+
+class PrefixFilterFormField(MultiMatchModelMultipleChoiceField):
+    @property
+    def filter(self):
+        from nautobot.ipam.filters import PrefixFilter  # avoid circular definition
+
+        return PrefixFilter
+
+    def _check_values(self, values):  # pylint: disable=arguments-renamed
+        null_value_present = self.null_label is not None and values and self.null_value in values
+        if null_value_present:
+            values = [v for v in values if v != self.null_value]
+        # deduplicate given values to avoid creating many querysets or
+        # requiring the database backend deduplicate efficiently.
+        try:
+            values = frozenset(values)
+        except TypeError:
+            raise ValidationError(self.error_messages["invalid_list"], code="invalid_list")
+        pk_values = set()
+        prefix_queries = []
+        for value in values:
+            if is_uuid(value):
+                pk_values.add(value)
+                query = Q(pk=value)
+            else:
+                ipnetwork = IPNetwork(value)
+                query = Q(
+                    network=ipnetwork.network,
+                    prefix_length=ipnetwork.prefixlen,
+                    broadcast=ipnetwork.broadcast or ipnetwork[-1],
+                )
+                prefix_queries.append(query)
+            if not self.queryset.filter(query).exists():
+                raise ValidationError(
+                    self.error_messages["invalid_choice"],
+                    code="invalid_choice",
+                    params={"value": value},
+                )
+        aggregate_query = Q(pk__in=pk_values)
+        for prefix_query in prefix_queries:
+            aggregate_query |= prefix_query
+        qs = self.queryset.filter(aggregate_query)
+        result = list(qs)
+        if null_value_present:
+            result.append(self.null_value)
+        return result

--- a/nautobot/ipam/tests/test_api.py
+++ b/nautobot/ipam/tests/test_api.py
@@ -221,50 +221,38 @@ class VRFPrefixAssignmentTest(APIViewTestCases.APIViewTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        cls.namespace = (
+            Namespace.objects.annotate(prefixes_count=Count("prefixes")).filter(prefixes_count__gte=3).first()
+        )
         cls.vrfs = (
-            VRF.objects.annotate(prefixes_count=Count("namespace__prefixes")).filter(prefixes_count__gte=2).distinct()
+            VRF.objects.create(name="TEST VRF 1", namespace=cls.namespace),
+            VRF.objects.create(name="TEST VRF 2", namespace=cls.namespace),
         )
-        cls.prefixes = Prefix.objects.all()
+        cls.prefixes = Prefix.objects.filter(namespace=cls.namespace)
 
-        VRFPrefixAssignment.objects.create(
-            vrf=cls.vrfs[0],
-            prefix=cls.prefixes.filter(namespace=cls.vrfs[0].namespace)[0],
-        )
-        VRFPrefixAssignment.objects.create(
-            vrf=cls.vrfs[0],
-            prefix=cls.prefixes.filter(namespace=cls.vrfs[0].namespace)[1],
-        )
-        VRFPrefixAssignment.objects.create(
-            vrf=cls.vrfs[1],
-            prefix=cls.prefixes.filter(namespace=cls.vrfs[1].namespace)[0],
-        )
-        VRFPrefixAssignment.objects.create(
-            vrf=cls.vrfs[1],
-            prefix=cls.prefixes.filter(namespace=cls.vrfs[1].namespace)[1],
-        )
         cls.create_data = [
             {
-                "vrf": cls.vrfs[2].pk,
-                "prefix": cls.prefixes.filter(namespace=cls.vrfs[2].namespace).exclude(vrfs=cls.vrfs[2])[0].pk,
+                "vrf": cls.vrfs[0].pk,
+                "prefix": cls.prefixes.first().pk,
             },
             {
-                "vrf": cls.vrfs[3].pk,
-                "prefix": cls.prefixes.filter(namespace=cls.vrfs[3].namespace).exclude(vrfs=cls.vrfs[3])[0].pk,
+                "vrf": cls.vrfs[0].pk,
+                "prefix": cls.prefixes.last().pk,
             },
             {
-                "vrf": cls.vrfs[4].pk,
-                "prefix": cls.prefixes.filter(namespace=cls.vrfs[4].namespace).exclude(vrfs=cls.vrfs[4])[0].pk,
+                "vrf": cls.vrfs[1].pk,
+                "prefix": cls.prefixes.first().pk,
             },
         ]
 
     def test_creating_invalid_vrf_prefix_assignments(self):
         duplicate_create_data = {
-            "vrf": self.vrfs[0].pk,
-            "prefix": self.prefixes.filter(namespace=self.vrfs[0].namespace)[0].pk,
+            "vrf": VRFPrefixAssignment.objects.first().vrf.pk,
+            "prefix": VRFPrefixAssignment.objects.first().prefix.pk,
         }
         wrong_namespace_create_data = {
             "vrf": self.vrfs[0].pk,
-            "prefix": self.prefixes.exclude(namespace=self.vrfs[0].namespace)[0].pk,
+            "prefix": Prefix.objects.exclude(namespace=self.namespace)[0].pk,
         }
         missing_field_create_data = {
             "vrf": self.vrfs[0].pk,

--- a/nautobot/tenancy/filters/__init__.py
+++ b/nautobot/tenancy/filters/__init__.py
@@ -11,7 +11,8 @@ from nautobot.core.filters import (
 from nautobot.core.utils.deprecation import class_deprecated_in_favor_of
 from nautobot.dcim.models import Device, Location, Rack, RackReservation
 from nautobot.extras.filters import NautobotFilterSet
-from nautobot.ipam.models import IPAddress, Prefix, RouteTarget, VLAN, VRF
+from nautobot.ipam.filters import PrefixFilter
+from nautobot.ipam.models import IPAddress, RouteTarget, VLAN, VRF
 from nautobot.tenancy.filters.mixins import TenancyModelFilterSetMixin
 from nautobot.tenancy.models import Tenant, TenantGroup
 from nautobot.virtualization.models import Cluster, VirtualMachine
@@ -112,10 +113,7 @@ class TenantFilterSet(NautobotFilterSet):
         field_name="locations",
         label="Has locations",
     )
-    prefixes = django_filters.ModelMultipleChoiceFilter(
-        queryset=Prefix.objects.all(),
-        label="Prefixes (ID)",
-    )
+    prefixes = PrefixFilter()
     has_prefixes = RelatedMembershipBooleanFilter(
         field_name="prefixes",
         label="Has prefixes",

--- a/nautobot/tenancy/tests/test_filters.py
+++ b/nautobot/tenancy/tests/test_filters.py
@@ -145,3 +145,13 @@ class TenantTestCase(FilterTestCases.FilterTestCase):
             self.filterset(params, self.queryset).qs,
             self.queryset.filter(locations__in=[self.locations[0], self.locations[1]]).distinct(),
         )
+
+    def test_prefixes_by_string(self):
+        """Test filtering by prefix strings as an alternative to pk."""
+        prefix = self.queryset.filter(prefixes__isnull=False).first().prefixes.first()
+        params = {"prefixes": [prefix.prefix]}
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset(params, self.queryset).qs,
+            self.queryset.filter(prefixes__network=prefix.network, prefixes__prefix_length=prefix.prefix_length),
+            ordered=False,
+        )


### PR DESCRIPTION
# Closes #5851
# What's Changed

- Add `PrefixFilter` and `PrefixFilterFormField` classes, which are subclasses of `NaturalKeyOrPKMultipleChoiceFilter` and `MultiMatchModelMultipleChoiceField` respectively. These work similarly to the base classes, except instead of performing a single natural-key database field lookup when given a non-UUID filter value, instead decompose the value into its component `network`/`prefix_length`/`broadcast` values and construct an appropriate Prefix query.
   - [ ] TODO: should I also have it filter by `ip_version` just to be safe in case of potential issues like #3319?
- Update relevant FilterSets to use the new PrefixFilter in place of a generic ModelMultipleChoiceFilter or custom method filter where applicable.
- Add test coverage for the newly supported filter values.
   - Add test case for `VRFPrefixAssignmentFilterSet`, previously absent.
      - Enhance IPAM data factories to create `VRFPrefixAssignment` records
      - Add missing `q` filter to `VRFPrefixAssignmentFilterSet`.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
