### PR TITLE
Fix #7699, Apps Marketplace breakage in 2.4.15

### DIFF
--- a/changes/7699.fixed
+++ b/changes/7699.fixed
@@ -1,0 +1,1 @@
+Fixed breakage of the "Apps Marketplace" view in Nautobot v2.4.15.

--- a/nautobot/extras/templates/extras/marketplace.html
+++ b/nautobot/extras/templates/extras/marketplace.html
@@ -70,7 +70,7 @@
         <a class="btn btn-primary" href="{% url 'apps:apps_list' %}">See Installed Apps</a>
     </div>
 
-    <h1>{% block page_heading %}{% render_title %}{% block page_heading %}</h1>
+    <h1>{% block page_heading %}{% render_title %}{% endblock page_heading %}</h1>
 
     <div class="row">
         <div class="col-md-12">

--- a/nautobot/extras/tests/test_plugins.py
+++ b/nautobot/extras/tests/test_plugins.py
@@ -393,6 +393,18 @@ class PluginDetailViewTest(TestCase):
         self.assertIn("For testing purposes only", response_body, msg=response_body)
 
 
+class MarketplaceViewTest(TestCase):
+    def test_view_anonymous(self):
+        self.client.logout()
+        response = self.client.get(reverse("apps:apps_marketplace"))
+        # Redirects to the login page
+        self.assertHttpStatus(response, 302)
+
+    def test_view_authenticated(self):
+        response = self.client.get(reverse("apps:apps_marketplace"))
+        self.assertHttpStatus(response, 200)
+
+
 class AppAPITest(APIViewTestCases.APIViewTestCase):
     model = ExampleModel
     bulk_update_data = {


### PR DESCRIPTION
# Closes #7699
# What's Changed

- Fix error in template
- Add very basic test case to make sure the view renders.

Tracking NAUTOBOT-1025