### PR TITLE
Add Job.logger.failure() and Job.fail() APIs

### DIFF
--- a/changes/6384.added
+++ b/changes/6384.added
@@ -1,0 +1,2 @@
+Added `Job.logger.failure()` API for Job logging, using custom `FAILURE` log level (between `WARNING` and `ERROR`).
+Added `Job.fail()` API, which can be used to fail a Job more gracefully than by raising an uncaught exception.

--- a/changes/6384.added
+++ b/changes/6384.added
@@ -1,2 +1,3 @@
 Added `Job.logger.failure()` API for Job logging, using custom `FAILURE` log level (between `WARNING` and `ERROR`).
 Added `Job.fail()` API, which can be used to fail a Job more gracefully than by raising an uncaught exception.
+Added `NautobotTestCaseMixin.assertJobResultStatus()` testing helper API.

--- a/changes/6384.changed
+++ b/changes/6384.changed
@@ -1,0 +1,1 @@
+Changed output of `nautobot-server runjob` command to include the traceback (if any) and count of `success`/`failure` log messages.

--- a/changes/6384.fixed
+++ b/changes/6384.fixed
@@ -1,0 +1,1 @@
+Fixed rendering of "actions" column in the JobResult table view.

--- a/changes/6384.fixed
+++ b/changes/6384.fixed
@@ -1,1 +1,2 @@
 Fixed rendering of "actions" column in the JobResult table view.
+Fixed incorrect `stacklevel` default value in Job `logger.success()` API.

--- a/changes/6384.housekeeping
+++ b/changes/6384.housekeeping
@@ -1,0 +1,2 @@
+Added `init: true` to development `docker-compose.yml` to avoid failed health-checks from remaining as zombie processes.
+Added `ExampleFailingJob` to example app to demonstrate the two different ways to fail a Job.

--- a/changes/6384.removed
+++ b/changes/6384.removed
@@ -1,0 +1,1 @@
+Removed the (undocumented) requirement for Jobs that implement a custom `before_start()` or `after_return()` method to call `super()` for the Job to execute successfully.

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -23,6 +23,7 @@ services:
         condition: service_healthy
     env_file:
       - dev.env
+    init: true
     tty: true
   celery_worker:
     image: "local/nautobot-dev:local-${NAUTOBOT_VER}-py${PYTHON_VER}"

--- a/examples/example_app/example_app/jobs.py
+++ b/examples/example_app/example_app/jobs.py
@@ -245,18 +245,18 @@ This is a Job that demonstrates as many Job features as it can.
         """
         self.logger.info("Success! The retval is `%s`, kwargs were `%s`", retval, kwargs)
 
-    def on_failure(self, retval, task_id, args, kwargs, einfo):
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
         """
         Called if either before_start() or run() raised an unhandled exception.
 
         Args:
-            retval (any): Exception that was raised, if any, otherwise value returned by `run()` or `before_start()`.
+            exc (any): Exception that was raised, if any, otherwise value returned by `run()` or `before_start()`.
             task_id (str): Present for Celery compatibility, can be ignored in most cases.
             args (list): Present for Celery compatibility, can be ignored in most cases.
             kwargs (dict): The keyword args that were (or would have been) passed into `run()`.
             einfo (any): Present for Celery compatibility, can be ignored in most cases.
         """
-        self.logger.error("Failure! The exception is `%s`, kwargs were `%s`", retval, kwargs)
+        self.logger.error("Failure! The exception is `%s`, kwargs were `%s`", exc, kwargs)
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         """

--- a/examples/example_app/example_app/jobs.py
+++ b/examples/example_app/example_app/jobs.py
@@ -224,15 +224,14 @@ This is a Job that demonstrates as many Job features as it can.
             "This is an info message, with an associated database object",
             extra={"object": kwargs["location_type_input"]},
         )
-        self.logger.success(
-            "You can use logger.success() to set the log level to `SUCCESS`.", extra={"grouping": "post_run"}
-        )
+        self.logger.success("You can use logger.success() to set the log level to `SUCCESS`.")
         self.logger.warning(
             "You can specify a custom grouping for messages, but do so with consideration.",
             extra={"grouping": "warning messages"},
         )
+        self.logger.failure("Note that *logging* a failure does _not_ automatically cause the job to fail.")
         self.logger.error("Note that *logging* an error does _not_ automatically cause the job to fail.")
-        self.logger.exception("Any supported Python log level can be logged but not all are automatically colorized.")
+        self.logger.critical("Any supported Python log level can be logged but not all are automatically colorized.")
 
     def on_success(self, retval, task_id, args, kwargs):
         """
@@ -246,18 +245,18 @@ This is a Job that demonstrates as many Job features as it can.
         """
         self.logger.info("Success! The retval is `%s`, kwargs were `%s`", retval, kwargs)
 
-    def on_failure(self, exc, task_id, args, kwargs, einfo):
+    def on_failure(self, retval, task_id, args, kwargs, einfo):
         """
         Called if either before_start() or run() raised an unhandled exception.
 
         Args:
-            exc (Exception): The exception that was raised.
+            retval (any): Exception that was raised, if any, otherwise value returned by `run()` or `before_start()`.
             task_id (str): Present for Celery compatibility, can be ignored in most cases.
             args (list): Present for Celery compatibility, can be ignored in most cases.
             kwargs (dict): The keyword args that were (or would have been) passed into `run()`.
             einfo (any): Present for Celery compatibility, can be ignored in most cases.
         """
-        self.logger.error("Failure! The exception is `%s`, kwargs were `%s`", exc, kwargs)
+        self.logger.error("Failure! The exception is `%s`, kwargs were `%s`", retval, kwargs)
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         """
@@ -490,7 +489,7 @@ class ExampleFailingJob(Job):
 
     fail_cleanly = BooleanVar(default=True)
 
-    def run(self, *args, fail_cleanly, **kwargs):
+    def run(self, *args, fail_cleanly, **kwargs):  # pylint: disable=arguments-differ
         self.logger.info("Job is running merrily along, when suddenly...")
         if fail_cleanly:
             self.fail("A failure occurs but is handled cleanly, allowing the job to continue...")

--- a/nautobot/__init__.py
+++ b/nautobot/__init__.py
@@ -18,6 +18,7 @@ def add_success_logger():
     logging.addLevelName(SUCCESS, "SUCCESS")
 
     def success(self, message, *args, **kwargs):
+        kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1  # so that funcName is the caller function, not "success"
         if self.isEnabledFor(SUCCESS):
             self._log(SUCCESS, message, args, **kwargs)
 
@@ -31,6 +32,7 @@ def add_failure_logger():
     logging.addLevelName(FAILURE, "FAILURE")
 
     def failure(self, message, *args, **kwargs):
+        kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1  # so that funcName is the caller function, not "failure"
         if self.isEnabledFor(FAILURE):
             self._log(FAILURE, message, args, **kwargs)
 

--- a/nautobot/__init__.py
+++ b/nautobot/__init__.py
@@ -14,18 +14,32 @@ __initialized = False
 
 def add_success_logger():
     """Add a custom log level for success messages."""
-    SUCCESS = 25
+    SUCCESS = 25  # between INFO and WARNING
     logging.addLevelName(SUCCESS, "SUCCESS")
 
-    def success(self, message, *args, **kws):
+    def success(self, message, *args, **kwargs):
         if self.isEnabledFor(SUCCESS):
-            self._log(SUCCESS, message, args, **kws)
+            self._log(SUCCESS, message, args, **kwargs)
 
     logging.Logger.success = success
     return success
 
 
+def add_failure_logger():
+    """Add a custom log level for failure messages less severe than an ERROR."""
+    FAILURE = 35  # between WARNING and ERROR
+    logging.addLevelName(FAILURE, "FAILURE")
+
+    def failure(self, message, *args, **kwargs):
+        if self.isEnabledFor(FAILURE):
+            self._log(FAILURE, message, args, **kwargs)
+
+    logging.Logger.failure = failure
+    return failure
+
+
 add_success_logger()
+add_failure_logger()
 logger = logging.getLogger(__name__)
 
 

--- a/nautobot/core/celery/__init__.py
+++ b/nautobot/core/celery/__init__.py
@@ -14,7 +14,7 @@ from django.utils.module_loading import import_string
 from kombu.serialization import register
 from prometheus_client import CollectorRegistry, multiprocess, start_http_server
 
-from nautobot import add_success_logger
+from nautobot import add_failure_logger, add_success_logger
 from nautobot.core.celery.control import discard_git_repository, refresh_git_repository  # noqa: F401  # unused-import
 from nautobot.core.celery.encoders import NautobotKombuJSONEncoder
 from nautobot.core.celery.log import NautobotDatabaseHandler
@@ -138,14 +138,16 @@ def add_nautobot_log_handler(logger_instance, log_format=None):
 
 @signals.after_setup_logger.connect
 def setup_nautobot_global_logging(logger, **kwargs):  # pylint: disable=redefined-outer-name
-    """Add SUCCESS log to celery global logger."""
+    """Add SUCCESS and FAILURE logs to celery global logger."""
     logger.success = add_success_logger()
+    logger.failure = add_failure_logger()
 
 
 @signals.after_setup_task_logger.connect
 def setup_nautobot_task_logging(logger, **kwargs):  # pylint: disable=redefined-outer-name
-    """Add SUCCESS log to celery task logger."""
+    """Add SUCCESS and FAILURE logs to celery task logger."""
     logger.success = add_success_logger()
+    logger.failure = add_failure_logger()
 
 
 @signals.celeryd_after_setup.connect

--- a/nautobot/core/jobs/__init__.py
+++ b/nautobot/core/jobs/__init__.py
@@ -295,8 +295,9 @@ class ImportObjects(Job):
                     validation_failed = True
             else:
                 validation_failed = True
-                for field, err in serializer.errors.items():
-                    self.logger.error("Row %d: `%s`: `%s`", row, field, err[0])
+                for field, errs in serializer.errors.items():
+                    for err in errs:
+                        self.logger.error("Row %d: `%s`: `%s`", row, field, err)
         return new_objs, validation_failed
 
     def run(self, *, content_type, csv_data=None, csv_file=None, roll_back_if_error=False):  # pylint:disable=arguments-differ

--- a/nautobot/core/testing/__init__.py
+++ b/nautobot/core/testing/__init__.py
@@ -68,6 +68,8 @@ def run_job_for_testing(job, username="test-user", profile=False, **kwargs):
         username=username, defaults={"is_superuser": True, "password": "password"}
     )
     # Run the job synchronously in the current thread as if it were being executed by a worker
+    # TODO: in Nautobot core testing, we set `CELERY_TASK_ALWAYS_EAGER = True`, so we *could* use enqueue_job() instead,
+    #       but switching now would be a potentially breaking change for apps...
     job_result = JobResult.execute_job(
         job_model=job,
         user=user_instance,

--- a/nautobot/core/testing/mixins.py
+++ b/nautobot/core/testing/mixins.py
@@ -18,6 +18,7 @@ from nautobot.core.models import fields as core_fields
 from nautobot.core.testing import utils
 from nautobot.core.utils import permissions
 from nautobot.extras import management, models as extras_models
+from nautobot.extras.choices import JobResultStatusChoices
 from nautobot.users import models as users_models
 
 # Use the proper swappable User model
@@ -187,6 +188,14 @@ class NautobotTestCaseMixin:
             if msg:
                 err_message = f"{msg}\n{err_message}"
         self.assertIn(response.status_code, expected_status, err_message)
+
+    def assertJobResultStatus(self, job_result, expected_status=JobResultStatusChoices.STATUS_SUCCESS):
+        """Assert that the given job_result has the expected_status, or print the job logs to aid in debugging."""
+        self.assertEqual(
+            job_result.status,
+            expected_status,
+            (job_result.traceback, list(job_result.job_log_entries.values_list("message", flat=True))),
+        )
 
     def assertInstanceEqual(self, instance, data, exclude=None, api=False):
         """

--- a/nautobot/core/tests/test_jobs.py
+++ b/nautobot/core/tests/test_jobs.py
@@ -70,7 +70,7 @@ class ExportObjectListTest(TransactionTestCase):
             username=self.user.username,  # otherwise run_job_for_testing defaults to a superuser account
             content_type=ContentType.objects.get_for_model(Status).pk,
         )
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertTrue(job_result.files.exists())
         self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_statuses.csv")
         csv_bytes = job_result.files.first().file.read()
@@ -86,7 +86,7 @@ class ExportObjectListTest(TransactionTestCase):
             "ExportObjectList",
             content_type=ContentType.objects.get_for_model(Status).pk,
         )
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertTrue(job_result.files.exists())
         self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_statuses.csv")
         csv_data = job_result.files.first().file.read().decode("utf-8")
@@ -107,7 +107,7 @@ class ExportObjectListTest(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Status).pk,
             export_template=et.pk,
         )
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertTrue(job_result.files.exists())
         self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_statuses.txt")
         text_data = job_result.files.first().file.read().decode("utf-8")
@@ -129,7 +129,7 @@ class ExportObjectListTest(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(DeviceType).pk,
             export_format="yaml",
         )
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertTrue(job_result.files.exists())
         self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_device_types.yaml")
         yaml_data = job_result.files.first().file.read().decode("utf-8")
@@ -220,7 +220,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Status).pk,
             csv_data=self.csv_data,
         )
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
         )
@@ -246,7 +246,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Prefix).pk,
             csv_file=csv_file.id,
         )
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
         )
@@ -287,7 +287,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Device).pk,
             csv_file=csv_file.id,
         )
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
         )
@@ -531,7 +531,7 @@ class LogsCleanupTestCase(TransactionTestCase):
             cleanup_types=[CleanupTypes.JOB_RESULT, CleanupTypes.OBJECT_CHANGE],
             max_age=0,
         )
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertEqual(job_result.result["extras.JobResult"], 1)
         self.assertEqual(job_result.result["extras.ObjectChange"], 1)
         with self.assertRaises(JobResult.DoesNotExist):
@@ -628,7 +628,7 @@ class BulkEditTestCase(TransactionTestCase):
             tag.content_types.add(self.namespace_ct)
 
     def _common_no_error_test_assertion(self, model, job_result, expected_count, **filter_params):
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertEqual(model.objects.filter(**filter_params).count(), expected_count)
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
@@ -960,7 +960,7 @@ class BulkDeleteTestCase(TransactionTestCase):
         )
 
     def _common_no_error_test_assertion(self, model, job_result, **filter_params):
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertEqual(model.objects.filter(**filter_params).count(), 0)
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()

--- a/nautobot/core/tests/test_jobs.py
+++ b/nautobot/core/tests/test_jobs.py
@@ -375,7 +375,11 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(LocationType).pk,
             csv_data=location_types_csv,
         )
-        self.assertEqual(location_types_job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertEqual(
+            location_types_job_result.status,
+            JobResultStatusChoices.STATUS_SUCCESS,
+            location_types_job_result.traceback,
+        )
 
         location_type_count = LocationType.objects.filter(name="ContactAssignmentImportTestLocationType").count()
         self.assertEqual(location_type_count, 1, f"Unexpected count of LocationTypes {location_type_count}")
@@ -386,7 +390,11 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Location).pk,
             csv_data=locations_csv,
         )
-        self.assertEqual(locations_job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertEqual(
+            locations_job_result.status,
+            JobResultStatusChoices.STATUS_SUCCESS,
+            locations_job_result.traceback,
+        )
 
         location_count = Location.objects.filter(location_type__name="ContactAssignmentImportTestLocationType").count()
         self.assertEqual(location_count, 2, f"Unexpected count of Locations {location_count}")
@@ -397,7 +405,11 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Contact).pk,
             csv_data=contacts_csv,
         )
-        self.assertEqual(contacts_job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertEqual(
+            contacts_job_result.status,
+            JobResultStatusChoices.STATUS_SUCCESS,
+            contacts_job_result.traceback,
+        )
 
         contact_count = Contact.objects.filter(name="Bob-ContactAssignmentImportTestLocation").count()
         self.assertEqual(contact_count, 1, f"Unexpected number of contacts {contact_count}")
@@ -408,7 +420,11 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Role).pk,
             csv_data=roles_csv,
         )
-        self.assertEqual(roles_job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertEqual(
+            roles_job_result.status,
+            JobResultStatusChoices.STATUS_SUCCESS,
+            roles_job_result.traceback,
+        )
 
         role_count = Role.objects.filter(name="ContactAssignmentImportTestLocation-On Site").count()
         self.assertEqual(role_count, 1, f"Unexpected number of role values {role_count}")
@@ -427,7 +443,11 @@ class ImportObjectsTestCase(TransactionTestCase):
             csv_data=associations_csv,
         )
 
-        self.assertEqual(associations_job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertEqual(
+            associations_job_result.status,
+            JobResultStatusChoices.STATUS_SUCCESS,
+            associations_job_result.traceback,
+        )
 
 
 class LogsCleanupTestCase(TransactionTestCase):

--- a/nautobot/core/tests/test_jobs.py
+++ b/nautobot/core/tests/test_jobs.py
@@ -48,7 +48,7 @@ class ExportObjectListTest(TransactionTestCase):
             username=self.user.username,  # otherwise run_job_for_testing defaults to a superuser account
             content_type=ContentType.objects.get_for_model(Status).pk,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         log_error = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertEqual(log_error.message, f'User "{self.user}" does not have permission to view status objects')
         self.assertFalse(job_result.files.exists())
@@ -70,7 +70,7 @@ class ExportObjectListTest(TransactionTestCase):
             username=self.user.username,  # otherwise run_job_for_testing defaults to a superuser account
             content_type=ContentType.objects.get_for_model(Status).pk,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertTrue(job_result.files.exists())
         self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_statuses.csv")
         csv_bytes = job_result.files.first().file.read()
@@ -86,7 +86,7 @@ class ExportObjectListTest(TransactionTestCase):
             "ExportObjectList",
             content_type=ContentType.objects.get_for_model(Status).pk,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertTrue(job_result.files.exists())
         self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_statuses.csv")
         csv_data = job_result.files.first().file.read().decode("utf-8")
@@ -107,7 +107,7 @@ class ExportObjectListTest(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Status).pk,
             export_template=et.pk,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertTrue(job_result.files.exists())
         self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_statuses.txt")
         text_data = job_result.files.first().file.read().decode("utf-8")
@@ -129,7 +129,7 @@ class ExportObjectListTest(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(DeviceType).pk,
             export_format="yaml",
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertTrue(job_result.files.exists())
         self.assertEqual(Path(job_result.files.first().file.name).name, "nautobot_device_types.yaml")
         yaml_data = job_result.files.first().file.read().decode("utf-8")
@@ -159,7 +159,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Status).pk,
             csv_data=self.csv_data,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         log_error = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertEqual(log_error.message, f'User "{self.user}" does not have permission to create status objects')
         self.assertFalse(Status.objects.filter(name__startswith="test_status").exists())
@@ -172,7 +172,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             username=self.user.username,  # otherwise run_job_for_testing defaults to a superuser account
             content_type=ContentType.objects.get_for_model(Status).pk,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
 
     def test_csv_import_with_constrained_permission(self):
         """Job should only allow the user to import objects they have permission to add."""
@@ -191,7 +191,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Status).pk,
             csv_data=self.csv_data,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         log_successes = JobLogEntry.objects.filter(
             job_result=job_result, log_level=LogLevelChoices.LOG_INFO, message__icontains="created"
         )
@@ -220,7 +220,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Status).pk,
             csv_data=self.csv_data,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
         )
@@ -246,7 +246,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Prefix).pk,
             csv_file=csv_file.id,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
         )
@@ -287,7 +287,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Device).pk,
             csv_file=csv_file.id,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
         )
@@ -313,7 +313,7 @@ class ImportObjectsTestCase(TransactionTestCase):
                 csv_data=csv_data,
                 roll_back_if_error=True,
             )
-            self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+            self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
             log_info = JobLogEntry.objects.filter(
                 job_result=job_result, log_level=LogLevelChoices.LOG_INFO, message__icontains="created"
             )
@@ -335,7 +335,7 @@ class ImportObjectsTestCase(TransactionTestCase):
                 content_type=ContentType.objects.get_for_model(Status).pk,
                 csv_data=csv_data,
             )
-            self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+            self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
             log_errors = JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
             self.assertEqual(log_errors[0].message, "Row 1: `color`: `Enter a valid hexadecimal RGB color code.`")
             self.assertFalse(Status.objects.filter(name="test_status0").exists())
@@ -375,11 +375,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(LocationType).pk,
             csv_data=location_types_csv,
         )
-        self.assertEqual(
-            location_types_job_result.status,
-            JobResultStatusChoices.STATUS_SUCCESS,
-            location_types_job_result.traceback,
-        )
+        self.assertJobResultStatus(location_types_job_result)
 
         location_type_count = LocationType.objects.filter(name="ContactAssignmentImportTestLocationType").count()
         self.assertEqual(location_type_count, 1, f"Unexpected count of LocationTypes {location_type_count}")
@@ -390,11 +386,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Location).pk,
             csv_data=locations_csv,
         )
-        self.assertEqual(
-            locations_job_result.status,
-            JobResultStatusChoices.STATUS_SUCCESS,
-            locations_job_result.traceback,
-        )
+        self.assertJobResultStatus(locations_job_result)
 
         location_count = Location.objects.filter(location_type__name="ContactAssignmentImportTestLocationType").count()
         self.assertEqual(location_count, 2, f"Unexpected count of Locations {location_count}")
@@ -405,11 +397,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Contact).pk,
             csv_data=contacts_csv,
         )
-        self.assertEqual(
-            contacts_job_result.status,
-            JobResultStatusChoices.STATUS_SUCCESS,
-            contacts_job_result.traceback,
-        )
+        self.assertJobResultStatus(contacts_job_result)
 
         contact_count = Contact.objects.filter(name="Bob-ContactAssignmentImportTestLocation").count()
         self.assertEqual(contact_count, 1, f"Unexpected number of contacts {contact_count}")
@@ -420,11 +408,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(Role).pk,
             csv_data=roles_csv,
         )
-        self.assertEqual(
-            roles_job_result.status,
-            JobResultStatusChoices.STATUS_SUCCESS,
-            roles_job_result.traceback,
-        )
+        self.assertJobResultStatus(roles_job_result)
 
         role_count = Role.objects.filter(name="ContactAssignmentImportTestLocation-On Site").count()
         self.assertEqual(role_count, 1, f"Unexpected number of role values {role_count}")
@@ -442,12 +426,7 @@ class ImportObjectsTestCase(TransactionTestCase):
             content_type=ContentType.objects.get_for_model(ContactAssociation).pk,
             csv_data=associations_csv,
         )
-
-        self.assertEqual(
-            associations_job_result.status,
-            JobResultStatusChoices.STATUS_SUCCESS,
-            associations_job_result.traceback,
-        )
+        self.assertJobResultStatus(associations_job_result)
 
 
 class LogsCleanupTestCase(TransactionTestCase):
@@ -489,7 +468,7 @@ class LogsCleanupTestCase(TransactionTestCase):
             cleanup_types=[CleanupTypes.JOB_RESULT],
             max_age=0,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         log_error = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertEqual(log_error.message, f'User "{self.user}" does not have permission to delete JobResult records')
         self.assertEqual(JobResult.objects.count(), job_result_count + 1)
@@ -504,7 +483,7 @@ class LogsCleanupTestCase(TransactionTestCase):
                 cleanup_types=[CleanupTypes.OBJECT_CHANGE],
                 max_age=0,
             )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         log_error = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertEqual(
             log_error.message, f'User "{self.user}" does not have permission to delete ObjectChange records'
@@ -552,7 +531,7 @@ class LogsCleanupTestCase(TransactionTestCase):
             cleanup_types=[CleanupTypes.JOB_RESULT, CleanupTypes.OBJECT_CHANGE],
             max_age=0,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertEqual(job_result.result["extras.JobResult"], 1)
         self.assertEqual(job_result.result["extras.ObjectChange"], 1)
         with self.assertRaises(JobResult.DoesNotExist):
@@ -649,7 +628,7 @@ class BulkEditTestCase(TransactionTestCase):
             tag.content_types.add(self.namespace_ct)
 
     def _common_no_error_test_assertion(self, model, job_result, expected_count, **filter_params):
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertEqual(model.objects.filter(**filter_params).count(), expected_count)
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
@@ -670,7 +649,7 @@ class BulkEditTestCase(TransactionTestCase):
             form_data={"pk": pk_list, "color": "aa1409"},
             username=self.user.username,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         job_log = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertEqual(job_log.message, f'User "{self.user}" does not have permission to update status objects')
 
@@ -981,7 +960,7 @@ class BulkDeleteTestCase(TransactionTestCase):
         )
 
     def _common_no_error_test_assertion(self, model, job_result, **filter_params):
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertEqual(model.objects.filter(**filter_params).count(), 0)
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
@@ -999,7 +978,7 @@ class BulkDeleteTestCase(TransactionTestCase):
             pk_list=statuses_to_delete,
             username=self.user.username,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         job_log = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertEqual(job_log.message, f'User "{self.user}" does not have permission to delete status objects')
         self.assertEqual(Status.objects.filter(pk__in=statuses_to_delete).count(), len(statuses_to_delete))
@@ -1022,7 +1001,7 @@ class BulkDeleteTestCase(TransactionTestCase):
             pk_list=statuses_to_delete,
             username=self.user.username,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         error_log = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertEqual(
             error_log.message, "You do not have permissions to delete some of the objects provided in `pk_list`."

--- a/nautobot/dcim/tests/test_jobs.py
+++ b/nautobot/dcim/tests/test_jobs.py
@@ -71,7 +71,7 @@ def create_common_data_for_software_related_test_cases():
 class TestSoftwareImageFileTestCase(TransactionTestCase):
     def test_correct_handling_for_model_protected_error(self):
         create_common_data_for_software_related_test_cases()
-        software_image_file = SoftwareImageFile.objects.first()
+        software_image_file = SoftwareImageFile.objects.get(image_file_name="software_image_file_qs_test_1.bin")
 
         self.add_permissions("dcim.delete_softwareimagefile")
         pk_list = [str(software_image_file.pk)]
@@ -86,9 +86,7 @@ class TestSoftwareImageFileTestCase(TransactionTestCase):
             pk_list=pk_list,
             username=self.user.username,
         )
-        logs = JobLogEntry.objects.filter(job_result=job_result)
-        print([(log.message, log.log_level) for log in logs])
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         error_log = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertIn("Caught ProtectedError while attempting to delete objects", error_log.message)
         self.assertEqual(initial_count, SoftwareImageFile.objects.all().count())
@@ -97,7 +95,7 @@ class TestSoftwareImageFileTestCase(TransactionTestCase):
 class TestSoftwareVersionTestCase(TransactionTestCase):
     def test_correct_handling_for_model_protected_error(self):
         create_common_data_for_software_related_test_cases()
-        software_version = SoftwareVersion.objects.first()
+        software_version = SoftwareVersion.objects.get(version="Test version 1.0.0")
 
         initial_count = SoftwareVersion.objects.all().count()
         self.add_permissions("dcim.delete_softwareversion")
@@ -112,7 +110,7 @@ class TestSoftwareVersionTestCase(TransactionTestCase):
             pk_list=pk_list,
             username=self.user.username,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         error_log = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertIn("Caught ProtectedError while attempting to delete objects", error_log.message)
         self.assertEqual(initial_count, SoftwareVersion.objects.all().count())

--- a/nautobot/docs/development/jobs/index.md
+++ b/nautobot/docs/development/jobs/index.md
@@ -687,7 +687,7 @@ Markdown rendering is supported for log messages, as well as [a limited subset o
     You can now use `self.logger.success()` to log a message at the level `SUCCESS`, which is located between the standard `INFO` and `WARNING` log levels.
 
 +++ 2.4.5 "`logger.failure()` added"
-    You can now use `self.logger.failure()` to log a message at the level `FAILURE`, which is located betwen the standard `WARNING` and `ERROR` log levels.
+    You can now use `self.logger.failure()` to log a message at the level `FAILURE`, which is located between the standard `WARNING` and `ERROR` log levels.
 
 ### File Output
 

--- a/nautobot/docs/development/jobs/index.md
+++ b/nautobot/docs/development/jobs/index.md
@@ -628,7 +628,7 @@ If both `before_start()` and `run()` are successful, the `on_success()` method w
 
 #### The `on_failure()` Method
 
-If either `before_start()` or `run()` raises any unhandled exception, or reports a failure overall through `fail()`, the `on_failure()` method will be called next, if implemented. It has the signature `on_failure(self, retval, task_id, args, kwargs, einfo)`; of these parameters, the `retval` will contain the exception that was raised (if any) or the return value from `before_start()` or `run()` (otherwise), and `kwargs` will contain the user-specified variables passed into the Job.
+If either `before_start()` or `run()` raises any unhandled exception, or reports a failure overall through `fail()`, the `on_failure()` method will be called next, if implemented. It has the signature `on_failure(self, exc, task_id, args, kwargs, einfo)`; of these parameters, the `exc` will contain the exception that was raised (if any) or the return value from `before_start()` or `run()` (otherwise), and `kwargs` will contain the user-specified variables passed into the Job.
 
 #### The `after_return()` Method
 
@@ -686,7 +686,7 @@ Markdown rendering is supported for log messages, as well as [a limited subset o
 +++ 2.4.0 "`logger.success()` added"
     You can now use `self.logger.success()` to log a message at the level `SUCCESS`, which is located between the standard `INFO` and `WARNING` log levels.
 
-+++ 2.4.4 "`logger.failure()` added"
++++ 2.4.5 "`logger.failure()` added"
     You can now use `self.logger.failure()` to log a message at the level `FAILURE`, which is located betwen the standard `WARNING` and `ERROR` log levels.
 
 ### File Output
@@ -712,7 +712,7 @@ The maximum size of any single created file (or in other words, the maximum numb
 
 Any uncaught exception raised from within the `run()` method will abort the `run()` method immediately (as usual in Python), and will result in the Job Result status being marked as `FAILURE`. The exception message and traceback will be recorded in the Job Result.
 
-Alternatively, in Nautobot v2.4.4 and later, you can more "cleanly" fail a Job by calling `self.fail(...)` and then either returning immediately from the `run()` method or continuing with the execution of the Job, as desired. In this case, after the `run()` method completes, the Job Result status will be automatically marked as `FAILURE` and no exception or traceback will be recorded.
+Alternatively, in Nautobot v2.4.5 and later, you can more "cleanly" fail a Job by calling `self.fail(...)` and then either returning immediately from the `run()` method or continuing with the execution of the Job, as desired. In this case, after the `run()` method completes, the Job Result status will be automatically marked as `FAILURE` and no exception or traceback will be recorded.
 
 As an example, the following Job will abort if the user does not put the word "Taco" in `occasion`, and fail (but not abort) if the variable does not additionally contain "Tuesday":
 

--- a/nautobot/docs/development/jobs/index.md
+++ b/nautobot/docs/development/jobs/index.md
@@ -152,6 +152,7 @@ As of Nautobot 2.4.0, the current list of reserved names (not including low-leve
 | `description_first_line`  | [metadata property](#description)                       |
 | `deserialize_data`        | internal class method                                   |
 | `dryrun_default`          | [metadata property](#dryrun_default)                    |
+| `fail`                    | [helper method](#marking-a-job-as-failed)               |
 | `file_path`               | deprecated class property                               |
 | `field_order`             | [metadata property](#field_order)                       |
 | `grouping`                | [module metadata property](#module-metadata-attributes) |
@@ -593,7 +594,7 @@ As Jobs are Python classes, you are of course free to define any number of other
 
 The `before_start()` method may optionally be implemented to perform any appropriate Job-specific setup before the `run()` method is called. It has the signature `before_start(self, task_id, args, kwargs)` for historical reasons; the `task_id` parameter will always be identical to `self.request.id`, the `args` parameter will generally be empty, and any user-specified variables passed into the Job execution will be present in the `kwargs` parameter.
 
-The return value from `before_start()` is ignored, but if it raises any exception, the Job execution will be marked as a failure and `run()` will not be called.
+The return value from `before_start()` is ignored, but if it raises any exception, the Job result status will be marked as `FAILURE` and `run()` will not be called.
 
 #### The `run()` Method
 
@@ -619,7 +620,7 @@ Again, defining user variables is totally optional; you may create a Job with a 
 !!! warning "Be cautious around bulk operations"
     The Django ORM provides methods to create/edit many objects at once, namely `bulk_create()` and `update()`. These are best avoided in most cases as they bypass a model's built-in validation and can easily lead to database corruption if not used carefully.
 
-If `run()` returns any value (even the implicit `None`), the Job execution will be marked as a success and the returned value will be stored in the associated JobResult database record. Conversely, if `run()` raises any exception, the Job execution will be marked as a failure and the traceback will be stored in the JobResult.
+If `run()` returns any value (even the implicit `None`), the returned value will be stored in the associated JobResult database record. (The Job Result will be marked as `SUCCESS` unless the `fail()` method was called at some point during `run()`, in which case it will be marked as `FAILURE`.) Conversely, if `run()` raises any exception, the Job execution will be marked as `FAILURE` and the traceback will be stored in the JobResult.
 
 #### The `on_success()` Method
 
@@ -627,11 +628,11 @@ If both `before_start()` and `run()` are successful, the `on_success()` method w
 
 #### The `on_failure()` Method
 
-If either `before_start()` or `run()` raises any unhandled exception, the `on_failure()` method will be called next, if implemented. It has the signature `on_failure(self, exc, task_id, args, kwargs, einfo)`; of these parameters, the `exc` will contain the exception that was raised, and `kwargs` will contain the user-specified variables passed into the Job.
+If either `before_start()` or `run()` raises any unhandled exception, or reports a failure overall through `fail()`, the `on_failure()` method will be called next, if implemented. It has the signature `on_failure(self, retval, task_id, args, kwargs, einfo)`; of these parameters, the `retval` will contain the exception that was raised (if any) or the return value from `before_start()` or `run()` (otherwise), and `kwargs` will contain the user-specified variables passed into the Job.
 
 #### The `after_return()` Method
 
-Regardless of the overall Job execution success or failure, the `after_return()` method will be called after `on_success()` or `on_failure()`. It has the signature `after_return(self, status, retval, task_id, args, kwargs, einfo)`; the `status` will indicate success or failure (using the `JobResultStatusChoices` enum), `retval` is *either* the return value from `run()` (on success) or the exception raised (on failure), and once again `kwargs` contains the user variables.
+Regardless of the overall Job execution success or failure, the `after_return()` method will be called after `on_success()` or `on_failure()`. It has the signature `after_return(self, status, retval, task_id, args, kwargs, einfo)`; the `status` will indicate success or failure (using the `JobResultStatusChoices` enum), `retval` is *either* the return value from `run()` or the exception raised, and once again `kwargs` contains the user variables.
 
 ### Logging
 
@@ -656,7 +657,7 @@ If a `grouping` is not provided it will default to the function name that logged
 
     class MyJob(Job):
         def run(self):
-            logger.info("This job is running!", extra={"grouping": "myjobisrunning", "object": self.job_result})
+            self.logger.info("This job is running!", extra={"grouping": "myjobisrunning", "object": self.job_result})
     ```
 
 To skip writing a log entry to the database, set the `skip_db_logging` key in the "extra" kwarg to `True` when calling the log function. The output will still be written to the console.
@@ -668,7 +669,7 @@ To skip writing a log entry to the database, set the `skip_db_logging` key in th
 
     class MyJob(Job):
         def run(self):
-            logger.info("This job is running!", extra={"skip_db_logging": True})
+            self.logger.info("This job is running!", extra={"skip_db_logging": True})
     ```
 
 Markdown rendering is supported for log messages, as well as [a limited subset of HTML](../../user-guide/platform-functionality/template-filters.md#render_markdown).
@@ -682,8 +683,11 @@ Markdown rendering is supported for log messages, as well as [a limited subset o
 +/- 2.0.0
     The `AbortTransaction` class was moved from the `nautobot.utilities.exceptions` module to `nautobot.core.exceptions`. Jobs should generally import it from `nautobot.apps.exceptions` if needed.
 
-+++ 2.4.0
-    You can now use `self.logger.success()` to set the log level to `SUCCESS`.
++++ 2.4.0 "`logger.success()` added"
+    You can now use `self.logger.success()` to log a message at the level `SUCCESS`, which is located between the standard `INFO` and `WARNING` log levels.
+
++++ 2.4.4 "`logger.failure()` added"
+    You can now use `self.logger.failure()` to log a message at the level `FAILURE`, which is located betwen the standard `WARNING` and `ERROR` log levels.
 
 ### File Output
 
@@ -706,20 +710,26 @@ The maximum size of any single created file (or in other words, the maximum numb
 
 ### Marking a Job as Failed
 
-To mark a Job as failed, raise an exception from within the `run()` method. The exception message will be logged to the traceback of the Job Result. The Job Result status will be set to `failed`. To output a Job log message you can use the `self.logger.error()` method.
+Any uncaught exception raised from within the `run()` method will abort the `run()` method immediately (as usual in Python), and will result in the Job Result status being marked as `FAILURE`. The exception message and traceback will be recorded in the Job Result.
 
-As an example, the following Job will fail if the user does not put the word "Taco" in `var1`:
+Alternatively, in Nautobot v2.4.4 and later, you can more "cleanly" fail a Job by calling `self.fail(...)` and then either returning immediately from the `run()` method or continuing with the execution of the Job, as desired. In this case, after the `run()` method completes, the Job Result status will be automatically marked as `FAILURE` and no exception or traceback will be recorded.
+
+As an example, the following Job will abort if the user does not put the word "Taco" in `occasion`, and fail (but not abort) if the variable does not additionally contain "Tuesday":
 
 ```python
 from nautobot.apps.jobs import Job, StringVar
 
 class MyJob(Job):
-    var1 = StringVar(...)
+    occasion = StringVar(...)
 
-    def run(self, var1):
-        if var1 != "Taco":
-            self.logger.error("var1 must be 'Taco'")
+    def run(self, occasion):
+        if not occasion.startswith("Taco"):
+            self.logger.failure("The occasion must begin with 'Taco'")
             raise Exception("Argument input validation failed.")
+        if not occasion.endswith(" Tuesday"):
+            self.fail("It's supposed to be Tuesday")
+        self.logger.info("Today is %s", occasion)
+        return occasion
 ```
 
 ### Accessing User and Job Result

--- a/nautobot/docs/release-notes/version-2.4.md
+++ b/nautobot/docs/release-notes/version-2.4.md
@@ -76,6 +76,21 @@ Jobs can now log `success` messages as a new logging level which will be appropr
 self.logger.success("All data is valid.")
 ```
 
++++ 2.4.4
+
+In Nautobot v2.4.4 and later, Jobs can now log `failure` messages as well:
+
+```python
+self.logger.failure("Something went wrong.")
+```
+
+In Nautobot v2.4.4 and later, Jobs can also mark their result as failed without raising an uncaught exception by calling the new `Job.fail(message)` API:
+
+```python
+self.fail("Something went wrong, and we'll fail in the end, but we can continue for now.")
+self.logger.info("Continuing...")
+```
+
 #### Kubernetes Job Execution and Job Queue Data Model (Experimental)
 
 *Please note that this functionality is considered Experimental in the v2.4.0 release and is subject to change in the future.*

--- a/nautobot/docs/release-notes/version-2.4.md
+++ b/nautobot/docs/release-notes/version-2.4.md
@@ -76,15 +76,15 @@ Jobs can now log `success` messages as a new logging level which will be appropr
 self.logger.success("All data is valid.")
 ```
 
-+++ 2.4.4
++++ 2.4.5
 
-In Nautobot v2.4.4 and later, Jobs can now log `failure` messages as well:
+In Nautobot v2.4.5 and later, Jobs can now log `failure` messages as well:
 
 ```python
 self.logger.failure("Something went wrong.")
 ```
 
-In Nautobot v2.4.4 and later, Jobs can also mark their result as failed without raising an uncaught exception by calling the new `Job.fail(message)` API:
+In Nautobot v2.4.5 and later, Jobs can also mark their result as failed without raising an uncaught exception by calling the new `Job.fail(message)` API:
 
 ```python
 self.fail("Something went wrong, and we'll fail in the end, but we can continue for now.")

--- a/nautobot/extras/choices.py
+++ b/nautobot/extras/choices.py
@@ -302,27 +302,30 @@ class JobResultStatusChoices(ChoiceSet):
 class LogLevelChoices(ChoiceSet):
     LOG_DEBUG = "debug"
     LOG_INFO = "info"
+    LOG_SUCCESS = "success"
     LOG_WARNING = "warning"
+    LOG_FAILURE = "failure"
     LOG_ERROR = "error"
     LOG_CRITICAL = "critical"
-    LOG_SUCCESS = "success"
 
     CHOICES = (
         (LOG_DEBUG, "Debug"),
         (LOG_INFO, "Info"),
+        (LOG_SUCCESS, "Success"),
         (LOG_WARNING, "Warning"),
+        (LOG_FAILURE, "Failure"),
         (LOG_ERROR, "Error"),
         (LOG_CRITICAL, "Critical"),
-        (LOG_SUCCESS, "Success"),
     )
 
     CSS_CLASSES = {
         LOG_DEBUG: "debug",
         LOG_INFO: "info",
+        LOG_SUCCESS: "success",
         LOG_WARNING: "warning",
+        LOG_FAILURE: "failure",
         LOG_ERROR: "error",
         LOG_CRITICAL: "critical",
-        LOG_SUCCESS: "success",
     }
 
 

--- a/nautobot/extras/choices.py
+++ b/nautobot/extras/choices.py
@@ -251,8 +251,10 @@ class JobResultStatusChoices(ChoiceSet):
     """
 
     STATUS_FAILURE = states.FAILURE
+    STATUS_IGNORED = states.IGNORED
     STATUS_PENDING = states.PENDING
     STATUS_RECEIVED = states.RECEIVED
+    STATUS_REJECTED = states.REJECTED
     STATUS_RETRY = states.RETRY
     STATUS_REVOKED = states.REVOKED
     STATUS_STARTED = states.STARTED

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -222,13 +222,13 @@ class BaseJob:
             (None): The return value of this handler is ignored.
         """
 
-    def on_failure(self, retval, task_id, args, kwargs, einfo):
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
         """Error handler.
 
         This is run by the worker when the task fails.
 
         Arguments:
-            retval (Any): Exception raised by the task **or** return value from the task, if it failed cleanly,
+            exc (Any): Exception raised by the task (if any) **or** return value from the task, if it failed cleanly,
                 such as if the Job called `self.fail()` rather than raising an exception.
             task_id (str): Unique id of the failed task.
             args (Tuple): Original arguments for the task that failed.

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -112,6 +112,27 @@ JOB_BUTTONS = """
 <a href="{% url 'extras:jobresult_list' %}?job_model={{ record.name | urlencode }}" class="btn btn-default btn-xs" title="Job Results"><i class="mdi mdi-format-list-bulleted" aria-hidden="true"></i></a>
 """
 
+JOB_RESULT_BUTTONS = """
+{% load helpers %}
+{% if perms.extras.run_job %}
+    {% if record.job_model and record.task_kwargs %}
+        <a href="{% url 'extras:job_run' pk=record.job_model.pk %}?kwargs_from_job_result={{ record.pk }}"
+           class="btn btn-xs btn-success" title="Re-run job with same arguments.">
+            <i class="mdi mdi-repeat"></i>
+        </a>
+    {% elif record.job_model is not None %}
+        <a href="{% url 'extras:job_run' pk=record.job_model.pk %}" class="btn btn-primary btn-xs"
+           title="Run job">
+            <i class="mdi mdi-play"></i>
+        </a>
+    {% else %}
+        <a href="#" class="btn btn-xs btn-default disabled" title="Job is not available, cannot be re-run">
+            <i class="mdi mdi-repeat-off"></i>
+        </a>
+    {% endif %}
+{% endif %}
+"""
+
 SCHEDULED_JOB_BUTTONS = """
 <a href="{% url 'extras:jobresult_list' %}?scheduled_job={{ record.name | urlencode }}" class="btn btn-default btn-xs" title="Job Results"><i class="mdi mdi-format-list-bulleted" aria-hidden="true"></i></a>
 """
@@ -877,30 +898,7 @@ class JobResultTable(BaseTable):
         linkify=True,
         verbose_name="Scheduled Job",
     )
-    actions = ButtonsColumn(
-        JobResult,
-        buttons=("delete",),
-        prepend_template="""
-            {% load helpers %}
-            {% if perms.extras.run_job %}
-                {% if record.job_model and record.task_kwargs %}
-                    <a href="{% url 'extras:job_run' pk=record.job_model.pk %}?kwargs_from_job_result={{ record.pk }}"
-                       class="btn btn-xs btn-success" title="Re-run job with same arguments.">
-                        <i class="mdi mdi-repeat"></i>
-                    </a>
-                {% elif record.job_model is not None %}
-                    <a href="{% url 'extras:job_run' pk=record.job_model.pk %}" class="btn btn-primary btn-xs"
-                       title="Run job">
-                        <i class="mdi mdi-play"></i>
-                    </a>
-                {% else %}
-                    <a href="#" class="btn btn-xs btn-default disabled" title="Job is not available, cannot be re-run">
-                        <i class="mdi mdi-repeat-off"></i>
-                    </a>
-                {% endif %}
-            {% endif %}
-        """,
-    )
+    actions = ButtonsColumn(JobResult, buttons=("delete",), prepend_template=JOB_RESULT_BUTTONS)
 
     def render_summary(self, record):
         """

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -675,7 +675,7 @@ def log_object_link(value, record):
 
 
 def log_entry_color_css(record):
-    if record.log_level.lower() in ("error", "critical"):
+    if record.log_level.lower() in ("failure", "error", "critical"):
         return "danger"
     return record.log_level.lower()
 
@@ -811,7 +811,7 @@ class JobLogEntryTable(BaseTable):
     def render_log_level(self, value):
         log_level = value.lower()
         # The css is label-danger for failure items.
-        if log_level in ["error", "critical"]:
+        if log_level in ["failure", "error", "critical"]:
             log_level = "danger"
         elif log_level == "debug":
             log_level = "default"
@@ -877,8 +877,10 @@ class JobResultTable(BaseTable):
         linkify=True,
         verbose_name="Scheduled Job",
     )
-    actions = tables.TemplateColumn(
-        template_code="""
+    actions = ButtonsColumn(
+        JobResult,
+        buttons=("delete",),
+        prepend_template="""
             {% load helpers %}
             {% if perms.extras.run_job %}
                 {% if record.job_model and record.task_kwargs %}
@@ -897,11 +899,7 @@ class JobResultTable(BaseTable):
                     </a>
                 {% endif %}
             {% endif %}
-            <a href="{% url 'extras:jobresult_delete' pk=record.pk %}" class="btn btn-xs btn-danger"
-               title="Delete this job result.">
-                <i class="mdi mdi-trash-can-outline"></i>
-            </a>
-        """
+        """,
     )
 
     def render_summary(self, record):
@@ -1094,7 +1092,7 @@ class ScheduledJobTable(BaseTable):
     last_run_at = tables.DateTimeColumn(verbose_name="Most Recent Run", format=settings.SHORT_DATETIME_FORMAT)
     crontab = tables.Column()
     total_run_count = tables.Column(verbose_name="Total Run Count")
-    actions = ButtonsColumn(ScheduledJob, buttons=("delete"), prepend_template=SCHEDULED_JOB_BUTTONS)
+    actions = ButtonsColumn(ScheduledJob, buttons=("delete",), prepend_template=SCHEDULED_JOB_BUTTONS)
 
     class Meta(BaseTable.Meta):
         model = ScheduledJob

--- a/nautobot/extras/test_jobs/atomic_transaction.py
+++ b/nautobot/extras/test_jobs/atomic_transaction.py
@@ -16,13 +16,13 @@ class TestAtomicDecorator(Job):
     Job that uses @transaction.atomic decorator to roll back changes.
     """
 
-    fail = BooleanVar()
+    should_fail = BooleanVar()
 
     @transaction.atomic
-    def run(self, fail=False):  # pylint:disable=arguments-differ
+    def run(self, should_fail=False):  # pylint:disable=arguments-differ
         try:
             Status.objects.create(name="Test database atomic rollback 1")
-            if fail:
+            if should_fail:
                 raise SimulatedError("simulated failure")
         except Exception:
             logger.error("Job failed, all database changes have been rolled back.")
@@ -35,13 +35,13 @@ class TestAtomicContextManager(Job):
     Job that uses `with transaction.atomic()` context manager to roll back changes.
     """
 
-    fail = BooleanVar()
+    should_fail = BooleanVar()
 
-    def run(self, fail=False):  # pylint:disable=arguments-differ
+    def run(self, should_fail=False):  # pylint:disable=arguments-differ
         try:
             with transaction.atomic():
                 Status.objects.create(name="Test database atomic rollback 2")
-                if fail:
+                if should_fail:
                     raise SimulatedError("simulated failure")
         except Exception as err:
             logger.error("Job failed, all database changes have been rolled back.")

--- a/nautobot/extras/test_jobs/fail.py
+++ b/nautobot/extras/test_jobs/fail.py
@@ -33,9 +33,9 @@ class TestFailJob(Job):
     def on_success(self, retval, task_id, args, kwargs):
         raise RuntimeError("on_success() was unexpectedly called!")
 
-    def on_failure(self, retval, task_id, args, kwargs, einfo):
-        if not isinstance(retval, RunJobTaskFailed):
-            raise RuntimeError(f"Expected retval to be a RunJobTaskFailed, but it was {retval!r}")
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        if not isinstance(exc, RunJobTaskFailed):
+            raise RuntimeError(f"Expected exc to be a RunJobTaskFailed, but it was {exc!r}")
         if task_id != self.request.id:
             raise RuntimeError(f"Expected task_id {task_id} to equal self.request.id {self.request.id}")
         if args:
@@ -115,9 +115,9 @@ class TestFailCleanly(TestFailJob):
         self.fail("Failure")
         return "We failed"
 
-    def on_failure(self, retval, task_id, args, kwargs, einfo):
-        if retval != "We failed":
-            raise RuntimeError(f"Expected retval to be the message returned from run(), but it was {retval!r}")
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        if exc != "We failed":
+            raise RuntimeError(f"Expected exc to be the message returned from run(), but it was {exc!r}")
         if task_id != self.request.id:  # pylint: disable=no-member
             raise RuntimeError(f"Expected task_id {task_id} to equal self.request.id {self.request.id}")  # pylint: disable=no-member
         if args:

--- a/nautobot/extras/test_jobs/pass.py
+++ b/nautobot/extras/test_jobs/pass.py
@@ -42,7 +42,7 @@ class TestPassJob(Job):
             raise RuntimeError(f"Expected kwargs to be empty, but it was {kwargs!r}")
         logger.info("on_success() was called as expected")
 
-    def on_failure(self, retval, task_id, args, kwargs, einfo):
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
         raise RuntimeError("on_failure() was unexpectedly called!")
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):

--- a/nautobot/extras/test_jobs/pass.py
+++ b/nautobot/extras/test_jobs/pass.py
@@ -42,7 +42,7 @@ class TestPassJob(Job):
             raise RuntimeError(f"Expected kwargs to be empty, but it was {kwargs!r}")
         logger.info("on_success() was called as expected")
 
-    def on_failure(self, exc, task_id, args, kwargs, einfo):
+    def on_failure(self, retval, task_id, args, kwargs, einfo):
         raise RuntimeError("on_failure() was unexpectedly called!")
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1917,7 +1917,7 @@ class JobTest(
         mock_get_worker_count.return_value = 1
         self.add_permissions("extras.run_job")
 
-        job_model = Job.objects.get(job_class_name="ExampleJob")
+        job_model = Job.objects.get(job_class_name="TestHasSensitiveVariables")
         job_model.enabled = True
         job_model.validated_save()
 

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -238,11 +238,7 @@ class GitTest(TransactionTestCase):
                     repository=self.repo.pk,
                 )
 
-                self.assertEqual(
-                    job_result.status,
-                    JobResultStatusChoices.STATUS_FAILURE,
-                    (job_result.result, list(job_result.job_log_entries.values_list("message", "log_object"))),
-                )
+                self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
                 self.repo.refresh_from_db()
 
                 log_entries = JobLogEntry.objects.filter(job_result=job_result)
@@ -308,11 +304,7 @@ class GitTest(TransactionTestCase):
                     repository=self.repo.pk,
                 )
 
-                self.assertEqual(
-                    job_result.status,
-                    JobResultStatusChoices.STATUS_SUCCESS,
-                    (job_result.traceback, list(job_result.job_log_entries.values_list("message", flat=True))),
-                )
+                self.assertJobResultStatus(job_result)
                 self.repo.refresh_from_db()
                 MockGitRepo.assert_called_with(
                     os.path.join(tempdir, self.repo.slug),
@@ -331,11 +323,7 @@ class GitTest(TransactionTestCase):
                 job_model = GitRepositorySync().job_model
                 job_result = run_job_for_testing(job=job_model, repository=self.repo.pk)
                 job_result.refresh_from_db()
-                self.assertEqual(
-                    job_result.status,
-                    JobResultStatusChoices.STATUS_SUCCESS,
-                    (job_result.traceback, list(job_result.job_log_entries.values_list("message", flat=True))),
-                )
+                self.assertJobResultStatus(job_result)
 
                 # Make sure explicit ConfigContext was successfully loaded from file
                 self.assert_explicit_config_context_exists("Frobozz 1000 NTP servers")
@@ -383,11 +371,7 @@ class GitTest(TransactionTestCase):
                 # Run the Git operation and refresh the object from the DB
                 job_result = run_job_for_testing(job=job_model, repository=self.repo.pk)
                 job_result.refresh_from_db()
-                self.assertEqual(
-                    job_result.status,
-                    JobResultStatusChoices.STATUS_SUCCESS,
-                    (job_result.traceback, list(job_result.job_log_entries.values_list("message", flat=True))),
-                )
+                self.assertJobResultStatus(job_result)
 
                 # Verify that objects have been removed from the database
                 self.assertEqual(
@@ -442,11 +426,7 @@ class GitTest(TransactionTestCase):
                 )
                 job_result.refresh_from_db()
 
-                self.assertEqual(
-                    job_result.status,
-                    JobResultStatusChoices.STATUS_FAILURE,
-                    job_result.result,
-                )
+                self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
 
                 # Due to transaction rollback on failure, the database should still/again match the pre-sync state, of
                 # no records owned by the repository.
@@ -547,11 +527,7 @@ class GitTest(TransactionTestCase):
                 )
                 job_result.refresh_from_db()
 
-                self.assertEqual(
-                    job_result.status,
-                    JobResultStatusChoices.STATUS_SUCCESS,
-                    (job_result.traceback, list(job_result.job_log_entries.values_list("message", flat=True))),
-                )
+                self.assertJobResultStatus(job_result)
 
                 # Make sure ConfigContext was successfully loaded from file
                 config_context = ConfigContext.objects.get(
@@ -591,15 +567,7 @@ class GitTest(TransactionTestCase):
                     delete_job_result = JobResult.objects.filter(name=repo_name).first()
                     # Make sure we didn't get the wrong JobResult
                     self.assertNotEqual(job_result, delete_job_result)
-                    self.assertEqual(
-                        delete_job_result.status,
-                        JobResultStatusChoices.STATUS_SUCCESS,
-                        (
-                            delete_job_result,
-                            delete_job_result.traceback,
-                            list(delete_job_result.job_log_entries.values_list("message", flat=True)),
-                        ),
-                    )
+                    self.assertJobResultStatus(delete_job_result)
 
                 with self.assertRaises(ConfigContext.DoesNotExist):
                     ConfigContext.objects.get(
@@ -637,11 +605,7 @@ class GitTest(TransactionTestCase):
                 job_model = GitRepositorySync().job_model
                 job_result = run_job_for_testing(job=job_model, repository=self.repo.pk)
                 job_result.refresh_from_db()
-                self.assertEqual(
-                    job_result.status,
-                    JobResultStatusChoices.STATUS_SUCCESS,
-                    (job_result.traceback, list(job_result.job_log_entries.values_list("message", flat=True))),
-                )
+                self.assertJobResultStatus(job_result)
 
                 self.assert_explicit_config_context_exists("Frobozz 1000 NTP servers")
                 self.assert_implicit_config_context_exists("Location context")
@@ -673,11 +637,7 @@ class GitTest(TransactionTestCase):
                 # Resync, attempting and failing to update to the new commit
                 job_result = run_job_for_testing(job=job_model, repository=self.repo.pk)
                 job_result.refresh_from_db()
-                self.assertEqual(
-                    job_result.status,
-                    JobResultStatusChoices.STATUS_FAILURE,
-                    job_result.result,
-                )
+                self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
                 log_entries = JobLogEntry.objects.filter(job_result=job_result)
 
                 # Assert database changes were rolled back
@@ -718,11 +678,7 @@ class GitTest(TransactionTestCase):
                 )
                 job_result.refresh_from_db()
 
-                self.assertEqual(
-                    job_result.status,
-                    JobResultStatusChoices.STATUS_SUCCESS,
-                    (job_result.traceback, list(job_result.job_log_entries.values_list("message", flat=True))),
-                )
+                self.assertJobResultStatus(job_result)
 
                 log_entries = JobLogEntry.objects.filter(job_result=job_result)
 

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -317,7 +317,7 @@ class JobTransactionTest(TransactionTestCase):
             pk_list=pk_list,
             username=self.user.username,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         error_log = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertIn(
             f"Unable to delete Job {system_job_queryset.first()}. System Job cannot be deleted", error_log.message
@@ -346,7 +346,7 @@ class JobTransactionTest(TransactionTestCase):
             },
             username=self.user.username,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertEqual(Job.objects.filter(description=job_description).count(), queryset.count())
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
@@ -389,7 +389,7 @@ class JobTransactionTest(TransactionTestCase):
             },
             username=self.user.username,
         )
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertEqual(Job.objects.filter(description=job_description).count(), queryset.count())
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
@@ -426,7 +426,7 @@ class JobTransactionTest(TransactionTestCase):
         module = "pass"
         name = "TestPassJob"
         job_result = create_job_result_and_run_job(module, name)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertEqual(job_result.result, True)
         logs = job_result.job_log_entries
         self.assertGreater(logs.count(), 0)
@@ -449,7 +449,7 @@ class JobTransactionTest(TransactionTestCase):
         name = "TestHasSensitiveVariables"
         # This function create_job_result_and_run_job and the subsequent functions' arguments are very messy
         job_result = create_job_result_and_run_job(module, name, "local", 1, 2, "3", kwarg_1=1, kwarg_2="2")
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertEqual(job_result.task_args, [])
         self.assertEqual(job_result.task_kwargs, {})
 
@@ -461,7 +461,7 @@ class JobTransactionTest(TransactionTestCase):
         for name in ["TestFailJob", "TestFailInBeforeStart", "TestFailCleanly", "TestFailCleanlyInBeforeStart"]:
             with self.subTest(job=name):
                 job_result = create_job_result_and_run_job(module, name)
-                self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+                self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
                 logs = job_result.job_log_entries
                 self.assertGreater(logs.count(), 0)
                 try:
@@ -483,7 +483,7 @@ class JobTransactionTest(TransactionTestCase):
         name = "TestFailWithSanitization"
         job_result = create_job_result_and_run_job(module, name)
         json_result = json.dumps(job_result.result)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         self.assertIn("(redacted)@github.com", json_result)
         self.assertNotIn("abc123@github.com", json_result)
         self.assertIn("(redacted)@github.com", job_result.traceback)
@@ -496,7 +496,7 @@ class JobTransactionTest(TransactionTestCase):
         module = "atomic_transaction"
         name = "TestAtomicDecorator"
         job_result = create_job_result_and_run_job(module, name)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         # Ensure DB transaction was not aborted
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job log messages were saved
@@ -514,7 +514,7 @@ class JobTransactionTest(TransactionTestCase):
         module = "atomic_transaction"
         name = "TestAtomicContextManager"
         job_result = create_job_result_and_run_job(module, name)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         # Ensure DB transaction was not aborted
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job log messages were saved
@@ -532,7 +532,7 @@ class JobTransactionTest(TransactionTestCase):
         module = "atomic_transaction"
         name = "TestAtomicDecorator"
         job_result = create_job_result_and_run_job(module, name, should_fail=True)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         # Ensure DB transaction was aborted
         self.assertFalse(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job log messages were saved
@@ -549,7 +549,7 @@ class JobTransactionTest(TransactionTestCase):
         module = "atomic_transaction"
         name = "TestAtomicContextManager"
         job_result = create_job_result_and_run_job(module, name, should_fail=True)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         # Ensure DB transaction was aborted
         self.assertFalse(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job log messages were saved
@@ -597,7 +597,7 @@ class JobTransactionTest(TransactionTestCase):
         job_result_data = json.loads(log_info.log_object) if log_info.log_object else None
 
         # Assert stuff
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertEqual(form_data, job_result_data)
 
     @override_settings(
@@ -652,7 +652,7 @@ class JobTransactionTest(TransactionTestCase):
         ).first()
 
         # Assert stuff
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertEqual(info_log.log_object, "")
         self.assertEqual(info_log.message, f"Role: {role.name}")
         self.assertEqual(job_result.result, "Nice Roles!")
@@ -671,7 +671,7 @@ class JobTransactionTest(TransactionTestCase):
         ).first()
 
         # Assert stuff
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         self.assertEqual(info_log.log_object, "")
         self.assertEqual(info_log.message, "The Location if any that the user provided.")
         self.assertEqual(job_result.result, "Nice Location (or not)!")
@@ -686,7 +686,7 @@ class JobTransactionTest(TransactionTestCase):
         job_result = create_job_result_and_run_job(module, name, **data)
 
         # Assert stuff
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         self.assertIn("location is a required field", job_result.traceback)
 
     def test_job_latest_result_property(self):
@@ -696,9 +696,9 @@ class JobTransactionTest(TransactionTestCase):
         module = "pass"
         name = "TestPassJob"
         job_result_1 = create_job_result_and_run_job(module, name)
-        self.assertEqual(job_result_1.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result_1, JobResultStatusChoices.STATUS_SUCCESS)
         job_result_2 = create_job_result_and_run_job(module, name)
-        self.assertEqual(job_result_2.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result_2, JobResultStatusChoices.STATUS_SUCCESS)
         _job_class, job_model = get_job_class_and_model(module, name)
         self.assertGreaterEqual(job_model.job_results.count(), 2)
         latest_job_result = job_model.latest_result
@@ -711,11 +711,7 @@ class JobTransactionTest(TransactionTestCase):
         # The job itself contains the 'assert' by loading the resulting profiling file from the workers filesystem
         job_result = create_job_result_and_run_job(module, name, profile=True)
 
-        self.assertEqual(
-            job_result.status,
-            JobResultStatusChoices.STATUS_SUCCESS,
-            msg="Profiling test job errored, this indicates that either no profiling file was created or it is malformed.",
-        )
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
 
         profiling_result = Path(f"{tempfile.gettempdir()}/nautobot-jobresult-{job_result.id}.pstats")
         self.assertTrue(profiling_result.exists())
@@ -773,7 +769,7 @@ class JobTransactionTest(TransactionTestCase):
         webhook.content_types.set([status_ct])
 
         job_result = create_job_result_and_run_job(module, name)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
 
         mock_enqueue_webhooks.assert_called_once()
 
@@ -876,7 +872,7 @@ class JobFileOutputTest(TransactionTestCase):
         data = {"lines": 3}
         job_result = create_job_result_and_run_job(module, name, **data)
 
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS, job_result.traceback)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
         # JobResult should have one attached file
         self.assertEqual(1, job_result.files.count())
         self.assertEqual(job_result.files.first().name, "output.txt")
@@ -907,7 +903,7 @@ class JobFileOutputTest(TransactionTestCase):
         # Exactly JOB_CREATE_FILE_MAX_SIZE bytes should be okay:
         with override_config(JOB_CREATE_FILE_MAX_SIZE=len("Hello world!\n")):
             job_result = create_job_result_and_run_job(module, name, **data)
-            self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS, job_result.traceback)
+            self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
             self.assertEqual(1, job_result.files.count())
             self.assertEqual(job_result.files.first().name, "output.txt")
             self.assertEqual(job_result.files.first().file.read().decode("utf-8"), "Hello World!\n")
@@ -915,7 +911,7 @@ class JobFileOutputTest(TransactionTestCase):
         # Even one byte over is too much:
         with override_config(JOB_CREATE_FILE_MAX_SIZE=len("Hello world!\n") - 1):
             job_result = create_job_result_and_run_job(module, name, **data)
-            self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+            self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
             self.assertIn("ValueError", job_result.traceback)
             self.assertEqual(0, job_result.files.count())
 
@@ -923,7 +919,7 @@ class JobFileOutputTest(TransactionTestCase):
         with override_config(JOB_CREATE_FILE_MAX_SIZE=10 << 20):
             with override_settings(JOB_CREATE_FILE_MAX_SIZE=len("Hello world!\n") - 1):
                 job_result = create_job_result_and_run_job(module, name, **data)
-                self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+                self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
                 self.assertIn("ValueError", job_result.traceback)
                 self.assertEqual(0, job_result.files.count())
 
@@ -1010,7 +1006,7 @@ class JobLocationCustomFieldTest(TransactionTestCase):
         job_result = create_job_result_and_run_job(module, name)
         job_result.refresh_from_db()
 
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
 
         # Test location with a value for custom_field
         location_1 = Location.objects.filter(name="Test Location One")
@@ -1088,7 +1084,7 @@ class JobButtonReceiverTransactionTest(TransactionTestCase):
         module = "job_button_receiver"
         name = "TestJobButtonReceiverFail"
         job_result = create_job_result_and_run_job(module, name, **self.data)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
 
 
 class JobHookReceiverTest(TestCase):
@@ -1160,7 +1156,7 @@ class JobHookReceiverTransactionTest(TransactionTestCase):
         module = "job_hook_receiver"
         name = "TestJobHookReceiverFail"
         job_result = create_job_result_and_run_job(module, name, **self.data)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
 
 
 class JobHookTest(TestCase):

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -346,7 +346,7 @@ class JobTransactionTest(TransactionTestCase):
             },
             username=self.user.username,
         )
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertEqual(Job.objects.filter(description=job_description).count(), queryset.count())
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
@@ -389,7 +389,7 @@ class JobTransactionTest(TransactionTestCase):
             },
             username=self.user.username,
         )
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertEqual(Job.objects.filter(description=job_description).count(), queryset.count())
         self.assertFalse(
             JobLogEntry.objects.filter(job_result=job_result, log_level=LogLevelChoices.LOG_WARNING).exists()
@@ -426,7 +426,7 @@ class JobTransactionTest(TransactionTestCase):
         module = "pass"
         name = "TestPassJob"
         job_result = create_job_result_and_run_job(module, name)
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertEqual(job_result.result, True)
         logs = job_result.job_log_entries
         self.assertGreater(logs.count(), 0)
@@ -449,7 +449,7 @@ class JobTransactionTest(TransactionTestCase):
         name = "TestHasSensitiveVariables"
         # This function create_job_result_and_run_job and the subsequent functions' arguments are very messy
         job_result = create_job_result_and_run_job(module, name, "local", 1, 2, "3", kwarg_1=1, kwarg_2="2")
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertEqual(job_result.task_args, [])
         self.assertEqual(job_result.task_kwargs, {})
 
@@ -496,7 +496,7 @@ class JobTransactionTest(TransactionTestCase):
         module = "atomic_transaction"
         name = "TestAtomicDecorator"
         job_result = create_job_result_and_run_job(module, name)
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         # Ensure DB transaction was not aborted
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job log messages were saved
@@ -514,7 +514,7 @@ class JobTransactionTest(TransactionTestCase):
         module = "atomic_transaction"
         name = "TestAtomicContextManager"
         job_result = create_job_result_and_run_job(module, name)
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         # Ensure DB transaction was not aborted
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job log messages were saved
@@ -597,7 +597,7 @@ class JobTransactionTest(TransactionTestCase):
         job_result_data = json.loads(log_info.log_object) if log_info.log_object else None
 
         # Assert stuff
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertEqual(form_data, job_result_data)
 
     @override_settings(
@@ -652,7 +652,7 @@ class JobTransactionTest(TransactionTestCase):
         ).first()
 
         # Assert stuff
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertEqual(info_log.log_object, "")
         self.assertEqual(info_log.message, f"Role: {role.name}")
         self.assertEqual(job_result.result, "Nice Roles!")
@@ -671,7 +671,7 @@ class JobTransactionTest(TransactionTestCase):
         ).first()
 
         # Assert stuff
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         self.assertEqual(info_log.log_object, "")
         self.assertEqual(info_log.message, "The Location if any that the user provided.")
         self.assertEqual(job_result.result, "Nice Location (or not)!")
@@ -696,9 +696,9 @@ class JobTransactionTest(TransactionTestCase):
         module = "pass"
         name = "TestPassJob"
         job_result_1 = create_job_result_and_run_job(module, name)
-        self.assertJobResultStatus(job_result_1, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result_1)
         job_result_2 = create_job_result_and_run_job(module, name)
-        self.assertJobResultStatus(job_result_2, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result_2)
         _job_class, job_model = get_job_class_and_model(module, name)
         self.assertGreaterEqual(job_model.job_results.count(), 2)
         latest_job_result = job_model.latest_result
@@ -711,7 +711,7 @@ class JobTransactionTest(TransactionTestCase):
         # The job itself contains the 'assert' by loading the resulting profiling file from the workers filesystem
         job_result = create_job_result_and_run_job(module, name, profile=True)
 
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
 
         profiling_result = Path(f"{tempfile.gettempdir()}/nautobot-jobresult-{job_result.id}.pstats")
         self.assertTrue(profiling_result.exists())
@@ -769,7 +769,7 @@ class JobTransactionTest(TransactionTestCase):
         webhook.content_types.set([status_ct])
 
         job_result = create_job_result_and_run_job(module, name)
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
 
         mock_enqueue_webhooks.assert_called_once()
 
@@ -872,7 +872,7 @@ class JobFileOutputTest(TransactionTestCase):
         data = {"lines": 3}
         job_result = create_job_result_and_run_job(module, name, **data)
 
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
         # JobResult should have one attached file
         self.assertEqual(1, job_result.files.count())
         self.assertEqual(job_result.files.first().name, "output.txt")
@@ -903,7 +903,7 @@ class JobFileOutputTest(TransactionTestCase):
         # Exactly JOB_CREATE_FILE_MAX_SIZE bytes should be okay:
         with override_config(JOB_CREATE_FILE_MAX_SIZE=len("Hello world!\n")):
             job_result = create_job_result_and_run_job(module, name, **data)
-            self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+            self.assertJobResultStatus(job_result)
             self.assertEqual(1, job_result.files.count())
             self.assertEqual(job_result.files.first().name, "output.txt")
             self.assertEqual(job_result.files.first().file.read().decode("utf-8"), "Hello World!\n")
@@ -1006,7 +1006,7 @@ class JobLocationCustomFieldTest(TransactionTestCase):
         job_result = create_job_result_and_run_job(module, name)
         job_result.refresh_from_db()
 
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
 
         # Test location with a value for custom_field
         location_1 = Location.objects.filter(name="Test Location One")

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -1367,7 +1367,7 @@ class JobModelTest(ModelTestCases.BaseModelTestCase):
     def setUpTestData(cls):
         # JobModel instances are automatically instantiated at startup, so we just need to look them up.
         cls.local_job = JobModel.objects.get(job_class_name="TestPassJob")
-        cls.job_containing_sensitive_variables = JobModel.objects.get(job_class_name="ExampleLoggingJob")
+        cls.job_containing_sensitive_variables = JobModel.objects.get(job_class_name="TestHasSensitiveVariables")
         cls.app_job = JobModel.objects.get(job_class_name="ExampleJob")
 
     def test_job_class(self):

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -1813,7 +1813,7 @@ class RelationshipJobTestCase(RequiredRelationshipTestMixin, TransactionTestCase
 
         # Try editing 6 VLANs and adding the required device (succeeds):
         job_result = self.create_job(pk_list, add_cr_vlans_devices_m2m__source=[str(device_for_association.id)])
-        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result)
 
         # Try editing 6 VLANs and removing the required device (fails):
         job_result = self.create_job(pk_list, remove_cr_vlans_devices_m2m__source=[str(device_for_association.id)])

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -1784,7 +1784,7 @@ class RelationshipJobTestCase(RequiredRelationshipTestMixin, TransactionTestCase
 
         pk_list = [str(vlan.id) for vlan in vlans]
         job_result = self.create_job(pk_list)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         error_log = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertIn("VLANs require at least one device, but no devices exist yet.", error_log.message)
 
@@ -1793,7 +1793,7 @@ class RelationshipJobTestCase(RequiredRelationshipTestMixin, TransactionTestCase
 
         # Try editing all 6 VLANs without adding the required device(fails):
         job_result = self.create_job(pk_list)
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         error_log = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertIn(
             '6 VLANs require a device for the required relationship \\"VLANs require at least one Device',
@@ -1802,7 +1802,7 @@ class RelationshipJobTestCase(RequiredRelationshipTestMixin, TransactionTestCase
 
         # Try editing 3 VLANs without adding the required device(fails):
         job_result = self.create_job(pk_list[:3])
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         error_log = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertIn(
             'These VLANs require a device for the required relationship \\"VLANs require at least one Device',
@@ -1813,11 +1813,11 @@ class RelationshipJobTestCase(RequiredRelationshipTestMixin, TransactionTestCase
 
         # Try editing 6 VLANs and adding the required device (succeeds):
         job_result = self.create_job(pk_list, add_cr_vlans_devices_m2m__source=[str(device_for_association.id)])
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_SUCCESS)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_SUCCESS)
 
         # Try editing 6 VLANs and removing the required device (fails):
         job_result = self.create_job(pk_list, remove_cr_vlans_devices_m2m__source=[str(device_for_association.id)])
-        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertJobResultStatus(job_result, JobResultStatusChoices.STATUS_FAILURE)
         error_log = JobLogEntry.objects.get(job_result=job_result, log_level=LogLevelChoices.LOG_ERROR)
         self.assertIn(
             '6 VLANs require a device for the required relationship \\"VLANs require at least one Device',

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2062,7 +2062,13 @@ def get_annotated_jobresult_queryset():
             error_log_count=count_related(
                 JobLogEntry,
                 "job_result",
-                filter_dict={"log_level__in": [LogLevelChoices.LOG_ERROR, LogLevelChoices.LOG_CRITICAL]},
+                filter_dict={
+                    "log_level__in": [
+                        LogLevelChoices.LOG_FAILURE,
+                        LogLevelChoices.LOG_ERROR,
+                        LogLevelChoices.LOG_CRITICAL,
+                    ],
+                },
             ),
         )
     )


### PR DESCRIPTION
# Closes #6384 
# What's Changed

- Add `Job.logger.failure()` support and corresponding `FAILURE` log level - similar to what was done in #6541.
   - Enhanced JobResult table, view, and JobLogEntry table to handle the new log level appropriately.
- Add `Job.fail(message)` API.
   - This allows a Job author to mark the job as failed without raising an uncaught exception and Celery reporting and recording a traceback.
   - This API does not itself automatically abort the Job execution in progress, but that can be done trivially if desired (e.g. `self.fail("an error occurred"); return None`) or the execution can continue normally if preferred with only a final terminal failure being reported.
- Update Job development docs
- Add example Job to the example App that demonstrates the two different ways of failing a Job (exception vs self.fail()) and their impacts.

Additionally:

- Add `init: true` to the development `docker-compose.yml` to address an issue I was encountering locally where timed-out healthchecks on a busy system were accumulating endlessly as zombie processes instead of being cleanly reaped.
- Moved code **out** of the default `Job.before_start()` and `Job.after_return()` method implementations to private functions, eliminating a "foot-gun" where a Job author might override these methods but forget to call `super()` (which we did **not** document as a requirement anywhere)

# Screenshots

![image](https://github.com/user-attachments/assets/3a029550-0217-4983-bd08-aaaddf095a79)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
