### PR TITLE
Add management command `check_job_approval_status`

### DIFF
--- a/changes/7364.added
+++ b/changes/7364.added
@@ -1,0 +1,1 @@
+Added new management command `check_job_approval_status` to detect scheduled jobs and jobs that still require approval. This command helps during upgrade to Nautobot 3.x.

--- a/nautobot/core/management/commands/check_job_approval_status.py
+++ b/nautobot/core/management/commands/check_job_approval_status.py
@@ -1,0 +1,40 @@
+from django.core.exceptions import ValidationError
+from django.core.management.base import BaseCommand
+
+from nautobot.extras.models import Job, ScheduledJob
+
+
+class ApprovalRequiredScheduledJobsError(ValidationError):
+    """Raised when scheduled jobs requiring approval are found during managment command."""
+
+
+class Command(BaseCommand):
+    help = "Checks for scheduled jobs and jobs that require approval."
+
+    def handle(self, *args, **options):
+        approval_required_scheduled_jobs = ScheduledJob.objects.filter(approval_required=True).values_list("id", "name")
+
+        if approval_required_scheduled_jobs:
+            message_lines = [
+                "There are scheduled jobs that still require approval.",
+                "Please clear, approve or deny the job in approval queue.",
+                "Below is a list of affected scheduled jobs:",
+            ]
+            for schedule_job_id, scheduled_job_name in approval_required_scheduled_jobs:
+                message_lines.append(f"    - ID: {schedule_job_id}, Name: {scheduled_job_name}")
+            raise ApprovalRequiredScheduledJobsError("\n".join(message_lines))
+
+        approval_required_jobs = Job.objects.filter(approval_required=True).values_list("name", flat=True)
+        if approval_required_jobs:
+            message_lines = [
+                "Following jobs still have `approval_required=True`.",
+                "These jobs will no longer trigger approval automatically.",
+                "After upgrading to Nautobot 3.x, you should add an approval workflow definition(s) covering these jobs.",
+                "Refer to the documentation: https://docs.nautobot.com/projects/core/en/next/user-guide/platform-functionality/approval-workflow/",
+                "Affected jobs (Names):",
+            ]
+            for job_name in approval_required_jobs:
+                message_lines.append(f"    - {job_name}")
+        else:
+            message_lines = ["No approval_required jobs or scheduled jobs found."]
+        self.stdout.write("\n".join(message_lines))

--- a/nautobot/core/tests/test_commands.py
+++ b/nautobot/core/tests/test_commands.py
@@ -1,9 +1,13 @@
 from io import StringIO
 
 from django.core.management import call_command
+from django.utils.timezone import now
 import yaml
 
+from nautobot.core.management.commands.check_job_approval_status import ApprovalRequiredScheduledJobsError
 from nautobot.core.testing import TestCase
+from nautobot.extras.choices import JobExecutionType
+from nautobot.extras.models import Job, ScheduledJob
 
 
 class ManagementCommandTestCase(TestCase):
@@ -29,3 +33,37 @@ class ManagementCommandTestCase(TestCase):
                 self.assertHttpStatus(
                     response, 200, f"{view_name}: {endpoint} returns status Code {response.status_code} instead of 200"
                 )
+
+    def test_check_job_approval_status_no_jobs(self):
+        out = StringIO()
+        # update all jobs to not have approval_required=True
+        Job.objects.update(approval_required=False)
+        call_command("check_job_approval_status", stdout=out)
+        output = out.getvalue()
+        self.assertIn("No approval_required jobs or scheduled jobs found.", output)
+
+    def test_check_job_approval_status_with__with_approval_required_jobs(self):
+        out = StringIO()
+        self.assertTrue(Job.objects.filter(approval_required=True).exists())
+        self.assertFalse(ScheduledJob.objects.filter(approval_required=True).exists())
+        call_command("check_job_approval_status", stdout=out)
+        output = out.getvalue()
+        self.assertIn("Following jobs still have `approval_required=True`.", output)
+
+    def test_check_job_approval_status_with_approval_required_scheduled_jobs(self):
+        job = Job.objects.first()
+        scheduled_job = ScheduledJob.objects.create(
+            name="Scheduled Job",
+            task="test_managment_command.TestManagmentCommand",
+            job_model=job,
+            interval=JobExecutionType.TYPE_IMMEDIATELY,
+            user=self.user,
+            approval_required=True,
+            start_time=now(),
+        )
+        self.assertTrue(ScheduledJob.objects.filter(approval_required=True).exists())
+        with self.assertRaises(ApprovalRequiredScheduledJobsError) as cm:
+            call_command("check_job_approval_status")
+
+        self.assertIn("There are scheduled jobs that still require approval.", str(cm.exception))
+        self.assertIn(scheduled_job.name, str(cm.exception))


### PR DESCRIPTION
# Relates #7364 
# What's Changed
Added new management command `check_job_approval_status` to detect scheduled jobs and jobs that still require approval. This command helps during upgrade to Nautobot 3.x.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
