### PR TITLE
Closes #7723: Fixed bug in which IPAddressToInterface could save Devices when not needed

### DIFF
--- a/changes/7723.fixed
+++ b/changes/7723.fixed
@@ -1,0 +1,1 @@
+Fixed bug in which `Device` objects could be saved when they didn't have to be.

--- a/nautobot/ipam/signals.py
+++ b/nautobot/ipam/signals.py
@@ -80,12 +80,16 @@ def ip_address_to_interface_pre_delete(instance, raw=False, **kwargs):
         )
 
     # Only nullify the primary_ip field if no other interfaces/vm_interfaces have the ip_address
+    host_needs_save = False
     if not other_assignments_exist and instance.ip_address == host.primary_ip4:
         host.primary_ip4 = None
+        host_needs_save = True
     elif not other_assignments_exist and instance.ip_address == host.primary_ip6:
         host.primary_ip6 = None
-    host.save()
+        host_needs_save = True
 
+    if host_needs_save:
+        host.save()
 
 @receiver(pre_save, sender=IPAddressToInterface)
 def ip_address_to_interface_assignment_created(sender, instance, raw=False, **kwargs):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #7723 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

Added a flag and a check to ensure that `Device` objects only get saved when their `primary_ip[46]` gets removed.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

No screenshots, but here's some before/after log data I captured whilst debugging this:

## Before

With this patch:

```diff
diff --git a/nautobot/ipam/signals.py b/nautobot/ipam/signals.py
index 3657da927..d3ef7f037 100644
--- a/nautobot/ipam/signals.py
+++ b/nautobot/ipam/signals.py
@@ -80,10 +80,20 @@ def ip_address_to_interface_pre_delete(instance, raw=False, **kwargs):
         )

     # Only nullify the primary_ip field if no other interfaces/vm_interfaces have the ip_address
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.debug(f"Starting handler logic for '{host=}' '{other_assignments_exist=}'")
     if not other_assignments_exist and instance.ip_address == host.primary_ip4:
+        logger.debug(f"  * Nuking '{host.primary_ip4=}'")
         host.primary_ip4 = None
     elif not other_assignments_exist and instance.ip_address == host.primary_ip6:
+        logger.debug(f"  * Nuking '{host.primary_ip6=}'")
         host.primary_ip6 = None
+
+    logger.debug(f"  * Saving '{host=}'")
     host.save()
```


```
00:55:27.314 DEBUG   nautobot.core.views.generic.ObjectEditView generic.py                                post() :
  Form validation was successful
00:55:27.400 DEBUG   nautobot.ipam.signals signals.py      ip_address_to_interface_pre_delete() :
  Starting handler logic for 'host=<Device: iad1-leaf-1>' 'other_assignments_exist=False'
00:55:27.400 DEBUG   nautobot.ipam.signals signals.py      ip_address_to_interface_pre_delete() :
    * No changes made; not saving 'host=<Device: iad1-leaf-1>'
00:55:27.400 INFO    nautobot.core.views.generic.ObjectEditView generic.py                     successful_post() :
```

## After
With this patch

```diff
diff --git a/nautobot/ipam/signals.py b/nautobot/ipam/signals.py
index 3657da927..5d057cdda 100644
--- a/nautobot/ipam/signals.py
+++ b/nautobot/ipam/signals.py
@@ -80,11 +80,24 @@ def ip_address_to_interface_pre_delete(instance, raw=False, **kwargs):
         )

     # Only nullify the primary_ip field if no other interfaces/vm_interfaces have the ip_address
+    host_needs_save = False
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.debug(f"Starting handler logic for '{host=}' '{other_assignments_exist=}'")
     if not other_assignments_exist and instance.ip_address == host.primary_ip4:
+        logger.debug(f"  * Nuking '{host.primary_ip4=}'")
         host.primary_ip4 = None
+        host_needs_save = True
     elif not other_assignments_exist and instance.ip_address == host.primary_ip6:
+        logger.debug(f"  * Nuking '{host.primary_ip6=}'")
         host.primary_ip6 = None
-    host.save()
+        host_needs_save = True
+
+    if host_needs_save:
+        logger.debug(f"  * Saving '{host=}'")
+        host.save()
+    else:
+        logger.debug(f"  * No changes made; not saving '{host=}'")
```

```
00:57:51.932 DEBUG   nautobot.core.views.generic.ObjectEditView generic.py                                post() :
  Form validation was successful
00:57:52.112 DEBUG   nautobot.ipam.signals signals.py      ip_address_to_interface_pre_delete() :
  Starting handler logic for 'host=<Device: iad1-leaf-1>' 'other_assignments_exist=False'
00:57:52.113 DEBUG   nautobot.ipam.signals signals.py      ip_address_to_interface_pre_delete() :
    * Nuking 'host.primary_ip4=<IPAddress: 10.0.0.3/24>'
00:57:52.113 DEBUG   nautobot.ipam.signals signals.py      ip_address_to_interface_pre_delete() :
    * Saving 'host=<Device: iad1-leaf-1>'
00:57:52.335 INFO    nautobot.core.views.generic.ObjectEditView generic.py                     successful_post() :
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
