### PR TITLE
Adjust renovate config

### DIFF
--- a/changes/xxxx.housekeeping
+++ b/changes/xxxx.housekeeping
@@ -1,0 +1,3 @@
+Adjusted Renovate configuration for `develop` and `next`.
+Added management of `npm` dependencies via Renovate.
+Added automatic refresh of `poetry.lock` and `package-lock.json` to Renovate configuration.

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "next"
   ],
   "enabledManagers": [
+    "npm",
     "pip_requirements",
     "poetry"
   ],
@@ -13,6 +14,10 @@
   "labels": [
     "dependencies"
   ],
+  "lockFileMaintenance": {
+    "description": "Update poetry.lock to keep transitive dependencies up-to-date once a week as well.",
+    "enabled": true
+  },
   "packageRules": [
     {
       "description": "Group patch-only updates to develop weekly to cut down on PR noise.",
@@ -37,10 +42,9 @@
         "next"
       ],
       "schedule": [
-        "before 2am on Friday"
-      ],
-      "rangeStrategy": "bump"
+        "before 2am on Tuesday"
+      ]
     }
   ],
-  "rangeStrategy": "in-range-only"
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
# Closes #7648
# What's Changed

- Add `npm` to the `enabledManagers` to begin managing our npm dependencies in `next` 
- Enable `lockFileMaintenance` to perform a weekly refresh of `poetry.lock` (and `package-lock.json` in next) to keep indirect (transitive) dependencies up to date (fixes #7648)
- Change `next` weekly schedule from Friday to Tuesday so that it will be less redundant with the changes in `develop` and can benefit from the biweekly post-release sync from `develop` up into `next`.
- Change strategy for `develop` to `bump` so that it will update `pyproject.toml` in addition to `poetry.lock`, same as `next` is already doing.

Tracking NAUTOBOT-1003
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
