### PR TITLE
Fix 'last_run' column in Job list view

### DIFF
--- a/changes/xxxx.fixed
+++ b/changes/xxxx.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect rendering of "Last run" column in Job list view.

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -730,7 +730,7 @@ class JobTable(BaseTable):
         accessor="latest_result",
         template_code="""
             {% if value %}
-                {{ value.created }} by {{ value.user }}
+                {{ value.date_created|date:settings.SHORT_DATETIME_FORMAT }} by {{ value.user }}
             {% else %}
                 <span class="text-muted">Never</span>
             {% endif %}

--- a/nautobot/extras/templates/extras/inc/job_tiles.html
+++ b/nautobot/extras/templates/extras/inc/job_tiles.html
@@ -58,7 +58,7 @@
                 <div style="flex: 1;">
                     Last run:
                     {% if row.record.latest_result %}
-                        <a href="{{ row.record.latest_result.get_absolute_url }}">{{ row.record.latest_result.date_created }} by {{ row.record.latest_result.user }}</a>
+                        <a href="{{ row.record.latest_result.get_absolute_url }}">{{ row.record.latest_result.date_created|date:settings.DATETIME_FORMAT }} by {{ row.record.latest_result.user }}</a>
                     {% else %}
                         <span class="text-muted">Never</span>
                     {% endif %}


### PR DESCRIPTION
# What's Changed

- `JobResult.created` changed to `JobResult.date_created` in v2.0 but the `last_run` TemplateColumn in JobTable wasn't updated accordingly - this fixes that.
- Also changed the Job list tiles view to respect `settings.DATETIME_FORMAT` (will want to revisit this as part of #7018)

# Screenshots

Before:

![image](https://github.com/user-attachments/assets/29e5a5e4-53f1-431d-8402-ef60b705f8ec)

![image](https://github.com/user-attachments/assets/677f7277-a39e-4699-a3b1-2e2b537c2e8f)


After:

![image](https://github.com/user-attachments/assets/814fcf3d-5558-45ec-9623-16a66eb08111)

![image](https://github.com/user-attachments/assets/1bde5277-e15c-46a4-9545-602853a631c9)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
