### PR TITLE
Ensure ordering and use more native constructs

### DIFF
--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -1251,6 +1251,10 @@ class ObjectFieldsPanel(KeyValueTablePanel):
         if isinstance(instance, TreeModel) and (self.fields == "__all__" or "_hierarchy" in self.fields):
             # using `_hierarchy` with the prepended `_` to try to archive a unique name, in cases where a model might have hierarchy field.
             data["_hierarchy"] = instance
+            if not hasattr(instance, "_hierarchy"):
+                instance._hierarchy = instance
+
+        ordered_data = {}
 
         for field_name in fields:
             if field_name in self.exclude_fields:
@@ -1264,13 +1268,13 @@ class ObjectFieldsPanel(KeyValueTablePanel):
                     continue
                 raise
 
-            data[field_name] = field_value
+            ordered_data[field_name] = field_value
 
         # Ensuring the `name` field is displayed first, if present.
-        if "name" in data:
-            data = {"name": data["name"], **{k: v for k, v in data.items() if k != "name"}}
+        if "name" in ordered_data:
+            ordered_data = {"name": ordered_data["name"], **{k: v for k, v in ordered_data.items() if k != "name"}}
 
-        return data
+        return ordered_data
 
     def render_key(self, key, value, context: Context):
         """Render the `verbose_name` of the model field whose name corresponds to the given key, if applicable."""

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -345,19 +345,6 @@ class LocationImagesTablePanel(object_detail.ObjectsTablePanel):
         return None
 
 
-class LocationHierarchyPanel(object_detail.ObjectFieldsPanel):
-    def get_data(self, context):
-        data = super().get_data(context)
-        obj = get_obj_from_context(context, self.context_object_key)
-        data["ancestors"] = obj
-        return data
-
-    def render_key(self, key, value, context):
-        if key == "ancestors":
-            return "Hierarchy"
-        return super().render_key(key, value, context)
-
-
 class LocationUIViewSet(NautobotUIViewSet):
     # We aren't accessing tree fields anywhere so this is safe (note that `parent` itself is a normal foreign
     # key, not a tree field). If we ever do access tree fields, this will perform worse, because django will
@@ -373,13 +360,13 @@ class LocationUIViewSet(NautobotUIViewSet):
 
     object_detail_content = object_detail.ObjectDetailContent(
         panels=(
-            LocationHierarchyPanel(
+            object_detail.ObjectFieldsPanel(
                 weight=100,
                 section=SectionChoices.LEFT_HALF,
                 fields=[
                     "location_type",
                     "status",
-                    "ancestors",
+                    "_hierarchy",
                     "tenant",
                     "facility",
                     "asn",
@@ -389,7 +376,6 @@ class LocationUIViewSet(NautobotUIViewSet):
                 value_transforms={
                     "location_type": [partial(helpers.hyperlinked_object, field="name")],
                     "time_zone": [helpers.format_timezone],
-                    "ancestors": [helpers.render_ancestor_hierarchy],
                 },
             ),
             LocationFieldsPanel(


### PR DESCRIPTION
@glennmatthews This enforces the order from fields, which is arguable more correct. That being said, I would presume it will change behavior somewhere, so want to make sure we are in agreement first. 

Essentially what was happening was, the order was set from insertion order, the magic `_hierarchy` key was inserted after before rest of dictionary was created and was always being pushed to the top. 