### PR TITLE
Fix MRO issues caused by UIComponentsMixin

### DIFF
--- a/nautobot/core/tests/test_views_generic.py
+++ b/nautobot/core/tests/test_views_generic.py
@@ -1,0 +1,39 @@
+from itertools import combinations
+
+from nautobot.core.testing import TestCase
+from nautobot.core.views import generic
+from nautobot.dcim.models import Location
+
+
+class TestViewsGeneric(TestCase):
+    def test_mro_resolve_for_generic_views(self):
+        """
+        Test if all the generic views can be used extend view class.
+
+        Tries to detect if there is no MRO issues according to the #7829.
+        """
+        generic_views = [
+            generic.GenericView,
+            generic.ObjectListView,
+            generic.ObjectView,
+            generic.ObjectEditView,
+            generic.ObjectDeleteView,
+            generic.BulkCreateView,
+            generic.ObjectImportView,
+            generic.BulkImportView,
+            generic.BulkEditView,
+            generic.BulkRenameView,
+            generic.BulkDeleteView,
+            generic.ComponentCreateView,
+            generic.BulkComponentCreateView,
+        ]
+        generic_views_pairs = combinations(generic_views, 2)
+
+        for base_view, extension_view in generic_views_pairs:
+            with self.subTest("Test different class inheritance."):
+
+                class MyMixin(base_view):
+                    pass
+
+                class MyView(MyMixin, extension_view):
+                    queryset = Location.objects.all()

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -68,7 +68,7 @@ from nautobot.core.views.utils import (
 from nautobot.extras.models import ExportTemplate, SavedView, UserSavedViewAssociation
 
 
-class GenericView(LoginRequiredMixin, UIComponentsMixin, View):
+class GenericView(UIComponentsMixin, LoginRequiredMixin, View):
     """
     Base class for non-object-related views.
 
@@ -76,7 +76,7 @@ class GenericView(LoginRequiredMixin, UIComponentsMixin, View):
     """
 
 
-class ObjectView(ObjectPermissionRequiredMixin, UIComponentsMixin, View):
+class ObjectView(UIComponentsMixin, ObjectPermissionRequiredMixin, View):
     """
     Retrieve a single object for display.
 
@@ -141,7 +141,7 @@ class ObjectView(ObjectPermissionRequiredMixin, UIComponentsMixin, View):
         return render(request, self.get_template_name(), context)
 
 
-class ObjectListView(ObjectPermissionRequiredMixin, UIComponentsMixin, View):
+class ObjectListView(UIComponentsMixin, ObjectPermissionRequiredMixin, View):
     """
     List a series of objects.
 
@@ -421,7 +421,7 @@ class ObjectListView(ObjectPermissionRequiredMixin, UIComponentsMixin, View):
         return {}
 
 
-class ObjectEditView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequiredMixin, View):
+class ObjectEditView(UIComponentsMixin, GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
     """
     Create or edit a single object.
 
@@ -569,7 +569,7 @@ class ObjectEditView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequi
         )
 
 
-class ObjectDeleteView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequiredMixin, View):
+class ObjectDeleteView(UIComponentsMixin, GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
     """
     Delete a single object.
 
@@ -646,7 +646,7 @@ class ObjectDeleteView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionReq
         )
 
 
-class BulkCreateView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequiredMixin, View):
+class BulkCreateView(UIComponentsMixin, GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
     """
     Create new objects in bulk.
 
@@ -760,7 +760,7 @@ class BulkCreateView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequi
         )
 
 
-class ObjectImportView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequiredMixin, View):
+class ObjectImportView(UIComponentsMixin, GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
     """
     Import a single object (YAML or JSON format).
 
@@ -908,7 +908,7 @@ class ObjectImportView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionReq
 
 
 class BulkImportView(
-    GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequiredMixin, View
+    UIComponentsMixin, GetReturnURLMixin, ObjectPermissionRequiredMixin, View
 ):  # 3.0 TODO: remove as it's no longer used
     """
     Import objects in bulk (CSV format).
@@ -1019,7 +1019,7 @@ class BulkImportView(
 
 
 class BulkEditView(
-    GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequiredMixin, BulkEditAndBulkDeleteModelMixin, View
+    UIComponentsMixin, GetReturnURLMixin, ObjectPermissionRequiredMixin, BulkEditAndBulkDeleteModelMixin, View
 ):
     """
     Edit objects in bulk.
@@ -1116,7 +1116,7 @@ class BulkEditView(
         return {}
 
 
-class BulkRenameView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequiredMixin, View):
+class BulkRenameView(UIComponentsMixin, GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
     """
     An extendable view for renaming objects in bulk.
     """
@@ -1217,7 +1217,7 @@ class BulkRenameView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequi
 
 
 class BulkDeleteView(
-    GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequiredMixin, BulkEditAndBulkDeleteModelMixin, View
+    UIComponentsMixin, GetReturnURLMixin, ObjectPermissionRequiredMixin, BulkEditAndBulkDeleteModelMixin, View
 ):
     """
     Delete objects in bulk.
@@ -1329,7 +1329,7 @@ class BulkDeleteView(
 
 
 # TODO: Replace with BulkCreateView
-class ComponentCreateView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequiredMixin, View):
+class ComponentCreateView(UIComponentsMixin, GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
     """
     Add one or more components (e.g. interfaces, console ports, etc.) to a Device or VirtualMachine.
     """
@@ -1435,7 +1435,7 @@ class ComponentCreateView(GetReturnURLMixin, UIComponentsMixin, ObjectPermission
         )
 
 
-class BulkComponentCreateView(GetReturnURLMixin, UIComponentsMixin, ObjectPermissionRequiredMixin, View):
+class BulkComponentCreateView(UIComponentsMixin, GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
     """
     Add one or more components (e.g. interfaces, console ports, etc.) to a set of Devices or VirtualMachines.
     """


### PR DESCRIPTION
# Closes #7829
# What's Changed
- Fix #7829: MRO conflict caused by inconsistent ordering of `ObjectPermissionRequiredMixin` and `UIComponentsMixin` across generic views.
- `UIComponentsMixin` is moved to the beginning of based classes in generic views to avoid other potential issues
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
