### PR TITLE
Fix incorrect Prefix.parent setting for certain /31 networks

### DIFF
--- a/changes/xxxx.fixed
+++ b/changes/xxxx.fixed
@@ -1,0 +1,1 @@
+Fixed a bug in which IPv4 /31 Prefix records might be assigned the wrong `parent` Prefix.

--- a/nautobot/ipam/querysets.py
+++ b/nautobot/ipam/querysets.py
@@ -356,7 +356,7 @@ class PrefixQuerySet(LocationToLocationsQuerySetMixin, BaseNetworkQuerySet):
         """
         # Validate that it's a real CIDR
         cidr = self._validate_cidr(cidr)
-        broadcast = str(cidr.broadcast or cidr.ip)
+        broadcast = str(cidr.broadcast or cidr[-1])
         ip_version = cidr.version
 
         try:

--- a/nautobot/ipam/tests/test_querysets.py
+++ b/nautobot/ipam/tests/test_querysets.py
@@ -819,3 +819,9 @@ class PrefixQuerysetTestCase(TestCase):
                     .order_by("-prefix_length")
                     .first(),
                 )
+
+        slash32 = Prefix.objects.create(prefix="10.1.1.154/32", namespace=namespace, status=self.status)
+        slash31 = Prefix.objects.create(prefix="10.1.1.154/31", namespace=namespace, status=self.status)
+        slash30 = Prefix.objects.create(prefix="10.1.1.154/30", namespace=namespace, status=self.status)
+        self.assertEqual(slash31, Prefix.objects.get_closest_parent(slash32.prefix))
+        self.assertEqual(slash30, Prefix.objects.get_closest_parent(slash31.prefix))

--- a/nautobot/ipam/utils/migrations.py
+++ b/nautobot/ipam/utils/migrations.py
@@ -587,7 +587,7 @@ def get_closest_parent(obj, qs):
     """
     # Validate that it's a real CIDR
     cidr = validate_cidr(obj)
-    broadcast = str(cidr.broadcast or cidr.ip)
+    broadcast = str(cidr.broadcast or cidr[-1])
 
     # Prepare the queryset filter
     lookup_kwargs = {


### PR DESCRIPTION
# What's Changed

Fix incorrect logic in `Prefix.objects.get_closest_parent()` that didn't account correctly for /31 networks (which, as represented as `netaddr.IPNetwork`, have a null `broadcast` value, but whose Nautobot `broadcast` should be the last (second) IP in the subnet, **not** as we incorrectly had it, the first IP). Based on a quick `git grep` these should be the only two places that need this fix. Added a unit test to catch this issue as well.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
