### PR TITLE
Fixed condition in `GetObjectViewTestCase.test_body_content_table_lis…

### DIFF
--- a/changes/8118.fixed
+++ b/changes/8118.fixed
@@ -1,0 +1,1 @@
+Fixed condition in `GetObjectViewTestCase.test_body_content_table_list_url` in which tests failed if it did not have data.

--- a/nautobot/core/testing/views.py
+++ b/nautobot/core/testing/views.py
@@ -415,6 +415,9 @@ class ViewTestCases:
             self.user.is_superuser = True
             self.user.save()
             instance = self._get_queryset().first()
+            if not instance:
+                # We should have a better mechanism to test against an empty instance, but this will remove blocker for now.
+                self.skipTest("No instances to test against.")
             errors = []
             model_name = self.model._meta.model_name
 


### PR DESCRIPTION
…t_url` in which tests failed if it did not have data.

