### PR TITLE
Fix 'invoke djhtml' in Docker compose

### DIFF
--- a/changes/xxxx.housekeeping
+++ b/changes/xxxx.housekeeping
@@ -1,0 +1,1 @@
+Fixed `invoke djhtml` task not working correctly in Docker compose.

--- a/tasks.py
+++ b/tasks.py
@@ -879,7 +879,7 @@ def djhtml(context, fix=False):
     command = "djhtml nautobot/*/templates --tabwidth 4"
     if not fix:
         command += " --check"
-    run_command(context, command)
+    run_command(context, f'bash -c "{command}"')  # needed for glob expansion
 
 
 @task


### PR DESCRIPTION
# What's Changed

Before:

```
> invoke djhtml
Error: [Errno 2] No such file or directory: 'nautobot/*/templates'
0 templates would have been reindented.
1 template could not be processed due to an error.
```

After:

```
> invoke djhtml
0 templates would have been reindented.
493 templates were already perfect!
```