### PR TITLE
#7547 Fixed worker-status page failing with a KeyError

### DIFF
--- a/changes/7547.fixed
+++ b/changes/7547.fixed
@@ -1,0 +1,1 @@
+Fixed worker-status page failing with a KeyError.

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -908,7 +908,7 @@ class JobResultTable(BaseTable):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Only calculate log counts for "summary" column if it's actually visible.
-        if self.columns["summary"].visible and isinstance(self.data.data, QuerySet):
+        if "summary" in self.columns and self.columns["summary"].visible and isinstance(self.data.data, QuerySet):
             self.data = TableData.from_data(
                 self.data.data.annotate(
                     debug_log_count=count_related(


### PR DESCRIPTION
#### Closes #7547

Just following @glennmatthews suggestion. Tested locally without issue

<img width="1060" height="710" alt="image" src="https://github.com/user-attachments/assets/ee71d4a8-9cc3-4d2b-9580-aff242015935" />
