### PR TITLE
Lock GHA actions to hashes, add enforcement

### DIFF
--- a/.github/actions/build-nautobot-image/action.yaml
+++ b/.github/actions/build-nautobot-image/action.yaml
@@ -57,7 +57,7 @@ runs:
   steps:
     - name: "Setup Metadata"
       id: "metadata"
-      uses: "docker/metadata-action@v4"
+      uses: "docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175" # v4
       with:
         images: "${{ inputs.image }}"
         flavor: |
@@ -72,7 +72,7 @@ runs:
     - name: "Build Dev"
       env:
         INVOKE_NAUTOBOT_PYTHON_VER: "${{ inputs.python-version }}"
-      uses: "docker/build-push-action@v4"
+      uses: "docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9" # v4
       with:
         push: "${{ inputs.push }}"
         target: "${{ inputs.target }}"

--- a/.github/actions/security-checks/action.yaml
+++ b/.github/actions/security-checks/action.yaml
@@ -1,0 +1,13 @@
+---
+name: "Security Checks"
+description: "Custom action to stack repo security checks"
+runs:
+  using: "composite"
+  steps:
+    - name: "Ensure using Github actions pinned to a hash"
+      uses: "zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633" # v3
+      with:
+        allowlist: |
+          actions/
+          networktocode/
+          nautobot/

--- a/.github/workflows/build_dependency_image.yml
+++ b/.github/workflows/build_dependency_image.yml
@@ -20,22 +20,24 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Security checks"
+        uses: "./.github/actions/security-checks"
       - name: "Get Git Branch/Tag Name" # For tagging dependencies image, supports branch or tag reference
         run: echo "branch=$(echo $GITHUB_REF | awk -F '/' '{print $NF}')" >> $GITHUB_OUTPUT
         id: "gitbranch"
       - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@v1"
+        uses: "docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480" # v1
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@v1"
+        uses: "docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9" # v1
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Docker Dependencies Metadata"
         id: "dockerdepmeta"
-        uses: "docker/metadata-action@v3"
+        uses: "docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242" # v3
         with:
           images: "ghcr.io/nautobot/nautobot-dependencies"
           flavor: |
@@ -45,7 +47,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=Nautobot Dependencies Base Image
       - name: "Build Dependencies Containers"
-        uses: "docker/build-push-action@v2"
+        uses: "docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a" # v2
         with:
           push: true
           target: dependencies

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -11,6 +11,14 @@ on:  # yamllint disable
   workflow_dispatch:
 
 jobs:
+  security-tooling:
+    name: "Security Tooling"
+    runs-on: "ubuntu-22.04"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Security checks"
+        uses: "./.github/actions/security-checks"
   check-schema:
     name: "Run REST API schema checks"
     runs-on: "ubuntu-24.04"
@@ -65,6 +73,8 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Security checks"
+        uses: "./.github/actions/security-checks"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
@@ -249,11 +259,11 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@v2"
+        uses: "docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7" # v2
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@v2"
+        uses: "docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55" # v2
       - name: "Login to GitHub Container Registry"
-        uses: "docker/login-action@v2"
+        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
         with:
           registry: "ghcr.io"
           username: "${{ github.actor }}"

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -17,6 +17,8 @@ jobs:
         uses: "actions/checkout@v4"
       - name: "Security checks"
         uses: "./.github/actions/security-checks"
+      - name: "Testing expansion"
+        run: "echo '${{ github.ref }}'"
   ruff:
     runs-on: "ubuntu-24.04"
     env:

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -9,6 +9,14 @@ on:  # yamllint disable
   workflow_call:
 
 jobs:
+  security-tooling:
+    name: "Security Tooling"
+    runs-on: "ubuntu-22.04"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Security checks"
+        uses: "./.github/actions/security-checks"
   ruff:
     runs-on: "ubuntu-24.04"
     env:
@@ -62,7 +70,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Run Hadolint"
-        uses: "hadolint/hadolint-action@v1.6.0"
+        uses: "hadolint/hadolint-action@d7b38582334d9ac11c12021c16f21d63015fa250" # v1.6.0
         with:
           dockerfile: "docker/Dockerfile"
   check-migrations:
@@ -388,11 +396,11 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@v2"
+        uses: "docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7" # v2
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@v2"
+        uses: "docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55" # v2
       - name: "Login to GitHub Container Registry"
-        uses: "docker/login-action@v2"
+        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
         with:
           registry: "ghcr.io"
           username: "${{ github.actor }}"

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -9,7 +9,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@f1a42f0f44eb83361d617a014663e1a76cf282d2 # v2
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: '90'

--- a/.github/workflows/plugin_upstream_testing_base.yml
+++ b/.github/workflows/plugin_upstream_testing_base.yml
@@ -27,6 +27,8 @@ jobs:
         uses: "actions/checkout@v4"
         with:
           ref: "${{ matrix.nautobot-version == 'develop' && 'develop' || matrix.nautobot-version == 'ltm-1.6' && 'ltm-1.6' || env.GITHUB_REF_NAME || 'develop' }}"
+      - name: "Security checks"
+        uses: "./.github/actions/security-checks"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
@@ -38,9 +40,9 @@ jobs:
         run: "poetry add --lock git+https://github.com/nautobot/nautobot.git#${{ matrix.nautobot-version }} --python ${{ env.PYTHON_VERSION }}"
       - name: "Set up Docker Buildx"
         id: "buildx"
-        uses: "docker/setup-buildx-action@v1"
+        uses: "docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9" # v1
       - name: "Build"
-        uses: "docker/build-push-action@v2"
+        uses: "docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a" # v2
         with:
           builder: "${{ steps.buildx.outputs.name }}"
           context: "./"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Security checks"
+        uses: "./.github/actions/security-checks"
       - name: "Set up Python"
         uses: "actions/setup-python@v2"
         with:
@@ -33,7 +35,7 @@ jobs:
       - name: "Run Poetry Build"
         run: "poetry build"
       - name: "Upload binaries to release"
-        uses: "svenstaro/upload-release-action@v2"
+        uses: "svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd" # v2
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           file: "dist/*"
@@ -41,7 +43,7 @@ jobs:
           overwrite: true
           file_glob: true
       - name: "Push to PyPI"
-        uses: "pypa/gh-action-pypi-publish@release/v1"
+        uses: "pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc" # release/v1
         with:
           user: "__token__"
           password: "${{ secrets.PYPI_API_TOKEN }}"
@@ -63,23 +65,23 @@ jobs:
       - run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: "gitbranch"
       - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@v1"
+        uses: "docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480" # v1
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@v1"
+        uses: "docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9" # v1
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: "Docker Metadata"
         id: "dockermeta"
-        uses: "docker/metadata-action@v3"
+        uses: "docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242" # v3
         with:
           images: "networktocode/nautobot,ghcr.io/nautobot/nautobot"
           flavor: |
@@ -90,7 +92,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=Nautobot
       - name: "Build"
-        uses: "docker/build-push-action@v2"
+        uses: "docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a" # v2
         with:
           push: true
           target: final
@@ -106,7 +108,7 @@ jobs:
             POETRY_INSTALLER_PARALLEL=false
       - name: "Docker Dev Metadata"
         id: "dockerdevmeta"
-        uses: "docker/metadata-action@v3"
+        uses: "docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242" # v3
         with:
           images: "networktocode/nautobot-dev,ghcr.io/nautobot/nautobot-dev"
           flavor: |
@@ -117,7 +119,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=Nautobot
       - name: "Build Dev Containers"
-        uses: "docker/build-push-action@v2"
+        uses: "docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a" # v2
         with:
           push: true
           target: final-dev
@@ -149,7 +151,7 @@ jobs:
         # ENVs cannot be used directly in job.if. This is a workaround to check
         # if SLACK_WEBHOOK_URL is present.
         if: "${{ env.SLACK_WEBHOOK_URL != '' }}"
-        uses: "slackapi/slack-github-action@v1.17.0"
+        uses: "slackapi/slack-github-action@8157a0f4d70c5099e42dcff1258b19bdaabb030b" # v1.17.0
         with:
           payload: |
             {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Security checks"
+        uses: "./.github/actions/security-checks"
       - name: "Set up Python"
         uses: "actions/setup-python@v2"
         with:
@@ -33,7 +35,7 @@ jobs:
       - name: "Run Poetry Build"
         run: "poetry build"
       - name: "Upload binaries to release"
-        uses: "svenstaro/upload-release-action@v2"
+        uses: "svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd" # v2
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           file: "dist/*"
@@ -41,7 +43,7 @@ jobs:
           overwrite: true
           file_glob: true
       - name: "Push to PyPI"
-        uses: "pypa/gh-action-pypi-publish@release/v1"
+        uses: "pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc" # release/v1
         with:
           user: "__token__"
           password: "${{ secrets.PYPI_API_TOKEN }}"
@@ -63,23 +65,23 @@ jobs:
       - run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: "gitbranch"
       - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@v2"
+        uses: "docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7" # v2
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@v2"
+        uses: "docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55" # v2
       - name: "Login to GitHub Container Registry"
-        uses: "docker/login-action@v2"
+        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
         with:
           registry: "ghcr.io"
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
       - name: "Login to Docker"
-        uses: "docker/login-action@v2"
+        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
         with:
           username: "${{ secrets.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_TOKEN }}"
       - name: "Docker Metadata"
         id: "dockermeta"
-        uses: "docker/metadata-action@v4"
+        uses: "docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175" # v4
         with:
           images: "networktocode/nautobot,ghcr.io/nautobot/nautobot"
           flavor: |
@@ -95,7 +97,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=Nautobot
       - name: "Build"
-        uses: "docker/build-push-action@v4"
+        uses: "docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9" # v4
         with:
           push: true
           target: final
@@ -111,7 +113,7 @@ jobs:
             POETRY_INSTALLER_PARALLEL=false
       - name: "Docker Dev Metadata"
         id: "dockerdevmeta"
-        uses: "docker/metadata-action@v4"
+        uses: "docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175" # v4
         with:
           images: "networktocode/nautobot-dev,ghcr.io/nautobot/nautobot-dev"
           flavor: |
@@ -127,7 +129,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=Nautobot
       - name: "Build Dev Containers"
-        uses: "docker/build-push-action@v4"
+        uses: "docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9" # v4
         with:
           push: true
           target: final-dev
@@ -159,7 +161,7 @@ jobs:
         # ENVs cannot be used directly in job.if. This is a workaround to check
         # if SLACK_WEBHOOK_URL is present.
         if: "${{ env.SLACK_WEBHOOK_URL != '' }}"
-        uses: "slackapi/slack-github-action@v1.17.0"
+        uses: "slackapi/slack-github-action@8157a0f4d70c5099e42dcff1258b19bdaabb030b" # v1.17.0
         with:
           payload: |
             {

--- a/changes/7036.housekeeping
+++ b/changes/7036.housekeeping
@@ -1,0 +1,1 @@
+Adds github action linter to CI.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

In [response to recent security news](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) in the Github Actions ecosystem. This PR takes some precautionary measures to try and  protect nautobot runner environments.

Particularly I've:

* Converted all Github actions to use actions from tags --> hashes on repositories we don't "trust". Open to debate on which repos we trust but first pass I assumed github `actions/*` and anything nautobot adjacent.
* Added a `security-checks` action to the repo, and added a job in most of the files to run this action. This in particular added `zgosalvez/github-actions-ensure-sha-pinned` which will throw build errors if we are using github actions without a hash. This serves as a linter in the future to try to and prevent tags getting reintroduced inadvertently. It looks like it scans all the github actions in the repo based on the output.

# Motivation

The recent issue with [tj-actions/changed-files](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) shows that using tags in github actions is a recipe for a security incident - particularly on repos we don't have a lot of trust with. Note that I also took this guidance directly from the [Github action hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions):

> Pin actions to a tag only if you trust the creator
> Although pinning to a commit SHA is the most secure option, specifying a tag is more convenient and is widely used. If you’d like to specify a tag, then be sure that you trust the action's creators. The ‘Verified creator’ badge on GitHub Marketplace is a useful signal, as it indicates that the action was written by a team whose identity has been verified by GitHub. Note that there is risk to this approach even if you trust the author, because a tag can be moved or deleted if a bad actor gains access to the repository storing the action.

and

> You can help mitigate this risk by following these good practices:

> Pin actions to a full length commit SHA

> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. When selecting a SHA, you should verify it is from the action's repository and not a repository fork.

# Screenshots

This is an example of what `zgosalvez/github-actions-ensure-sha-pinned-actions` looks like if it fails in CI:

![image](https://github.com/user-attachments/assets/f2b50d02-01e3-4a3f-b6ca-5781610df9b7)


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Confirm whether this wacky named branch causes other security concerns.