### PR TITLE
Fixed issue where the active button was not displayed when switching …

### DIFF
--- a/changes/8017.fixed
+++ b/changes/8017.fixed
@@ -1,0 +1,1 @@
+Fixed issue where the active button was not displayed when switching between JSON and YAML views.

--- a/nautobot/extras/templates/extras/inc/configcontext_format.html
+++ b/nautobot/extras/templates/extras/inc/configcontext_format.html
@@ -1,6 +1,6 @@
 <div class="float-end">
     <div class="btn-group btn-group-xs" role="group">
-        <a href="?data_format=json" class="btn {% if format == 'json' %}btn-primary{% else %}btn-secondary{% endif %}">JSON</a>
-        <a href="?data_format=yaml" class="btn {% if format == 'yaml' %}btn-primary{% else %}btn-secondary{% endif %}">YAML</a>
+        <a href="?data_format=json" class="btn {% if data_format == 'json' %}btn-primary{% else %}btn-secondary{% endif %}">JSON</a>
+        <a href="?data_format=yaml" class="btn {% if data_format == 'yaml' %}btn-primary{% else %}btn-secondary{% endif %}">YAML</a>
     </div>
 </div>


### PR DESCRIPTION
…between JSON and YAML views.

As a mental note, we should be using `django_querystring` in these url generations. 

before

<img width="200" height="88" alt="image" src="https://github.com/user-attachments/assets/3880fd12-fdae-4959-b655-5b266903fab0" />


after

<img width="283" height="104" alt="image" src="https://github.com/user-attachments/assets/eb758785-048b-4a64-a52d-53d1e7459a93" />
