### PR TITLE
fix: draggable homepage panels on firefox

### DIFF
--- a/changes/7480.fixed
+++ b/changes/7480.fixed
@@ -1,0 +1,1 @@
+Fixed draggable homepage panels on Firefox.

--- a/nautobot/core/templates/home.html
+++ b/nautobot/core/templates/home.html
@@ -55,17 +55,19 @@
                     {% with cookie_key='homepanel-'|add:panel_name|slugify %}
                         <div class="card-header nb-draggable-handle">
                             <strong class="text-body nb-text-none">{{ panel_name }}</strong>
-                            <button
+                            {% comment %}Not using <button> element here because of Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=568313 {% endcomment %}
+                            <span
                                 class="btn stretched-link nb-collapse-toggle nb-cursor-unset"
-                                type="button"
                                 panel-id="homepanel-{{ panel_name|slugify }}"
+                                role="button"
+                                tabindex="0"
                                 data-bs-toggle="collapse"
                                 data-bs-target="#homepanel-{{ panel_name|slugify }}"
                                 aria-expanded="{% if request.COOKIES|default:''|get_item:cookie_key|default:'False' == 'False' %}true{% else %}false{% endif %}"
                                 aria-controls="homepanel-{{ panel_name|slugify }}"
                             >
                                 <span class="mdi mdi-chevron-down"></span>
-                            </button>
+                            </span>
                         </div>
                         <ul
                             id="homepanel-{{ panel_name|slugify }}"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Fix v3 UI draggable homepage panels on Firefox. As it turns out, Firefox has a long-standing bug that prevents using HTML Drag and Drop API on `<button>` elements: https://bugzilla.mozilla.org/show_bug.cgi?id=568313

Tracking: NAUTOBOT-873