### PR TITLE
Add user object access to custom validators

### DIFF
--- a/changes/6966.added
+++ b/changes/6966.added
@@ -1,0 +1,1 @@
+Added support for accessing the current user within Custom Validators via `self.context["user"]`.

--- a/nautobot/docs/development/apps/api/platform-features/custom-validators.md
+++ b/nautobot/docs/development/apps/api/platform-features/custom-validators.md
@@ -33,11 +33,11 @@ custom_validators = [LocationValidator]
 
 +++ 2.4.4
 
-Custom validators have access to the current user via `self.context['user']` whenever the custom validator is invoked within a web request context. This is true for any Web UI, REST API request, Job execution, and anytime the `web_request_context` context manager is used in `nbshell` or a out of band script. In the event a custom validator is run outside of a web request context, `self.context['user']` will be populated with an instance of `AnonymousUser` from `django.contrib.auth`. This allows a custom validator author to write code this is durable to cases where a real user is not available.
+Custom validators have access to the current user via `self.context['user']` whenever the custom validator is invoked within a web request context. This is true for any Web UI, REST API request, Job execution, and anytime the `web_request_context` context manager is used in `nbshell` or a out of band script. In the event a custom validator is run outside of a web request context, `self.context['user']` will be populated with an instance of `AnonymousUser` from `django.contrib.auth`. This allows a custom validator author to write code that is durable to cases where a real user is not available.
 
 With the user object, you can inspect the groups and permissions that the user has, allowing more granular access related validation.
 
-This example shows a custom validator that only allows users in the group ___ to change the tenant of a location:
+This example shows a custom validator that only allows users in the group "Tenant Managers" to change the tenant of a location:
 
 ```python
 # custom_validators.py

--- a/nautobot/docs/development/apps/api/platform-features/custom-validators.md
+++ b/nautobot/docs/development/apps/api/platform-features/custom-validators.md
@@ -4,7 +4,7 @@ Apps can register custom validator classes which implement model validation logi
 
 App authors must raise `django.core.exceptions.ValidationError` within the `clean()` method to trigger validation error messages which are propagated to the user and prevent saving of the model instance. A convenience method `validation_error()` may be used to simplify this process. Raising a `ValidationError` is no different than vanilla Django, and the convenience method will simply pass the provided message through to the exception.
 
-When a CustomValidator is instantiated, the model instance is assigned to context dictionary using the `object` key, much like TemplateExtension. E.g. `self.context['object']`.
+When a CustomValidator is instantiated, the model instance is assigned to context dictionary using the `object` key, much like TemplateExtension. E.g. `self.context['object']`. The context is also populated with the current request user object. E.g. `self.context['user']`.
 
 Declared subclasses should be gathered into a list or tuple for integration with Nautobot. By default, Nautobot looks for an iterable named `custom_validators` within a `custom_validators.py` file. (This can be overridden by setting `custom_validators` to a custom value on the app's `NautobotAppConfig`.) An example is below.
 
@@ -27,4 +27,46 @@ class LocationValidator(CustomValidator):
 
 
 custom_validators = [LocationValidator]
+```
+
+## User Context
+
++++ 2.4.4
+
+Custom validators have access to the current user via `self.context['user']` whenever the custom validator is invoked within a web request context. This is true for any Web UI, REST API request, Job execution, and anytime the `web_request_context` context manager is used in `nbshell` or a out of band script. In the event a custom validator is run outside of a web request context, `self.context['user']` will be populated with an instance of `AnonymousUser` from `django.contrib.auth`. This allows a custom validator author to write code this is durable to cases where a real user is not available.
+
+With the user object, you can inspect the groups and permissions that the user has, allowing more granular access related validation.
+
+This example shows a custom validator that only allows users in the group ___ to change the tenant of a location:
+
+```python
+# custom_validators.py
+from nautobot.apps.models import CustomValidator
+
+
+class LocationTenantValidator(CustomValidator):
+    """Custom validator for Locations to enforce that only some users can update the Tenant."""
+
+    model = 'dcim.location'
+
+    def clean(self):
+        new_object_state = self.context["object"]
+        if not new_object_state.present_in_database:
+            # This is a brand new Location, so skip the rest of the checks here
+            return
+
+        # Get a copy of the object as it currently exists in the database
+        current_object_state = new_object_state._meta.model.objects.get(id=new_object_state.id)
+
+        # Compare the tenant values between the two states
+        if new_object_state.tenant != current_object_state.tenant:
+
+            # Check if the user has permission to change the tenant, via being a member of "Tenant Managers"
+            if not self.context["user"].groups.filter(name="Tenant Managers").exists():
+                self.validation_error({
+                    "tenant": "You do not have permission to change the tenant"
+                })
+
+
+custom_validators = [LocationTenantValidator]
 ```

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -727,6 +727,7 @@ def register_plugin_menu_items(section_name, menu_items):
 # Model Validators
 #
 
+
 class CustomValidatorContext(dict):
     def __init__(self, obj):
         """
@@ -739,6 +740,7 @@ class CustomValidatorContext(dict):
         cause such validation logic to fail closed.
         """
         from django.contrib.auth.models import AnonymousUser
+
         from nautobot.extras.signals import change_context_state
 
         change_context = change_context_state.get()

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -3,7 +3,6 @@ from functools import partial
 from importlib import import_module
 import inspect
 from logging import getLogger
-from re import A
 
 from django.conf import settings
 from django.core.exceptions import ValidationError

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -744,9 +744,10 @@ class CustomValidatorContext(dict):
         from nautobot.extras.signals import change_context_state
 
         change_context = change_context_state.get()
+        user = None
         if change_context:
             user = change_context.get_user()
-        else:
+        if user is None:
             user = AnonymousUser()
 
         super().__init__(object=obj, user=user)

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -3,6 +3,7 @@ from functools import partial
 from importlib import import_module
 import inspect
 from logging import getLogger
+from re import A
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -727,6 +728,28 @@ def register_plugin_menu_items(section_name, menu_items):
 # Model Validators
 #
 
+class CustomValidatorContext(dict):
+    def __init__(self, obj):
+        """
+        If there is an active change context, meaning we are in a web request context,
+        we have access to the current user object. Otherwise, we are likely running inside
+        a management command or other non-web or non-Job context, and we should use an AnonymousUser.
+        This ensures people's custom validators don't outright break when running in non-web
+        contexts, and should generally provide a sane default, given validation based on the
+        user is commonly going to be least-privelege based, and thus the AnonymousUser will
+        cause such validation logic to fail closed.
+        """
+        from django.contrib.auth.models import AnonymousUser
+        from nautobot.extras.signals import change_context_state
+
+        change_context = change_context_state.get()
+        if change_context:
+            user = change_context.get_user()
+        else:
+            user = AnonymousUser()
+
+        super().__init__(object=obj, user=user)
+
 
 class CustomValidator:
     """
@@ -742,7 +765,7 @@ class CustomValidator:
     model = None
 
     def __init__(self, obj):
-        self.context = {"object": obj}
+        self.context = CustomValidatorContext(obj)
 
     def validation_error(self, message):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

This adds support for accessing the current user object via `self.context["user"]` from a custom validator, in most situations (when inside of a `web_request_context` (yes this includes Jobs). Otherwise, an `AnonymousUser` is returned so developers can rely on a sane default user that does not have any permissions.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
