### PR TITLE
Avoid an AttributeError due to migration state in v1.x-v2.x upgrade

### DIFF
--- a/changes/6952.fixed
+++ b/changes/6952.fixed
@@ -1,0 +1,1 @@
+Fixed an `AttributeError` exception when upgrading from v1.x to v2.x with certain existing data in the database.


### PR DESCRIPTION
# Closes #6952
# What's Changed

Because loading `Tag.changed` in the midst of the v1.x to v2.x migration can throw an exception due to the database state (1.x) still having this as a `DateField` but the model state (2.x) expecting a `DateTimeField`, and given that the migrations that are calling into this code path only actually care about `Tag.name`, fix this in the simplest way by replacing `obj.tags.all()` with `obj.tags.only("name")`.

My first attempt at fixing this issue was to replace the suspect usage of `extras_models.TaggedItem` in these migrations with `apps.get_model("extras", "taggeditem")` but that simply injected a different set of issues because the stripped-down "historical" model returned by `apps.get_model()` doesn't have all of the APIs that `TagsManager` implicitly expects.

This second attempt is less elegant, but it does seem to work. :-)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
