### PR TITLE
Fix NautobotCSVParser to correctly parse M2M fields

### DIFF
--- a/nautobot/core/tests/test_csv.py
+++ b/nautobot/core/tests/test_csv.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 
 from nautobot.core.constants import CSV_NO_OBJECT, CSV_NULL_TYPE, VARBINARY_IP_FIELD_REPR_OF_CSV_NO_OBJECT
 from nautobot.dcim.api.serializers import DeviceSerializer
-from nautobot.dcim.models.devices import Controller, Device, DeviceType
+from nautobot.dcim.models.devices import Controller, Device, DeviceType, Platform, SoftwareImageFile, SoftwareVersion
 from nautobot.dcim.models.locations import Location
 from nautobot.extras.models.roles import Role
 from nautobot.extras.models.statuses import Status
@@ -317,3 +317,94 @@ class CSVParsingRelatedTestCase(TestCase):
             tenant=self.device2.tenant,
         )
         self.assertEqual(device4.tags.count(), 0)
+
+    @override_settings(ALLOWED_HOSTS=["*"])
+    def test_m2m_field_import(self):
+        """Test CSV import of M2M field."""
+
+        platform = Platform.objects.first()
+        software_version_status = Status.objects.get_for_model(SoftwareVersion).first()
+        software_image_file_status = Status.objects.get_for_model(SoftwareImageFile).first()
+
+        software_version = SoftwareVersion.objects.create(
+            platform=platform, version="Test version 1.0.0", status=software_version_status
+        )
+        software_image_files = (
+            SoftwareImageFile.objects.create(
+                software_version=software_version,
+                image_file_name="software_image_file_qs_test_1.bin",
+                status=software_image_file_status,
+            ),
+            SoftwareImageFile.objects.create(
+                software_version=software_version,
+                image_file_name="software_image_file_qs_test_2.bin",
+                status=software_image_file_status,
+                default_image=True,
+            ),
+            SoftwareImageFile.objects.create(
+                software_version=software_version,
+                image_file_name="software_image_file_qs_test_3.bin",
+                status=software_image_file_status,
+            ),
+        )
+
+        user = UserFactory.create()
+        user.is_superuser = True
+        user.is_active = True
+        user.save()
+        self.client.force_login(user)
+
+        with self.subTest("Import M2M field using list of UUIDs"):
+            import_data = f"""name,device_type,location,role,status,software_image_files
+TestDevice5,{self.device.device_type.pk},{self.device.location.pk},{self.device.role.pk},{self.device.status.pk},"{software_image_files[0].pk},{software_image_files[1].pk}"
+"""
+            data = {"csv_data": import_data}
+            url = reverse("dcim:device_import")
+            response = self.client.post(url, data)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(Device.objects.count(), 3)
+
+            # Assert TestDevice5 got created with the right fields
+            device5 = Device.objects.get(
+                name="TestDevice5",
+                location=self.device.location,
+                device_type=self.device.device_type,
+                role=self.device.role,
+                status=self.device.status,
+                tenant=None,
+            )
+            self.assertEqual(device5.software_image_files.count(), 2)
+
+        with self.subTest("Import M2M field using multiple identifying fields"):
+            import_data = f"""name,device_type,location,role,status,software_image_files__software_version,software_image_files__image_file_name
+TestDevice6,{self.device.device_type.pk},{self.device.location.pk},{self.device.role.pk},{self.device.status.pk},"{software_version.pk},{software_version.pk}","{software_image_files[0].image_file_name},{software_image_files[1].image_file_name}"
+"""
+            data = {"csv_data": import_data}
+            url = reverse("dcim:device_import")
+            response = self.client.post(url, data)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(Device.objects.count(), 4)
+
+            # Assert TestDevice5 got created with the right fields
+            device6 = Device.objects.get(
+                name="TestDevice6",
+                location=self.device.location,
+                device_type=self.device.device_type,
+                role=self.device.role,
+                status=self.device.status,
+                tenant=None,
+            )
+            self.assertEqual(device6.software_image_files.count(), 2)
+
+        with self.subTest("Import M2M field using incorrect number of values"):
+            import_data = f"""name,device_type,location,role,status,software_image_files__software_version,software_image_files__image_file_name
+TestDevice7,{self.device.device_type.pk},{self.device.location.pk},{self.device.role.pk},{self.device.status.pk},"{software_version.pk},{software_version.pk}","{software_image_files[0].image_file_name},{software_image_files[1].image_file_name},{software_image_files[2].image_file_name}"
+"""
+            data = {"csv_data": import_data}
+            url = reverse("dcim:device_import")
+            response = self.client.post(url, data)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, "Incorrect number of values provided for the software_image_files field")
+            self.assertEqual(Device.objects.count(), 4)


### PR DESCRIPTION
# What's Changed
Fixes NautobotCSVParser incorrectly parses M2M fields
# Screenshots
<img width="837" alt="Screen Shot 2025-05-28 at 8 29 57 PM" src="https://github.com/user-attachments/assets/a1d1ceba-dd52-4e6d-a36d-7bb47aa12f99" />

# Details
CSV import fails when M2M field is defined by multiple fields instead of UUID, because parser only accounts for a list of UUIDs:
```
if isinstance(serializer_field, serializers.ManyRelatedField):
    # A list of related objects, represented as a list of composite-keys
    if value:
        value = value.split(",")
    else:
        value = []
```

Example CSV file that fails for `Device` import:
```
name,device_type__manufacturer__name,device_type__model,location__name,location__location_type__name,role,status,software_image_files__software_version,software_image_files__image_file_name
TestDevice-1,Arista,7280RA,Aisle-06,Aisle,Switch,Active,"44723c38-b97c-4edf-952f-cef02fd5560b","test_image_1.bin"
TestDevice-2,Arista,7280RA,Aisle-06,Aisle,Switch,Active,"44723c38-b97c-4edf-952f-cef02fd5560b,44723c38-b97c-4edf-952f-cef02fd5560b","test_image_1.bin,test_image_2.bin"
```
# TODO
- [ ] Fix parser
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
