### PR TITLE
Issue #7283 fix - Dynamic groups pagination not working

### DIFF
--- a/changes/.7283.fixed
+++ b/changes/.7283.fixed
@@ -1,0 +1,1 @@
+Fixed dynamic groups pagination for members tab.

--- a/nautobot/extras/templates/extras/dynamicgroup.html
+++ b/nautobot/extras/templates/extras/dynamicgroup.html
@@ -3,7 +3,7 @@
 
 {% block extra_nav_tabs %}
         <li role="presentation"{% if request.GET.tab == 'members' %} class="active"{% endif %}>
-            <a href="{{ object.get_absolute_url }}#members" onclick="switch_tab(this.href, reload=false)" aria-controls="members" role="tab" data-toggle="tab">
+            <a href="{{ object.get_absolute_url }}#members" onclick="switch_tab(this.href)" aria-controls="members" role="tab" data-toggle="tab">
                 Members {% badge object.count %}
             </a>
         </li>


### PR DESCRIPTION
# Closes #7283 
# What's Changed
Onclick variable in html code changed for dynamic groups members. Pagination was inserting ?tab=main into the url and it would go to the main dynamic group. This means you would have to click on members again to see the page 2 members.

URL before:
http://127.0.0.1:8080/extras/dynamic-groups/ee634809-963d-495c-848f-953b68cbece9/?tab=main&page=2
URL after:
http://127.0.0.1:8080/extras/dynamic-groups/ee634809-963d-495c-848f-953b68cbece9/?tab=members&page=2

Now when selecting any pages at the bottom of the members page you will see the members instead over going back to main dynamic group page.

# Screenshots
Before:

![image](https://github.com/user-attachments/assets/b6a8dc36-6889-413f-a8c2-58d8fc30da3c)

After:

![image](https://github.com/user-attachments/assets/559083c6-e1d2-49d8-9c7b-9145dccbbde5)

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example

