### PR TITLE
Add Saved View capability to JobResult

### DIFF
--- a/changes/7758.added
+++ b/changes/7758.added
@@ -1,0 +1,1 @@
+Added SavedView capability to JobResults model.

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -48,7 +48,7 @@ from nautobot.extras.constants import (
 )
 from nautobot.extras.managers import JobResultManager, ScheduledJobsManager
 from nautobot.extras.models import ChangeLoggedModel, GitRepository
-from nautobot.extras.models.mixins import ContactMixin, DynamicGroupsModelMixin, NotesMixin
+from nautobot.extras.models.mixins import ContactMixin, DynamicGroupsModelMixin, NotesMixin, SavedViewMixin
 from nautobot.extras.querysets import JobQuerySet, ScheduledJobExtendedQuerySet
 from nautobot.extras.utils import (
     ChangeLoggedModelsQuery,
@@ -631,7 +631,7 @@ class JobQueueAssignment(BaseModel):
     "custom_links",
     "graphql",
 )
-class JobResult(BaseModel, CustomFieldModel):
+class JobResult(SavedViewMixin, BaseModel, CustomFieldModel):
     """
     This model stores the results from running a Job.
     """


### PR DESCRIPTION
# Closes #7758
# What's Changed
Added SavedViewMixin to the JobResult Object, to enable Saved View capability for the Job Results page in Nautobot.

Based on my testing...this was literally the only update that was needed and I was able to add/remove/etc the Saved Views for the Job Results page without issue. Let me know if I'm missing something!