### PR TITLE
build: add npm manager to renovate configuration

### DIFF
--- a/changes/7505.added
+++ b/changes/7505.added
@@ -1,0 +1,1 @@
+Added "npm" manager to Renovate configuration.

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "baseBranches": ["develop", "next"],
-  "enabledManagers": ["pip_requirements", "poetry"],
+  "enabledManagers": ["npm", "pip_requirements", "poetry"],
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# What's Changed
Add `"npm"` manager to Renovate configuration.

Tracking NAUTOBOT-848