### PR TITLE
Introduce `construct_cache_key()` and make Redis caches branch-aware

### DIFF
--- a/nautobot/apps/utils.py
+++ b/nautobot/apps/utils.py
@@ -1,6 +1,7 @@
 """Nautobot utility functions."""
 
 from nautobot.core.releases import get_latest_release
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.color import foreground_color, hex_to_rgb, lighten_color, rgb_to_hex
 from nautobot.core.utils.config import get_settings_or_config
 from nautobot.core.utils.data import (
@@ -83,6 +84,7 @@ __all__ = (
     "check_if_key_is_graphql_safe",
     "class_deprecated",
     "class_deprecated_in_favor_of",
+    "construct_cache_key",
     "convert_git_diff_log_to_list",
     "convert_querydict_to_factory_formset_acceptable_querydict",
     "deepmerge",

--- a/nautobot/core/api/fields.py
+++ b/nautobot/core/api/fields.py
@@ -25,8 +25,9 @@ class ChoiceField(serializers.Field):
     """
     Represent a ChoiceField as {'value': <DB value>, 'label': <string>}. Accepts a single value on write.
 
-    :param choices: An iterable of choices in the form (value, key).
-    :param allow_blank: Allow blank values in addition to the listed choices.
+    Args:
+        choices (Iterable): An iterable of choices in the form (value, key).
+        allow_blank (bool): Allow blank values in addition to the listed choices.
     """
 
     def __init__(self, choices, allow_blank=False, **kwargs):

--- a/nautobot/core/forms/fields.py
+++ b/nautobot/core/forms/fields.py
@@ -482,13 +482,14 @@ class AutoPositionPatternField(ExpandableNameField):
 
 class DynamicModelChoiceMixin:
     """
-    :param display_field: The name of the attribute of an API response object to display in the selection list
-    :param query_params: A dictionary of additional key/value pairs to attach to the API request
-    :param initial_params: A dictionary of child field references to use for selecting a parent field's initial value
-    :param null_option: The string used to represent a null selection (if any)
-    :param disabled_indicator: The name of the field which, if populated, will disable selection of the
-        choice (optional)
-    :param depth: Nested serialization depth when making API requests (default: `0` or a flat representation)
+    Args:
+        display_field (str): The name of the attribute of an API response object to display in the selection list
+        query_params (Optional[dict]): Additional key/value pairs to attach to the API request
+        initial_params (Optional[dict]): Child field references to use for selecting a parent field's initial value
+        null_option (Optional[str]): The string used to represent a null selection (if any)
+        disabled_indicator (Optional[str]): The name of the field which, if populated, will disable selection of the
+            choice
+        depth (int): Nested serialization depth when making API requests (default: `0` or a flat representation)
     """
 
     filter = django_filters.ModelChoiceFilter  # 2.0 TODO(Glenn): can we rename this? pylint: disable=redefined-builtin
@@ -886,7 +887,8 @@ class TagFilterField(DynamicModelMultipleChoiceField):
     """
     A filter field for the tags of a model. Only the tags used by a model are displayed.
 
-    :param model: The model of the filter
+    Args:
+        model (Model): The model of the filter
     """
 
     def __init__(self, model, *args, query_params=None, queryset=None, **kwargs):

--- a/nautobot/core/forms/widgets.py
+++ b/nautobot/core/forms/widgets.py
@@ -178,8 +178,9 @@ class APISelect(SelectWithDisabled):
         """
         Add details for an additional query param in the form of a data-* JSON-encoded list attribute.
 
-        :param name: The name of the query param
-        :param value: The value of the query param
+        Args:
+            name (str): The name of the query param
+            value (Any): The value of the query param
         """
         key = f"data-query-param-{name}"
 

--- a/nautobot/core/models/__init__.py
+++ b/nautobot/core/models/__init__.py
@@ -13,6 +13,7 @@ from django.utils.functional import classproperty
 from nautobot.core.models.managers import BaseManager
 from nautobot.core.models.querysets import CompositeKeyQuerySetMixin, RestrictedQuerySet
 from nautobot.core.models.utils import construct_composite_key, construct_natural_slug, deconstruct_composite_key
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.lookup import get_route_for_model
 
 __all__ = (
@@ -115,7 +116,7 @@ class BaseModel(models.Model):
 
         Necessary for use with _content_type_cached and management commands.
         """
-        return f"nautobot.{cls._meta.label_lower}._content_type"
+        return construct_cache_key(cls, method_name="_content_type")
 
     @classproperty  # https://github.com/PyCQA/pylint-django/issues/240
     def _content_type_cached(cls):  # pylint: disable=no-self-argument

--- a/nautobot/core/models/fields.py
+++ b/nautobot/core/models/fields.py
@@ -244,8 +244,9 @@ class NaturalOrderingField(models.CharField):
     """
     A field which stores a naturalized representation of its target field, to be used for ordering its parent model.
 
-    :param target_field: Name of the field of the parent model to be naturalized
-    :param naturalize_function: The function used to generate a naturalized value (optional)
+    Args:
+        target_field (str): Name of the field of the parent model to be naturalized
+        naturalize_function (function): The function used to generate a naturalized value (optional)
     """
 
     description = "Stores a representation of its target field suitable for natural ordering"

--- a/nautobot/core/models/ordering.py
+++ b/nautobot/core/models/ordering.py
@@ -28,9 +28,10 @@ def naturalize(value, max_length, integer_places=8):
         location00000010router00000004
         location00000010router00000019
 
-    :param value: The value to be naturalized
-    :param max_length: The maximum length of the returned string. Characters beyond this length will be stripped.
-    :param integer_places: The number of places to which each integer will be expanded. (Default: 8)
+    Args:
+        value (str): The value to be naturalized
+        max_length (int): The maximum length of the returned string. Characters beyond this length will be stripped.
+        integer_places (int): The number of places to which each integer will be expanded. (Default: 8)
     """
     if not value:
         return value
@@ -50,8 +51,9 @@ def naturalize_interface(value, max_length):
     Similar in nature to naturalize(), but takes into account a particular naming format adapted from the old
     InterfaceManager.
 
-    :param value: The value to be naturalized
-    :param max_length: The maximum length of the returned string. Characters beyond this length will be stripped.
+    Args:
+        value (str): The value to be naturalized
+        max_length (int): The maximum length of the returned string. Characters beyond this length will be stripped.
     """
     output = ""
     match = re.search(INTERFACE_NAME_REGEX, value)

--- a/nautobot/core/models/querysets.py
+++ b/nautobot/core/models/querysets.py
@@ -112,8 +112,9 @@ class RestrictedQuerySet(CompositeKeyQuerySetMixin, QuerySet):
         Filter the QuerySet to return only objects on which the specified user has been granted the specified
         permission.
 
-        :param user: User instance
-        :param action: The action which must be permitted (e.g. "view" for "dcim.view_location"); default is 'view'
+        Args:
+            user (User): User instance
+            action (str): The action which must be permitted (e.g. "view" for "dcim.view_location"); default is 'view'
         """
         # Resolve the full name of the required permission
         app_label = self.model._meta.app_label

--- a/nautobot/core/models/tree_queries.py
+++ b/nautobot/core/models/tree_queries.py
@@ -7,6 +7,7 @@ from tree_queries.query import TreeManager as TreeManager_, TreeQuerySet as Tree
 
 from nautobot.core.models import BaseManager, querysets
 from nautobot.core.signals import invalidate_max_depth_cache
+from nautobot.core.utils.cache import construct_cache_key
 
 
 class TreeQuerySet(TreeQuerySet_, querysets.RestrictedQuerySet):
@@ -89,7 +90,7 @@ class TreeManager(TreeManager_, BaseManager.from_queryset(TreeQuerySet)):
 
     @property
     def max_depth_cache_key(self):
-        return f"nautobot.{self.model._meta.concrete_model._meta.label_lower}.max_depth"
+        return construct_cache_key(self, method_name="max_depth", branch_aware=True)
 
     @property
     def max_depth(self):
@@ -97,10 +98,11 @@ class TreeManager(TreeManager_, BaseManager.from_queryset(TreeQuerySet)):
 
         Generally TreeManagers are persistent objects while TreeQuerySets are not, hence the difference in behavior.
         """
-        max_depth = cache.get(self.max_depth_cache_key)
+        cache_key = self.max_depth_cache_key
+        max_depth = cache.get(cache_key)
         if max_depth is None:
             max_depth = self.max_tree_depth()
-            cache.set(self.max_depth_cache_key, max_depth)
+            cache.set(cache_key, max_depth)
         return max_depth
 
 
@@ -123,7 +125,7 @@ class TreeModel(TreeNode):
         """
         if not hasattr(self, "name"):
             raise NotImplementedError("default TreeModel.display implementation requires a `name` attribute!")
-        cache_key = f"nautobot.{self._meta.concrete_model._meta.label_lower}.{self.id}.display"
+        cache_key = construct_cache_key(self, method_name="display", branch_aware=True)
         display_str = cache.get(cache_key, "")
         if display_str:
             return display_str

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -30,9 +30,7 @@ logger = logging.getLogger(__name__)
 
 class BaseTable(django_tables2.Table):
     """
-    Default table for object lists
-
-    :param user: Personalize table display for the given user (optional). Has no effect if AnonymousUser is passed.
+    Default table for object lists.
     """
 
     class Meta:
@@ -59,7 +57,7 @@ class BaseTable(django_tables2.Table):
             *args (list, optional): Passed through to django_tables2.Table
             table_changes_pending (bool): TODO
             saved_view (SavedView, optional): TODO
-            user (User, optional): TODO
+            user (User, optional): Personalize table display for the given user (optional)
             hide_hierarchy_ui (bool): Whether to display or hide hierarchy indentation of nested objects.
             order_by (list, optional): Field(s) to sort by
             data_transform_callback (function, optional): A function that takes the given `data` as an input and
@@ -396,9 +394,10 @@ class ButtonsColumn(django_tables2.TemplateColumn):
     """
     Render edit, delete, and changelog buttons for an object.
 
-    :param model: Model class to use for calculating URL view names
-    :param prepend_template: Additional template content to render in the column (optional)
-    :param return_url_extra: String to append to the return URL (e.g. for specifying a tab) (optional)
+    Args:
+        model (type(Model)): Model class to use for calculating URL view names
+        prepend_template (Optional[str]): Additional template content to render in the column
+        return_url_extra (Optional[str]): String to append to the return URL (e.g. for specifying a tab)
     """
 
     buttons = ("changelog", "edit", "delete")
@@ -487,9 +486,9 @@ class ApprovalButtonsColumn(django_tables2.TemplateColumn):
     """
     Render detail, changelog, approve, deny, and comment buttons for an approval workflow stage.
 
-    :param model: Model class to use for calculating URL view names
-    :param prepend_template: Additional template content to render in the column (optional)
-    :param return_url_extra: String to append to the return URL (e.g. for specifying a tab) (optional)
+    Args:
+        model (type(Model)): Model class to use for calculating URL view names
+        return_url_extra (Optional[str]): String to append to the return URL (e.g. for specifying a tab)
     """
 
     buttons = ("detail", "changelog", "approve", "deny")
@@ -688,9 +687,9 @@ class ContentTypesColumn(django_tables2.ManyToManyColumn):
     performance hit to querysets for table views. If this becomes an issue,
     set `sort_items=False`.
 
-    :param sort_items: Whether to sort by `(app_label, name)`. (default: True)
-    :param truncate_words:
-        Number of words at which to truncate, or `None` to disable. (default: None)
+    Args:
+        sort_items (bool): Whether to sort by `(app_label, name)`.
+        truncate_words (Optional[int]): Number of words at which to truncate, or `None` to disable.
     """
 
     def __init__(self, sort_items=True, truncate_words=None, *args, **kwargs):

--- a/nautobot/core/testing/mixins.py
+++ b/nautobot/core/testing/mixins.py
@@ -220,10 +220,11 @@ class NautobotTestCaseMixin:
         Compare a model instance to a dictionary, checking that its attribute values match those specified
         in the dictionary.
 
-        :param instance: Python object instance
-        :param data: Dictionary of test data used to define the instance
-        :param exclude: List of fields to exclude from comparison (e.g. passwords, which get hashed)
-        :param api: Set to True is the data is a JSON representation of the instance
+        Args:
+            instance (Model): Django model instance
+            data (dict): Dictionary of test data used to define the instance
+            exclude (Optional[List[str]]): List of fields to exclude from comparison (e.g. passwords, which get hashed)
+            api (bool): Set to True is the data is a JSON representation of the instance
         """
         if exclude is None:
             exclude = []

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -404,9 +404,11 @@ class GraphQLExtendSchemaRelationship(GraphQLTestCaseBase):
     def tearDown(self):
         """Ensure that relationship caches are cleared to avoid leakage into other tests."""
         with contextlib.suppress(redis.exceptions.ConnectionError):
-            cache.delete_pattern(f"{construct_cache_key(Relationship.objects, method_name='get_for_model_source')}(*)")
             cache.delete_pattern(
-                f"{construct_cache_key(Relationship.objects, method_name='get_for_model_destination')}(*)"
+                f"{construct_cache_key(Relationship.objects, method_name='get_for_model_source', branch_aware=True)}(*)"
+            )
+            cache.delete_pattern(
+                f"{construct_cache_key(Relationship.objects, method_name='get_for_model_destination', branch_aware=True)}(*)"
             )
 
     def test_extend_relationship_default_prefix(self):

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -38,6 +38,7 @@ from nautobot.core.graphql.schema import (
 from nautobot.core.graphql.types import DateType, OptimizedNautobotObjectType
 from nautobot.core.graphql.utils import str_to_var_name
 from nautobot.core.testing import create_test_user, NautobotTestClient, TestCase
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.dcim.choices import ConsolePortTypeChoices, InterfaceModeChoices, InterfaceTypeChoices, PortTypeChoices
 from nautobot.dcim.filters import DeviceFilterSet, LocationFilterSet
 from nautobot.dcim.graphql.types import DeviceType as DeviceTypeGraphQL
@@ -403,8 +404,10 @@ class GraphQLExtendSchemaRelationship(GraphQLTestCaseBase):
     def tearDown(self):
         """Ensure that relationship caches are cleared to avoid leakage into other tests."""
         with contextlib.suppress(redis.exceptions.ConnectionError):
-            cache.delete_pattern(f"{Relationship.objects.get_for_model_source.cache_key_prefix}.*")
-            cache.delete_pattern(f"{Relationship.objects.get_for_model_destination.cache_key_prefix}.*")
+            cache.delete_pattern(f"{construct_cache_key(Relationship.objects, method_name='get_for_model_source')}(*)")
+            cache.delete_pattern(
+                f"{construct_cache_key(Relationship.objects, method_name='get_for_model_destination')}(*)"
+            )
 
     def test_extend_relationship_default_prefix(self):
         """Verify that relationships are correctly added to the schema."""

--- a/nautobot/core/tests/test_models.py
+++ b/nautobot/core/tests/test_models.py
@@ -130,7 +130,7 @@ class NaturalKeyTestCase(BaseModelTest):
             self.FakeBaseModel._content_type_cached
             self.assertEqual(mock__content_type.call_count, 1)
 
-            time.sleep(2)  # Let the cache expire
+            time.sleep(3)  # Let the cache expire
 
             self.FakeBaseModel._content_type_cached
             self.assertEqual(mock__content_type.call_count, 2)

--- a/nautobot/core/utils/cache.py
+++ b/nautobot/core/utils/cache.py
@@ -13,10 +13,10 @@ def construct_cache_key(obj, *, method_name=None, branch_aware=True, **params):
     Construct a consistently-structured Django/Redis cache key for the given obj and/or method name.
 
     Args:
-        obj: A model class, model instance, model manager, class, or function that will make use of the cache.
+        obj (Any): A model class, model instance, model manager, class, or function that will make use of the cache.
         method_name (str): Name of a specific method on `obj`. May be omitted only if `obj` is itself a function.
         branch_aware (bool): Whether this cache key needs to vary by branch when Version Control is enabled.
-        **params: Parameters that should further narrow the scope of the cache key.
+        **params (dict): Parameters that should further narrow the scope of the cache key.
 
     Examples:
         >>> construct_cache_key(Location.objects, method_name="max_depth")

--- a/nautobot/core/utils/cache.py
+++ b/nautobot/core/utils/cache.py
@@ -1,0 +1,65 @@
+"""Utilities for conveniently working with the Django/Redis cache."""
+
+import logging
+
+from django.conf import settings
+from django.db import models
+
+logger = logging.getLogger(__name__)
+
+
+def construct_cache_key(obj, *, method_name=None, branch_aware=True, **params):
+    """
+    Construct a consistently-structured Django/Redis cache key for the given obj and/or method name.
+
+    Args:
+        obj: A model class, model instance, model manager, class, or function that will make use of the cache.
+        method_name (str): Name of a specific method on `obj`. May be omitted only if `obj` is itself a function.
+        branch_aware (bool): Whether this cache key needs to vary by branch when Version Control is enabled.
+        **params: Parameters that should further narrow the scope of the cache key.
+
+    Examples:
+        >>> construct_cache_key(Location.objects, method_name="max_depth")
+        'nautobot.dcim.location.max_depth'
+        >>> construct_cache_key(MinMaxValidationRule, method_name="get_for_model")
+        'nautobot.data_validation.minmaxvalidationrule.get_for_model'
+        >>> construct_cache_key(MinMaxValidationRule, method_name="get_for_model", content_type="dcim.location")
+        'nautobot.data_validation.minmaxvalidationrule.get_for_model(content_type=dcim.location)'
+        >>> construct_cache_key(CustomField.objects, method_name="get_for_model", model="dcim.location", exclude_filter_disabled=True, listing=True)
+        'nautobot.extras.customfield.get_for_model(model=dcim.location,exclude_filter_disabled=True,listing=True)'
+        >>> from nautobot.extras.utils import change_logged_models_queryset
+        >>> construct_cache_key(change_logged_models_queryset)
+        'nautobot.extras.utils.change_logged_models_queryset'
+    """
+    if isinstance(obj, models.Model):
+        tokens = ["nautobot", obj._meta.concrete_model._meta.label_lower, str(obj.pk), method_name]
+    elif isinstance(obj, models.Manager):
+        tokens = ["nautobot", obj.model._meta.concrete_model._meta.label_lower, method_name]
+    elif isinstance(obj, type):
+        # A class object
+        if issubclass(obj, models.Model):
+            tokens = ["nautobot", obj._meta.concrete_model._meta.label_lower, method_name]
+        elif issubclass(obj, models.Manager):
+            tokens = ["nautobot", obj.model._meta.concrete_model._meta.label_lower, method_name]
+        else:
+            tokens = [obj.__module__, obj.__name__, method_name]
+    elif method_name is not None:
+        # An instance of any class not specifically handled above
+        tokens = [obj.__module__, obj.__class__.__name__, method_name]
+    else:
+        # A standalone function
+        tokens = [obj.__module__, obj.__name__]
+
+    if branch_aware and "nautobot_version_control" in settings.PLUGINS:
+        from nautobot_version_control.utils import active_branch  # pylint: disable=import-error
+
+        tokens += ["branch", active_branch()]
+
+    cache_key = ".".join(tokens)
+
+    params_tokens = [f"{key}={value}" for key, value in params.items()]
+    if params_tokens:
+        cache_key += f"({','.join(params_tokens)})"
+
+    logger.debug("Constructed cache key is %s", cache_key)
+    return cache_key

--- a/nautobot/core/utils/cache.py
+++ b/nautobot/core/utils/cache.py
@@ -31,6 +31,7 @@ def construct_cache_key(obj, *, method_name=None, branch_aware=True, **params):
         >>> construct_cache_key(change_logged_models_queryset)
         'nautobot.extras.utils.change_logged_models_queryset'
     """
+    method_name_must_be_set = True
     if isinstance(obj, models.Model):
         tokens = ["nautobot", obj._meta.concrete_model._meta.label_lower, str(obj.pk), method_name]
     elif isinstance(obj, models.Manager):
@@ -49,6 +50,10 @@ def construct_cache_key(obj, *, method_name=None, branch_aware=True, **params):
     else:
         # A standalone function
         tokens = [obj.__module__, obj.__name__]
+        method_name_must_be_set = False
+
+    if method_name_must_be_set and method_name is None:
+        raise ValueError("method_name must be specified for the given obj")
 
     if branch_aware and "nautobot_version_control" in settings.PLUGINS:
         from nautobot_version_control.utils import active_branch  # pylint: disable=import-error

--- a/nautobot/core/utils/data.py
+++ b/nautobot/core/utils/data.py
@@ -28,9 +28,10 @@ def flatten_dict(d, prefix="", separator="."):
     """
     Flatten nested dictionaries into a single level by joining key names with a separator.
 
-    :param d: The dictionary to be flattened
-    :param prefix: Initial prefix (if any)
-    :param separator: The character to use when concatenating key names
+    Args:
+        d (dict): The dictionary to be flattened
+        prefix (str): Initial prefix (if any)
+        separator (str): The character to use when concatenating key names
     """
     ret = {}
     for k, v in d.items():
@@ -46,8 +47,10 @@ def flatten_iterable(iterable):
     """
     Flatten a nested iterable such as a list of lists, keeping strings intact.
 
-    :param iterable: The iterable to be flattened
-    :returns: generator
+    Args:
+        iterable (Iterable): The iterable to be flattened
+
+    Yields: str
     """
     for i in iterable:
         if hasattr(i, "__iter__") and not isinstance(i, str):

--- a/nautobot/core/utils/git.py
+++ b/nautobot/core/utils/git.py
@@ -41,10 +41,10 @@ def swap_status_initials(data):
 
 def convert_git_diff_log_to_list(logs):
     """
-    Convert Git diff log into a list splitted by \\n
+    Convert Git diff log into a list splitted by `\\n`
 
-    Example:
-        >>> git_log = "M\tindex.html\nR\tsample.txt"
+    Examples:
+        >>> git_log = "M\\tindex.html\\nR\\tsample.txt"
         >>> print(convert_git_diff_log_to_list(git_log))
         ["Modification - index.html", "Renaming - sample.txt"]
     """

--- a/nautobot/core/utils/lookup.py
+++ b/nautobot/core/utils/lookup.py
@@ -33,12 +33,14 @@ def get_changes_for_model(model):
 def get_model_from_name(model_name):
     """Given a full model name in dotted format (example: `dcim.model`), a model class is returned if valid.
 
-    :param model_name: Full dotted name for a model as a string (ex: `dcim.model`)
-    :type model_name: str
+    Args:
+        model_name (str): Full dotted name for a model as a string (ex: `dcim.model`)
 
-    :raises TypeError: If given model name is not found.
+    Raises:
+        TypeError: If given model name is not found.
 
-    :return: Found model.
+    Returns:
+        (Model): Found model.
     """
 
     try:

--- a/nautobot/core/utils/permissions.py
+++ b/nautobot/core/utils/permissions.py
@@ -7,8 +7,9 @@ def get_permission_for_model(model, action):
     """
     Resolve the named permission for a given model (or instance) and action (e.g. view or add).
 
-    :param model: A model or instance
-    :param action: View, add, change, or delete (string)
+    Args:
+        model (Any): A model or instance
+        action (str): View, add, change, or delete
     """
     if action not in ("view", "add", "change", "delete"):
         raise ValueError(f"Unsupported action: {action}")
@@ -21,7 +22,8 @@ def resolve_permission(name):
     Given a permission name, return the app_label, action, and model_name components. For example, "dcim.view_location"
     returns ("dcim", "view", "location").
 
-    :param name: Permission name in the format <app_label>.<action>_<model>
+    Args:
+        name (str): Permission name in the format `<app_label>.<action>_<model>`
     """
     try:
         app_label, codename = name.split(".")
@@ -37,7 +39,8 @@ def resolve_permission_ct(name):
     Given a permission name, return the relevant ContentType and action. For example, "dcim.view_location" returns
     (Location, "view").
 
-    :param name: Permission name in the format <app_label>.<action>_<model>
+    Args:
+        name (str): Permission name in the format `<app_label>.<action>_<model>`
     """
     app_label, action, model_name = resolve_permission(name)
     try:
@@ -52,7 +55,8 @@ def permission_is_exempt(name):
     """
     Determine whether a specified permission is exempt from evaluation.
 
-    :param name: Permission name in the format <app_label>.<action>_<model>
+    Args:
+        name (str): Permission name in the format `<app_label>.<action>_<model>`
     """
     app_label, action, model_name = resolve_permission(name)
 

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -267,8 +267,9 @@ class NautobotViewSetMixin(GenericViewSet, AccessMixin, GetReturnURLMixin, FormV
         """
         Resolve the named permissions for a given model (or instance) and a list of actions (e.g. view or add).
 
-        :param model: A model or instance
-        :param actions: A list of actions to perform on the model
+        Args:
+            model (Union[type(Model), Model]): A model or instance
+            actions (List[str]): A list of actions to perform on the model
         """
         model_permissions = []
         for action in actions:

--- a/nautobot/data_validation/signals.py
+++ b/nautobot/data_validation/signals.py
@@ -10,7 +10,6 @@ from nautobot.data_validation.models import (
     RegularExpressionValidationRule,
     RequiredValidationRule,
     UniqueValidationRule,
-    ValidationRuleManager,
 )
 
 
@@ -23,9 +22,9 @@ from nautobot.data_validation.models import (
 @receiver(post_save, sender=UniqueValidationRule)
 @receiver(post_delete, sender=UniqueValidationRule)
 def invalidate_validation_rule_caches(sender, **kwargs):
-    for method in [
-        ValidationRuleManager.get_for_model,
-        ValidationRuleManager.get_enabled_for_model,
+    for prefix in [
+        sender.objects.get_for_model_cache_key_prefix,
+        sender.objects.get_enabled_for_model_cache_key_prefix,
     ]:
         with contextlib.suppress(redis.exceptions.ConnectionError):
-            cache.delete_pattern(f"{method.cache_key_prefix}.{sender._meta.concrete_model._meta.model_name}.*")
+            cache.delete_pattern(f"{prefix}(*)")

--- a/nautobot/data_validation/tests/__init__.py
+++ b/nautobot/data_validation/tests/__init__.py
@@ -14,7 +14,7 @@ class ValidationRuleTestCaseMixin:
     def tearDown(self):
         """Ensure that validation rule caches are cleared to avoid leakage into other tests."""
         with contextlib.suppress(redis.exceptions.ConnectionError):
-            cache.delete_pattern(f"{self.model.objects.get_for_model.cache_key_prefix}.*")
-            cache.delete_pattern(f"{self.model.objects.get_enabled_for_model.cache_key_prefix}.*")
+            cache.delete_pattern(f"{self.model.objects.get_for_model_cache_key_prefix}(*)")
+            cache.delete_pattern(f"{self.model.objects.get_enabled_for_model_cache_key_prefix}(*)")
         if hasattr(super(), "tearDown"):
             super().tearDown()

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -15,6 +15,7 @@ from nautobot.core.models.generics import BaseModel, PrimaryModel
 from nautobot.core.models.ordering import naturalize_interface
 from nautobot.core.models.query_functions import CollateAsChar
 from nautobot.core.models.tree_queries import TreeModel
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.data import UtilizationData
 from nautobot.dcim.choices import (
     ConsolePortTypeChoices,
@@ -1337,4 +1338,5 @@ class ModuleBay(PrimaryModel):
 
         if self.parent_device is not None:
             # Set the has_module_bays cache key on the parent device - see Device.has_module_bays()
-            cache.set(f"nautobot.dcim.device.{self.parent_device.pk}.has_module_bays", True, timeout=5)
+            cache_key = construct_cache_key(self.parent_device, method_name="has_module_bays", branch_aware=True)
+            cache.set(cache_key, True, timeout=5)

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -18,6 +18,7 @@ from nautobot.core.models import BaseManager, RestrictedQuerySet
 from nautobot.core.models.fields import JSONArrayField, LaxURLField, NaturalOrderingField
 from nautobot.core.models.generics import BaseModel, OrganizationalModel, PrimaryModel
 from nautobot.core.models.tree_queries import TreeModel
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.config import get_settings_or_config
 from nautobot.dcim.choices import (
     ControllerCapabilitiesChoices,
@@ -897,7 +898,7 @@ class Device(PrimaryModel, ConfigContextModel):
         instantiated_components = []
         for model, templates in component_models:
             model.objects.bulk_create([x.instantiate(device=self) for x in templates])
-        cache_key = f"nautobot.dcim.device.{self.pk}.has_module_bays"
+        cache_key = construct_cache_key(self, method_name="has_module_bays")
         cache.delete(cache_key)
         return instantiated_components
 
@@ -996,7 +997,7 @@ class Device(PrimaryModel, ConfigContextModel):
         """
         Cacheable property for determining whether this Device has any ModuleBays, and therefore may contain Modules.
         """
-        cache_key = f"nautobot.dcim.device.{self.pk}.has_module_bays"
+        cache_key = construct_cache_key(self, method_name="has_module_bays")
         module_bays_exists = cache.get(cache_key)
         if module_bays_exists is None:
             module_bays_exists = self.module_bays.exists()

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -898,7 +898,7 @@ class Device(PrimaryModel, ConfigContextModel):
         instantiated_components = []
         for model, templates in component_models:
             model.objects.bulk_create([x.instantiate(device=self) for x in templates])
-        cache_key = construct_cache_key(self, method_name="has_module_bays")
+        cache_key = construct_cache_key(self, method_name="has_module_bays", branch_aware=True)
         cache.delete(cache_key)
         return instantiated_components
 
@@ -997,7 +997,7 @@ class Device(PrimaryModel, ConfigContextModel):
         """
         Cacheable property for determining whether this Device has any ModuleBays, and therefore may contain Modules.
         """
-        cache_key = construct_cache_key(self, method_name="has_module_bays")
+        cache_key = construct_cache_key(self, method_name="has_module_bays", branch_aware=True)
         module_bays_exists = cache.get(cache_key)
         if module_bays_exists is None:
             module_bays_exists = self.module_bays.exists()

--- a/nautobot/docs/development/core/caching.md
+++ b/nautobot/docs/development/core/caching.md
@@ -17,11 +17,4 @@ When adding a signal that interacts with the cache, you may want to wrap the cac
 
 ## Cache keys
 
-* For database models with caches, cache keys should generally take the form `"nautobot.{model._meta.label_lower}.[{uuid}.]..."`. For example:
-    * `Location.objects.max_depth()` --> `nautobot.dcim.location.max_depth`
-    * `Location.display` (instance attribute) --> `nautobot.dcim.location.00000000-0000-0000-0000-000000000000.display`
-    * `ComputedField.objects.get_for_model(Location)` --> `nautobot.extras.computedfield.get_for_model.dcim.location`
-    * `CustomField.objects.get_for_model(Location, False)` --> `nautobot.extras.customfield.get_for_model.dcim.location.False`
-* For functions and methods that don't belong to a database model, cache keys should generally take the form `"{dotted.module.path.function}..."`. For example:
-    * `nautobot.core.releases.get_latest_release()` --> `nautobot.core.releases.get_latest_release`
-    * `nautobot.extras.utils.changed_logged_models_queryset()` --> `nautobot.extras.utils.change_logged_models_queryset`
+In general, cache keys used by Nautobot should be constructed via the `construct_cache_key()` method from `nautobot.core.utils.cache` (or `nautobot.apps.utils`, for App developers). This ensures a consistent structure for cache keys and helps to avoid unintended collisions. Refer to the [function documentation](../../code-reference/nautobot/apps/utils.md#nautobot.apps.utils.construct_cache_key) for examples.

--- a/nautobot/extras/context_managers.py
+++ b/nautobot/extras/context_managers.py
@@ -21,16 +21,18 @@ class ChangeContext:
     one will be generated to relate any changes to this transaction. Convenience
     classes are provided for each context.
 
-    :param user: User object
-    :param request: WSGIRequest object to retrieve user from django rest framework after authentication is performed
-    :param context: Context of the transaction, must match a choice in nautobot.extras.choices.ObjectChangeEventContextChoices
-    :param context_detail: Optional extra details about the transaction (ex: the plugin name that initiated the change)
-    :param change_id: Optional uuid object to uniquely identify the transaction. One will be generated if not supplied
+    Args:
+        user (User): User object
+        request (WSGIRequest): object to retrieve user from django rest framework after authentication is performed
+        context (ObjectChangeEventContextChoices): Context of the transaction
+        context_detail (Optional[str]): extra details about the transaction (ex: plugin name that initiated the change)
+        change_id (Optional[UUID]): Object to uniquely identify the transaction. One will be generated if not supplied
 
     The next two parameters are used as caching fields when updating an object with no previous ObjectChange instances.
     They are used to populate the `pre_change` field of an ObjectChange snapshot in get_snapshot().
-    :param pre_object_data: Optional dictionary of serialized object data to be used in the object snapshot
-    :param pre_object_data_v2: Optional dictionary of serialized object data to be used in the object snapshot
+
+        pre_object_data (dict): Optional dictionary of serialized object data to be used in the object snapshot
+        pre_object_data_v2 (dict): Optional dictionary of serialized object data to be used in the object snapshot
     """
 
     defer_object_changes = False  # advanced usage, for creating object changes in bulk
@@ -151,12 +153,10 @@ class WebChangeContext(ChangeContext):
 
 
 @contextmanager
-def change_logging(change_context):
+def change_logging(change_context: ChangeContext):
     """
     Enable change logging by connecting the appropriate signals to their receivers before code is run, and
     disconnecting them afterward.
-
-    :param change_context: ChangeContext instance
     """
 
     # Set change logging state
@@ -182,22 +182,22 @@ def web_request_context(
     By default, when working with the Django ORM, neither change logging nor webhook processing occur
     unless manually invoked and this context manager handles those functions. A valid User object must be provided.
 
-    Example usage:
+    Examples:
+        >>> from nautobot.extras.context_managers import web_request_context
+        >>> user = User.objects.get(username="admin")
+        >>> with web_request_context(user, context_detail="manual-fix"):
+        ...     lt = Location.objects.get(name="Root")
+        ...     lax = Location(name="LAX", location_type=lt)
+        ...     lax.validated_save()
 
-    >>> from nautobot.extras.context_managers import web_request_context
-    >>> user = User.objects.get(username="admin")
-    >>> with web_request_context(user, context_detail="manual-fix"):
-    ...     lt = Location.objects.get(name="Root")
-    ...     lax = Location(name="LAX", location_type=lt)
-    ...     lax.validated_save()
-
-    :param user: User object
-    :param context_detail: Optional extra details about the transaction (ex: the plugin name that initiated the change)
-    :param change_id: Optional uuid object to uniquely identify the transaction. One will be generated if not supplied
-    :param context: Optional string value of the generated change log entries' "change_context" field.
-        Defaults to `ObjectChangeEventContextChoices.CONTEXT_ORM`.
-        Valid choices are in `nautobot.extras.choices.ObjectChangeEventContextChoices`.
-    :param request: Optional web request instance, one will be generated if not supplied
+    Args:
+        user (User): User object
+        context_detail (str): Optional extra details about the transaction (ex: plugin name that initiated the change)
+        change_id (Optional[UUID]): Object to uniquely identify the transaction. One will be generated if not supplied
+        context (str): Optional string value of the generated change log entries' "change_context" field.
+            Defaults to `ObjectChangeEventContextChoices.CONTEXT_ORM`.
+            Valid choices are in `nautobot.extras.choices.ObjectChangeEventContextChoices`.
+        request (Request): Optional web request instance, one will be generated if not supplied
     """
     from nautobot.extras.jobs import enqueue_job_hooks  # prevent circular import
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -39,6 +39,7 @@ from nautobot.core.forms import (
     JSONField,
 )
 from nautobot.core.forms.widgets import ClearableFileInput
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.config import get_settings_or_config
 from nautobot.core.utils.logging import sanitize
 from nautobot.core.utils.lookup import get_model_from_name
@@ -261,7 +262,7 @@ class BaseJob:
     @classproperty
     def singleton_cache_key(cls) -> str:  # pylint: disable=no-self-argument
         """Cache key for singleton jobs."""
-        return f"nautobot.extras.jobs.running.{cls.class_path}"
+        return construct_cache_key(cls, method_name="running", class_path=cls.class_path)
 
     @final
     @classproperty

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -262,7 +262,7 @@ class BaseJob:
     @classproperty
     def singleton_cache_key(cls) -> str:  # pylint: disable=no-self-argument
         """Cache key for singleton jobs."""
-        return construct_cache_key(cls, method_name="running", class_path=cls.class_path)
+        return construct_cache_key(cls, method_name="running", branch_aware=False, class_path=cls.class_path)
 
     @final
     @classproperty

--- a/nautobot/extras/models/customfields.py
+++ b/nautobot/extras/models/customfields.py
@@ -35,6 +35,7 @@ from nautobot.core.models.querysets import RestrictedQuerySet
 from nautobot.core.models.validators import validate_regex
 from nautobot.core.settings_funcs import is_truthy
 from nautobot.core.templatetags.helpers import render_markdown
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.data import render_jinja2
 from nautobot.extras.choices import CustomFieldFilterLogicChoices, CustomFieldTypeChoices
 from nautobot.extras.models import ChangeLoggedModel
@@ -55,8 +56,10 @@ class ComputedFieldManager(BaseManager.from_queryset(RestrictedQuerySet)):
         Returns a queryset by default, or a list if `get_queryset` param is False.
         """
         concrete_model = model._meta.concrete_model
-        cache_key = f"{self.get_for_model.cache_key_prefix}.{concrete_model._meta.label_lower}"
-        list_cache_key = f"{cache_key}.list"
+        cache_key = construct_cache_key(self, method_name="get_for_model", model=concrete_model._meta.label_lower)
+        list_cache_key = construct_cache_key(
+            self, method_name="get_for_model", model=concrete_model._meta.label_lower, listing=True
+        )
         if not get_queryset:
             listing = cache.get(list_cache_key)
             if listing is not None:
@@ -72,8 +75,6 @@ class ComputedFieldManager(BaseManager.from_queryset(RestrictedQuerySet)):
             return listing
         return queryset
 
-    get_for_model.cache_key_prefix = "nautobot.extras.computedfield.get_for_model"
-
     def populate_list_caches(self):
         """Populate all caches for `get_for_model(..., get_queryset=False)` lookups."""
         queryset = self.all().select_related("content_type")
@@ -82,7 +83,8 @@ class ComputedFieldManager(BaseManager.from_queryset(RestrictedQuerySet)):
             listings[f"{cf.content_type.app_label}.{cf.content_type.model}"].append(cf)
         for ct in ContentType.objects.all():
             label = f"{ct.app_label}.{ct.model}"
-            cache.set(f"{self.get_for_model.cache_key_prefix}.{label}.list", listings[label])
+            cache_key = construct_cache_key(self, method_name="get_for_model", model=label, listing=True)
+            cache.set(cache_key, listings[label])
 
 
 @extras_features("graphql")
@@ -401,10 +403,19 @@ class CustomFieldManager(BaseManager.from_queryset(RestrictedQuerySet)):
             get_queryset (bool): Whether to return a QuerySet or a list.
         """
         concrete_model = model._meta.concrete_model
-        cache_key = (
-            f"{self.get_for_model.cache_key_prefix}.{concrete_model._meta.label_lower}.{exclude_filter_disabled}"
+        cache_key = construct_cache_key(
+            self,
+            method_name="get_for_model",
+            model=concrete_model._meta.label_lower,
+            exclude_filter_disabled=exclude_filter_disabled,
         )
-        list_cache_key = f"{cache_key}.list"
+        list_cache_key = construct_cache_key(
+            self,
+            method_name="get_for_model",
+            model=concrete_model._meta.label_lower,
+            exclude_filter_disabled=exclude_filter_disabled,
+            listing=True,
+        )
         if not get_queryset:
             listing = cache.get(list_cache_key)
             if listing is not None:
@@ -422,19 +433,15 @@ class CustomFieldManager(BaseManager.from_queryset(RestrictedQuerySet)):
             return listing
         return queryset
 
-    get_for_model.cache_key_prefix = "nautobot.extras.customfield.get_for_model"
-
     def keys_for_model(self, model):
         """Return list of all keys for CustomFields assigned to the given model."""
         concrete_model = model._meta.concrete_model
-        cache_key = f"{self.keys_for_model.cache_key_prefix}.{concrete_model._meta.label_lower}"
+        cache_key = construct_cache_key(self, method_name="keys_for_model", model=concrete_model._meta.label_lower)
         keys = cache.get(cache_key)
         if keys is None:
             keys = list(self.get_for_model(model).values_list("key", flat=True))
             cache.set(cache_key, keys)
         return keys
-
-    keys_for_model.cache_key_prefix = "nautobot.extras.customfield.keys_for_model"
 
     def populate_list_caches(self):
         """Populate all caches for `get_for_model(..., get_queryset=False)` and `keys_for_model` lookups."""
@@ -450,9 +457,19 @@ class CustomFieldManager(BaseManager.from_queryset(RestrictedQuerySet)):
                 key_listings[label].append(cf.key)
         for ct in ContentType.objects.all():
             label = f"{ct.app_label}.{ct.model}"
-            cache.set(f"{self.get_for_model.cache_key_prefix}.{label}.True.list", cf_listings[label][True])
-            cache.set(f"{self.get_for_model.cache_key_prefix}.{label}.False.list", cf_listings[label][False])
-            cache.set(f"{self.keys_for_model.cache_key_prefix}.{label}", key_listings[label])
+            cache.set(
+                construct_cache_key(
+                    self, method_name="get_for_model", model=label, exclude_filter_disabled=True, listing=True
+                ),
+                cf_listings[label][True],
+            )
+            cache.set(
+                construct_cache_key(
+                    self, method_name="get_for_model", model=label, exclude_filter_disabled=True, listing=False
+                ),
+                cf_listings[label][False],
+            )
+            cache.set(construct_cache_key(self, method_name="keys_for_model", model=label), key_listings[label])
 
 
 @extras_features("webhooks")
@@ -572,10 +589,6 @@ class CustomField(
         return self.label
 
     @property
-    def choices_cache_key(self):
-        return f"nautobot.extras.customfield.choices.{self.pk}"
-
-    @property
     def choices(self) -> list[str]:
         """
         Cacheable shorthand for retrieving custom_field_choices values associated with this model.
@@ -585,10 +598,11 @@ class CustomField(
         """
         if self.type not in [CustomFieldTypeChoices.TYPE_SELECT, CustomFieldTypeChoices.TYPE_MULTISELECT]:
             return []
-        choices = cache.get(self.choices_cache_key)
+        cache_key = construct_cache_key(self, method_name="choices")
+        choices = cache.get(cache_key)
         if choices is None:
             choices = list(self.custom_field_choices.order_by("weight", "value").values_list("value", flat=True))
-            cache.set(self.choices_cache_key, choices)
+            cache.set(cache_key, choices)
         return choices
 
     def save(self, *args, **kwargs):

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -29,7 +29,10 @@ logger = logging.getLogger(__name__)
 class GitRepositoryManager(BaseManager.from_queryset(RestrictedQuerySet)):
     def get_for_provided_contents(self, provided_contents_type):
         cache_key = construct_cache_key(
-            self, method_name="get_for_provided_contents", provided_contents_type=provided_contents_type
+            self,
+            method_name="get_for_provided_contents",
+            branch_aware=True,
+            provided_contents_type=provided_contents_type,
         )
         queryset = cache.get(cache_key)
         if queryset is None:

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -18,6 +18,7 @@ from nautobot.core.models.fields import AutoSlugField, LaxURLField, slugify_dash
 from nautobot.core.models.generics import PrimaryModel
 from nautobot.core.models.querysets import RestrictedQuerySet
 from nautobot.core.models.validators import EnhancedURLValidator
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.git import GitRepo
 from nautobot.core.utils.module_loading import check_name_safe_to_import_privately
 from nautobot.extras.utils import extras_features
@@ -27,14 +28,14 @@ logger = logging.getLogger(__name__)
 
 class GitRepositoryManager(BaseManager.from_queryset(RestrictedQuerySet)):
     def get_for_provided_contents(self, provided_contents_type):
-        cache_key = f"{self.get_for_provided_contents.cache_key_prefix}.{provided_contents_type}"
+        cache_key = construct_cache_key(
+            self, method_name="get_for_provided_contents", provided_contents_type=provided_contents_type
+        )
         queryset = cache.get(cache_key)
         if queryset is None:
             queryset = self.get_queryset().filter(provided_contents__contains=provided_contents_type)
             cache.set(cache_key, queryset)
         return queryset
-
-    get_for_provided_contents.cache_key_prefix = "nautobot.extras.gitrepository.get_for_provided_contents"
 
 
 @extras_features(

--- a/nautobot/extras/models/metadata.py
+++ b/nautobot/extras/models/metadata.py
@@ -12,6 +12,7 @@ from nautobot.core.models.fields import JSONArrayField
 from nautobot.core.models.generics import PrimaryModel
 from nautobot.core.models.querysets import RestrictedQuerySet
 from nautobot.core.settings_funcs import is_truthy
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.extras.choices import MetadataTypeDataTypeChoices
 from nautobot.extras.models.change_logging import ChangeLoggedModel
 from nautobot.extras.models.contacts import Contact, Team
@@ -24,15 +25,13 @@ class MetadataTypeManager(BaseManager.from_queryset(RestrictedQuerySet)):
     def get_for_model(self, model):
         """Return all MetadataTypes assigned to the given model."""
         concrete_model = model._meta.concrete_model
-        cache_key = f"{self.get_for_model.cache_key_prefix}.{concrete_model._meta.label_lower}"
+        cache_key = construct_cache_key(self, method_name="get_for_model", model=concrete_model._meta.label_lower)
         queryset = cache.get(cache_key)
         if queryset is None:
             content_type = ContentType.objects.get_for_model(concrete_model)
             queryset = self.get_queryset().filter(content_types=content_type)
             cache.set(cache_key, queryset)
         return queryset
-
-    get_for_model.cache_key_prefix = "nautobot.extras.metadatatype.get_for_model"
 
 
 @extras_features(

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -23,6 +23,7 @@ from nautobot.core.models import BaseManager, BaseModel
 from nautobot.core.models.fields import AutoSlugField, slugify_dashes_to_underscores
 from nautobot.core.models.querysets import RestrictedQuerySet
 from nautobot.core.templatetags.helpers import bettertitle
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.lookup import get_filterset_for_model, get_route_for_model
 from nautobot.extras.choices import RelationshipRequiredSideChoices, RelationshipSideChoices, RelationshipTypeChoices
 from nautobot.extras.models import ChangeLoggedModel
@@ -449,8 +450,16 @@ class RelationshipManager(BaseManager.from_queryset(RestrictedQuerySet)):
             get_queryset (bool): Whether to return a queryset or an object list.
         """
         concrete_model = model._meta.concrete_model
-        cache_key = f"{self.get_for_model_source.cache_key_prefix}.{concrete_model._meta.label_lower}.{hidden}"
-        list_cache_key = f"{cache_key}.list"
+        cache_key = construct_cache_key(
+            self, method_name="get_for_model_source", model=concrete_model._meta.label_lower, hidden=hidden
+        )
+        list_cache_key = construct_cache_key(
+            self,
+            method_name="get_for_model_source",
+            model=concrete_model._meta.label_lower,
+            hidden=hidden,
+            listing=True,
+        )
         if not get_queryset:
             listing = cache.get(list_cache_key)
             if listing is not None:
@@ -470,8 +479,6 @@ class RelationshipManager(BaseManager.from_queryset(RestrictedQuerySet)):
             return listing
         return queryset
 
-    get_for_model_source.cache_key_prefix = "nautobot.extras.relationship.get_for_model_source"
-
     def get_for_model_destination(self, model, hidden=None, get_queryset=True):
         """
         Return all Relationships assigned to the given model for the destination side only.
@@ -482,8 +489,16 @@ class RelationshipManager(BaseManager.from_queryset(RestrictedQuerySet)):
             get_queryset (bool): Whether to return a queryset or an object list.
         """
         concrete_model = model._meta.concrete_model
-        cache_key = f"{self.get_for_model_destination.cache_key_prefix}.{concrete_model._meta.label_lower}.{hidden}"
-        list_cache_key = f"{cache_key}.list"
+        cache_key = construct_cache_key(
+            self, method_name="get_for_model_destination", model=concrete_model._meta.label_lower, hidden=hidden
+        )
+        list_cache_key = construct_cache_key(
+            self,
+            method_name="get_for_model_destination",
+            model=concrete_model._meta.label_lower,
+            hidden=hidden,
+            listing=True,
+        )
         if not get_queryset:
             listing = cache.get(list_cache_key)
             if listing is not None:
@@ -504,8 +519,6 @@ class RelationshipManager(BaseManager.from_queryset(RestrictedQuerySet)):
             cache.set(list_cache_key, listing)
             return listing
         return queryset
-
-    get_for_model_destination.cache_key_prefix = "nautobot.extras.relationship.get_for_model_destination"
 
     def get_required_for_model(self, model):
         """
@@ -536,11 +549,15 @@ class RelationshipManager(BaseManager.from_queryset(RestrictedQuerySet)):
             label = f"{ct.app_label}.{ct.model}"
             for hidden in ["None", "True", "False"]:
                 cache.set(
-                    f"{self.get_for_model_source.cache_key_prefix}.{label}.{hidden}.list",
+                    construct_cache_key(
+                        self, method_name="get_for_model_source", model=label, hidden=hidden, listing=True
+                    ),
                     listings["source"][label][hidden],
                 )
                 cache.set(
-                    f"{self.get_for_model_destination.cache_key_prefix}.{label}.{hidden}.list",
+                    construct_cache_key(
+                        self, method_name="get_for_model_destination", model=label, hidden=hidden, listing=True
+                    ),
                     listings["destination"][label][hidden],
                 )
 

--- a/nautobot/extras/models/relationships.py
+++ b/nautobot/extras/models/relationships.py
@@ -451,11 +451,16 @@ class RelationshipManager(BaseManager.from_queryset(RestrictedQuerySet)):
         """
         concrete_model = model._meta.concrete_model
         cache_key = construct_cache_key(
-            self, method_name="get_for_model_source", model=concrete_model._meta.label_lower, hidden=hidden
+            self,
+            method_name="get_for_model_source",
+            branch_aware=True,
+            model=concrete_model._meta.label_lower,
+            hidden=hidden,
         )
         list_cache_key = construct_cache_key(
             self,
             method_name="get_for_model_source",
+            branch_aware=True,
             model=concrete_model._meta.label_lower,
             hidden=hidden,
             listing=True,
@@ -490,11 +495,16 @@ class RelationshipManager(BaseManager.from_queryset(RestrictedQuerySet)):
         """
         concrete_model = model._meta.concrete_model
         cache_key = construct_cache_key(
-            self, method_name="get_for_model_destination", model=concrete_model._meta.label_lower, hidden=hidden
+            self,
+            method_name="get_for_model_destination",
+            branch_aware=True,
+            model=concrete_model._meta.label_lower,
+            hidden=hidden,
         )
         list_cache_key = construct_cache_key(
             self,
             method_name="get_for_model_destination",
+            branch_aware=True,
             model=concrete_model._meta.label_lower,
             hidden=hidden,
             listing=True,
@@ -550,13 +560,23 @@ class RelationshipManager(BaseManager.from_queryset(RestrictedQuerySet)):
             for hidden in ["None", "True", "False"]:
                 cache.set(
                     construct_cache_key(
-                        self, method_name="get_for_model_source", model=label, hidden=hidden, listing=True
+                        self,
+                        method_name="get_for_model_source",
+                        branch_aware=True,
+                        model=label,
+                        hidden=hidden,
+                        listing=True,
                     ),
                     listings["source"][label][hidden],
                 )
                 cache.set(
                     construct_cache_key(
-                        self, method_name="get_for_model_destination", model=label, hidden=hidden, listing=True
+                        self,
+                        method_name="get_for_model_destination",
+                        branch_aware=True,
+                        model=label,
+                        hidden=hidden,
+                        listing=True,
                     ),
                     listings["destination"][label][hidden],
                 )

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -143,10 +143,10 @@ def invalidate_models_cache(sender, **kwargs):
 
     with contextlib.suppress(redis.exceptions.ConnectionError):
         # TODO: *maybe* target more narrowly, e.g. only clear the cache for specific related content-types?
-        cache_key = construct_cache_key(manager, method_name="get_for_model")
+        cache_key = construct_cache_key(manager, method_name="get_for_model", branch_aware=True)
         cache.delete_pattern(f"{cache_key}(*)")
         if hasattr(manager, "keys_for_model"):
-            cache_key = construct_cache_key(manager, method_name="keys_for_model")
+            cache_key = construct_cache_key(manager, method_name="keys_for_model", branch_aware=True)
             cache.delete_pattern(f"{cache_key}(*)")
 
 
@@ -158,9 +158,9 @@ def invalidate_choices_cache(sender, instance, **kwargs):
     """Invalidate the choices cache for CustomFields."""
     with contextlib.suppress(redis.exceptions.ConnectionError):
         if sender is CustomField:
-            cache_key = construct_cache_key(instance, method_name="choices")
+            cache_key = construct_cache_key(instance, method_name="choices", branch_aware=True)
         else:
-            cache_key = construct_cache_key(instance.custom_field, method_name="choices")
+            cache_key = construct_cache_key(instance.custom_field, method_name="choices", branch_aware=True)
         cache.delete(cache_key)
 
 
@@ -175,7 +175,7 @@ def invalidate_relationship_models_cache(sender, **kwargs):
     ):
         with contextlib.suppress(redis.exceptions.ConnectionError):
             # TODO: *maybe* target more narrowly, e.g. only clear the cache for specific related content-types?
-            cache_key = construct_cache_key(Relationship.objects, method_name=method_name)
+            cache_key = construct_cache_key(Relationship.objects, method_name=method_name, branch_aware=True)
             cache.delete_pattern(f"{cache_key}(*)")
 
 
@@ -209,7 +209,9 @@ def _handle_changed_object_pre_save(sender, instance, raw=False, **kwargs):
 @receiver(post_delete, sender=GitRepository)
 def invalidate_gitrepository_provided_contents_cache(sender, **kwargs):
     with contextlib.suppress(redis.exceptions.ConnectionError):
-        cache_key = construct_cache_key(GitRepository.objects, method_name="get_for_provided_contents")
+        cache_key = construct_cache_key(
+            GitRepository.objects, method_name="get_for_provided_contents", branch_aware=True
+        )
         cache.delete_pattern(f"{cache_key}(*)")
 
 

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -186,9 +186,11 @@ class RelationshipBaseTest:
     def tearDown(self):
         """Ensure that relationship caches are cleared to avoid leakage into other tests."""
         with contextlib.suppress(redis.exceptions.ConnectionError):
-            cache.delete_pattern(f"{construct_cache_key(Relationship.objects, method_name='get_for_model_source')}(*)")
             cache.delete_pattern(
-                f"{construct_cache_key(Relationship.objects, method_name='get_for_model_destination')}(*)"
+                f"{construct_cache_key(Relationship.objects, method_name='get_for_model_source', branch_aware=True)}(*)"
+            )
+            cache.delete_pattern(
+                f"{construct_cache_key(Relationship.objects, method_name='get_for_model_destination', branch_aware=True)}(*)"
             )
 
 

--- a/nautobot/extras/tests/test_relationships.py
+++ b/nautobot/extras/tests/test_relationships.py
@@ -17,6 +17,7 @@ from nautobot.core.forms import (
 from nautobot.core.tables import RelationshipColumn
 from nautobot.core.testing import create_job_result_and_run_job, TestCase, TransactionTestCase
 from nautobot.core.testing.models import ModelTestCases
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.lookup import get_route_for_model
 from nautobot.dcim.forms import DeviceForm
 from nautobot.dcim.models import (
@@ -185,8 +186,10 @@ class RelationshipBaseTest:
     def tearDown(self):
         """Ensure that relationship caches are cleared to avoid leakage into other tests."""
         with contextlib.suppress(redis.exceptions.ConnectionError):
-            cache.delete_pattern(f"{Relationship.objects.get_for_model_source.cache_key_prefix}.*")
-            cache.delete_pattern(f"{Relationship.objects.get_for_model_destination.cache_key_prefix}.*")
+            cache.delete_pattern(f"{construct_cache_key(Relationship.objects, method_name='get_for_model_source')}(*)")
+            cache.delete_pattern(
+                f"{construct_cache_key(Relationship.objects, method_name='get_for_model_destination')}(*)"
+            )
 
 
 class RelationshipTest(RelationshipBaseTest, ModelTestCases.BaseModelTestCase):

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -139,7 +139,7 @@ def change_logged_models_queryset():
     Cache is cleared by post_migrate signal (nautobot.extras.signals.post_migrate_clear_content_type_caches).
     """
     queryset = None
-    cache_key = construct_cache_key(change_logged_models_queryset)
+    cache_key = construct_cache_key(change_logged_models_queryset, branch_aware=False)
     with contextlib.suppress(redis.exceptions.ConnectionError):
         queryset = cache.get(cache_key)
     if queryset is None:
@@ -399,8 +399,9 @@ def get_celery_queues():
     from nautobot.core.celery import app  # prevent circular import
 
     celery_queues = None
+    cache_key = construct_cache_key(get_celery_queues, branch_aware=False)
     with contextlib.suppress(redis.exceptions.ConnectionError):
-        celery_queues = cache.get("nautobot.extras.utils.get_celery_queues")
+        celery_queues = cache.get(cache_key)
 
     if celery_queues is None:
         celery_queues = {}
@@ -420,7 +421,7 @@ def get_celery_queues():
                 for queue in distinct_queues:
                     celery_queues[queue] = celery_queues.get(queue, 0) + 1
         with contextlib.suppress(redis.exceptions.ConnectionError):
-            cache.set("nautobot.extras.utils.get_celery_queues", celery_queues, timeout=5)
+            cache.set(cache_key, celery_queues, timeout=5)
 
     return celery_queues
 

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -25,6 +25,7 @@ from nautobot.core.constants import CHARFIELD_MAX_LENGTH
 from nautobot.core.exceptions import FilterSetFieldNotFound
 from nautobot.core.models.managers import TagsManager
 from nautobot.core.models.utils import find_models_with_matching_fields
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.data import is_uuid
 from nautobot.core.utils.lookup import get_filterset_for_model, get_model_for_view_name
 from nautobot.core.utils.requests import is_single_choice_field
@@ -138,7 +139,7 @@ def change_logged_models_queryset():
     Cache is cleared by post_migrate signal (nautobot.extras.signals.post_migrate_clear_content_type_caches).
     """
     queryset = None
-    cache_key = "nautobot.extras.utils.change_logged_models_queryset"
+    cache_key = construct_cache_key(change_logged_models_queryset)
     with contextlib.suppress(redis.exceptions.ConnectionError):
         queryset = cache.get(cache_key)
     if queryset is None:
@@ -207,7 +208,7 @@ class FeatureQuery:
         Cache is cleared by post_migrate signal (nautobot.extras.signals.post_migrate_clear_content_type_caches).
         """
         choices = None
-        cache_key = f"nautobot.extras.utils.FeatureQuery.choices.{self.feature}"
+        cache_key = construct_cache_key(self, method_name="choices", feature=self.feature)
         with contextlib.suppress(redis.exceptions.ConnectionError):
             choices = cache.get(cache_key)
         if choices is None:
@@ -223,7 +224,7 @@ class FeatureQuery:
         Cache is cleared by post_migrate signal (nautobot.extras.signals.post_migrate_clear_content_type_caches).
         """
         subclasses = None
-        cache_key = f"nautobot.extras.utils.FeatureQuery.subclasses.{self.feature}"
+        cache_key = construct_cache_key(self, method_name="subclasses", feature=self.feature)
         with contextlib.suppress(redis.exceptions.ConnectionError):
             subclasses = cache.get(cache_key)
         if subclasses is None:


### PR DESCRIPTION
# What's Changed

- Introduce a new API, `construct_cache_key()`, as a way of standardizing our Redis cache keys across the app and providing a central point of extension.
    - This function includes a `branch_aware` boolean parameter indicating whether a given cache key should include the active VC branch name (when available) as a part of the key.
- Update Redis cache keys across the app to use `construct_cache_key()` where appropriate and set `branch_aware` as appropriate to each cache
- In reviewing the autogenerated docs for this API, I noticed that a number of existing methods already present in `nautobot.apps` exports were not rendering their docs correctly, so I've corrected their docstrings as needed to render more cleanly.
- Add tests and update existing tests as needed.

Tracking NAUTOBOT-829

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
