### PR TITLE
Closes #7636: Fixed bug where 'resolve_<foo>' method in graphql/types.py was not called for reverse relationship

### DIFF
--- a/changes/7636.fixed
+++ b/changes/7636.fixed
@@ -1,0 +1,1 @@
+Fixed a bug in which "resolve_<foo>" methods in a graphql/types.py files were not called where <foo> was a reverse relationship.

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -221,6 +221,11 @@ def extend_schema_type_filter(schema_type, model):
         child_schema_type = registry["graphql_types"].get(field.related_model._meta.label_lower)
         if child_schema_type:
             resolver_name = f"resolve_{field.name}"
+
+            if resolver_fn := getattr(schema_type, resolver_name, None):
+                setattr(schema_type, resolver_name, resolver_fn)
+                continue
+
             search_params = generate_list_search_parameters(child_schema_type)
             # Add OneToMany field to schema_type
             schema_type._meta.fields[field.name] = graphene.Field.mounted(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #7636 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

Added a check for `resolve_<foo>` in the class in the `schema_type` class instance, which permits plugin developers to at least create their own optimizations until it's better handled in core.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

With the following code in my plugin's graphql/types.py:

```python
"""Custom GraphQL types for nautobot_dns_models."""

from nautobot.core.graphql.types import OptimizedNautobotObjectType
from nautobot_dns_models.models import DNSZoneModel
from nautobot_dns_models.filters import DNSZoneModelFilterSet


class DNSZoneModelType(OptimizedNautobotObjectType):
    """Optimized GraphQL Type for DNSZone with prefetched A records."""

    def resolve_name(self, info):
        print(f"[DNSZoneModelType] Entering resolve_name")

        #
        # Just for testing
        return self.name

    #
    # This is graphql query optimization
    def resolve_a_records(self, info):
        """A resolver for the a_records field w."""
        print(f"[DNSZoneModelType] Entering resolve_a_records")

        #
        # Just for testing
        return seld.a_records

    class Meta:
        model = DNSZoneModel
        filterset_class = DNSZoneModelFilterSet


graphql_types = [
    DNSZoneModelType,
]
```


## Before

```
[DNSZoneModelType] Entering resolve_name   <-- just the 'name'
18:42:37.255 INFO    django.server :
 "POST /graphql/ HTTP/1.1" 200 498
```

## After

```
[DNSZoneModelType] Entering resolve_name         <-- 'name'
[DNSZoneModelType] Entering resolve_a_records    <-- 'a_records'
18:41:27.995 INFO    django.server :
 "POST /graphql/ HTTP/1.1" 200 498
18:41:28.110 INFO    django.server :
 "POST /graphql/ HTTP/1.1" 200 10861565
```


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
