### PR TITLE
Fix duplicate records in DynamicGroup.update_cached_members()

### DIFF
--- a/changes/7631.fixed
+++ b/changes/7631.fixed
@@ -1,0 +1,1 @@
+Fixed duplicate records returned in some cases by `DynamicGroup.update_cached_members()`.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #7631
# What's Changed

- Add a test case that demonstrates the issue described by #7631.
- Ensure that `DynamicGroup._get_group_queryset()` (which underlies `DynamicGroup.update_cached_members()`) returns a queryset without duplicate entries. (See the code comments for reasoning and caveats).

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
