### PR TITLE
7250 fix custom fields

### DIFF
--- a/changes/7250.fixed
+++ b/changes/7250.fixed
@@ -1,0 +1,1 @@
+Fixed JSON and MULTISELECT custom field being returned as a `repr()` string when using GraphQL.

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -23,7 +23,7 @@ from nautobot.core.graphql.generators import (
     generate_schema_type,
     generate_null_choices_resolver,
 )
-from nautobot.core.graphql.types import ContentTypeType, DateType
+from nautobot.core.graphql.types import ContentTypeType, DateType, JSON
 from nautobot.dcim.graphql.types import (
     CableType,
     CablePathType,
@@ -84,6 +84,8 @@ CUSTOM_FIELD_MAPPING = {
     CustomFieldTypeChoices.TYPE_DATE: DateType(),
     CustomFieldTypeChoices.TYPE_URL: graphene.String(),
     CustomFieldTypeChoices.TYPE_SELECT: graphene.String(),
+    CustomFieldTypeChoices.TYPE_JSON: JSON(),
+    CustomFieldTypeChoices.TYPE_MULTISELECT: JSON(),
 }
 
 

--- a/nautobot/core/graphql/types.py
+++ b/nautobot/core/graphql/types.py
@@ -56,3 +56,13 @@ class DateType(graphene.Date):
             return date
         else:
             raise GraphQLError(f'Received not compatible date "{date!r}"')
+
+
+class JSON(graphene.Scalar):
+    @staticmethod
+    def serialize_data(dt):
+        return dt
+
+    serialize = serialize_data
+    parse_value = serialize_data
+    parse_literal = serialize_data


### PR DESCRIPTION
# Closes #7250 
# What's Changed
Based on #4940, I added a JSON class to correct the output of custom fields in GraphQL when using cf_<label>. This update resolves an issue where JSON and MULTISELECT custom fields were being returned as repr() strings instead of proper data structures.
Changes include fixing GraphQL serialization for:
- JSON custom fields
- MULTISELECT custom fields

# Screenshots
## BEFORE JSON
![before json field](https://github.com/user-attachments/assets/18290d29-5638-4264-9004-be9627996645)
## AFTER JSON
![after json field](https://github.com/user-attachments/assets/7fd841fa-66a3-4e4c-ab42-33b74b3ca8f4)
## BEFORE MULTISELECT
![multiselect before](https://github.com/user-attachments/assets/64f032cb-1f0e-45b2-a201-2f4d27d4f874)
## AFTER MUTLISELECT
![multiselect after](https://github.com/user-attachments/assets/26af2218-77d3-4a87-870e-27ed6c5d08a6)
![mutliselect after 2](https://github.com/user-attachments/assets/6bfe251b-e23e-400d-a382-7fd13d7d1345)

# TODO
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
