### PR TITLE
Fix content-type filtering on ObjectMetaData

### DIFF
--- a/changes/7309.fixed
+++ b/changes/7309.fixed
@@ -1,0 +1,1 @@
+Fixed Content-Type filtering on ObjectMetaData.

--- a/nautobot/core/tests/test_utils.py
+++ b/nautobot/core/tests/test_utils.py
@@ -714,6 +714,17 @@ class LookupRelatedFunctionTest(TestCase):
                 form_field.queryset, extras_utils.ChangeLoggedModelsQuery().as_queryset()
             )
 
+            form_field = filtering.get_filterset_parameter_form_field(
+                extras_models.ObjectMetadata, "assigned_object_type"
+            )
+            self.assertIsInstance(form_field, forms.MultipleContentTypeField)
+            self.assertQuerysetEqualAndNotEmpty(
+                form_field.queryset,
+                ContentType.objects.filter(extras_utils.FeatureQuery("metadata").get_query()).order_by(
+                    "app_label", "model"
+                ),
+            )
+
         with self.subTest("Test prefers_id"):
             form_field = filtering.get_filterset_parameter_form_field(dcim_models.Device, "location")
             self.assertEqual("id", form_field.to_field_name)

--- a/nautobot/core/utils/filtering.py
+++ b/nautobot/core/utils/filtering.py
@@ -135,10 +135,13 @@ def get_filterset_parameter_form_field(model, parameter, filterset=None):
         from nautobot.core.models.fields import slugify_dashes_to_underscores  # Avoid circular import
 
         plural_name = slugify_dashes_to_underscores(model._meta.verbose_name_plural)
+
         # Cable-connectable models use "cable_terminations", not "cables", as the feature name
         if plural_name == "cables":
             plural_name = "cable_terminations"
         elif plural_name == "metadata_types":
+            plural_name = "metadata"
+        elif plural_name == "object_metadata":
             plural_name = "metadata"
         try:
             form_field = MultipleContentTypeField(choices_as_strings=True, feature=plural_name)


### PR DESCRIPTION
# Closes #7309 
# What's Changed
Fixed content-type filtering on ObjectMetaData

# Screenshots
Object Metadata with 3 instances with assigned object to: 1 IPAddress and 2 Prefixes
![after object Metadata](https://github.com/user-attachments/assets/1027c57b-8329-45b5-9c4b-de16e874a488)

## BEFORE
![error before](https://github.com/user-attachments/assets/aa7f989b-8ad8-45da-b9e7-5695a47c1ad2)

## AFTER Object Metadata filter by content-type: ipaddress
![after object metadata ipaddress](https://github.com/user-attachments/assets/46033a45-54cf-4b51-9737-e6355ab264c4)

## AFTER Object Metadata filter by content-type: prefix
![after object metadata prefix](https://github.com/user-attachments/assets/78247716-54dd-4e6b-8be9-b25691db746e)


# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
