### PR TITLE
Fix missing `tagged_items` in API response from Create Tag

### DIFF
--- a/changes/7649.fixed
+++ b/changes/7649.fixed
@@ -1,0 +1,1 @@
+Fix missing `tagged_items` in JSON response when creating Tag object with API `/api/extras/tags/` endpoint.

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -1116,6 +1116,7 @@ class TagSerializer(NautobotModelSerializer):
 
         return attrs
 
+    @extend_schema_field(serializers.IntegerField(read_only=True))
     def get_tagged_items(self, obj):
         return TaggedItem.objects.filter(tag=obj).count()
 

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.db.models import Count
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist

--- a/nautobot/extras/api/serializers.py
+++ b/nautobot/extras/api/serializers.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.db.models import Count
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
@@ -89,6 +90,7 @@ from nautobot.extras.models import (
     Webhook,
 )
 from nautobot.extras.models.mixins import NotesMixin
+from nautobot.extras.models.tags import TaggedItem
 from nautobot.extras.utils import (
     ChangeLoggedModelsQuery,
     FeatureQuery,
@@ -1087,7 +1089,7 @@ class StatusSerializer(NautobotModelSerializer):
 
 
 class TagSerializer(NautobotModelSerializer):
-    tagged_items = serializers.IntegerField(read_only=True)
+    tagged_items = serializers.SerializerMethodField()
     content_types = ContentTypeField(
         queryset=TaggableClassesQuery().as_queryset(),
         many=True,
@@ -1114,6 +1116,8 @@ class TagSerializer(NautobotModelSerializer):
 
         return attrs
 
+    def get_tagged_items(self, obj):
+        return TaggedItem.objects.filter(tag=obj).count()
 
 #
 # Teams


### PR DESCRIPTION
# Closes #7649
# What's Changed

Adds the missing `tagged_items` key in the API response from create Tag object at `/api/extras/tags/`


Example response from this change, tested on a Nautobot v2.4.15b1 Docker container
```json
{
  "id": "a01bf613-a6b2-43f4-97e8-ffddee21ca0a",
  "object_type": "extras.tag",
  "display": "test-tag-1",
  "url": "http://127.0.0.1:8080/api/extras/tags/a01bf613-a6b2-43f4-97e8-ffddee21ca0a/",
  "natural_slug": "test-tag-1_a01b",
  "tagged_items": 0,
  "content_types": [
    "ipam.prefix"
  ],
  "name": "test-tag-1",
  "color": "00ff00",
  "description": "",
  "created": "2025-08-05T16:27:42.689795Z",
  "last_updated": "2025-08-05T16:27:42.689807Z",
  "notes_url": "http://127.0.0.1:8080/api/extras/tags/a01bf613-a6b2-43f4-97e8-ffddee21ca0a/notes/",
  "custom_fields": {},
  "computed_fields": {},
  "relationships": {}
}

```

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Screenshot showing the Integer typing is maintained
<img width="1854" height="2097" alt="image" src="https://github.com/user-attachments/assets/8426943b-d0f9-4235-8dc6-059085970c92" />


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design


# Notes
The extend_schema_field decorator maintains the "integer" typing for the Swagger Docs, otherwise it will show as String