### PR TITLE
Fix missing tagging of 'latest' Docker images in 2.4.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           poetry-install-options: "--no-root"
           poetry-version: "2.1.4"
-          python-version: "3.13"
+          python-version: "3.12"
       - name: "Build Documentation"
         run: "poetry run mkdocs build --no-directory-urls --strict"
       - name: "Run Poetry Build"
@@ -73,14 +73,14 @@ jobs:
         with:
           images: "networktocode/nautobot,ghcr.io/nautobot/nautobot"
           flavor: |
-            latest=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
+            latest=${{ ! github.event.release.prerelease && matrix.python-version == 3.12 }}
           tags: |
             type=semver,pattern={{version}}-py${{ matrix.python-version }}
-            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.13 }}
+            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.12 }}
             type=semver,pattern={{major}}.{{minor}}-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.12 }}
             type=raw,value=latest-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-            type=raw,value=stable,enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
+            type=raw,value=stable,enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.12 }}
             type=raw,value=stable-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
           labels: |
             org.opencontainers.image.title=Nautobot
@@ -105,14 +105,14 @@ jobs:
         with:
           images: "networktocode/nautobot-dev,ghcr.io/nautobot/nautobot-dev"
           flavor: |
-            latest=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
+            latest=${{ ! github.event.release.prerelease && matrix.python-version == 3.12 }}
           tags: |
             type=semver,pattern={{version}}-py${{ matrix.python-version }}
-            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.13 }}
+            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.12 }}
             type=semver,pattern={{major}}.{{minor}}-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.12 }}
             type=raw,value=latest-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-            type=raw,value=stable,enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
+            type=raw,value=stable,enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.12 }}
             type=raw,value=stable-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
           labels: |
             org.opencontainers.image.title=Nautobot

--- a/changes/7977.housekeeping
+++ b/changes/7977.housekeeping
@@ -1,0 +1,1 @@
+Restored tagging of `latest` Docker images inadvertently untagged in 2.4.20.


### PR DESCRIPTION
Regression introduced by #7930 - as a backport from `next` it made it so that the `latest` tag was applied to Python 3.13 images, but in 2.x we don't yet support 3.13, only 3.12.