### PR TITLE
housekeeping: improve frontend dev environment

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -52,23 +52,28 @@ jobs:
   ui-build-check:
     name: "Check UI src and dist files validity and integrity"
     runs-on: "ubuntu-24.04"
-    defaults:
-      run:
-        working-directory: "nautobot/project-static"
+    env:
+      INVOKE_NAUTOBOT_LOCAL: "True"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-install-options: "--only dev --only linting"
+          poetry-version: "1.8.5"
+          python-version: "3.13"
       - name: "Setup Node.js"
         uses: "actions/setup-node@v4"
         with:
           node-version: "22"
       - name: "Install npm dependencies"
-        run: "npm ci"
+        run: "poetry run invoke npm --command ci"
       - name: "Calculate checksum of originally committed UI dist files"
         run: |
           echo "original_checksum=$(find dist -type f -exec md5sum {} + | sort -k 2 | md5sum)" >> "$GITHUB_ENV"
       - name: "Build UI from source"
-        run: "npm run build"
+        run: "poetry run invoke ui-build"
       - name: "Re-calculate checksum of UI dist files after the build"
         run: |
           echo "updated_checksum=$(find dist -type f -exec md5sum {} + | sort -k 2 | md5sum)" >> "$GITHUB_ENV"

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -162,40 +162,50 @@ jobs:
   ui-code-check:
     name: "Check UI code style and formatting"
     runs-on: "ubuntu-24.04"
-    defaults:
-      run:
-        working-directory: "nautobot/project-static"
+    env:
+      INVOKE_NAUTOBOT_LOCAL: "True"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-install-options: "--only dev --only linting"
+          poetry-version: "1.8.5"
+          python-version: "3.13"
       - name: "Setup Node.js"
         uses: "actions/setup-node@v4"
         with:
           node-version: "22"
       - name: "Install npm dependencies"
-        run: "npm ci"
-      - name: "Run code-check"
-        run: "npm run code-check"
+        run: "poetry run invoke npm --command ci"
+      - name: "Run ui-code-check"
+        run: "poetry run invoke ui-code-check"
   ui-build-check:
     name: "Check UI src and dist files validity and integrity"
     runs-on: "ubuntu-24.04"
-    defaults:
-      run:
-        working-directory: "nautobot/project-static"
+    env:
+      INVOKE_NAUTOBOT_LOCAL: "True"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-install-options: "--only dev --only linting"
+          poetry-version: "1.8.5"
+          python-version: "3.13"
       - name: "Setup Node.js"
         uses: "actions/setup-node@v4"
         with:
           node-version: "22"
       - name: "Install npm dependencies"
-        run: "npm ci"
+        run: "poetry run invoke npm --command ci"
       - name: "Calculate checksum of originally committed UI dist files"
         run: |
           echo "original_checksum=$(find dist -type f -exec md5sum {} + | sort -k 2 | md5sum)" >> "$GITHUB_ENV"
       - name: "Build UI from source"
-        run: "npm run build"
+        run: "poetry run invoke ui-build"
       - name: "Re-calculate checksum of UI dist files after the build"
         run: |
           echo "updated_checksum=$(find dist -type f -exec md5sum {} + | sort -k 2 | md5sum)" >> "$GITHUB_ENV"

--- a/changes/7785.housekeeping
+++ b/changes/7785.housekeeping
@@ -1,0 +1,1 @@
+Added `invoke` commands and renamed existing `npm` commands for frontend development.

--- a/development/docker-compose.dev.yml
+++ b/development/docker-compose.dev.yml
@@ -21,7 +21,7 @@ services:
       - ../:/source
   ui_build:
     image: "local/nautobot-dev:local-${NAUTOBOT_VER}-py${PYTHON_VER}"
-    entrypoint: "bash -c 'cd /source/nautobot/project-static && npm run build -- --watch'"
+    entrypoint: "bash -c 'npm --prefix /source/nautobot/project-static run build:watch'"
     healthcheck:
       disable: true
     tty: true

--- a/nautobot/docs/development/core/getting-started.md
+++ b/nautobot/docs/development/core/getting-started.md
@@ -172,44 +172,50 @@ Example output:
 ```no-highlight
 Available tasks:
 
-  branch                 Switch to a different Git branch, creating it if requested.
-  build                  Build Nautobot docker image.
-  build-and-check-docs   Build docs for use within Nautobot.
+  branch                       Switch to a different Git branch, creating it if requested.
+  build                        Build Nautobot docker image.
+  build-and-check-docs         Build docs for use within Nautobot.
   build-dependencies
-  buildx                 Build Nautobot docker image using the experimental buildx docker functionality (multi-arch
-                         capability).
-  check-migrations       Check for missing migrations.
-  check-schema           Render the REST API schema and check for problems.
-  cli                    Launch a bash shell inside the running Nautobot (or other) Docker container.
-  createsuperuser        Create a new Nautobot superuser account (default: "admin"), will prompt for password.
-  debug                  Start Nautobot and its dependencies in debug mode.
-  destroy                Destroy all containers and volumes.
-  docker-push            Tags and pushes docker images to the appropriate repos, intended for release use only.
-  dumpdata               Dump data from database to db_output file.
-  hadolint               Check Dockerfile for hadolint compliance and other style issues.
-  lint                   Run all linters.
-  loaddata               Load data from file.
-  logs                   View the logs of a docker compose service.
-  makemigrations         Perform makemigrations operation in Django.
-  markdownlint           Lint Markdown files.
-  migrate                Perform migrate operation in Django.
-  migration-test         Test database migration from a given dataset to latest Nautobot schema.
-  nbshell                Launch an interactive Nautobot shell.
-  open-docs-web          Navigate to the mkdocs interface in your web browser.
-  open-nautobot-web      Navigate to the Nautobot interface in your web browser.
-  open-selenium-vnc      Navigate to the selenium VNC browser view.
-  post-upgrade           Performs Nautobot common post-upgrade operations using a single entrypoint.
-  pylint                 Perform static analysis of Nautobot code.
-  restart                Gracefully restart containers.
-  ruff                   Run ruff to perform code formatting and linting.
-  serve-docs             Runs local instance of mkdocs serve on port 8001 (ctrl-c to stop).
-  showmigrations         Perform showmigrations operation in Django.
-  start                  Start Nautobot and its dependencies in detached mode.
-  stop                   Stop Nautobot and its dependencies.
-  tests                  Run Nautobot automated tests.
-  version                Show the version of Nautobot Python package or bump it when a valid bump rule is provided.
-  vscode                 Launch Visual Studio Code with the appropriate Environment variables to run in a container.
-  yamllint               Run yamllint to validate formatting applies to YAML standards.
+  buildx                       Build Nautobot docker image using the experimental buildx docker functionality (multi-arch capability).
+  check-migrations             Check for missing migrations.
+  check-schema                 Render the REST API schema and check for problems.
+  cli                          Launch a bash shell inside the running Nautobot (or other) Docker container.
+  createsuperuser              Create a new Nautobot superuser account (default: "admin"), will prompt for password.
+  debug                        Start Nautobot and its dependencies in debug mode.
+  destroy                      Destroy all containers and volumes.
+  docker-push                  Tags and pushes docker images to the appropriate repos, intended for release use only.
+  dump-service-ports-to-disk   Useful for downstream utilities without direct docker access to determine ports.
+  dumpdata                     Dump data from database to db_output file.
+  eslint                       Run ESLint to perform JavaScript code linting. Optionally, make an attempt to fix found issues with `--fix` flag.
+  hadolint                     Check Dockerfile for hadolint compliance and other style issues.
+  lint                         Run all linters.
+  loaddata                     Load data from file.
+  logs                         View the logs of a docker compose service.
+  makemigrations               Perform makemigrations operation in Django.
+  markdownlint                 Lint Markdown files.
+  migrate                      Perform migrate operation in Django.
+  migration-test               Test database migration from a given dataset to latest Nautobot schema.
+  nbshell                      Launch an interactive Nautobot shell.
+  npm                          Execute any given npm command inside `project-static` directory.
+  open-docs-web                Navigate to the mkdocs interface in your web browser.
+  open-nautobot-web            Navigate to the Nautobot interface in your web browser.
+  open-selenium-vnc            Navigate to the selenium VNC browser view.
+  post-upgrade                 Performs Nautobot common post-upgrade operations using a single entrypoint.
+  prettier                     Run Prettier to perform JavaScript code formatting. By default only validate the formatting, optionally apply it with `--fix` flag.
+  pylint                       Perform static analysis of Nautobot code.
+  restart                      Gracefully restart containers.
+  ruff                         Run ruff to perform code formatting and linting.
+  serve-docs                   Runs local instance of mkdocs serve on port 8001 (ctrl-c to stop).
+  showmigrations               Perform showmigrations operation in Django.
+  start                        Start Nautobot and its dependencies in detached mode.
+  stop                         Stop Nautobot and its dependencies.
+  tests                        Run Nautobot automated tests.
+  ui-build                     Build Nautobot UI from source.
+  ui-code-check                Check Nautobot UI source code style and formatting.
+  ui-code-format               Format Nautobot UI source code.
+  version                      Show the version of Nautobot Python package or bump it when a valid bump rule is provided.
+  vscode                       Visual Studio Code specific environment helpers.
+  yamllint                     Run yamllint to validate formatting applies to YAML standards.
 ```
 
 #### Using Docker with Invoke

--- a/nautobot/docs/development/core/release-checklist.md
+++ b/nautobot/docs/development/core/release-checklist.md
@@ -43,15 +43,14 @@ Every minor version release should refresh `poetry.lock`, so that it lists the m
 !!! hint
     You may use `poetry update --dry-run` to have Poetry automatically tell you what package updates are available and the versions it would upgrade.
 
-### Update Static Libraries
+### Update UI Libraries
 
-Update the following static libraries to their most recent stable release:
+Update UI libraries to their latest version (specified by the tag config) respecting the semver constraints of both package and its dependencies:
 
-* [Bootstrap 3](https://getbootstrap.com/docs/3.4)
-* [Material Design Icons](https://materialdesignicons.com/)
-* [Select2](https://github.com/select2/select2/releases)
-* [jQuery](https://jquery.com/download/)
-* [jQuery UI](https://jqueryui.com/)
+```no-highlight
+invoke npm --command "update --save"
+invoke ui-build
+```
 
 ### Link to the Release Notes Page
 

--- a/nautobot/docs/development/core/style-guide.md
+++ b/nautobot/docs/development/core/style-guide.md
@@ -27,7 +27,7 @@ invoke markdownlint
 invoke ruff
 invoke pylint
 invoke eslint
-invoke prettier --check
+invoke prettier
 ```
 
 or, as a single command:

--- a/nautobot/docs/development/core/style-guide.md
+++ b/nautobot/docs/development/core/style-guide.md
@@ -6,6 +6,8 @@ Nautobot generally follows the [Django style guide](https://docs.djangoproject.c
 * [Pylint](https://pylint.pycqa.org/en/latest/) is used for Python static code analysis.
 * [Hadolint](https://github.com/hadolint/hadolint) is used to lint and validate Docker best practices in the Dockerfile.
 * [PyMarkdown](https://github.com/jackdewinter/pymarkdown) is used to lint and validate Markdown (documentation) files.
+* [ESLint](https://github.com/eslint/eslint) is used to lint and validate JavaScript files.
+* [Prettier](https://github.com/prettier/prettier) is used to format and validate JavaScript files.
 
 Nautobot-specific configuration of these tools is maintained in the `pyproject.toml` file as appropriate to the individual tool.
 
@@ -24,6 +26,8 @@ invoke hadolint
 invoke markdownlint
 invoke ruff
 invoke pylint
+invoke eslint
+invoke prettier --check
 ```
 
 or, as a single command:

--- a/nautobot/project-static/package.json
+++ b/nautobot/project-static/package.json
@@ -2,11 +2,14 @@
   "name": "nautobot",
   "scripts": {
     "build": "webpack build --mode=production",
-    "code-check": "run-s lint format-check",
-    "lint": "eslint src",
-    "format": "prettier src --write",
-    "format-check": "prettier src --check",
-    "prebuild": "npm run code-check"
+    "build:watch": "npm run build -- --watch",
+    "code:check": "run-s eslint prettier:check",
+    "code:format": "run-s eslint:fix prettier",
+    "eslint": "eslint src",
+    "eslint:fix": "npm run eslint -- --fix",
+    "prebuild": "npm run code:check",
+    "prettier": "prettier src --write",
+    "prettier:check": "prettier src --check"
   },
   "dependencies": {
     "@graphiql/plugin-explorer": "0.1.15",

--- a/nautobot/project-static/package.json
+++ b/nautobot/project-static/package.json
@@ -3,13 +3,13 @@
   "scripts": {
     "build": "webpack build --mode=production",
     "build:watch": "npm run build -- --watch",
-    "code:check": "run-s eslint prettier:check",
-    "code:format": "run-s eslint:fix prettier",
+    "code:check": "run-s eslint prettier",
+    "code:format": "run-s eslint:fix prettier:fix",
     "eslint": "eslint src",
     "eslint:fix": "npm run eslint -- --fix",
     "prebuild": "npm run code:check",
-    "prettier": "prettier src --write",
-    "prettier:check": "prettier src --check"
+    "prettier": "prettier src --check",
+    "prettier:fix": "prettier src --write"
   },
   "dependencies": {
     "@graphiql/plugin-explorer": "0.1.15",

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -41,6 +41,12 @@ invoke ruff || EXIT=1
 echo "Check static analysis via pylint..."
 invoke pylint || EXIT=1
 
+echo "Check JavaScript files code style via ESLint..."
+invoke eslint || EXIT=1
+
+echo "Check JavaScript files code style via Prettier..."
+invoke prettier --check || EXIT=1
+
 if [ $EXIT != 0 ]; then
 	printf "${RED}COMMIT FAILED${NOCOLOR}\n"
 fi

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -45,7 +45,7 @@ echo "Check JavaScript files code style via ESLint..."
 invoke eslint || EXIT=1
 
 echo "Check JavaScript files code style via Prettier..."
-invoke prettier --check || EXIT=1
+invoke prettier || EXIT=1
 
 if [ $EXIT != 0 ]; then
 	printf "${RED}COMMIT FAILED${NOCOLOR}\n"

--- a/tasks.py
+++ b/tasks.py
@@ -915,12 +915,12 @@ def eslint(context, fix=False):
     npm(context, command)
 
 
-@task(help={"check": "Only validate code formatting. Do not apply automatic formatting to source files."})
-def prettier(context, check=False):
-    """Run Prettier to perform JavaScript code formatting. Optionally, only validate the formatting with `--check` flag."""
+@task(help={"fix": "Automatically apply recommended formatting."})
+def prettier(context, fix=False):
+    """Run Prettier to perform JavaScript code formatting. By default only validate the formatting, optionally apply it with `--fix` flag."""
     command = "run prettier"
-    if check:
-        command += ":check"
+    if fix:
+        command += ":fix"
     npm(context, command)
 
 
@@ -1097,7 +1097,7 @@ def lint(context):
     ruff(context)
     pylint(context)
     eslint(context)
-    prettier(context, check=True)
+    prettier(context)
     check_migrations(context)
     check_schema(context)
     build_and_check_docs(context)

--- a/tasks.py
+++ b/tasks.py
@@ -734,14 +734,14 @@ def ui_build(context, watch=False):
 
 
 @task
-def ui_code_check(context, watch=False):
+def ui_code_check(context):
     """Check Nautobot UI source code style and formatting."""
     command = "run code:check"
     npm(context, command)
 
 
 @task
-def ui_code_format(context, watch=False):
+def ui_code_format(context):
     """Format Nautobot UI source code."""
     command = "run code:format"
     npm(context, command)


### PR DESCRIPTION
# What's Changed
Add the following `invoke` commands and rename existing `npm` commands to align them with the former:
1. `invoke npm --command {any given npm command}`
2. `invoke ui-build` (with an optional `--watch` flag)
3. `invoke ui-code-check`
4. `invoke ui-code-format`
5. `invoke eslint` (with an optional `--fix` flag)
6. `invoke prettier` (with an optional `--check` flag)

Tracking NAUTOBOT-809