### PR TITLE
Update CI and Docker build to use Poetry 2.1.4

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -44,7 +44,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Run check-schema"
         # REST API schema generation currently includes GraphQL schema generation, which is dependent on the DB :-(
@@ -77,7 +77,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Run unittest"
         run: "poetry run invoke tests --failfast --no-keepdb --no-cache-test-fixtures --parallel"
@@ -113,7 +113,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--extras mysql"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.9"
       - name: "Run unittest"
         run: "poetry run invoke tests --failfast --no-keepdb --no-cache-test-fixtures --parallel"
@@ -147,7 +147,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--extras mysql"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.9"
       - name: "Run migration test"
         run: "poetry run invoke migration-test --db-engine mysql --dataset $MIGRATION_TEST_DATASET"
@@ -178,7 +178,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Run migration test"
         run: "poetry run invoke migration-test --db-engine postgres --dataset $MIGRATION_TEST_DATASET"
@@ -214,7 +214,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Run Integration Tests"
         # If NAUTOBOT_SELENIUM_HOST is set to 'localhost' or '127.0.0.1' the connection does not work

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -28,7 +28,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--only dev --only linting"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Linting: ruff"
         run: "poetry run invoke ruff --output-format github"
@@ -43,7 +43,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--only dev --only linting"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Linting: yamllint"
         run: "poetry run invoke yamllint"
@@ -58,7 +58,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--only dev --only linting"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Linting: pymarkdownlnt"
         run: "poetry run invoke markdownlint"
@@ -97,7 +97,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Run check migrations"
         run: "poetry run invoke check-migrations"
@@ -126,7 +126,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Run check-schema"
         # REST API schema generation currently includes GraphQL schema generation, which is dependent on the DB :-(
@@ -155,7 +155,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Run pylint"
         run: "poetry run invoke pylint"
@@ -187,7 +187,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.9"
       - name: "Run unittest"
         run: "poetry run invoke tests --failfast --no-keepdb --no-cache-test-fixtures --parallel"
@@ -233,7 +233,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--extras mysql"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Run unittest"
         run: "poetry run invoke tests --failfast --no-keepdb --no-cache-test-fixtures --parallel --coverage"
@@ -294,7 +294,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--extras mysql"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.9"
       - name: "Run migration test"
         run: "poetry run invoke migration-test --db-engine mysql --dataset $MIGRATION_TEST_DATASET"
@@ -332,7 +332,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Run migration test"
         run: "poetry run invoke migration-test --db-engine postgres --dataset $MIGRATION_TEST_DATASET"
@@ -375,7 +375,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Run Integration Tests"
         # If NAUTOBOT_SELENIUM_HOST is set to 'localhost' or '127.0.0.1' the connection does not work
@@ -399,7 +399,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Check for changelog entry"
         run: |

--- a/.github/workflows/plugin_upstream_testing_base.yml
+++ b/.github/workflows/plugin_upstream_testing_base.yml
@@ -31,7 +31,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "${{ env.PYTHON_VERSION }}"
       # This deviates from the app CI since we can't force invoke to run locally using the `INVOKE_APPNAME_LOCAL` environment variable
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -83,7 +83,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "${{ env.PYTHON_VERSION }}"
       - name: "Copy credentials"
         run: "cp development/creds.example.env development/creds.env"
@@ -114,7 +114,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: ""  # override default "--only dev"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "${{ env.PYTHON_VERSION }}"
       - name: "Copy credentials"
         run: "cp development/creds.example.env development/creds.env"

--- a/changes/xxxx.housekeeping
+++ b/changes/xxxx.housekeeping
@@ -1,0 +1,1 @@
+Updated CI workflows and Docker image build to use Poetry 2.1.4.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,10 +107,10 @@ FROM python:${PYTHON_VER}-slim-bookworm AS poetry
 # This also makes it so that Poetry will *not* be included in the "final" image since it's not installed to /usr/local/
 ARG POETRY_HOME=/opt/poetry
 ARG POETRY_INSTALLER_PARALLEL=true
-ARG POETRY_VERSION=1.8.2
+ARG POETRY_VERSION=2.1.4
 ARG POETRY_VIRTUALENVS_CREATE=false
 ADD https://install.python-poetry.org /tmp/install-poetry.py
-RUN python /tmp/install-poetry.py
+RUN python /tmp/install-poetry.py --version ${POETRY_VERSION}
 
 # Add poetry install location to the $PATH
 ENV PATH="${POETRY_HOME}/bin:${PATH}"


### PR DESCRIPTION
Does **not** include the PEP 621 `pyproject.toml` changes that Poetry v2 now supports - see #6727 for draft work in that direction. This purely just moves us to the latest (backwards-compatible) version of Poetry.