### PR TITLE
Expose additional Device properties in GraphQL

### DIFF
--- a/changes/6053.added
+++ b/changes/6053.added
@@ -1,0 +1,1 @@
+Added `primary_ip` property to GraphQL `DeviceType` to simplify lookup of primary IPs when a mixture of IPv4 and IPv6 are involved.

--- a/changes/6053.fixed
+++ b/changes/6053.fixed
@@ -1,0 +1,2 @@
+Added `all_interfaces`, `all_modules`, etc. properties to GraphQL `DeviceType` to facilitate lookup of components belonging to descendant modules.
+Added `common_vc_interfaces`, `vc_interfaces` properties to GraphQL `DeviceType` to facilitate lookup of components when VirtualChassis are involved.

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -35,6 +35,8 @@ from nautobot.dcim.graphql.types import (
     FrontPortType,
     InterfaceType,
     LocationType,
+    ModuleBayType,
+    ModuleType,
     PlatformType,
     PowerFeedType,
     PowerOutletType,
@@ -62,6 +64,8 @@ registry["graphql_types"]["dcim.consoleserverport"] = ConsoleServerPortType
 registry["graphql_types"]["dcim.device"] = DeviceType
 registry["graphql_types"]["dcim.frontport"] = FrontPortType
 registry["graphql_types"]["dcim.interface"] = InterfaceType
+registry["graphql_types"]["dcim.modulebay"] = ModuleBayType
+registry["graphql_types"]["dcim.module"] = ModuleType
 registry["graphql_types"]["dcim.platform"] = PlatformType
 registry["graphql_types"]["dcim.powerfeed"] = PowerFeedType
 registry["graphql_types"]["dcim.poweroutlet"] = PowerOutletType

--- a/nautobot/dcim/graphql/types.py
+++ b/nautobot/dcim/graphql/types.py
@@ -11,6 +11,8 @@ from nautobot.dcim.filters import (
     FrontPortFilterSet,
     InterfaceFilterSet,
     LocationFilterSet,
+    ModuleBayFilterSet,
+    ModuleFilterSet,
     PlatformFilterSet,
     PowerFeedFilterSet,
     PowerOutletFilterSet,
@@ -28,6 +30,8 @@ from nautobot.dcim.models import (
     FrontPort,
     Interface,
     Location,
+    Module,
+    ModuleBay,
     Platform,
     PowerFeed,
     PowerOutlet,
@@ -55,10 +59,34 @@ class DeviceType(OptimizedNautobotObjectType):
         filterset_class = DeviceFilterSet
         exclude = ["_name"]
 
+    all_console_ports = graphene.List("nautobot.dcim.graphql.types.ConsolePortType")
+    all_console_server_ports = graphene.List("nautobot.dcim.graphql.types.ConsoleServerPortType")
+    all_front_ports = graphene.List("nautobot.dcim.graphql.types.FrontPortType")
+    all_interfaces = graphene.List("nautobot.dcim.graphql.types.InterfaceType")
+    all_module_bays = graphene.List("nautobot.dcim.graphql.types.ModuleBayType")
+    all_modules = graphene.List("nautobot.dcim.graphql.types.ModuleType")
+    all_power_ports = graphene.List("nautobot.dcim.graphql.types.PowerPortType")
+    all_power_outlets = graphene.List("nautobot.dcim.graphql.types.PowerOutletType")
+    all_rear_ports = graphene.List("nautobot.dcim.graphql.types.RearPortType")
+    common_vc_interfaces = graphene.List("nautobot.dcim.graphql.types.InterfaceType")
     dynamic_groups = graphene.List("nautobot.extras.graphql.types.DynamicGroupType")
+    primary_ip = graphene.Field("nautobot.ipam.graphql.types.IPAddressType")
+    vc_interfaces = graphene.List("nautobot.dcim.graphql.types.InterfaceType")
 
     def resolve_dynamic_groups(self, args):
         return DynamicGroup.objects.get_for_object(self)
+
+
+class ModuleBayType(OptimizedNautobotObjectType):
+    class Meta:
+        model = ModuleBay
+        filterset_class = ModuleBayFilterSet
+
+
+class ModuleType(OptimizedNautobotObjectType):
+    class Meta:
+        model = Module
+        filterset_class = ModuleFilterSet
 
 
 class PlatformType(OptimizedNautobotObjectType):


### PR DESCRIPTION
# Closes #6053
# What's Changed

Because `@property` are not automatically exposed in GraphQL, augment the `DeviceType` definition to explicitly expose `all_interfaces`, `all_console_ports`, etc. as well as `primary_ip`, `vc_interfaces`, and `common_vc_interfaces` properties.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
