### PR TITLE
Fix ScheduledJob creation with a non-default queue, etc.

### DIFF
--- a/changes/7043.added
+++ b/changes/7043.added
@@ -1,0 +1,1 @@
+Added support for `job_queue` parameter to `JobResult.execute_job()`, `JobResult.enqueue_job()`, and `ScheduledJob.create_schedule()`.

--- a/changes/7043.changed
+++ b/changes/7043.changed
@@ -1,0 +1,1 @@
+Changed "Run Job" form to display a warning when submitting a Job against a Celery queue that has no active workers, but allow the job to be submitted, instead of blocking the Job altogether.

--- a/changes/7043.fixed
+++ b/changes/7043.fixed
@@ -1,0 +1,1 @@
+Fixed regression introduced in 2.4.0 involving inability to specify a non-default job queue when scheduling a Job.

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -76,6 +76,7 @@ class NautobotScheduleEntry(ModelEntry):
             self._disable(model)
 
         if isinstance(model.celery_kwargs, Mapping):
+            # TODO: this allows model.celery_kwargs to override keys like `nautobot_job_user_id`; is that desirable?
             self.options.update(model.celery_kwargs)
 
         # copy-paste from django_celery_beat.schedulers

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -703,10 +703,8 @@ class JobViewSetBase(
             # of errors under messages
             return Response({"errors": e.message_dict if hasattr(e, "error_dict") else e.messages}, status=400)
 
-        queue = get_job_queue(task_queue)
-        if queue is None:
-            queue = job_model.default_job_queue
-        if queue.queue_type == JobQueueTypeChoices.TYPE_CELERY and not get_worker_count(queue=task_queue):
+        job_queue = get_job_queue(task_queue) or job_model.default_job_queue
+        if job_queue.queue_type == JobQueueTypeChoices.TYPE_CELERY and not get_worker_count(queue=task_queue):
             raise CeleryWorkerNotRunningException(queue=task_queue)
 
         # Default to a null JobResult.
@@ -737,7 +735,7 @@ class JobViewSetBase(
                 interval=schedule_data.get("interval"),
                 crontab=schedule_data.get("crontab", ""),
                 approval_required=approval_required,
-                task_queue=task_queue,
+                job_queue=job_queue,
                 **job_class.serialize_data(cleaned_data),
             )
         else:
@@ -748,7 +746,7 @@ class JobViewSetBase(
             job_result = JobResult.enqueue_job(
                 job_model,
                 request.user,
-                task_queue=task_queue,
+                job_queue=job_queue,
                 **job_class.serialize_data(cleaned_data),
             )
 

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -1,10 +1,11 @@
 # Data models relating to Jobs
 
 import contextlib
-from datetime import timedelta
+from datetime import datetime, timedelta
 import json
 import logging
 import signal
+from typing import Optional, TYPE_CHECKING, Union
 
 from billiard.exceptions import SoftTimeLimitExceeded
 from celery.exceptions import NotRegistered
@@ -57,6 +58,11 @@ from nautobot.extras.utils import (
 )
 
 from .customfields import CustomFieldModel
+
+if TYPE_CHECKING:
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
 
 logger = logging.getLogger(__name__)
 
@@ -329,12 +335,12 @@ class Job(PrimaryModel):
             raise NotRegistered from err
 
     @property
-    def task_queues(self):
+    def task_queues(self) -> list[str]:
         """Deprecated backward-compatibility property for the list of queue names for this Job."""
         return self.job_queues.values_list("name", flat=True)
 
     @task_queues.setter
-    def task_queues(self, value):
+    def task_queues(self, value: Union[str, list[str]]):
         job_queues = []
         # value is going to be a comma separated list of queue names
         if isinstance(value, str):
@@ -748,49 +754,34 @@ class JobResult(BaseModel, CustomFieldModel):
                 )
 
     @classmethod
-    def execute_job(cls, job_model, user, *job_args, celery_kwargs=None, profile=False, job_result=None, **job_kwargs):
+    def execute_job(cls, *args, **kwargs):
         """
         Create a JobResult instance and run a job in the current process, blocking until the job finishes.
 
         Running tasks synchronously in celery is *NOT* supported and if possible `enqueue_job` with synchronous=False
         should be used instead.
 
-        Args:
-            job_model (Job): The Job to be enqueued for execution
-            user (User): User object to link to the JobResult instance
-            celery_kwargs (dict, optional): Dictionary of kwargs to pass as **kwargs to Celery when job is run
-            profile (bool, optional): Whether to run cProfile on the job execution
-            job_result (JobResult, optional): Existing JobResult with status PENDING, used in kubernetes job execution
-            *job_args: positional args passed to the job task
-            **job_kwargs: keyword args passed to the job task
+        Args: see `enqueue_job()`
 
         Returns:
             JobResult instance
         """
-        return cls.enqueue_job(
-            job_model,
-            user,
-            *job_args,
-            celery_kwargs=celery_kwargs,
-            profile=profile,
-            job_result=job_result,
-            synchronous=True,
-            **job_kwargs,
-        )
+        return cls.enqueue_job(*args, **kwargs, synchronous=True)
 
     @classmethod
     def enqueue_job(
         cls,
-        job_model,
-        user,
+        job_model: Job,
+        user: "User",
         *job_args,
-        celery_kwargs=None,
-        profile=False,
-        schedule=None,
-        task_queue=None,
-        job_result=None,
-        synchronous=False,
-        ignore_singleton_lock=False,
+        celery_kwargs: Optional[dict] = None,
+        profile: bool = False,
+        schedule: Optional["ScheduledJob"] = None,
+        job_queue: Optional["JobQueue"] = None,
+        task_queue: Optional[str] = None,  # deprecated!
+        job_result: Optional["JobResult"] = None,
+        synchronous: bool = False,
+        ignore_singleton_lock: bool = False,
         **job_kwargs,
     ):
         """Create/Modify a JobResult instance and enqueue a job to be executed asynchronously by a Celery worker.
@@ -798,13 +789,16 @@ class JobResult(BaseModel, CustomFieldModel):
         Args:
             job_model (Job): The Job to be enqueued for execution.
             user (User): User object to link to the JobResult instance.
-            celery_kwargs (dict, optional): Dictionary of kwargs to pass as **kwargs to `apply_async()`/`apply()` when job is run.
-            profile (bool, optional): If True, dump cProfile stats on the job execution.
-            schedule (ScheduledJob, optional): ScheduledJob instance to link to the JobResult. Cannot be used with synchronous=True.
-            task_queue (str, optional): The celery queue to send the job to. If not set, use the default celery queue.
-            job_result (JobResult, optional): Existing JobResult with status PENDING, to be modified and to be used in kubernetes job execution.
-            synchronous (bool, optional): If True, run the job in the current process, blocking until the job completes.
-            ignore_singleton_lock (bool, optional): If True, invalidate the singleton lock before running the job.
+            celery_kwargs (dict): Dictionary of kwargs to pass as **kwargs to `apply_async()`/`apply()` when job is run.
+            profile (bool): If True, dump cProfile stats on the job execution.
+            schedule (ScheduledJob): ScheduledJob instance to link to the JobResult.
+                Cannot be used with synchronous=True.
+            job_queue (JobQueue): Job queue to send the job to. If not set, use the default queue for the given Job.
+            task_queue (str): The celery queue name to send the job to. **Deprecated, prefer `job_queue` instead.**
+            job_result (JobResult): Existing JobResult with status PENDING, to be modified and to be used
+                in kubernetes job execution.
+            synchronous (bool): If True, run the job in the current process, blocking until the job completes.
+            ignore_singleton_lock (bool): If True, invalidate the singleton lock before running the job.
               This allows singleton jobs to run twice, or makes it possible to remove the lock when the first instance
               of the job failed to remove it for any reason.
             *job_args: positional args passed to the job task (UNUSED)
@@ -817,6 +811,20 @@ class JobResult(BaseModel, CustomFieldModel):
 
         if schedule is not None and synchronous:
             raise ValueError("Scheduled jobs cannot be run synchronously")
+
+        if job_queue is not None and task_queue is not None and job_queue.name != task_queue:
+            raise ValueError("task_queue and job_queue are mutually exclusive")
+        if job_queue is not None and task_queue is None:
+            task_queue = job_queue.name
+        elif task_queue is not None and job_queue is None:
+            job_queue = JobQueue.objects.get(name=task_queue)
+        else:  # both none
+            if celery_kwargs is not None and "queue" in celery_kwargs:
+                task_queue = celery_kwargs["queue"]
+                job_queue = JobQueue.objects.get(name=task_queue)
+            else:
+                job_queue = job_model.default_job_queue
+                task_queue = job_queue.name
 
         if job_result is None:
             job_result = cls.objects.create(
@@ -835,10 +843,6 @@ class JobResult(BaseModel, CustomFieldModel):
                     f"There is a mismatch between the job specified {job_model} and the job associated with the job result {job_result.job_model}"
                 )
 
-        if task_queue is None:
-            task_queue = job_model.default_job_queue.name
-
-        job_queue = JobQueue.objects.get(name=task_queue)
         # Kubernetes Job Queue logic
         # As we execute Kubernetes jobs, we want to execute `run_kubernetes_job_and_return_job_result`
         # the first time the kubernetes job is enqueued to spin up the kubernetes pod.
@@ -863,6 +867,7 @@ class JobResult(BaseModel, CustomFieldModel):
             job_celery_kwargs["time_limit"] = job_model.time_limit
 
         if celery_kwargs is not None:
+            # TODO: this lets celery_kwargs override keys like `queue` and `nautobot_job_user_id`; is that desirable?
             job_celery_kwargs.update(celery_kwargs)
 
         if synchronous:
@@ -1208,7 +1213,6 @@ class ScheduledJob(BaseModel):
         ordering = ["name"]
 
     def save(self, *args, **kwargs):
-        self.queue = self.queue or ""
         # make sure non-valid crontab doesn't get saved
         if self.interval == JobExecutionType.TYPE_CUSTOM:
             try:
@@ -1253,12 +1257,12 @@ class ScheduledJob(BaseModel):
         return self.to_cron()
 
     @property
-    def queue(self):
+    def queue(self) -> str:
         """Deprecated backward-compatibility property for the queue name this job is scheduled for."""
         return self.job_queue.name if self.job_queue else ""
 
     @queue.setter
-    def queue(self, value):
+    def queue(self, value: str):
         if value:
             try:
                 self.job_queue = JobQueue.objects.get(name=value)
@@ -1301,14 +1305,15 @@ class ScheduledJob(BaseModel):
         cls,
         job_model,
         user,
-        name=None,
-        start_time=None,
-        interval=JobExecutionType.TYPE_IMMEDIATELY,
-        crontab="",
-        profile=False,
-        approval_required=False,
-        task_queue=None,
-        ignore_singleton_lock=False,
+        name: Optional[str] = None,
+        start_time: Optional[datetime] = None,
+        interval: str = JobExecutionType.TYPE_IMMEDIATELY,
+        crontab: str = "",
+        profile: bool = False,
+        approval_required: bool = False,
+        job_queue: Optional[JobQueue] = None,
+        task_queue: Optional[str] = None,  # deprecated!
+        ignore_singleton_lock: bool = False,
         **job_kwargs,
     ):
         """
@@ -1321,20 +1326,31 @@ class ScheduledJob(BaseModel):
         Parameters:
             job_model (JobModel): The job model instance.
             user (User): The user who is scheduling the job.
-            name (str, optional): The name of the scheduled job. Defaults to None.
-            start_time (datetime, optional): The start time for the job. Defaults to None.
-            interval (JobExecutionType, optional): The interval type for the job execution.
+            name (str): The name of the scheduled job. Automatically derived from the job_model and start_time if unset.
+            start_time (datetime): The start time for the job. Defaults to the current time if unset.
+            interval (JobExecutionType): The interval type for the job execution.
                 Defaults to JobExecutionType.TYPE_IMMEDIATELY.
-            crontab (str, optional): The crontab string for the schedule. Defaults to "".
-            profile (bool, optional): Flag indicating whether to profile the job. Defaults to False.
-            approval_required (bool, optional): Flag indicating if approval is required. Defaults to False.
-            task_queue (str, optional): The task queue for the job. Defaults to None, which will use the configured default celery queue.
-            ignore_singleton_lock (bool, optional): Flag indicating whether to ignore singleton locks. Defaults to False.
+            crontab (str): The crontab string for the schedule. Defaults to "".
+            profile (bool): Flag indicating whether to profile the job. Defaults to False.
+            approval_required (bool): Flag indicating if approval is required. Defaults to False.
+            job_queue (JobQueue): The Job queue to use. If unset, use the configured default celery queue.
+            task_queue (str): The queue name to use. **Deprecated, prefer `job_queue`.**
+            ignore_singleton_lock (bool): Whether to ignore singleton locks. Defaults to False.
             **job_kwargs: Additional keyword arguments to pass to the job.
 
         Returns:
             ScheduledJob instance
         """
+
+        if job_queue is not None and task_queue is not None and job_queue.name != task_queue:
+            raise ValueError("task_queue and job_queue are mutually exclusive")
+        if job_queue is not None and task_queue is None:
+            task_queue = job_queue.name
+        elif task_queue is not None and job_queue is None:
+            job_queue = JobQueue.objects.get(name=task_queue)
+        else:  # both None
+            job_queue = job_model.default_job_queue
+            task_queue = job_queue.name
 
         if interval == JobExecutionType.TYPE_IMMEDIATELY:
             start_time = timezone.localtime()
@@ -1376,7 +1392,7 @@ class ScheduledJob(BaseModel):
             user=user,
             approval_required=approval_required,
             crontab=crontab,
-            queue=task_queue,
+            job_queue=job_queue,
         )
         scheduled_job.validated_save()
         return scheduled_job

--- a/nautobot/extras/templates/extras/jobresult.html
+++ b/nautobot/extras/templates/extras/jobresult.html
@@ -115,7 +115,7 @@
                     <td>{{ result.worker }}</td>
                 </tr>
                 <tr>
-                    <td>Queue</td>
+                    <td>Queue Name</td>
                     <td>{{ result.celery_kwargs.queue}}</td>
                 </tr>
                 <tr>

--- a/nautobot/extras/templates/extras/scheduledjob.html
+++ b/nautobot/extras/templates/extras/scheduledjob.html
@@ -49,20 +49,24 @@
                   </td>
               </tr>
               <tr>
+                  <td>Job</td>
+                  <td>{{ object.job_model|hyperlinked_object }}</td>
+              </tr>
+              <tr>
                   <td>Requester</td>
                   <td>
-                      {{ object.user }}
+                      {{ object.user|placeholder }}
                   </td>
+              </tr>
+              <tr>
+                  <td>Approval Required?</td>
+                  <td>{{ object.approval_required | render_boolean }}</td>
               </tr>
               <tr>
                   <td>Approver</td>
                   <td>
                       {{ object.approved_by_user | placeholder }}
                   </td>
-              </tr>
-              <tr>
-                  <td>Approval Required?</td>
-                  <td>{{ object.approval_required | render_boolean }}</td>
               </tr>
               <tr>
                   <td>Approved At</td>
@@ -82,6 +86,10 @@
                   <td>{{ object.enabled | render_boolean }}</td>
               </tr>
               <tr>
+                  <td>Job Queue</td>
+                  <td>{{ object.job_queue | hyperlinked_object }}</td>
+              </tr>
+              <tr>
                   <td>Interval</td>
                   <td>
                       {{ object.interval }}
@@ -95,9 +103,9 @@
               <tr>
                   <td>Start Time</td>
                   <td>
-                      {{ object.start_time|timezone:object.time_zone|date:'Y-m-d H:i:s T' }}
+                      {{ object.start_time|timezone:object.time_zone|date:settings.SHORT_DATETIME_FORMAT }}
                       {% if default_time_zone != object.time_zone %}
-                          <br>{{ object.start_time|timezone:default_time_zone|date:'Y-m-d H:i:s T' }}
+                          <br>{{ object.start_time|timezone:default_time_zone|date:settings.SHORT_DATETIME_FORMAT }}
                       {% endif %}
                   </td>
               </tr>
@@ -105,9 +113,9 @@
                   <td>Last Run At</td>
                   <td>
                       {% if object.last_run_at %}
-                          {{ object.last_run_at|timezone:object.time_zone|date:'Y-m-d H:i:s T' }}
+                          {{ object.last_run_at|timezone:object.time_zone|date:settings.SHORT_DATETIME_FORMAT }}
                           {% if default_time_zone != object.time_zone %}
-                              <br>{{ object.last_run_at|timezone:default_time_zone|date:'Y-m-d H:i:s T' }}
+                              <br>{{ object.last_run_at|timezone:default_time_zone|date:SHORT_DATETIME_FORMAT }}
                           {% endif %}
                       {% else %}
                           {{ object.last_run_at|placeholder }}
@@ -141,4 +149,12 @@
           </table>
       </div>
     {% endif %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <strong>Celery Keyword Arguments</strong>
+        </div>
+        <div class="panel-body">
+            {% include 'extras/inc/json_data.html' with data=object.celery_kwargs format="json" %}
+        </div>
+    </div>
 {% endblock %}

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1739,7 +1739,7 @@ class JobTest(
         # Ensure the enqueue_job args deserialize to the same as originally inputted
         expected_enqueue_job_args = (self.job_model, self.user)
         expected_enqueue_job_kwargs = {
-            "task_queue": self.job_model.default_job_queue.name,
+            "job_queue": self.job_model.default_job_queue,
             **self.job_class.serialize_data(deserialized_data),
         }
         mock_enqueue_job.assert_called_with(*expected_enqueue_job_args, **expected_enqueue_job_kwargs)

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -6,7 +6,7 @@ import hmac
 import logging
 import re
 import sys
-from typing import Optional
+from typing import Optional, TYPE_CHECKING, Union
 
 from django.apps import apps
 from django.conf import settings
@@ -36,6 +36,9 @@ from nautobot.extras.constants import (
     JOB_OVERRIDABLE_FIELDS,
 )
 from nautobot.extras.registry import registry
+
+if TYPE_CHECKING:
+    from nautobot.extras.models import JobQueue
 
 logger = logging.getLogger(__name__)
 
@@ -409,10 +412,12 @@ def get_celery_queues():
     return celery_queues
 
 
-def get_worker_count(request=None, queue=None):
+def get_worker_count(request=None, queue: Optional[Union[str, "JobQueue"]] = None) -> int:
     """
-    Return a count of the active Celery workers in a specified queue (Could be a JobQueue instance, instance pk or instance name).
-    Defaults to the `CELERY_TASK_DEFAULT_QUEUE` setting.
+    Return a count of the active Celery workers in a specified queue.
+
+    Args:
+        queue (str, JobQueue, None): queue name or JobQueue to check; if unset, defaults to CELERY_TASK_DEFAULT_QUEUE.
     """
     from nautobot.extras.models import JobQueue
 
@@ -434,7 +439,7 @@ def get_worker_count(request=None, queue=None):
     return celery_queues.get(queue, 0)
 
 
-def get_job_queue_worker_count(request=None, job_queue=None):
+def get_job_queue_worker_count(request=None, job_queue: Optional["JobQueue"] = None) -> int:
     """
     Return a count of the active Celery workers in a specified queue. Defaults to the `CELERY_TASK_DEFAULT_QUEUE` setting.
     Same as get_worker_count() method above, but job_queue is an actual JobQueue model instance.
@@ -449,27 +454,24 @@ def get_job_queue_worker_count(request=None, job_queue=None):
     return celery_queues.get(queue, 0)
 
 
-def get_job_queue(job_queue):
+def get_job_queue(job_queue: str) -> Optional["JobQueue"]:
     """
     Search for a JobQueue instance based on the str job_queue.
     If no existing Job Queue not found, return None
     """
     from nautobot.extras.models import JobQueue
 
-    queue = None
     if is_uuid(job_queue):
         try:
             # check if the string passed in is a valid UUID
-            queue = JobQueue.objects.get(pk=job_queue)
+            return JobQueue.objects.get(pk=job_queue)
         except JobQueue.DoesNotExist:
-            queue = None
-    else:
-        try:
-            # check if the string passed in is a valid name
-            queue = JobQueue.objects.get(name=job_queue)
-        except JobQueue.DoesNotExist:
-            queue = None
-    return queue
+            return None
+    try:
+        # check if the string passed in is a valid name
+        return JobQueue.objects.get(name=job_queue)
+    except JobQueue.DoesNotExist:
+        return None
 
 
 def task_queues_as_choices(task_queues):

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -73,7 +73,7 @@ from nautobot.dcim.tables import (
     VirtualDeviceContextTable,
 )
 from nautobot.extras.context_managers import deferred_change_logging_for_bulk_operation
-from nautobot.extras.utils import fixup_filterset_query_params, get_base_template, get_job_queue, get_worker_count
+from nautobot.extras.utils import fixup_filterset_query_params, get_base_template, get_worker_count
 from nautobot.ipam.models import IPAddress, Prefix, VLAN
 from nautobot.ipam.tables import IPAddressTable, PrefixTable, VLANTable
 from nautobot.virtualization.models import VirtualMachine, VMInterface
@@ -1376,14 +1376,16 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
                     # for example "?kwargs_from_job_result=<UUID>&integervar=22"
                     explicit_initial = initial
                     initial = job_result.task_kwargs.copy()
-                    job_queue = job_result.celery_kwargs.get("queue", None)
-                    jq = None
-                    if job_queue is not None:
+                    task_queue = job_result.celery_kwargs.get("queue", None)
+                    job_queue = None
+                    if task_queue is not None:
                         try:
-                            jq = JobQueue.objects.get(name=job_queue, queue_type=JobQueueTypeChoices.TYPE_CELERY)
+                            job_queue = JobQueue.objects.get(
+                                name=task_queue, queue_type=JobQueueTypeChoices.TYPE_CELERY
+                            )
                         except JobQueue.DoesNotExist:
                             pass
-                    initial["_job_queue"] = jq
+                    initial["_job_queue"] = job_queue
                     initial["_profile"] = job_result.celery_kwargs.get("nautobot_job_profile", False)
                     initial["_ignore_singleton_lock"] = job_result.celery_kwargs.get(
                         "nautobot_job_ignore_singleton_lock", False
@@ -1427,7 +1429,6 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
         job_class = get_job(job_model.class_path, reload=True)
         job_form = job_class.as_form(request.POST, request.FILES) if job_class is not None else None
         schedule_form = forms.JobScheduleForm(request.POST)
-        job_queue = request.POST.get("_job_queue")
 
         return_url = request.POST.get("_return_url")
         if return_url is not None and url_has_allowed_host_and_scheme(url=return_url, allowed_hosts=request.get_host()):
@@ -1435,13 +1436,8 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
         else:
             return_url = None
 
-        queue = get_job_queue(job_queue)
-        if queue is None:
-            queue = job_model.default_job_queue
-        # Allow execution only if a worker process is running on a celery queue and the job is runnable.
-        if queue.queue_type == JobQueueTypeChoices.TYPE_CELERY and not get_worker_count(queue=job_queue):
-            messages.error(request, "Unable to run or schedule job: Celery worker process not running.")
-        elif not job_model.installed or job_class is None:
+        # Allow execution only if the job is runnable.
+        if not job_model.installed or job_class is None:
             messages.error(request, "Unable to run or schedule job: Job is not presently installed.")
         elif not job_model.enabled:
             messages.error(request, "Unable to run or schedule job: Job is not enabled to be run.")
@@ -1459,15 +1455,17 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
             )
         elif job_form is not None and job_form.is_valid() and schedule_form.is_valid():
             job_queue = job_form.cleaned_data.pop("_job_queue", None)
-            jq = None
-            if job_queue is not None:
-                try:
-                    jq = JobQueue.objects.get(pk=job_queue)
-                except (ValidationError, JobQueue.DoesNotExist):
-                    try:
-                        jq = JobQueue.objects.get(name=job_queue)
-                    except JobQueue.DoesNotExist:
-                        pass
+            if job_queue is None:
+                job_queue = job_model.default_job_queue
+
+            if job_queue.queue_type == JobQueueTypeChoices.TYPE_CELERY and not get_worker_count(queue=job_queue):
+                messages.warning(
+                    request,
+                    format_html(
+                        "No celery workers found for queue {}, job may never run unless a worker is started.",
+                        job_queue,
+                    ),
+                )
 
             dryrun = job_form.cleaned_data.get("dryrun", False)
             # Run the job. A new JobResult is created.
@@ -1484,7 +1482,7 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
                     interval=schedule_type,
                     crontab=schedule_form.cleaned_data.get("_recurrence_custom_time"),
                     approval_required=job_model.approval_required,
-                    task_queue=jq.name if jq else None,
+                    job_queue=job_queue,
                     profile=profile,
                     ignore_singleton_lock=ignore_singleton_lock,
                     **job_class.serialize_data(job_form.cleaned_data),
@@ -1505,7 +1503,7 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
                     request.user,
                     profile=profile,
                     ignore_singleton_lock=ignore_singleton_lock,
-                    task_queue=jq.name if jq else None,
+                    job_queue=job_queue,
                     **job_class.serialize_data(job_kwargs),
                 )
 
@@ -1602,7 +1600,7 @@ class JobApprovalRequestView(generic.ObjectView):
         if job_class is not None:
             # Render the form with all fields disabled
             initial = instance.kwargs
-            initial["_job_queue"] = instance.queue
+            initial["_job_queue"] = instance.job_queue
             initial["_profile"] = instance.celery_kwargs.get("profile", False)
             job_form = job_class().as_form(initial=initial, approval_view=True)
         else:


### PR DESCRIPTION
# Closes #7043 
# What's Changed

- Fix setting a non-default job queue when submitting a ScheduledJob via the UI (#7043)
- Enhance `JobResult.execute_job()`, `JobResult.enqueue_job()`, and `ScheduledJob.create_schedule()` to support a `job_queue` parameter, and document the existing `task_queue` parameter as deprecated.
- Change Job submission via the UI to warn but permit submitting or scheduling a job against a queue with no active workers, instead of blocking it. (The API still blocks this case for now)
- Enhance ScheduledJob detail view with additional fields.
- Add some type annotations to various Job APIs.

# Screenshots

![image](https://github.com/user-attachments/assets/102a54a7-6d1e-46ac-9bf8-86165ffeb218)

![image](https://github.com/user-attachments/assets/86df779b-f9b3-4a9c-9448-2b7c0b3edde8)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
