### PR TITLE
Release 1.6.32

### DIFF
--- a/changes/6672.security
+++ b/changes/6672.security
@@ -1,1 +1,0 @@
-Added enforcement of user authentication when serving uploaded media files (GHSA-rh67-4c8j-hjjh).

--- a/changes/7250.fixed
+++ b/changes/7250.fixed
@@ -1,1 +1,0 @@
-Fixed JSON and MULTISELECT custom field being returned as a `repr()` string when using GraphQL.

--- a/changes/7305.added
+++ b/changes/7305.added
@@ -1,2 +1,0 @@
-Added RackRoleFilterForm, ManufacturerFilterForm, DeviceRoleFilterForm, PlatformFilterForm, RoleFilterForm, TenantGroupFilterForm, ClusterTypeFilterForm, ClusterGroupFilterForm, CustomFieldFilterForm, CircuitTypeFilterForm and set them to proper `filterset_form` or `filterset_form_class` in views.
-Added a generic test case that asserts that all list views provide an appropriate FilterForm class.

--- a/changes/7429.security
+++ b/changes/7429.security
@@ -1,1 +1,0 @@
-Added protections against access of various security-related and/or data-altering methods of various Nautobot models from within a Jinja2 sandboxed environment or the Django template renderer ([GHSA-wjw6-95h5-4jpx](https://github.com/nautobot/nautobot/security/advisories/GHSA-wjw6-95h5-4jpx)).

--- a/changes/7432.documentation
+++ b/changes/7432.documentation
@@ -1,4 +1,0 @@
-Added "Security Notices" document to the documentation under **Administration**.
-Fixed a number of broken links in the documentation.
-Added latest security disclosures to the documentation.
-Removed John Anderson as a point of contact for Nautobot security issues.

--- a/nautobot/docs/release-notes/version-1.6.md
+++ b/nautobot/docs/release-notes/version-1.6.md
@@ -89,6 +89,13 @@ As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support ins
 
 - [#7250](https://github.com/nautobot/nautobot/issues/7250) - Fixed JSON and MULTISELECT custom field being returned as a `repr()` string when using GraphQL.
 
+### Documentation
+
+- [#7432](https://github.com/nautobot/nautobot/issues/7432) - Added "Security Notices" document to the documentation under **Administration**.
+- [#7432](https://github.com/nautobot/nautobot/issues/7432) - Fixed a number of broken links in the documentation.
+- [#7432](https://github.com/nautobot/nautobot/issues/7432) - Added latest security disclosures to the documentation.
+- [#7432](https://github.com/nautobot/nautobot/issues/7432) - Removed John Anderson as a point of contact for Nautobot security issues.
+
 ## v1.6.31 (2025-05-12)
 
 ### Security

--- a/nautobot/docs/release-notes/version-1.6.md
+++ b/nautobot/docs/release-notes/version-1.6.md
@@ -73,6 +73,22 @@ As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support ins
 
 <!-- towncrier release notes start -->
 
+## v1.6.32 (2025-06-09)
+
+### Security
+
+- [#6672](https://github.com/nautobot/nautobot/issues/6672) - Added enforcement of user authentication when serving uploaded media files ([GHSA-rh67-4c8j-hjjh](https://github.com/nautobot/nautobot/security/advisories/GHSA-rh67-4c8j-hjjh)).
+- [#7429](https://github.com/nautobot/nautobot/issues/7429) - Added protections against access of various security-related and/or data-altering methods of various Nautobot models from within a Jinja2 sandboxed environment or the Django template renderer ([GHSA-wjw6-95h5-4jpx](https://github.com/nautobot/nautobot/security/advisories/GHSA-wjw6-95h5-4jpx)).
+
+### Added
+
+- [#7305](https://github.com/nautobot/nautobot/issues/7305) - Added RackRoleFilterForm, ManufacturerFilterForm, DeviceRoleFilterForm, PlatformFilterForm, RoleFilterForm, TenantGroupFilterForm, ClusterTypeFilterForm, ClusterGroupFilterForm, CustomFieldFilterForm, CircuitTypeFilterForm and set them to proper `filterset_form` or `filterset_form_class` in views.
+- [#7305](https://github.com/nautobot/nautobot/issues/7305) - Added a generic test case that asserts that all list views provide an appropriate FilterForm class.
+
+### Fixed
+
+- [#7250](https://github.com/nautobot/nautobot/issues/7250) - Fixed JSON and MULTISELECT custom field being returned as a `repr()` string when using GraphQL.
+
 ## v1.6.31 (2025-05-12)
 
 ### Security
@@ -85,7 +101,7 @@ As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support ins
 
 ### Housekeeping
 
-- [#6618](https://github.com/nautobot/nautobot/issues/6618) - Update GitHub actions *.yml file to use minimum ubuntu-24.04 since ubuntu-20.04 is deprecated.
+- [#6618](https://github.com/nautobot/nautobot/issues/6618) - Update GitHub actions `*.yml` file to use minimum ubuntu-24.04 since ubuntu-20.04 is deprecated.
 - [#6988](https://github.com/nautobot/nautobot/issues/6988) - Updated GitHub Actions to use `networktocode/gh-action-setup-poetry-environment@v6`.
 
 ## v1.6.30 (2025-01-06)
@@ -133,7 +149,7 @@ As Python 3.7 has reached end-of-life, Nautobot 1.6 and later do not support ins
 
 ### Fixed
 
-- [#6081](https://github.com/nautobot/nautobot/issues/6081) - Fixed AttributeError during pre_migrate when permission constraints are applied to custom fields.
+- [#6081](https://github.com/nautobot/nautobot/issues/6081) - Fixed AttributeError during `pre_migrate` when permission constraints are applied to custom fields.
 
 ## v1.6.26 (2024-07-22)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "1.6.31"
+version = "1.6.32"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Security

- [#6672](https://github.com/nautobot/nautobot/issues/6672) - Added enforcement of user authentication when serving uploaded media files ([GHSA-rh67-4c8j-hjjh](https://github.com/nautobot/nautobot/security/advisories/GHSA-rh67-4c8j-hjjh)).
- [#7429](https://github.com/nautobot/nautobot/issues/7429) - Added protections against access of various security-related and/or data-altering methods of various Nautobot models from within a Jinja2 sandboxed environment or the Django template renderer ([GHSA-wjw6-95h5-4jpx](https://github.com/nautobot/nautobot/security/advisories/GHSA-wjw6-95h5-4jpx)).

### Added

- [#7305](https://github.com/nautobot/nautobot/issues/7305) - Added RackRoleFilterForm, ManufacturerFilterForm, DeviceRoleFilterForm, PlatformFilterForm, RoleFilterForm, TenantGroupFilterForm, ClusterTypeFilterForm, ClusterGroupFilterForm, CustomFieldFilterForm, CircuitTypeFilterForm and set them to proper `filterset_form` or `filterset_form_class` in views.
- [#7305](https://github.com/nautobot/nautobot/issues/7305) - Added a generic test case that asserts that all list views provide an appropriate FilterForm class.

### Fixed

- [#7250](https://github.com/nautobot/nautobot/issues/7250) - Fixed JSON and MULTISELECT custom field being returned as a `repr()` string when using GraphQL.


TODO:
- [x] #7432 