### PR TITLE
config setting to disable summary field in jobresult list view

### DIFF
--- a/changes/7185.added
+++ b/changes/7185.added
@@ -1,0 +1,1 @@
+Added constance config setting to disable the `summary` field in the `JobResultTable` for performance issues

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -128,6 +128,14 @@ INSTALLATION_METRICS_ENABLED = is_truthy(os.getenv("NAUTOBOT_INSTALLATION_METRIC
 if "NAUTOBOT_JOB_CREATE_FILE_MAX_SIZE" in os.environ and os.environ["NAUTOBOT_JOB_CREATE_FILE_MAX_SIZE"] != "":
     JOB_CREATE_FILE_MAX_SIZE = int(os.environ["NAUTOBOT_JOB_CREATE_FILE_MAX_SIZE"])
 
+# Display summary field in JobResult objects in list view? Default is True, but needs to be configurable for performance
+# purposes if there are a lot of JobResult objects with large numbers of log messages.
+if (
+    "NAUTOBOT_JOB_RESULTS_SUMMARY_FIELD_ENABLED" in os.environ
+    and os.environ["NAUTOBOT_JOB_RESULTS_SUMMARY_FIELD_ENABLED"] != ""
+):
+    JOB_RESULTS_SUMMARY_FIELD_ENABLED = is_truthy(os.environ["NAUTOBOT_JOB_RESULTS_SUMMARY_FIELD_ENABLED"])
+
 # The storage backend to use for Job input files and Job output files
 JOB_FILE_IO_STORAGE = os.getenv("NAUTOBOT_JOB_FILE_IO_STORAGE", "db_file_storage.storage.DatabaseFileStorage")
 
@@ -770,6 +778,12 @@ CONSTANCE_CONFIG = {
         ),
         field_type=int,
     ),
+    "JOB_RESULTS_SUMMARY_FIELD_ENABLED": ConstanceConfigItem(
+        default=True,
+        help_text="Enable the 'Summary' column in Job Result list view.\n"
+        "This can be disabled if performance issues are encountered due to job results with large numbers of log messages.",
+        field_type=bool,
+    ),
     "LOCATION_NAME_AS_NATURAL_KEY": ConstanceConfigItem(
         default=False,
         help_text="Location names are not guaranteed globally-unique by Nautobot but in practice they often are. "
@@ -862,7 +876,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
     "Installation Metrics": ["DEPLOYMENT_ID"],
     "Natural Keys": ["DEVICE_NAME_AS_NATURAL_KEY", "LOCATION_NAME_AS_NATURAL_KEY"],
     "Pagination": ["PAGINATE_COUNT", "MAX_PAGE_SIZE", "PER_PAGE_DEFAULTS"],
-    "Performance": ["JOB_CREATE_FILE_MAX_SIZE"],
+    "Performance": ["JOB_CREATE_FILE_MAX_SIZE", "JOB_RESULTS_SUMMARY_FIELD_ENABLED"],
     "Rack Elevation Rendering": [
         "RACK_ELEVATION_DEFAULT_UNIT_HEIGHT",
         "RACK_ELEVATION_DEFAULT_UNIT_WIDTH",

--- a/nautobot/core/settings.yaml
+++ b/nautobot/core/settings.yaml
@@ -1058,6 +1058,7 @@ properties:
       If `True`, the Job Result "summary" column will be available in the Job Results list UI.
       If `False`, the column will not be available.
     environment_variable: "NAUTOBOT_JOB_RESULTS_SUMMARY_FIELD_ENABLED"
+    is_constance_config: true
     type: "boolean"
     version_added: "2.4.8"
   JOBS_ROOT:

--- a/nautobot/core/settings.yaml
+++ b/nautobot/core/settings.yaml
@@ -1052,6 +1052,14 @@ properties:
       "`JOB_CREATE_FILE_MAX_SIZE`": "#job_create_file_max_size"
     type: "string"
     version_added: "2.1.0"
+  JOB_RESULTS_SUMMARY_FIELD_ENABLED:
+    default: true
+    description: >-
+      If `True`, the Job Result "summary" column will be available in the Job Results list UI.
+      If `False`, the column will not be available.
+    environment_variable: "NAUTOBOT_JOB_RESULTS_SUMMARY_FIELD_ENABLED"
+    type: "boolean"
+    version_added: "2.4.8"
   JOBS_ROOT:
     "$ref": "#/definitions/absolute_path"
     default: "~/.nautobot/jobs"

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -21,7 +21,6 @@ from nautobot.core.templatetags.helpers import (
     render_json,
     render_markdown,
 )
-from nautobot.core.utils.config import get_settings_or_config
 from nautobot.tenancy.tables import TenantColumn
 
 from .choices import MetadataTypeDataTypeChoices

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -16,7 +16,12 @@ from nautobot.core.tables import (
     TagColumn,
     ToggleColumn,
 )
-from nautobot.core.templatetags.helpers import render_boolean, render_json, render_markdown
+from nautobot.core.templatetags.helpers import (
+    render_boolean,
+    render_json,
+    render_markdown,
+)
+from nautobot.core.utils.config import get_settings_or_config
 from nautobot.tenancy.tables import TenantColumn
 
 from .choices import MetadataTypeDataTypeChoices
@@ -724,7 +729,9 @@ class JobTable(BaseTable):
     time_limit = tables.Column()
     default_job_queue = tables.Column(linkify=True)
     job_queues_count = LinkedCountColumn(
-        viewname="extras:jobqueue_list", url_params={"jobs": "pk"}, verbose_name="Job Queues"
+        viewname="extras:jobqueue_list",
+        url_params={"jobs": "pk"},
+        verbose_name="Job Queues",
     )
     last_run = tables.TemplateColumn(
         accessor="latest_result",
@@ -1050,7 +1057,11 @@ class ObjectMetadataTable(BaseTable):
             return render_boolean(record.value)
         elif record.metadata_type.data_type == MetadataTypeDataTypeChoices.TYPE_CONTACT_TEAM:
             if record.contact:
-                return format_html('<a href="{}">{}</a>', record.contact.get_absolute_url(), record.contact)
+                return format_html(
+                    '<a href="{}">{}</a>',
+                    record.contact.get_absolute_url(),
+                    record.contact,
+                )
             else:
                 return format_html('<a href="{}">{}</a>', record.team.get_absolute_url(), record.team)
         return record.value

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -728,9 +728,7 @@ class JobTable(BaseTable):
     time_limit = tables.Column()
     default_job_queue = tables.Column(linkify=True)
     job_queues_count = LinkedCountColumn(
-        viewname="extras:jobqueue_list",
-        url_params={"jobs": "pk"},
-        verbose_name="Job Queues",
+        viewname="extras:jobqueue_list", url_params={"jobs": "pk"}, verbose_name="Job Queues"
     )
     last_run = tables.TemplateColumn(
         accessor="latest_result",
@@ -1056,11 +1054,7 @@ class ObjectMetadataTable(BaseTable):
             return render_boolean(record.value)
         elif record.metadata_type.data_type == MetadataTypeDataTypeChoices.TYPE_CONTACT_TEAM:
             if record.contact:
-                return format_html(
-                    '<a href="{}">{}</a>',
-                    record.contact.get_absolute_url(),
-                    record.contact,
-                )
+                return format_html('<a href="{}">{}</a>', record.contact.get_absolute_url(), record.contact)
             else:
                 return format_html('<a href="{}">{}</a>', record.team.get_absolute_url(), record.team)
         return record.value


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #7178
# What's Changed
* Constance config setting to allow the `summary` field of the `JobResultTable` to be disabled, preventing the expensive database query in the case that many jobs with large numbers of log entries exist.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
![image](https://github.com/user-attachments/assets/6efa87af-bea1-447c-9aff-41cb41167a9a)
![image](https://github.com/user-attachments/assets/ab4fcf3b-a6c0-4aa6-96e1-edc7cabd7e09)
![image](https://github.com/user-attachments/assets/b9b4ff9f-ad16-40cf-b3d0-50dc565d6b38)
![image](https://github.com/user-attachments/assets/63504e21-14b0-479d-8067-6edc9cf78cde)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x ] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x ] Attached Screenshots, Payload Example
- [x ] Documentation Updates (when adding/changing features)

