### PR TITLE
Delete cablepath if stale data is left behind breaking constraints

### DIFF
--- a/changes/8424.fixed
+++ b/changes/8424.fixed
@@ -1,0 +1,1 @@
+Fixed a bug that in rare cases makes `nautobot-server trace_cable` fail with an IntegrityError

--- a/nautobot/dcim/management/commands/trace_paths.py
+++ b/nautobot/dcim/management/commands/trace_paths.py
@@ -93,7 +93,7 @@ class Command(BaseCommand):
             for i, obj in enumerate(origins, start=1):
                 try:
                     create_cablepath(obj)
-                except IntegrityError as e:
+                except IntegrityError:
                     content_type = ContentType.objects.get_for_model(obj)
                     broken_cablepath = CablePath.objects.get(origin_type=content_type, origin_id=obj.pk)
                     broken_cablepath.delete()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8424
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

Clear stale CablePath that makes a new one break constraints

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
