### PR TITLE
6906 Fix clone to directory to use

### DIFF
--- a/changes/6906.fixed
+++ b/changes/6906.fixed
@@ -1,0 +1,1 @@
+`GitRepository.clone_to_directory` now uses configured Secrets for Repository to prepare correct `from_url`.

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -220,6 +220,8 @@ class GitRepository(PrimaryModel):
         Returns:
             Returns the absolute path of the cloned repo if clone was successful, otherwise returns None.
         """
+        from nautobot.extras.datasources import get_repo_access_url
+
         if branch and head:
             raise ValueError("Cannot specify both branch and head")
 
@@ -233,7 +235,8 @@ class GitRepository(PrimaryModel):
             branch = self.branch
 
         try:
-            repo_helper = GitRepo(path_name, self.remote_url, depth=depth, branch=branch)
+            remote_url = get_repo_access_url(self)
+            repo_helper = GitRepo(path_name, remote_url, depth=depth, branch=branch)
             if head:
                 repo_helper.checkout(branch, head)
         except Exception as e:


### PR DESCRIPTION
# Closes #6906 
# What's Changed

`GitRepository.clone_to_directory` now uses the `get_repo_access_url` to ensure that repository `SecretsGroup` will be properly applied to the `remote_url` during the clone process.

Tested by using `GitRepository.objects.first().clone_to_directory()` in `nautobot-server shell` console.

# Screenshots

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
