### PR TITLE
feature: add dark theme to special views

### DIFF
--- a/nautobot/core/templates/graphene/graphiql.html
+++ b/nautobot/core/templates/graphene/graphiql.html
@@ -49,13 +49,13 @@ add "&raw" to the end of the URL within a browser.
             [data-bs-theme="dark"] .graphiql-dialog-overlay,
             [data-bs-theme="dark"] .graphiql-tooltip,
             [data-bs-theme="dark"] [data-radix-popper-content-wrapper] {
-                --color-primary: 211, 96%, 36% !important; /* $blue-0-dark: #045ab4; */
-                --color-secondary: 218, 14%, 36% !important; /* $gray-3-dark: #4f5868; */
-                --color-tertiary: 0, 0%, 80% !important; /* $black-0-dark: #cbcbcb; */
-                --color-success: 126, 100%, 18% !important; /* $green-0-dark: #005c09; */
-                --color-warning: 31, 94%, 45% !important; /* $orange-0-dark: #e07807; */
-                --color-error: 0, 92%, 31% !important; /* $red-0-dark: #960606; */
-                --color-base: 222, 20%, 10% !important; /* $gray-0-dark: #14171e; */
+                --color-primary: 209, 100%, 60% !important; /* $blue-0-dark: #339dff; */
+                --color-secondary: 0, 0%, 71% !important; /* $gray-3-dark: #b5b5b5; */
+                --color-tertiary: 0, 0%, 100% !important; /* $black-0-dark: #ffffff; */
+                --color-success: 27, 63%, 49% !important; /* $green-0-dark: #2ecc40; */
+                --color-warning: 30, 100%, 60% !important; /* $orange-0-dark: #ff9933; */
+                --color-error: 0, 100%, 65% !important; /* $red-0-dark: #ff4c4c; */
+                --color-base: 0, 0%, 12% !important; /* $gray-0-dark: #1e1e1e; */
             }
 
             #main-content {

--- a/nautobot/core/templates/redoc_ui.html
+++ b/nautobot/core/templates/redoc_ui.html
@@ -51,6 +51,13 @@
 
         {# Redoc doesn't change outer page styles. #}
         body { margin: 0; padding: 0; }
+
+        [data-bs-theme="dark"] .redoc-wrap,
+        [data-bs-theme="dark"] .redoc-wrap > :last-child,
+        [data-bs-theme="dark"] .redoc-wrap .api-content > [data-section-id] > [data-section-id] > :last-child,
+        [data-bs-theme="dark"] .redoc-wrap .menu-content .operation-type {
+            filter: hue-rotate(180deg) invert(1);
+        }
     </style>
 {% endblock extra_styles %}
 

--- a/nautobot/core/templates/swagger_ui.html
+++ b/nautobot/core/templates/swagger_ui.html
@@ -7,13 +7,27 @@
 {% block extra_styles %}
     <link rel="stylesheet" href="{% static 'drf_spectacular_sidecar/swagger-ui-dist/swagger-ui.css' %}">
     <style>
-      /* Manual styling inherited from drf-spectacular */
+        /* Manual styling inherited from drf-spectacular */
         html { box-sizing: border-box; overflow-y: scroll; }
         *, *:after, *:before { box-sizing: inherit; }
-        body { background: #fafafa; margin: 0; }
-      /* Style overrides to address conflicts between Swagger styling and Nautobot/Bootstrap styling */
+        body { background: var(--bs-body-bg); margin: 0; }
+        /* Style overrides to address conflicts between Swagger styling and Nautobot/Bootstrap styling */
         pre.version { border: none; background: none; }
         .loading-container .loading { display: block; }
+        /* Dark theme support */
+        [data-bs-theme="dark"] .swagger-ui,
+        [data-bs-theme="dark"] .swagger-ui .backdrop-ux,
+        [data-bs-theme="dark"] .swagger-ui .microlight,
+        [data-bs-theme="dark"] .swagger-ui .opblock .opblock-summary-method {
+            filter: hue-rotate(180deg) invert(1);
+        }
+        [data-bs-theme="dark"] .swagger-ui input:is([type="email"], [type="file"], [type="password"], [type="search"], [type="text"]),
+        [data-bs-theme="dark"] .swagger-ui textarea {
+            color: var(--bs-body-bg);
+        }
+        [data-bs-theme="dark"] .swagger-ui .scheme-container {
+            background: transparent;
+        }
     </style>
 {% endblock extra_styles %}
 


### PR DESCRIPTION
# What's Changed
1. Update GraphiQL dark theme colors.
2. Add *simplified* dark theme to Swagger (`/api/docs/`) and Redoc (`/api/redoc/`) views. Simplified  in this case means theme implemented without using Nautobot color palette, mostly with CSS `filter` property.

# Screenshots
| GraphiQL | Swagger | Redoc |
| - | - | - |
| <img width="3200" height="1800" alt="graphiql" src="https://github.com/user-attachments/assets/03549837-010a-4d56-a310-59c26ad20642" /> | <img width="3200" height="1800" alt="swagger" src="https://github.com/user-attachments/assets/5784a76d-6173-43af-9175-497daa9b1783" /> | <img width="3200" height="1800" alt="redoc" src="https://github.com/user-attachments/assets/87343c9d-12b7-4ea8-b1ba-0ac664b5aaa6" /> |

Tracking NAUTOBOT-1015