### PR TITLE
Fix rendered docs missing from wheels

### DIFF
--- a/changes/8274.fixed
+++ b/changes/8274.fixed
@@ -1,0 +1,1 @@
+Fixed unintended omission of the rendered documentation from `.whl` packages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [
 ]
 include = [
     # Rendered documentation - Poetry by default would exclude these files as they are in .gitignore
-    "nautobot/project-static/docs/**/*",
+    {path = "nautobot/project-static/docs/**/*", format = ["sdist", "wheel"]},
 ]
 exclude = [
     # Source code of the documentation doesn't need to be included since we package the rendered docs


### PR DESCRIPTION
# Closes #8274 

Will likely need a double-commit to ltm-2.4.

# What's Changed

Explicitly instruct Poetry to package the rendered docs in both `sdist` and `wheel` distributions, as Poetry 2.x defaults to only including in `sdist`. Now both distributions show comparable file counts:

```
❯ tar tvfz dist/nautobot-3.0.3b1-py3-none-any.whl | wc -l
    2794

❯ tar tvfz dist/nautobot-3.0.3b1.tar.gz | wc -l          
    2793
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
