### PR TITLE
Change Prefix list view and Prefix prefixes view to not show utilization by default.

### DIFF
--- a/changes/7486.changed
+++ b/changes/7486.changed
@@ -1,0 +1,1 @@
+Changed Prefix list view and Prefix prefixes view default configuration to not show "utilization" by default, as it is not performant at scale.

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -446,7 +446,6 @@ class PrefixDetailTable(PrefixTable):
             "status",
             "children",
             "vrf_count",
-            "utilization",
             "tenant",
             "location_count",
             "vlan",


### PR DESCRIPTION
# Relates #7486
# What's Changed
Due to performance impact:

Hide "Utilization" column from Prefix list view and Prefix prefixes view by default.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design

Tracking NAUTOBOT-798