### PR TITLE
Towncrier and version bump

### DIFF
--- a/changes/7076.fixed
+++ b/changes/7076.fixed
@@ -1,1 +1,0 @@
-Fixed various font sizes that are used by the admin interface.

--- a/changes/8404.fixed
+++ b/changes/8404.fixed
@@ -1,1 +1,0 @@
-Fixed the ability to re-run a Kubernetes Job.

--- a/changes/8428.security
+++ b/changes/8428.security
@@ -1,1 +1,0 @@
-Updated dependency `pyasn1` to `0.6.2` to mitigate CVE-2026-23490. As this is not a direct dependency, it will not auto-update when upgrading; please be sure to upgrade your local environment.

--- a/nautobot/docs/release-notes/version-2.4.md
+++ b/nautobot/docs/release-notes/version-2.4.md
@@ -166,6 +166,17 @@ As Python 3.8 has reached end-of-life, Nautobot 2.4 requires a minimum of Python
 
 <!-- towncrier release notes start -->
 
+## v2.4.26 (2026-02-02)
+
+### Security in v2.4.26
+
+- [#8428](https://github.com/nautobot/nautobot/issues/8428) - Updated dependency `pyasn1` to `0.6.2` to mitigate CVE-2026-23490. As this is not a direct dependency, it will not auto-update when upgrading; please be sure to upgrade your local environment.
+
+### Fixed in v2.4.26
+
+- [#7076](https://github.com/nautobot/nautobot/issues/7076) - Fixed various font sizes that are used by the admin interface.
+- [#8404](https://github.com/nautobot/nautobot/issues/8404) - Fixed the ability to re-run a Kubernetes Job.
+
 ## v2.4.25 (2026-01-09)
 
 ### Security in v2.4.25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "2.4.25"
+version = "2.4.26"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Security in v2.4.26

- [#8428](https://github.com/nautobot/nautobot/issues/8428) - Updated dependency `pyasn1` to `0.6.2` to mitigate CVE-2026-23490. As this is not a direct dependency, it will not auto-update when upgrading; please be sure to upgrade your local environment.

### Fixed in v2.4.26

- [#7076](https://github.com/nautobot/nautobot/issues/7076) - Fixed various font sizes that are used by the admin interface.
- [#8404](https://github.com/nautobot/nautobot/issues/8404) - Fixed the ability to re-run a Kubernetes Job.