### PR TITLE
FIx Location (etc.) list-view sorting by custom field

### DIFF
--- a/changes/7330.fixed
+++ b/changes/7330.fixed
@@ -1,0 +1,1 @@
+Fixed a `FieldError` exception when sorting tree-model (Location, LocationType, RackGroup, etc.) tables by a custom field column.

--- a/changes/7330.fixed
+++ b/changes/7330.fixed
@@ -1,1 +1,2 @@
 Fixed a `FieldError` exception when sorting tree-model (Location, LocationType, RackGroup, etc.) tables by a custom field column.
+Fixed removal of list-view filters when reverting the table sorting to default.

--- a/nautobot/core/tests/test_tables.py
+++ b/nautobot/core/tests/test_tables.py
@@ -18,8 +18,18 @@ class TableTestCase(TestCase):
     def _validate_sorted_tree_queryset_same_with_table_queryset(self, queryset, table_class, field_name):
         with self.subTest(f"Assert sorting {table_class.__name__} on '{field_name}'"):
             table = table_class(queryset.with_tree_fields(), order_by=field_name)
-            table_queryset_data = table.data.data.values_list("pk", flat=True)
-            sorted_queryset = queryset.with_tree_fields().extra(order_by=[field_name]).values_list("pk", flat=True)
+            table_queryset_data = table.data.data.values_list(field_name, flat=True)
+            sorted_queryset = (
+                queryset.with_tree_fields().extra(order_by=[field_name]).values_list(field_name, flat=True)
+            )
+            self.assertEqual(list(table_queryset_data), list(sorted_queryset))
+
+        with self.subTest(f"Assert sorting {table_class.__name__} on '-{field_name}'"):
+            table = table_class(queryset.with_tree_fields(), order_by=f"-{field_name}")
+            table_queryset_data = table.data.data.values_list(field_name, flat=True)
+            sorted_queryset = (
+                queryset.with_tree_fields().extra(order_by=[f"-{field_name}"]).values_list(field_name, flat=True)
+            )
             self.assertEqual(list(table_queryset_data), list(sorted_queryset))
 
     def test_tree_model_table_orderable(self):
@@ -61,14 +71,41 @@ class TableTestCase(TestCase):
             table_avail_fields = set(model_field_names) & set(table_class.Meta.fields)
             for table_field_name in table_avail_fields:
                 self._validate_sorted_tree_queryset_same_with_table_queryset(queryset, table_class, table_field_name)
-                self._validate_sorted_tree_queryset_same_with_table_queryset(
-                    queryset, table_class, f"-{table_field_name}"
-                )
 
         # Test for `rack_count`
         queryset = RackGroupTable.Meta.model.objects.annotate(rack_count=count_related(Rack, "rack_group")).all()
         self._validate_sorted_tree_queryset_same_with_table_queryset(queryset, RackGroupTable, "rack_count")
-        self._validate_sorted_tree_queryset_same_with_table_queryset(queryset, RackGroupTable, "-rack_count")
+
+        # https://github.com/nautobot/nautobot/issues/7330 - sorting by custom field
+        l1 = Location.objects.first()
+        l1._custom_field_data["example_app_auto_custom_field"] = "alpha"
+        l1.validated_save()
+        l2 = Location.objects.last()
+        l2._custom_field_data["example_app_auto_custom_field"] = "omega"
+        l2.validated_save()
+        table = LocationTable(
+            Location.objects.exclude(_custom_field_data__example_app_auto_custom_field="Default value")
+        )
+
+        table.order_by = ["cf_example_app_auto_custom_field"]
+        table_queryset_data = table.data.data.values_list("pk", flat=True)
+        sorted_queryset = (
+            Location.objects.with_tree_fields()
+            .exclude(_custom_field_data__example_app_auto_custom_field="Default value")
+            .extra(order_by=["_custom_field_data__example_app_auto_custom_field"])
+            .values_list("pk", flat=True)
+        )
+        self.assertEqual(list(table_queryset_data), list(sorted_queryset))
+
+        table.order_by = ["-cf_example_app_auto_custom_field"]
+        table_queryset_data = table.data.data.values_list("pk", flat=True)
+        sorted_queryset = (
+            Location.objects.with_tree_fields()
+            .exclude(_custom_field_data__example_app_auto_custom_field="Default value")
+            .extra(order_by=["-_custom_field_data__example_app_auto_custom_field"])
+            .values_list("pk", flat=True)
+        )
+        self.assertEqual(list(table_queryset_data), list(sorted_queryset))
 
     def test_base_table_apis(self):
         """

--- a/nautobot/project-static/js/table_sorting_indicator.js
+++ b/nautobot/project-static/js/table_sorting_indicator.js
@@ -22,8 +22,6 @@ document.addEventListener("DOMContentLoaded", function() {
             } else if (sortParam === "-" + columnName) {
                 // If the column is already sorted in descending order, reset to default
                 searchParams.delete("sort");
-                window.location.replace(window.location.pathname); // Reload the page with the default view without adding a new entry to history
-                return;
             } else {
                 // If no sort or default state, set to ascending
                 searchParams.set("sort", columnName);


### PR DESCRIPTION
# Closes #7330
# Closes #6341 

# What's Changed

Basically, the custom `BaseTable.order_by` property setter added in #5218 didn't account correctly for custom fields (and likely some other sortable column types as well) where the column name didn't directly correspond to the database accessor. After some investigation, I found the custom logic in this method to now be mostly unnecessary , apparently due to fact that we now automatically do `hide_hierarchy_ui=True` when sorting (as added in #5475).

At first I just removed this custom setter method entirely, but found that while the UI worked fine without it, the unit test added in #5218 began to fail, because unlike our generic view code, it does not explicitly add `hide_hierarchy_ui=True` to the sorted tables it instantiates. Therefore I re-added the setter, but replaced the broken logic from #5218 with a few lines of new code to ensure that applying ordering to the table automatically adds `hide_hierarchy_ui=True` to it as well.

Additionally, in testing this manually, I noticed that sorting a filtered view works as expected on the first two clicks in a column header ("sort ascending" and "sort descending" respectively) but the third click ("remove sorting") was inadvertently removing the filtering as well. That turned out to be a simple fix so I've included it in this PR as well.

tracking NAUTOBOT-791

# Screenshots

<img width="1455" height="223" alt="image" src="https://github.com/user-attachments/assets/47633a79-ca15-4aab-9298-1c717d9017b5" />

<img width="1456" height="241" alt="image" src="https://github.com/user-attachments/assets/c10965d8-d465-4f36-bd4b-4f0b35288253" />

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
