### PR TITLE
Add `@unsafe`, `.alters_data`, and/or `.do_not_call_in_templates` to various model methods

### DIFF
--- a/changes/7417.security
+++ b/changes/7417.security
@@ -1,0 +1,1 @@
+Added protections against access of various security-related and/or data-altering methods of various Nautobot models from within a Jinja2 sandboxed environment or the Django template renderer ([GHSA-wjw6-95h5-4jpx](https://github.com/nautobot/nautobot/security/advisories/GHSA-wjw6-95h5-4jpx)).

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -132,6 +132,8 @@ class BaseModel(models.Model):
         self.full_clean()
         self.save(*args, **kwargs)
 
+    validated_save.alters_data = True
+
     def natural_key(self) -> list:
         """
         Smarter default implementation of natural key construction.

--- a/nautobot/dcim/models/device_component_templates.py
+++ b/nautobot/dcim/models/device_component_templates.py
@@ -82,6 +82,8 @@ class ComponentTemplateModel(
         """
         raise NotImplementedError()
 
+    instantiate.alters_data = True
+
     def to_objectchange(self, action, **kwargs):
         """
         Return a new ObjectChange with the `related_object` pinned to the `device_type` by default.
@@ -121,6 +123,8 @@ class ComponentTemplateModel(
             _custom_field_data=custom_field_data,
             **kwargs,
         )
+
+    instantiate_model.alters_data = True
 
 
 class ModularComponentTemplateModel(ComponentTemplateModel):

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -182,6 +182,8 @@ class ModularComponentModel(ComponentModel):
                 if save:
                     self.save(update_fields=["_name", "name"])
 
+    render_name_template.alters_data = True
+
     def to_objectchange(self, action, **kwargs):
         """
         Return a new ObjectChange with the `related_object` pinned to the parent `device` or `module`.
@@ -820,6 +822,8 @@ class Interface(ModularComponentModel, CableTermination, PathEndpoint, BaseInter
                 instance.validated_save()
         return len(ip_addresses)
 
+    add_ip_addresses.alters_data = True
+
     def remove_ip_addresses(self, ip_addresses):
         """Remove one or more IPAddress instances from this interface's `ip_addresses` many-to-many relationship.
 
@@ -838,6 +842,8 @@ class Interface(ModularComponentModel, CableTermination, PathEndpoint, BaseInter
                 deleted_count, _ = qs.delete()
                 count += deleted_count
         return count
+
+    remove_ip_addresses.alters_data = True
 
     @property
     def is_connectable(self):
@@ -939,6 +945,8 @@ class InterfaceRedundancyGroup(PrimaryModel):  # pylint: disable=too-many-ancest
         )
         return instance.validated_save()
 
+    add_interface.alters_data = True
+
     def remove_interface(self, interface):
         """
         Remove an interface.
@@ -951,6 +959,8 @@ class InterfaceRedundancyGroup(PrimaryModel):  # pylint: disable=too-many-ancest
             interface=interface,
         )
         return instance.delete()
+
+    remove_interface.alters_data = True
 
 
 @extras_features("graphql")
@@ -1287,3 +1297,5 @@ class ModuleBay(PrimaryModel):
 
         if not self.position:
             self.position = self.name
+
+    clean.alters_data = True

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -897,6 +897,8 @@ class Device(PrimaryModel, ConfigContextModel):
             model.objects.bulk_create([x.instantiate(device=self) for x in templates])
         return instantiated_components
 
+    create_components.alters_data = True
+
     @property
     def display(self):
         if self.name:
@@ -1858,6 +1860,8 @@ class Module(PrimaryModel):
             model.objects.bulk_create([x.instantiate(device=None, module=self) for x in templates])
         return instantiated_components
 
+    create_components.alters_data = True
+
     def render_component_names(self):
         """
         Replace the {module}, {module.parent}, {module.parent.parent}, etc. template variables in descendant
@@ -1881,6 +1885,8 @@ class Module(PrimaryModel):
 
         for child in self.get_children():
             child.render_component_names()
+
+    render_component_names.alters_data = True
 
     def get_cables(self, pk_list=False):
         """

--- a/nautobot/docs/development/apps/api/platform-features/secrets-providers.md
+++ b/nautobot/docs/development/apps/api/platform-features/secrets-providers.md
@@ -17,6 +17,8 @@ For a simple (insecure!) example, we could define a "constant-value" provider th
 ```python
 # secrets.py
 from django import forms
+from jinja2.sandbox import unsafe
+
 from nautobot.apps.secrets import SecretsProvider
 from nautobot.utilities.forms import BootstrapMixin
 
@@ -41,6 +43,7 @@ class ConstantValueSecretsProvider(SecretsProvider):
         )
 
     @classmethod
+    @unsafe  # prevent this function from being called by a Jinja2 template
     def get_value_for_secret(cls, secret, obj=None, **kwargs):
         """
         Return the value defined in the Secret.parameters "constant" key.

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -269,6 +269,8 @@ class CustomFieldModel(models.Model):
                 elif cf.required:
                     raise ValidationError(f"Missing required custom field '{cf.key}'.")
 
+    clean.alters_data = True
+
     # Computed Field Methods
     def has_computed_fields(self, advanced_ui=None):
         """

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -180,6 +180,8 @@ class GitRepository(PrimaryModel):
             return enqueue_git_repository_diff_origin_and_local(self, user)
         return enqueue_pull_git_repository_and_refresh_data(self, user)
 
+    sync.alters_data = True
+
     @contextmanager
     def clone_to_directory_context(self, path=None, branch=None, head=None, depth=0):
         """
@@ -206,6 +208,8 @@ class GitRepository(PrimaryModel):
             # Cleanup the temporary directory
             if path_name:
                 self.cleanup_cloned_directory(path_name)
+
+    clone_to_directory_context.alters_data = True
 
     def clone_to_directory(self, path=None, branch=None, head=None, depth=0):
         """
@@ -246,6 +250,8 @@ class GitRepository(PrimaryModel):
         logger.info(f"Cloned repository {self.name} to {path_name}")
         return path_name
 
+    clone_to_directory.alters_data = True
+
     def cleanup_cloned_directory(self, path):
         """
         Cleanup the cloned directory.
@@ -259,3 +265,5 @@ class GitRepository(PrimaryModel):
         except OSError as os_error:
             # log error if the cleanup fails
             logger.error(f"Failed to cleanup temporary directory at {path}: {os_error}")
+
+    cleanup_cloned_directory.alters_data = True

--- a/nautobot/extras/models/groups.py
+++ b/nautobot/extras/models/groups.py
@@ -338,6 +338,8 @@ class DynamicGroup(PrimaryModel):
 
         return self.members
 
+    _set_members.alters_data = True
+
     def add_members(self, objects_to_add):
         """Add the given list or QuerySet of objects to this staticly defined group."""
         if self.group_type != DynamicGroupTypeChoices.TYPE_STATIC:
@@ -353,6 +355,8 @@ class DynamicGroup(PrimaryModel):
             existing_members = self.members
             objects_to_add = [obj for obj in objects_to_add if obj not in existing_members]
         return self._add_members(objects_to_add)
+
+    add_members.alters_data = True
 
     def _add_members(self, objects_to_add):
         """
@@ -377,6 +381,8 @@ class DynamicGroup(PrimaryModel):
             ]
             StaticGroupAssociation.all_objects.bulk_create(sgas, batch_size=1000)
 
+    _add_members.alters_data = True
+
     def remove_members(self, objects_to_remove):
         """Remove the given list or QuerySet of objects from this staticly defined group."""
         if self.group_type != DynamicGroupTypeChoices.TYPE_STATIC:
@@ -389,6 +395,8 @@ class DynamicGroup(PrimaryModel):
                 if not isinstance(obj, self.model):
                     raise TypeError(f"{obj} is not a {self.model._meta.label_lower}")
         return self._remove_members(objects_to_remove)
+
+    remove_members.alters_data = True
 
     def _remove_members(self, objects_to_remove):
         """Internal API for removing the given list or QuerySet from the cached/static members of this Group."""
@@ -417,6 +425,8 @@ class DynamicGroup(PrimaryModel):
             if self.group_type != DynamicGroupTypeChoices.TYPE_STATIC:
                 logger.debug("Re-connecting the _handle_deleted_object signal")
                 pre_delete.connect(_handle_deleted_object)
+
+    _remove_members.alters_data = True
 
     @property
     @method_deprecated("Members are now cached in the database via StaticGroupAssociations rather than in Redis.")
@@ -450,6 +460,8 @@ class DynamicGroup(PrimaryModel):
         logger.debug("Refreshed cache for %s, now with %d members", self, self.count)
 
         return members
+
+    update_cached_members.alters_data = True
 
     def has_member(self, obj, use_cache=False):
         """
@@ -559,6 +571,8 @@ class DynamicGroup(PrimaryModel):
             new_filter[field_name] = new_value
 
         self.filter = new_filter
+
+    set_filter.alters_data = True
 
     def get_initial(self):
         """
@@ -815,6 +829,8 @@ class DynamicGroup(PrimaryModel):
         instance = self.children.through(parent_group=self, group=child, operator=operator, weight=weight)
         return instance.validated_save()
 
+    add_child.alters_data = True
+
     # TODO: unused in core
     def remove_child(self, child):
         """
@@ -828,6 +844,8 @@ class DynamicGroup(PrimaryModel):
 
         instance = self.children.through.objects.get(parent_group=self, group=child)
         return instance.delete()
+
+    remove_child.alters_data = True
 
     def get_descendants(self, group=None):
         """

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -753,6 +753,8 @@ class JobResult(BaseModel, CustomFieldModel):
                     duration.total_seconds()
                 )
 
+    set_status.alters_data = True
+
     @classmethod
     def execute_job(cls, *args, **kwargs):
         """
@@ -767,6 +769,8 @@ class JobResult(BaseModel, CustomFieldModel):
             JobResult instance
         """
         return cls.enqueue_job(*args, **kwargs, synchronous=True)
+
+    execute_job.__func__.alters_data = True
 
     @classmethod
     def enqueue_job(
@@ -938,6 +942,8 @@ class JobResult(BaseModel, CustomFieldModel):
 
         return job_result
 
+    enqueue_job.__func__.alters_data = True
+
     def log(
         self,
         message,
@@ -988,6 +994,8 @@ class JobResult(BaseModel, CustomFieldModel):
             log.save()
         else:
             log.save(using=JOB_LOGS)
+
+    log.alters_data = True
 
 
 #
@@ -1076,12 +1084,16 @@ class ScheduledJobs(models.Model):
         if not instance.no_changes:
             cls.update_changed()
 
+    changed.__func__.alters_data = True
+
     @classmethod
     def update_changed(cls, raw=False, **kwargs):
         """This function acts as a signal handler to track changes to the scheduled job that is triggered after a change"""
         if raw:
             return
         cls.objects.update_or_create(ident=1, defaults={"last_update": timezone.now()})
+
+    update_changed.__func__.alters_data = True
 
     @classmethod
     def last_change(cls):
@@ -1396,6 +1408,8 @@ class ScheduledJob(BaseModel):
         )
         scheduled_job.validated_save()
         return scheduled_job
+
+    create_schedule.__func__.alters_data = True
 
     def to_cron(self):
         tz = self.time_zone

--- a/nautobot/extras/models/metadata.py
+++ b/nautobot/extras/models/metadata.py
@@ -251,6 +251,8 @@ class ObjectMetadata(ChangeLoggedModel, BaseModel):
         self.clean()
         return super().validated_save(*args, **kwargs)
 
+    validated_save.alters_data = True
+
     def clean(self):
         """
         Validate a value according to the field's type validation rules.

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -457,6 +457,8 @@ class ExportTemplate(
         if self.file_extension.startswith("."):
             self.file_extension = self.file_extension[1:]
 
+    clean.alters_data = True
+
 
 #
 # External integrations
@@ -918,6 +920,8 @@ class UserSavedViewAssociation(BaseModel):
     def clean(self):
         super().clean()
         self.view_name = self.saved_view.view
+
+    clean.alters_data = True
 
 
 #

--- a/nautobot/extras/secrets/__init__.py
+++ b/nautobot/extras/secrets/__init__.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from jinja2.sandbox import unsafe
+
 from nautobot.extras.registry import registry
 
 from .exceptions import SecretError, SecretParametersError, SecretProviderError, SecretValueNotFoundError
@@ -31,6 +33,7 @@ class SecretsProvider(ABC):
 
     @classmethod
     @abstractmethod
+    @unsafe
     def get_value_for_secret(cls, secret, obj=None, **kwargs):
         """Retrieve the stored value described by the given Secret record.
 

--- a/nautobot/extras/secrets/providers.py
+++ b/nautobot/extras/secrets/providers.py
@@ -7,6 +7,7 @@ import os
 
 from django import forms
 from django.core.exceptions import ValidationError
+from jinja2.sandbox import unsafe
 
 from nautobot.core.forms import BootstrapMixin
 from nautobot.extras.secrets import SecretsProvider
@@ -23,6 +24,7 @@ class EnvironmentVariableSecretsProvider(SecretsProvider):
         variable = forms.CharField(required=True, help_text="Environment variable name")
 
     @classmethod
+    @unsafe
     def get_value_for_secret(cls, secret, obj=None, **kwargs):
         """Retrieve the appropriate environment variable's value."""
         rendered_parameters = secret.rendered_parameters(obj=obj)
@@ -58,6 +60,7 @@ class TextFileSecretsProvider(SecretsProvider):
             return self.cleaned_data
 
     @classmethod
+    @unsafe
     def get_value_for_secret(cls, secret, obj=None, **kwargs):
         """
         Retrieve the appropriate text file's contents.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -200,6 +200,8 @@ class VRF(PrimaryModel):
         instance.validated_save()
         return instance
 
+    add_device.alters_data = True
+
     def remove_device(self, device):
         """
         Remove a `device` from this VRF.
@@ -212,6 +214,8 @@ class VRF(PrimaryModel):
         """
         instance = self.devices.through.objects.get(vrf=self, device=device)
         return instance.delete()
+
+    remove_device.alters_data = True
 
     def add_virtual_machine(self, virtual_machine, rd="", name=""):
         """
@@ -231,6 +235,8 @@ class VRF(PrimaryModel):
         instance.validated_save()
         return instance
 
+    add_virtual_machine.alters_data = True
+
     def remove_virtual_machine(self, virtual_machine):
         """
         Remove a `virtual_machine` from this VRF.
@@ -243,6 +249,8 @@ class VRF(PrimaryModel):
         """
         instance = self.virtual_machines.through.objects.get(vrf=self, virtual_machine=virtual_machine)
         return instance.delete()
+
+    remove_virtual_machine.alters_data = True
 
     def add_virtual_device_context(self, virtual_device_context, rd="", name=""):
         """
@@ -264,6 +272,8 @@ class VRF(PrimaryModel):
         instance.validated_save()
         return instance
 
+    add_virtual_device_context.alters_data = True
+
     def remove_virtual_device_context(self, virtual_device_context):
         """
         Remove a `virtual_device_context` from this VRF.
@@ -279,6 +289,8 @@ class VRF(PrimaryModel):
         )
         return instance.delete()
 
+    remove_virtual_device_context.alters_data = True
+
     def add_prefix(self, prefix):
         """
         Add a `prefix` to this VRF. Each object must be in the same Namespace.
@@ -293,6 +305,8 @@ class VRF(PrimaryModel):
         instance.validated_save()
         return instance
 
+    add_prefix.alters_data = True
+
     def remove_prefix(self, prefix):
         """
         Remove a `prefix` from this VRF.
@@ -305,6 +319,8 @@ class VRF(PrimaryModel):
         """
         instance = self.prefixes.through.objects.get(vrf=self, prefix=prefix)
         return instance.delete()
+
+    remove_prefix.alters_data = True
 
 
 @extras_features("graphql")
@@ -373,6 +389,8 @@ class VRFDeviceAssignment(BaseModel):
             raise ValidationError(
                 "A VRFDeviceAssignment entry must be associated with a device, a virtual machine, or a virtual device context."
             )
+
+    clean.alters_data = True
 
 
 @extras_features("graphql")
@@ -640,6 +658,8 @@ class Prefix(PrimaryModel):
             self.prefix_length = prefix.prefixlen
             self.ip_version = prefix.version
 
+    _deconstruct_prefix.alters_data = True
+
     def delete(self, *args, **kwargs):
         """
         A Prefix with children will be impossible to delete and raise a `ProtectedError`.
@@ -705,6 +725,8 @@ class Prefix(PrimaryModel):
             return parent
         return None
 
+    get_parent.alters_data = True
+
     def clean(self):
         if self.prefix is not None:  # missing network/prefix_length will be caught by super().clean()
             # Clear host bits from prefix
@@ -715,6 +737,8 @@ class Prefix(PrimaryModel):
             self.parent = self.get_parent()
 
         super().clean()
+
+    clean.alters_data = True
 
     def save(self, *args, **kwargs):
         self.clean()
@@ -821,6 +845,8 @@ class Prefix(PrimaryModel):
 
         return query.update(parent=self)
 
+    reparent_subnets.alters_data = True
+
     def reparent_ips(self):
         """Determine the list of child IPAddresses and set the parent to self."""
         query = IPAddress.objects.select_for_update().filter(
@@ -831,6 +857,8 @@ class Prefix(PrimaryModel):
         )
 
         return query.update(parent=self)
+
+    reparent_ips.alters_data = True
 
     def supernets(self, direct=False, include_self=False, for_update=False):
         """
@@ -1228,6 +1256,8 @@ class IPAddress(PrimaryModel):
             self.mask_length = address.prefixlen
             self.ip_version = address.version
 
+    _deconstruct_address.alters_data = True
+
     natural_key_field_names = ["parent__namespace", "host"]
 
     def _get_closest_parent(self):
@@ -1288,6 +1318,8 @@ class IPAddress(PrimaryModel):
             self.dns_name = self.dns_name.lower()
 
         super().clean()
+
+    clean.alters_data = True
 
     def save(self, *args, **kwargs):
         self.clean()  # MUST do data fixup as above

--- a/nautobot/users/models.py
+++ b/nautobot/users/models.py
@@ -139,6 +139,8 @@ class User(BaseModel, AbstractUser):
         if commit:
             self.save()
 
+    set_config.alters_data = True
+
     def clear_config(self, path, commit=False):
         """
         Delete a configuration parameter specified by its dotted path. The key and any child keys will be deleted.
@@ -165,6 +167,8 @@ class User(BaseModel, AbstractUser):
 
         if commit:
             self.save()
+
+    clear_config.alters_data = True
 
 
 #

--- a/nautobot/virtualization/models.py
+++ b/nautobot/virtualization/models.py
@@ -444,6 +444,8 @@ class VMInterface(PrimaryModel, BaseInterface):
                 instance.validated_save()
         return len(ip_addresses)
 
+    add_ip_addresses.alters_data = True
+
     def remove_ip_addresses(self, ip_addresses):
         """Remove one or more IPAddress instances from this interface's `ip_addresses` many-to-many relationship.
 
@@ -462,6 +464,8 @@ class VMInterface(PrimaryModel, BaseInterface):
                 deleted_count, _ = qs.delete()
                 count += deleted_count
         return count
+
+    remove_ip_addresses.alters_data = True
 
     @property
     def parent(self):


### PR DESCRIPTION
# Closes GHSA-wjw6-95h5-4jpx
# What's Changed

- Annotate `Secret.get_value` and `SecretsGroup.get_secret_value` methods with Jinja2 `@unsafe` decorator and Django `do_not_call_in_templates` attribute so that these methods cannot be called in either a Jinja2 sandboxed environment or a Django template environment.
- Annotate various other data-altering or otherwise potentially-destructive model methods with Django `alters_data` attribute, which has the same effect as the above in both Jinja2 and Django templates.

(I've used the mix of the two approaches here as I believe it's most *truthful* to the semantics of these various methods, but we could if preferred pick one approach or the other and use it throughout instead.)

- Add unit tests for many of the more egregious cases.

An equivalent PR for ltm-1.6 will follow shortly.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
