### PR TITLE
Change `ObjectsTablePanel` queryset `.distinct()` calls to opt-in to fix performance

### DIFF
--- a/changes/7471.added
+++ b/changes/7471.added
@@ -1,0 +1,1 @@
+Added support for `distinct` optional parameter when defining an `ObjectsTablePanel` UI component.

--- a/changes/7471.changed
+++ b/changes/7471.changed
@@ -1,0 +1,2 @@
+Changed UI `ObjectsTablePanel` to only apply `.distinct()` to queries when explicitly requested, instead of unconditionally. Improves performance of rendering these tables in most cases.
+Changed `DeviceType` detail view to apply proper ordering to the table of related `SoftwareImageFile` records.

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -731,6 +731,7 @@ class ObjectsTablePanel(Panel):
         table_class=None,
         table_filter=None,
         table_attribute=None,
+        distinct=False,
         select_related_fields=None,
         prefetch_related_fields=None,
         order_by_fields=None,
@@ -773,6 +774,7 @@ class ObjectsTablePanel(Panel):
             table_attribute (str, optional): The attribute of the detail view instance that contains the queryset to
                 initialize the table class. e.g. `dynamic_groups`.
                 Mutually exclusive with `table_filter`.
+            distinct (bool, optional): If True, apply `.distinct()` to the table queryset.
             select_related_fields (list, optional): list of fields to pass to table queryset's `select_related` method.
             prefetch_related_fields (list, optional): list of fields to pass to table queryset's `prefetch_related`
                 method.
@@ -808,6 +810,7 @@ class ObjectsTablePanel(Panel):
                 table_class,
                 table_filter,
                 table_attribute,
+                distinct,
                 select_related_fields,
                 prefetch_related_fields,
                 order_by_fields,
@@ -816,8 +819,8 @@ class ObjectsTablePanel(Panel):
         ):
             raise ValueError(
                 "context_table_key cannot be combined with any of the args that are used to dynamically construct the "
-                "table (table_class, table_filter, table_attribute, select_related_fields, prefetch_related_fields, "
-                "order_by_fields, hide_hierarchy_ui)."
+                "table (table_class, table_filter, table_attribute, distinct, select_related_fields, "
+                "prefetch_related_fields, order_by_fields, hide_hierarchy_ui)."
             )
         self.context_table_key = context_table_key
         self.table_class = table_class
@@ -829,6 +832,7 @@ class ObjectsTablePanel(Panel):
             raise ValueError("You must provide a `related_field_name` when specifying `table_attribute`")
         self.table_filter = table_filter
         self.table_attribute = table_attribute
+        self.distinct = distinct
         self.select_related_fields = select_related_fields
         self.prefetch_related_fields = prefetch_related_fields
         self.order_by_fields = order_by_fields
@@ -932,7 +936,8 @@ class ObjectsTablePanel(Panel):
                 )
             if self.order_by_fields:
                 body_content_table_queryset = body_content_table_queryset.order_by(*self.order_by_fields)
-            body_content_table_queryset = body_content_table_queryset.distinct()
+            if self.distinct:
+                body_content_table_queryset = body_content_table_queryset.distinct()
             body_content_table = body_content_table_class(
                 body_content_table_queryset, hide_hierarchy_ui=self.hide_hierarchy_ui, user=request.user
             )

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -964,6 +964,7 @@ class DeviceTypeUIViewSet(NautobotUIViewSet):
                 weight=200,
                 table_class=tables.SoftwareImageFileTable,
                 table_filter="device_types",
+                order_by_fields=["image_file_name"],
                 select_related_fields=["software_version", "status"],
                 exclude_columns=["actions", "tags"],
                 related_field_name="device_types",

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2755,6 +2755,7 @@ class SecretUIViewSet(
                 table_title="Groups containing this secret",
                 table_class=tables.SecretsGroupTable,
                 table_attribute="secrets_groups",
+                distinct=True,
                 related_field_name="secrets",
                 footer_content_template_path=None,
             ),


### PR DESCRIPTION
# Closes #7471 
# What's Changed

- Change `ObjectsTablePanel` to add a `distinct=False` optional parameter that controls whether we do a `.distinct()` on the object queryset. **This is a behavior change** from what was introduced in #6540 where we added the `.distinct()` unconditionally to all `ObjectsTablePanel` to address the specific case of the Secret --> SecretsGroup many-to-many relationship. This improves performance in the majority of cases where the `.distinct()` is unnecessary and slows the database query, especially at scale.
- Add an explicit `distinct=True` to the one known case where it's needed (Secret -> SecretsGroup table)
- I noticed while manually checking the above change that the DeviceType related SoftwareImageFiles table was unordered; to improve usability I've added an explicit `order_by_fields` to that panel definition.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design

Tracking: NAUTOBOT-1022