### PR TITLE
fix: reference to version control branch list url

### DIFF
--- a/changes/7740.fixed
+++ b/changes/7740.fixed
@@ -1,0 +1,1 @@
+Fix bug with invalid reference to Nautobot version control branch list URL.

--- a/changes/7740.fixed
+++ b/changes/7740.fixed
@@ -1,1 +1,1 @@
-Fix bug with invalid reference to Nautobot version control branch list URL.
+Fixed bug with invalid reference to Nautobot version control branch list URL.

--- a/nautobot/core/templates/inc/nav_menu.html
+++ b/nautobot/core/templates/inc/nav_menu.html
@@ -36,7 +36,7 @@
                             aria-label="Find a branch..."
                             class="form-select nautobot-select2-api"
                             data-allow-clear="false"
-                            data-url="{% url 'plugins-api:nautobot_version_control-api:branch_list' %}"
+                            data-url="{% url 'plugins-api:nautobot_version_control-api:branch-list' %}"
                             display-field="name"
                             id="sidenav-branch-picker-select"
                             name="branch"


### PR DESCRIPTION
# What's Changed
Fix bug with invalid reference to Nautobot version control branch list URL pointed out in https://github.com/nautobot/nautobot/pull/7736#discussion_r2308512085.

Tracking NAUTOBOT-999