### PR TITLE
Fixed multiple locations where actions buttons was not included.

### DIFF
--- a/changes/8189.fixed
+++ b/changes/8189.fixed
@@ -1,0 +1,1 @@
+Fixed multiple locations where actions buttons was not included.

--- a/nautobot/dcim/tables/power.py
+++ b/nautobot/dcim/tables/power.py
@@ -2,6 +2,7 @@ import django_tables2 as tables
 
 from nautobot.core.tables import (
     BaseTable,
+    ButtonsColumn,
     ChoiceFieldColumn,
     LinkedCountColumn,
     TagColumn,
@@ -36,6 +37,7 @@ class PowerPanelTable(BaseTable):
         verbose_name="Feeds",
     )
     tags = TagColumn(url_name="dcim:powerpanel_list")
+    actions = ButtonsColumn(PowerPanel)
 
     class Meta(BaseTable.Meta):
         model = PowerPanel
@@ -81,6 +83,7 @@ class PowerFeedTable(StatusTableMixin, CableTerminationTable):
     max_utilization = tables.TemplateColumn(template_code="{{ value }}%")
     available_power = tables.Column(verbose_name="Available power (VA)")
     tags = TagColumn(url_name="dcim:powerfeed_list")
+    actions = ButtonsColumn(PowerFeed)
 
     class Meta(BaseTable.Meta):
         model = PowerFeed

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -1469,7 +1469,7 @@ class NoteTable(BaseTable):
 
     class Meta(BaseTable.Meta):
         model = Note
-        fields = ("created", "last_updated", "note", "user_name")
+        fields = ("created", "last_updated", "note", "user_name", "actions")
 
     def render_note(self, value):
         return render_markdown(value)
@@ -1658,7 +1658,7 @@ class RoleTable(BaseTable):
 
     class Meta(BaseTable.Meta):
         model = Role
-        fields = ["pk", "name", "color", "weight", "content_types", "description"]
+        fields = ["pk", "name", "color", "weight", "content_types", "description", "actions"]
 
 
 class RoleTableMixin(BaseTable):
@@ -1678,6 +1678,7 @@ class SecretTable(BaseTable):
     pk = ToggleColumn()
     name = tables.LinkColumn()
     tags = TagColumn(url_name="extras:secret_list")
+    actions = ButtonsColumn(Secret)
 
     class Meta(BaseTable.Meta):
         model = Secret
@@ -1687,6 +1688,7 @@ class SecretTable(BaseTable):
             "provider",
             "description",
             "tags",
+            "actions",
         )
         default_columns = (
             "pk",
@@ -1694,6 +1696,7 @@ class SecretTable(BaseTable):
             "provider",
             "description",
             "tags",
+            "actions",
         )
 
     def render_provider(self, value):
@@ -1705,6 +1708,7 @@ class SecretsGroupTable(BaseTable):
 
     pk = ToggleColumn()
     name = tables.LinkColumn()
+    actions = ButtonsColumn(SecretsGroup)
 
     class Meta(BaseTable.Meta):
         model = SecretsGroup
@@ -1712,11 +1716,13 @@ class SecretsGroupTable(BaseTable):
             "pk",
             "name",
             "description",
+            "actions",
         )
         default_columns = (
             "pk",
             "name",
             "description",
+            "actions",
         )
 
 
@@ -1823,6 +1829,7 @@ class WebhookTable(BaseTable):
     type_update = BooleanColumn()
     type_delete = BooleanColumn()
     ssl_verification = BooleanColumn()
+    actions = ButtonsColumn(Webhook)
 
     class Meta(BaseTable.Meta):
         model = Webhook
@@ -1839,6 +1846,7 @@ class WebhookTable(BaseTable):
             "type_delete",
             "ssl_verification",
             "ca_file_path",
+            "actions",
         )
         default_columns = (
             "pk",
@@ -1847,6 +1855,7 @@ class WebhookTable(BaseTable):
             "payload_url",
             "http_content_type",
             "enabled",
+            "actions",
         )
 
 

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -207,10 +207,11 @@ class NamespaceTable(BaseTable):
     name = tables.LinkColumn()
     tenant = TenantColumn()
     tags = TagColumn(url_name="ipam:namespace_list")
+    actions = ButtonsColumn(Namespace)
 
     class Meta(BaseTable.Meta):
         model = Namespace
-        fields = ("pk", "name", "description", "tenant", "location")
+        fields = ("pk", "name", "description", "tenant", "location", "actions")
 
 
 #

--- a/nautobot/load_balancers/tables.py
+++ b/nautobot/load_balancers/tables.py
@@ -64,6 +64,7 @@ class VirtualServerTable(BaseTable):
             "ssl_offload",
             "certificate_profiles_count",
             "tags",
+            "actions",
         )
 
         default_columns = (
@@ -108,6 +109,7 @@ class LoadBalancerPoolTable(BaseTable):
             "load_balancer_pool_member_count",
             "health_check_monitor",
             "tenant",
+            "actions",
         )
         default_columns = (
             "pk",
@@ -153,6 +155,7 @@ class LoadBalancerPoolMemberTable(StatusTableMixin, BaseTable):
             "health_check_monitor",
             "certificate_profiles_count",
             "tenant",
+            "actions",
         )
         default_columns = (
             "pk",
@@ -206,6 +209,7 @@ class HealthCheckMonitorTable(BaseTable):
             "load_balancer_pool_count",
             "load_balancer_pool_member_count",
             "tenant",
+            "actions",
         )
         default_columns = (
             "pk",
@@ -243,6 +247,7 @@ class CertificateProfileTable(BaseTable):
             "expiration_date",
             "cipher",
             "tenant",
+            "actions",
         )
         default_columns = (
             "pk",

--- a/nautobot/tenancy/tables.py
+++ b/nautobot/tenancy/tables.py
@@ -77,8 +77,9 @@ class TenantTable(BaseTable):
     name = tables.Column(linkify=True)
     tenant_group = tables.Column(linkify=True)
     tags = TagColumn(url_name="tenancy:tenant_list")
+    actions = ButtonsColumn(Tenant)
 
     class Meta(BaseTable.Meta):
         model = Tenant
-        fields = ("pk", "name", "tenant_group", "description", "tags")
-        default_columns = ("pk", "name", "tenant_group", "description")
+        fields = ("pk", "name", "tenant_group", "description", "tags", "actions")
+        default_columns = ("pk", "name", "tenant_group", "description", "actions")


### PR DESCRIPTION
At somepoint it would be great to create a test for these, but not so simple with assignment tables and similar. I went through a manual cleanup, and will note:

- Did not go through all of the "extras" models, as many are unique 
- Same for Device Components
- My understanding is fields should be a superset of default_columns, if I saw actions in default_columns, I added it to fields.