### PR TITLE
Documented options for controlling Celery worker prefetching.

### DIFF
--- a/changes/7845.documentation
+++ b/changes/7845.documentation
@@ -1,0 +1,1 @@
+Documented options for controlling Celery worker prefetching behavior in the "Task Queues" guide.


### PR DESCRIPTION
# Closes #7845 

# What's Changed
Documented options for controlling Celery worker prefetching.

# Screenshots
<img width="1167" height="812" alt="image" src="https://github.com/user-attachments/assets/3ae45835-7333-4d9f-a729-c4fe3d94ec58" />
<img width="1158" height="446" alt="image" src="https://github.com/user-attachments/assets/6f37685c-6f06-47b7-9a15-ad5014b4a096" />
