### PR TITLE
Render only active tab

### DIFF
--- a/changes/7865.fixed
+++ b/changes/7865.fixed
@@ -1,0 +1,1 @@
+Fixed `DistinctViewTab` and `Tab` to be rendered only when tab is active

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -406,7 +406,12 @@ class Tab(Component):
         return self.label
 
     def render(self, context: Context):
-        """Render the tab's contents (layout and panels) to HTML."""
+        """
+        Render the tab's contents (layout and panels) to HTML.
+        """
+        if not self.is_active_tab(context):
+            return ""
+
         if not self.should_render(context):
             return ""
 
@@ -423,6 +428,12 @@ class Tab(Component):
         ):
             tab_content = render_component_template(self.LAYOUT_TEMPLATE_PATHS[self.layout], context)
             return render_component_template(self.content_wrapper_template_path, context, tab_content=tab_content)
+
+    def is_active_tab(self, context: Context):
+        """
+        Check if this tab is active to render it or skip rendering.
+        """
+        return context.get("view_action") == "retrieve" and context.get("detail")
 
 
 class DistinctViewTab(Tab):
@@ -488,6 +499,12 @@ class DistinctViewTab(Tab):
             self.label,
             render_to_string("utilities/templatetags/badge.html", badge(self.related_object_count, True)),
         )
+
+    def is_active_tab(self, context: Context):
+        """
+        Render this tab only, when it's active
+        """
+        return context.get("view_action") == self.tab_id
 
 
 class Panel(Component):


### PR DESCRIPTION
# Closes NAUTOBOT-1051
# What's Changed

- `DistinctViewTab` is now rendered only when `view_action` match `tab_id` - in other words, when tab is active or user clicked tab and was redirected to the tab url
- `Tab` is now rendered only when `view_action` is `retrieve` - it's not anymore rendered, when `DistinctViewTab` is active

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
