### PR TITLE
Fix Children in `location_retrieve.html`

### DIFF
--- a/changes/7662.fixed
+++ b/changes/7662.fixed
@@ -1,0 +1,1 @@
+Fixed the Children section in `location_retrieve.html` to properly display child locations of the same Location Type (e.g., sites within sites, rooms within rooms).

--- a/nautobot/dcim/templates/dcim/location_retrieve.html
+++ b/nautobot/dcim/templates/dcim/location_retrieve.html
@@ -59,7 +59,7 @@
             <tr>
                 <td>Children</td>
                 <td>
-                    {% if object.location_type.children.all %}
+                    {% if object.children.all %}
                         <a href="{% url 'dcim:location_list' %}?parent={{ object.pk }}">{{ children_table.rows|length }}</a>
                     {% else %}
                         {{ None|placeholder }}
@@ -230,7 +230,7 @@
 {% endblock content_right_page %}
 
 {% block content_full_width_page %}
-    {% if object.location_type.children.all %}
+    {% if object.children.all %}
         <div class="panel panel-default">
             <div class="panel-heading">
                 <strong>Children</strong>


### PR DESCRIPTION

# What's Changed

Fixed an issue where locations of the same Location Type (e.g., sites within sites or rooms within rooms) didn't correctly display their child locations in the UI. While the child locations correctly referenced their parent in the hierarchy, the parent locations failed to show their nested children. This has been resolved, and parent locations now properly display their child locations as expected.

# Screenshots
<img width="828" height="749" alt="Screenshot 2025-08-11 at 18 27 20" src="https://github.com/user-attachments/assets/fe344c69-fa13-43ec-80d0-2fd62941be53" />
<img width="817" height="722" alt="Screenshot 2025-08-11 at 18 27 38" src="https://github.com/user-attachments/assets/9e166891-4c55-49ee-b042-7f48ca982b2e" />
<img width="1642" height="208" alt="Screenshot 2025-08-11 at 18 27 52" src="https://github.com/user-attachments/assets/c5afc5dc-e841-43c5-bfc0-01e891333f24" />

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
