### PR TITLE
Fixed missing description field on interface creation form.

### DIFF
--- a/changes/8306.fixed
+++ b/changes/8306.fixed
@@ -1,0 +1,1 @@
+Fixed missing description field on interface creation form.

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -3364,6 +3364,7 @@ class InterfaceCreateForm(ModularComponentCreateForm, InterfaceCommonForm, RoleN
         label="Management only",
         help_text="This interface is used only for out-of-band management",
     )
+    description = forms.CharField(max_length=CHARFIELD_MAX_LENGTH, required=False, label="Description")
     ip_addresses = DynamicModelMultipleChoiceField(
         queryset=IPAddress.objects.all(),
         required=False,


### PR DESCRIPTION
Fixed #8306 