### PR TITLE
Fixed timezone management in Scheduled Job detail page

### DIFF
--- a/changes/7859.fixed
+++ b/changes/7859.fixed
@@ -1,0 +1,1 @@
+Fixed timezone management in Scheduled Job detail page

--- a/nautobot/extras/templates/extras/scheduledjob.html
+++ b/nautobot/extras/templates/extras/scheduledjob.html
@@ -103,9 +103,10 @@
             <tr>
                 <td>Start Time</td>
                 <td>
-                    {{ object.start_time|timezone:object.time_zone|date:settings.SHORT_DATETIME_FORMAT }}
                     {% if default_time_zone != object.time_zone %}
-                        <br>{{ object.start_time|timezone:default_time_zone|date:settings.SHORT_DATETIME_FORMAT }}
+                        {{ object.start_time|timezone:default_time_zone|date:settings.SHORT_DATETIME_FORMAT }}
+                    {% else %}
+                        {{ object.start_time|timezone:object.time_zone|date:settings.SHORT_DATETIME_FORMAT }}
                     {% endif %}
                 </td>
             </tr>
@@ -113,9 +114,10 @@
                 <td>Last Run At</td>
                 <td>
                     {% if object.last_run_at %}
-                        {{ object.last_run_at|timezone:object.time_zone|date:settings.SHORT_DATETIME_FORMAT }}
                         {% if default_time_zone != object.time_zone %}
-                            <br>{{ object.last_run_at|timezone:default_time_zone|date:SHORT_DATETIME_FORMAT }}
+                            {{ object.last_run_at|timezone:default_time_zone|date:settings.SHORT_DATETIME_FORMAT }}
+                        {% else %}
+                            {{ object.last_run_at|timezone:object.time_zone|date:settings.SHORT_DATETIME_FORMAT }}
                         {% endif %}
                     {% else %}
                         {{ object.last_run_at|placeholder }}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #7859 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Fixed a big where the page would be blank if the user had a timezone other than UTC set.

Page no longer displays two times (with no explicit timezone) if user has timezone set, only its local time
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
