### PR TITLE
Fixed LogsCleanup job to not try and delete objects with a protected relationship

### DIFF
--- a/changes/7848.fixed
+++ b/changes/7848.fixed
@@ -1,0 +1,1 @@
+Fixed the Logs Cleanup job to skip records with a protected relationship instead of raising an error.

--- a/nautobot/core/jobs/cleanup.py
+++ b/nautobot/core/jobs/cleanup.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.core.exceptions import PermissionDenied
-from django.db.models import CASCADE
+from django.db.models import CASCADE, PROTECT
 from django.db.models.signals import pre_delete
 from django.utils import timezone
 
@@ -67,6 +67,18 @@ class LogsCleanup(Job):
                 cascade_queryset = related_model.objects.filter(**{f"{related_field_name}__id__in": queryset})
                 if cascade_queryset.exists():
                     self.recursive_delete_with_cascade(cascade_queryset, deletion_summary)
+            elif related_object.on_delete is PROTECT:
+                self.logger.warning(
+                    "Skipping %s records with a protected relationship to %s."
+                    " You must delete the related object(s) first.",
+                    queryset.model._meta.label,
+                    related_object.related_model._meta.label,
+                )
+                items_to_exclude = related_object.related_model.objects.values_list(
+                    related_object.field.name, flat=True
+                )
+                queryset = queryset.exclude(id__in=items_to_exclude)
+                deletion_summary.update({related_object.related_model._meta.label: 0})
 
         genericrelation_related_fields = [
             field for field in queryset.model._meta.private_fields if hasattr(field, "bulk_related_objects")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #7848
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
This PR changes the Logs Cleanup system job to detect objects related to JobResult and ObjectChange that use `on_delete=PROTECT` and excludes them from pruning instead of attempting to delete them and raising an error.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
In order to test this, in my local dev I created a few bad models:

```python
class BadExampleModel(OrganizationalModel):
    name = models.CharField(max_length=CHARFIELD_MAX_LENGTH, unique=True)
    job_result = models.ForeignKey(JobResult, on_delete=models.PROTECT)

    class Meta:
        ordering = ["name"]


class AnotherBadExampleModel(OrganizationalModel):
    name = models.CharField(max_length=CHARFIELD_MAX_LENGTH, unique=True)
    object_change = models.ForeignKey(ObjectChange, on_delete=models.PROTECT)

    class Meta:
        ordering = ["name"]
```

I then created a few objects via the shell and ran the Logs Cleanup job:
<img width="1540" height="841" alt="Screenshot 2025-11-13 at 10 56 06 AM" src="https://github.com/user-attachments/assets/64b45ff3-a5ac-43d1-8912-2b030334c0d3" />


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example

NAUTOBOT-1086