### PR TITLE
Fix MinMaxValidationRule compatibility with DecimalField

### DIFF
--- a/changes/7326.fixed
+++ b/changes/7326.fixed
@@ -1,0 +1,2 @@
+Fixed handling of `DecimalFields` (such as `Location.latitude` and `Location.longitude`) with `MinMaxValidationRule`.
+Fixed rendering of Location latitude/longitude in detail view when either one is exactly zero.

--- a/nautobot/data_validation/custom_validators.py
+++ b/nautobot/data_validation/custom_validators.py
@@ -9,8 +9,10 @@ A common clean method for all these classes looks for any
 validation rules that have been defined for the given model.
 """
 
+from decimal import Decimal
 import inspect
 import logging
+from math import isclose
 import os
 import re
 from typing import Optional
@@ -96,19 +98,29 @@ class BaseValidator(CustomValidator):
                     }
                 )
 
-            elif not isinstance(field_value, (int, float)):
+            elif not isinstance(field_value, (int, float, Decimal)):
                 self.validation_error(
                     {
                         rule.field: f"Unable to validate against min/max rule {rule} because the field value is not numeric."
                     }
                 )
 
-            elif rule.min is not None and field_value is not None and field_value < rule.min:
+            elif (
+                rule.min is not None
+                and field_value is not None
+                and field_value < rule.min
+                and not isclose(field_value, rule.min)  # to handle differences in Decimal vs float precision
+            ):
                 self.validation_error(
                     {rule.field: rule.error_message or f"Value is less than minimum value: {rule.min}"}
                 )
 
-            elif rule.max is not None and field_value is not None and field_value > rule.max:
+            elif (
+                rule.max is not None
+                and field_value is not None
+                and field_value > rule.max
+                and not isclose(field_value, rule.max)  # to handle differences in Decimal vs float precision
+            ):
                 self.validation_error(
                     {rule.field: rule.error_message or f"Value is more than maximum value: {rule.max}"}
                 )

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -290,7 +290,7 @@ class LocationGeographicalInfoFieldsPanel(object_detail.ObjectFieldsPanel):
         data = super().get_data(context)
         obj = get_obj_from_context(context, self.context_object_key)
 
-        if obj and obj.latitude and obj.longitude:
+        if obj and obj.latitude is not None and obj.longitude is not None:
             data["GPS Coordinates"] = f"{obj.latitude}, {obj.longitude}"
         else:
             data["GPS Coordinates"] = None


### PR DESCRIPTION
# Closes #7326 
# What's Changed

- Add support for MinMaxValidationRule validation against DecimalField
- Update test to properly exercise this support
- Fix an issue in Location detail view rendering that I noticed during manual testing.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
