### PR TITLE
Fix remove legacy scroll offset adjustment interfering with anchor navigation

### DIFF
--- a/changes/7328.fixed
+++ b/changes/7328.fixed
@@ -1,0 +1,1 @@
+Fixed an issue in the Golden Config App where clicking a Configuration Compliance Feature Navigation link or loading a page with a hash would not scroll to the correct section due to conflicting legacy scroll offset logic.

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -1003,17 +1003,3 @@ $(document).ready((e) => {
     document.querySelectorAll("textarea.form-control").forEach(function(element) {element.addEventListener("keydown", submitOnEnter)});
 })
 
-// Scroll up an offset equal to the first nav element if a hash is present
-// Cannot use '#navbar' because it is not always visible, like in small windows
-function headerOffsetScroll() {
-    if (window.location.hash) {
-        // Short wait needed to allow the page to scroll to the element
-        setTimeout(function() {
-            window.scrollBy(0, -$('nav').height())
-        }, 10);
-    }
-}
-
-// Account for the header height when hash-scrolling
-window.addEventListener('load', headerOffsetScroll);
-window.addEventListener('hashchange', headerOffsetScroll);


### PR DESCRIPTION

# Closes #7328 
# What's Changed
<!--
Fixed an issue in the Golden Config App where clicking a Configuration Compliance Feature Navigation link or loading a page with a hash would not scroll to the correct section due to conflicting legacy scroll offset logic.

-->