### PR TITLE
Fixed Rack Elevation filtering by adding `filterset_form` to `RackElevationListView`

### DIFF
--- a/changes/6985.fixed
+++ b/changes/6985.fixed
@@ -1,0 +1,1 @@
+Fixed Rack Elevation filtering by adding `filterset_form` to the `RackElevationListView`.

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -585,6 +585,7 @@ class RackElevationListView(generic.ObjectListView):
         "reverse",  # control of ordering
     )
     filterset = filters.RackFilterSet
+    filterset_form = forms.RackFilterForm
     action_buttons = []
     template_name = "dcim/rack_elevation_list.html"
 


### PR DESCRIPTION
# Closes #6985 
# What's Changed
- Added `filterset_form` to `RackElevationListView`
# Screenshots
## Before
![old rack elevation filter](https://github.com/user-attachments/assets/fc4fcfdf-a6b9-4504-ae06-ad667ce15ac9)
## After
![rack elevation view](https://github.com/user-attachments/assets/030e164f-c218-4665-9c16-a383b9d13de1)
![new rack elevation filter](https://github.com/user-attachments/assets/779f3cbc-f215-42d3-95ea-d3d27c7ba6d8)
![rack elevation default filter](https://github.com/user-attachments/assets/90959cbf-cf15-4dea-881e-e110afa22975)

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
