### PR TITLE
[ltm-2.4] Closes #8484: Added polish types variants to CS connector type

### DIFF
--- a/changes/8484.added
+++ b/changes/8484.added
@@ -1,0 +1,1 @@
+Added polish type variants to CS connector in PortTypeChoices

--- a/nautobot/dcim/choices.py
+++ b/nautobot/dcim/choices.py
@@ -1249,6 +1249,9 @@ class PortTypeChoices(ChoiceSet):
     TYPE_LX5_APC = "lx5-apc"
     TYPE_SPLICE = "splice"
     TYPE_CS = "cs"
+    TYPE_CS_PC = "cs-pc"
+    TYPE_CS_UPC = "cs-upc"
+    TYPE_CS_APC = "cs-apc"
     TYPE_SN = "sn"
     TYPE_SMA_905 = "sma-905"
     TYPE_SMA_906 = "sma-906"
@@ -1305,6 +1308,9 @@ class PortTypeChoices(ChoiceSet):
                 (TYPE_SC_APC, "SC/APC"),
                 (TYPE_ST, "ST"),
                 (TYPE_CS, "CS"),
+                (TYPE_CS_PC, "CS/PC"),
+                (TYPE_CS_UPC, "CS/UPC"),
+                (TYPE_CS_APC, "CS/APC"),
                 (TYPE_SN, "SN"),
                 (TYPE_SMA_905, "SMA 905"),
                 (TYPE_SMA_906, "SMA 906"),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8484 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

Backport from `develop`.

Added `apc` and `npc` polishes to the `cs` connector type as they exist (ref: https://www.senko.com/product/cs-standard-connector/). Also added `pc` polish as I believe it technically exists, and it's consistent with other options in the file.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## Front ports (Before)
<img width="1131" height="186" alt="Screenshot 2026-02-01 at 3 17 47 PM" src="https://github.com/user-attachments/assets/f4d228fe-5f8c-4ad9-b673-6c5e243372bb" />



## Front ports (After)
<img width="831" height="269" alt="Screenshot 2026-02-01 at 3 18 50 PM" src="https://github.com/user-attachments/assets/7efd1461-0f59-4d54-af69-6067b3c295c7" />


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
