### PR TITLE
Revert debug task behavior, modify ephemeral port to be async

### DIFF
--- a/changes/6943.housekeeping
+++ b/changes/6943.housekeeping
@@ -1,0 +1,1 @@
+Mimic `debug` invoke task to previous behavior.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
As a follow-up to [https://github.com/nautobot/nautobot/pull/6896](https://github.com/nautobot/nautobot/pull/6896) I realized I changed the behavior of the original `debug` task to make it different in a way developers might not appreciate/agree with/enjoy.

So I've reverted back to the old behavior and modifying the port detection logic in a way that allows it to run concurrently in parallel.

Previous behavior:
1. Launch `inv debug`
2. Containers start in foreground with logs streaming from all containers
3. Ctrl+C to exit stops logs streaming and kills containers

Current behavior:
1. launch `inv debug`
2. Containers start in background
3. Port mappings wrote to disk
4. Container logs followed again
5. Ctrl+C will stop following logs BUT containers still remain active

New behavior:
1. launch `inv debug`
2. Port mapping detection starts in background thread, looping until the required services are detected
3. Containers start in foreground as previous behavior
2. Ctrl+C will stop following logs and kill active containers 


# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example