### PR TITLE
Cache module bay parents to avoid multiple expensive lookups

### DIFF
--- a/changes/8382.fixed
+++ b/changes/8382.fixed
@@ -1,0 +1,4 @@
+The nautobot.dcim.models.Device.all_modules property was previously used to look up related modules for multiple attributes (console ports, interfaces, power ports, module bays, etc.).
+The underlying queryset can take 1–3 seconds to resolve parent modules, and this query was executed repeatedly when loading the Device Details page.
+
+This PR addresses the issue by caching the all_modules primary keys in a temporary property, which related port types and module bays can reference. This eliminates redundant all_modules queries during Device Details page rendering.

--- a/changes/8382.fixed
+++ b/changes/8382.fixed
@@ -1,4 +1,1 @@
-The nautobot.dcim.models.Device.all_modules property was previously used to look up related modules for multiple attributes (console ports, interfaces, power ports, module bays, etc.).
-The underlying queryset can take 1–3 seconds to resolve parent modules, and this query was executed repeatedly when loading the Device Details page.
-
-This PR addresses the issue by caching the all_modules primary keys in a temporary property, which related port types and module bays can reference. This eliminates redundant all_modules queries during Device Details page rendering.
+Improved performance when rendering the Device detail page by caching and reusing the set of associated Module PKs to reduce repeated expensive queries.

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -18,8 +18,8 @@ from nautobot.core.models import BaseManager, RestrictedQuerySet
 from nautobot.core.models.fields import JSONArrayField, LaxURLField, NaturalOrderingField
 from nautobot.core.models.generics import BaseModel, OrganizationalModel, PrimaryModel
 from nautobot.core.models.tree_queries import TreeModel
-from nautobot.core.utils.config import get_settings_or_config
 from nautobot.core.utils.cache import construct_cache_key
+from nautobot.core.utils.config import get_settings_or_config
 
 from nautobot.dcim.choices import (
     ControllerCapabilitiesChoices,

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -20,7 +20,6 @@ from nautobot.core.models.generics import BaseModel, OrganizationalModel, Primar
 from nautobot.core.models.tree_queries import TreeModel
 from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.config import get_settings_or_config
-
 from nautobot.dcim.choices import (
     ControllerCapabilitiesChoices,
     DeviceFaceChoices,

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 
 from constance.test import override_config
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.db.models import Model
@@ -11,6 +12,7 @@ from django.test.utils import override_settings
 from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, Provider, ProviderNetwork
 from nautobot.core import settings
 from nautobot.core.testing.models import ModelTestCases
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.dcim.choices import (
     CableStatusChoices,
     CableTypeChoices,
@@ -1880,6 +1882,8 @@ class DeviceTestCase(ModelTestCases.BaseModelTestCase):
         self.device.validated_save()
 
     def test_all_x_properties(self):
+        cache_key = construct_cache_key(Device.objects, method_name='_all_module_pks')
+
         self.assertTrue(self.device.has_module_bays)
         self.assertEqual(self.device.all_modules.count(), 0)
         self.assertEqual(self.device.all_module_bays.count(), 1)
@@ -1948,6 +1952,7 @@ class DeviceTestCase(ModelTestCases.BaseModelTestCase):
             parent_module_bay=parent_module_bay,
         )
 
+        cache.delete(cache_key)
         self.assertEqual(self.device.all_modules.count(), 1)
         self.assertEqual(self.device.all_module_bays.count(), 2)
         self.assertEqual(self.device.all_console_server_ports.count(), 2)
@@ -1965,6 +1970,7 @@ class DeviceTestCase(ModelTestCases.BaseModelTestCase):
             parent_module_bay=child_module_bay,
         )
 
+        cache.delete(cache_key)
         self.assertEqual(self.device.all_modules.count(), 2)
         self.assertEqual(self.device.all_module_bays.count(), 3)
         self.assertEqual(self.device.all_console_server_ports.count(), 3)


### PR DESCRIPTION
Cache primary keys for nautobot.dcim.models.Device.all_modules() - eliminating multiple lookups on Device details page load.
