### PR TITLE
Fix NoteUIViewSet to set user and user_name correctly on note creation

### DIFF
--- a/changes/7855.fixed
+++ b/changes/7855.fixed
@@ -1,1 +1,1 @@
-Fixed NoteUIViewSet bug where new Notes saved with user_name="Undefined" even for authenticated users. Overrides form_valid() to apply alter_obj() before saving, ensuring user and user_name are correctly set.
+Fixed NoteUIViewSet to correctly populate `user` and `user_name` fields on Note creation. Override form_save() to assign the currently authenticated user and username, removing the previous alter_obj() approach and ensuring notes display the correct creator.

--- a/changes/7855.fixed
+++ b/changes/7855.fixed
@@ -1,0 +1,1 @@
+Fixed NoteUIViewSet bug where new Notes saved with user_name="Undefined" even for authenticated users. Overrides form_valid() to apply alter_obj() before saving, ensuring user and user_name are correctly set.

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2463,7 +2463,7 @@ class NoteUIViewSet(
     def alter_obj(self, obj, request, url_args, url_kwargs):
         obj.user = request.user
         return obj
-    
+
     def form_valid(self, form):
         """
         Called after the form is validated. Overrides to ensure

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2475,20 +2475,16 @@ class NoteUIViewSet(
             Note: The saved or unsaved Note instance with `user` and `user_name` set.
 
         Behavior:
-            - Sets `user` to the currently authenticated user if available.
-            - Sets `user_name` to the username of the authenticated user or "Undefined"
-            if no user is logged in.
+            - Sets `user` to the currently authenticated user.
+            - Sets `user_name` to the username of the authenticated user.
             - Saves the instance if `commit=True`.
         """
         # Get instance without committing to DB
         obj = super().form_save(form, commit=False, *args, **kwargs)
 
-        # Assign user info
-        if self.request.user.is_authenticated:
-            obj.user = self.request.user
-            obj.user_name = self.request.user.get_username()
-        else:
-            obj.user_name = "Undefined"
+        # Assign user info (only authenticated users can create notes)
+        obj.user = self.request.user
+        obj.user_name = self.request.user.get_username()
 
         # Save to DB if commit is True
         if commit:

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2497,7 +2497,6 @@ class NoteUIViewSet(
         return obj
 
 
-
 class ObjectNotesView(generic.GenericView):
     """
     Present a list of notes associated to a particular object.

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2460,18 +2460,42 @@ class NoteUIViewSet(
         ),
     )
 
-    def alter_obj(self, obj, request, url_args, url_kwargs):
-        obj.user = request.user
+    def form_save(self, form, commit=True, *args, **kwargs):
+        """
+        Save the form instance while ensuring the Note's `user` and `user_name` fields
+        are correctly populated.
+
+        Args:
+            form (Form): The validated form instance to be saved.
+            commit (bool): If True, save the instance to the database immediately.
+            *args, **kwargs: Additional arguments to maintain compatibility with
+                            the parent method signature.
+
+        Returns:
+            Note: The saved or unsaved Note instance with `user` and `user_name` set.
+
+        Behavior:
+            - Sets `user` to the currently authenticated user if available.
+            - Sets `user_name` to the username of the authenticated user or "Undefined"
+            if no user is logged in.
+            - Saves the instance if `commit=True`.
+        """
+        # Get instance without committing to DB
+        obj = super().form_save(form, commit=False, *args, **kwargs)
+
+        # Assign user info
+        if self.request.user.is_authenticated:
+            obj.user = self.request.user
+            obj.user_name = self.request.user.get_username()
+        else:
+            obj.user_name = "Undefined"
+
+        # Save to DB if commit is True
+        if commit:
+            obj.save()
+
         return obj
 
-    def form_valid(self, form):
-        """
-        Called after the form is validated. Overrides to ensure
-        the note's user/user_name are set before saving.
-        """
-        # Apply alter_obj before saving
-        self.obj = self.alter_obj(form.instance, self.request, None, None)
-        return super().form_valid(form)
 
 
 class ObjectNotesView(generic.GenericView):

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2463,6 +2463,15 @@ class NoteUIViewSet(
     def alter_obj(self, obj, request, url_args, url_kwargs):
         obj.user = request.user
         return obj
+    
+    def form_valid(self, form):
+        """
+        Called after the form is validated. Overrides to ensure
+        the note's user/user_name are set before saving.
+        """
+        # Apply alter_obj before saving
+        self.obj = self.alter_obj(form.instance, self.request, None, None)
+        return super().form_valid(form)
 
 
 class ObjectNotesView(generic.GenericView):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #7847
# What's Changed

- Removed alter_obj() from NoteUIViewSet and moved the user assignment logic into form_save() to ensure user and user_name are correctly set when creating a Note. This fixes the issue where notes were showing "Undefined" for user_name.

# Screenshots
| View            | Before                                                                                     | After                                                                                       |
|-----------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
|  Add View       |<img width="1683" height="842" alt="image" src="https://github.com/user-attachments/assets/2f3b1a90-6c77-4f7d-84e3-272ecf40efa6" />|<img width="1657" height="887" alt="image" src="https://github.com/user-attachments/assets/dab6f20c-cc8b-4d34-82a0-55328bb4abc7" />|
|  List View       |<img width="1686" height="615" alt="image" src="https://github.com/user-attachments/assets/ba4396a3-6805-4381-8254-5fb5cb3c2351" />|<img width="1672" height="610" alt="image" src="https://github.com/user-attachments/assets/fb441aff-455c-4fb6-8fd0-a7094650b077" />|
|  Detail View       |<img width="1680" height="735" alt="image" src="https://github.com/user-attachments/assets/48b5b4f4-8788-419c-b03f-c1ddef496626" />|<img width="1662" height="727" alt="image" src="https://github.com/user-attachments/assets/a1c5502d-0c91-4372-ab6b-64db44a86403" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
