### PR TITLE
introduces extra annotations to improve prefix list view performance

### DIFF
--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -1,4 +1,4 @@
-from django.db.models import Prefetch, QuerySet
+from django.db.models import Prefetch, QuerySet, F
 from django.utils.safestring import mark_safe
 import django_tables2 as tables
 from django_tables2.data import TableData
@@ -51,7 +51,7 @@ UTILIZATION_GRAPH = """
 PREFIX_COPY_LINK = """
 {% load helpers %}
 {% if not table.hide_hierarchy_ui %}
-{% tree_hierarchy_ui_representation record.ancestors.count|as_range table.hide_hierarchy_ui base_tree_depth|default:0 %}
+{% tree_hierarchy_ui_representation record.ancestors_count|as_range table.hide_hierarchy_ui base_tree_depth|default:0 %}
 {% endif %}
 <span class="hover_copy">
   <a href="\

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -323,7 +323,9 @@ class PrefixListView(generic.ObjectListView):
     filterset_form = forms.PrefixFilterForm
     table = tables.PrefixDetailTable
     template_name = "ipam/prefix_list.html"
-    queryset = Prefix.objects.all()
+    queryset = (
+        Prefix.objects.all().annotate_descendants_count().annotate_ancestors_count().annotate_ip_address_children()
+    )
 
 
 class PrefixView(generic.ObjectView):


### PR DESCRIPTION

# Closes #<ISSUE NUMBER GOES HERE>DNE
# What's Changed

## Query behaviour before

- 1 query per prefix for IP address children for utilization
- 1 query per prefix for prefix children count
- 1 query per prefix for ancestors count

<img width="260" height="251" alt="Screenshot 2025-07-29 at 13 49 49" src="https://github.com/user-attachments/assets/bbd342c6-248c-44ec-a1c5-ebe0c5d70b17" />

## Query behaviour after

- the above queries are done along with the normal paginated query through `annotate`

<img width="296" height="221" alt="Screenshot 2025-07-29 at 13 49 27" src="https://github.com/user-attachments/assets/c9b941d3-97f5-4c95-9136-2fb565cbc7fc" />

# TODO

- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
