### PR TITLE
[2.4] Closes #8519: Improve cable color display in dark mode

### DIFF
--- a/changes/8519.fixed
+++ b/changes/8519.fixed
@@ -1,0 +1,1 @@
+Fixed cable color display in dark mode to ensure cable colors render closer to the configured value.

--- a/nautobot/dcim/templates/dcim/trace/cable.html
+++ b/nautobot/dcim/templates/dcim/trace/cable.html
@@ -4,7 +4,7 @@
     <div class="cable-info">&nbsp;</div>
     {% with color=cable.color|default:'606060' status=cable.status.name %}
         <div class="cable-color"
-             style="border-color: {{ color|fgcolor }}; background: {% if status == 'Connected' %}#{{ color }}{% else %}repeating-linear-gradient(#{{ color }}, #{{color}} 16px, transparent 16px, transparent 32px){% endif %}; border-style: none {% if status == 'Connected' %}solid{% else %}dashed{% endif %}"
+             style="border-color: #9a9a9a; background: {% if status == 'Connected' %}#{{ color }}{% else %}repeating-linear-gradient(#{{ color }}, #{{color}} 19px, #9a9a9a 19px, #9a9a9a 20px, transparent 20px, transparent 32px, #9a9a9a 32px, #9a9a9a 33px){% endif %}; border-style: none solid"
         >
             &nbsp;
         </div>

--- a/nautobot/dcim/templates/dcim/trace/cable.html
+++ b/nautobot/dcim/templates/dcim/trace/cable.html
@@ -1,6 +1,6 @@
 {% load helpers %}
 
-<div class="cable" style="border-left-color: #{% if cable.color == 'ffffff' %}909090; border-left-style: double; border-left-width: 6px;{% else %}{{ cable.color|default:'606060' }};{% endif %} {% if cable.status.name != 'Connected' %} border-left-style: dashed{% endif %}">
+<div class="cable" data-cable-color="#{% if cable.color == 'ffffff' %}909090{% else %}{{ cable.color|default:'606060' }}{% endif %}" data-cable-status="{{ cable.status.name }}" style="border-left-color: #{% if cable.color == 'ffffff' %}909090{% else %}{{ cable.color|default:'606060' }}{% endif %}; {% if cable.color == 'ffffff' %}border-left-style: double; border-left-width: 6px;{% endif %} {% if cable.status.name != 'Connected' %}border-left-style: dashed;{% endif %}">
     <strong>{{ cable|hyperlinked_object }}</strong><br>
     {% if cable.type %}
         {{ cable.get_type_display|default:"" }}<br />

--- a/nautobot/dcim/templates/dcim/trace/cable.html
+++ b/nautobot/dcim/templates/dcim/trace/cable.html
@@ -1,15 +1,25 @@
 {% load helpers %}
 
-<div class="cable" data-cable-color="#{% if cable.color == 'ffffff' %}909090{% else %}{{ cable.color|default:'606060' }}{% endif %}" data-cable-status="{{ cable.status.name }}" style="border-left-color: #{% if cable.color == 'ffffff' %}909090{% else %}{{ cable.color|default:'606060' }}{% endif %}; {% if cable.color == 'ffffff' %}border-left-style: double; border-left-width: 6px;{% endif %} {% if cable.status.name != 'Connected' %}border-left-style: dashed;{% endif %}">
-    <strong>{{ cable|hyperlinked_object }}</strong><br>
-    {% if cable.type %}
-        {{ cable.get_type_display|default:"" }}<br />
-    {% endif %}
-    {% if cable.length %}
-        ({{ cable.length }} {{ cable.get_length_unit_display }})<br />
-    {% endif %}
-    <span class="label" style="color: {{cable.status.color|fgcolor}}; background-color: #{{cable.status.color}}">{{ cable.get_status_display }}</span><br />
-    {% for tag in cable.tags.all %}
-        {% tag tag 'dcim:cable_list' %}
-    {% endfor %}
+<div class="cable">
+    <div class="cable-info">&nbsp;</div>
+    {% with color=cable.color|default:'606060' status=cable.status.name %}
+        <div class="cable-color"
+             style="border-color: {{ color|fgcolor }}; background: {% if status == 'Connected' %}#{{ color }}{% else %}repeating-linear-gradient(#{{ color }}, #{{color}} 16px, transparent 16px, transparent 32px){% endif %}; border-style: none {% if status == 'Connected' %}solid{% else %}dashed{% endif %}"
+        >
+            &nbsp;
+        </div>
+    {% endwith %}
+    <div class="cable-info">
+        <strong>{{ cable|hyperlinked_object }}</strong><br>
+        {% if cable.type %}
+            {{ cable.get_type_display|default:"" }}<br />
+        {% endif %}
+        {% if cable.length %}
+            ({{ cable.length }} {{ cable.get_length_unit_display }})<br />
+        {% endif %}
+        <span class="label" style="color: {{cable.status.color|fgcolor}}; background-color: #{{cable.status.color}}">{{ cable.get_status_display }}</span><br />
+        {% for tag in cable.tags.all %}
+            {% tag tag 'dcim:cable_list' %}
+        {% endfor %}
+    </div>
 </div>

--- a/nautobot/project-static/css/base.css
+++ b/nautobot/project-static/css/base.css
@@ -189,12 +189,18 @@ table.report th a {
     border: 3px solid #30C030;
 }
 .cable-trace .cable {
-    border-left-style: solid;
-    border-left-width: 4px;
-    margin: 12px 0 12px 50%;
+    margin: 12px 0;
+    display: flex;
+}
+.cable-trace .cable-color {
+    border-left-width: 1px;
+    border-right-width: 1px;
+    width: 12px;
+}
+.cable-trace .cable .cable-info {
     padding: 24px;
     text-align: left;
-    width: 50%;
+    width: calc(50% - 6px);
 }
 .cable-trace .trace-end {
     margin-top: 48px;

--- a/nautobot/project-static/css/dark.css
+++ b/nautobot/project-static/css/dark.css
@@ -23,42 +23,8 @@ html[data-theme="dark"] #select2-id_color-results,        /* Colored choices, li
 html[data-theme="dark"] #select2-id_color-container,      /* Colored choices, like statuses */
 html[data-theme="dark"] .hljs,                            /* highlight.js maintains its own dark theme */
 html[data-theme="dark"] .editor-container,                /* Monaco editor maintains its own dark theme */
-html[data-theme="dark"] .cable {              /* Cable colors */
+html[data-theme="dark"] .cable-color {                    /* Cable colors */
   filter: invert(1) hue-rotate(180deg);
-}
-
-/* Counter-invert cable children to keep text readable */
-html[data-theme="dark"] .cable > * {
-  filter: invert(1) hue-rotate(180deg);
-}
-
-/* Pure CSS cable color overrides for dark mode */
-
-/* White - Connected */
-html[data-theme="dark"] .cable[data-cable-color="#909090"][data-cable-status="Connected"] {
-  border-left-color: white !important;
-  border-left-width: 4px !important;
-}
-
-/* White - Not Connected */
-html[data-theme="dark"] .cable[data-cable-color="#909090"]:not([data-cable-status="Connected"]) {
-  border-left-color: white !important;
-  border-left-style: dashed !important;
-  border-left-width: 4px !important;
-}
-
-/* Black - Connected */
-html[data-theme="dark"] [data-cable-color="#111111"][data-cable-status="Connected"] {
-  border-left-color: #9e9e9e !important;
-  border-left-style: double !important;
-  border-left-width: 6px !important;
-}
-
-/* Black - Not Connected */
-html[data-theme="dark"] [data-cable-color="#111111"]:not([data-cable-status="Connected"]) {
-  border-left-color: #9e9e9e !important;
-  border-left-style: dashed !important;
-  border-left-width: 6px !important;
 }
 
 /* Labels in API Swagger docs */

--- a/nautobot/project-static/css/dark.css
+++ b/nautobot/project-static/css/dark.css
@@ -23,12 +23,12 @@ html[data-theme="dark"] #select2-id_color-results,        /* Colored choices, li
 html[data-theme="dark"] #select2-id_color-container,      /* Colored choices, like statuses */
 html[data-theme="dark"] .hljs,                            /* highlight.js maintains its own dark theme */
 html[data-theme="dark"] .editor-container,                /* Monaco editor maintains its own dark theme */
-html[data-theme="dark"] [data-cable-color] {              /* Cable colors */
+html[data-theme="dark"] .cable {              /* Cable colors */
   filter: invert(1) hue-rotate(180deg);
 }
 
 /* Counter-invert cable children to keep text readable */
-html[data-theme="dark"] [data-cable-color] > * {
+html[data-theme="dark"] .cable > * {
   filter: invert(1) hue-rotate(180deg);
 }
 

--- a/nautobot/project-static/css/dark.css
+++ b/nautobot/project-static/css/dark.css
@@ -22,8 +22,43 @@ html[data-theme="dark"] .select2-selection__choice,       /* Colored choices, li
 html[data-theme="dark"] #select2-id_color-results,        /* Colored choices, like statuses */
 html[data-theme="dark"] #select2-id_color-container,      /* Colored choices, like statuses */
 html[data-theme="dark"] .hljs,                            /* highlight.js maintains its own dark theme */
-html[data-theme="dark"] .editor-container {               /* Monaco editor maintains its own dark theme */
+html[data-theme="dark"] .editor-container,                /* Monaco editor maintains its own dark theme */
+html[data-theme="dark"] [data-cable-color] {              /* Cable colors */
   filter: invert(1) hue-rotate(180deg);
+}
+
+/* Counter-invert cable children to keep text readable */
+html[data-theme="dark"] [data-cable-color] > * {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+/* Pure CSS cable color overrides for dark mode */
+
+/* White - Connected */
+html[data-theme="dark"] .cable[data-cable-color="#909090"][data-cable-status="Connected"] {
+  border-left-color: white !important;
+  border-left-width: 4px !important;
+}
+
+/* White - Not Connected */
+html[data-theme="dark"] .cable[data-cable-color="#909090"]:not([data-cable-status="Connected"]) {
+  border-left-color: white !important;
+  border-left-style: dashed !important;
+  border-left-width: 4px !important;
+}
+
+/* Black - Connected */
+html[data-theme="dark"] [data-cable-color="#111111"][data-cable-status="Connected"] {
+  border-left-color: #9e9e9e !important;
+  border-left-style: double !important;
+  border-left-width: 6px !important;
+}
+
+/* Black - Not Connected */
+html[data-theme="dark"] [data-cable-color="#111111"]:not([data-cable-status="Connected"]) {
+  border-left-color: #9e9e9e !important;
+  border-left-style: dashed !important;
+  border-left-width: 6px !important;
 }
 
 /* Labels in API Swagger docs */


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8519 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

This attempts to improve the visibility of colors in dark mode for the `ltm-2.4` branch. The code does a few things: first, it adds `data-cable-color` and `data-cable-status` attributes to the cable `<div>`. Then it adds that attribute to the list of items in dark.css which are double-inverted. This handles most colors, with varying degrees of success; yellow and aqua are particularly vulnerable to mutations with the double inversion:

## Colors in light mode
<table>
<tr>
<th>Light Mode</th>
<th>Dark Mode (before patch)</th>
<th>Dark Mode (after)</th>
</tr>
<tr>
<td>
<img width="100%" height="50%" alt="light mode - current" src="https://github.com/user-attachments/assets/3fc0cbb8-e2cf-4fdc-8f61-efa36853c53a" />
</td>
<td>
<img width="100%" height="50%" alt="dark mode - current" src="https://github.com/user-attachments/assets/fa3a2a25-cb8d-4075-b730-97c522e03cac" />
</td>
<td>
<img width="100%" height="50%" alt="dark mode - new updated" src="https://github.com/user-attachments/assets/505b6553-ef79-4653-9cf1-6b48d8798b34" />
</td>
</tr>
</table>

I recommend downloading the files and comparing them locally; they're a bit larger than they appear above.

Lastly, special handling is applied to the black and white cables. The black cables need extra adjustment because they're dark like the background so, as with white cables in the white theme, the colors are tweaked in a comparable way to make them more obvious. The white cables need extra adjustment because a straight inversion is insufficient due to the way they're handled in light mode. I've tried to keep the behavior as similar to how light mode works as I can, even when I think light mode gets it wrong. See the screenshots below for more detail.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
## Colors

These work as expected, modulo color funkiness caused by the double-inversion. I spent some time trying to see if there was a way to make the yellows/aquas more like their light mode counterparts, but either that info is irretrievable or my CSS skills aren't up to the task. As evidenced the this patch (and the screenshots above), simply re-inverting and rotation the hue 180º works pretty well for most colors, but not all of them.

Here's a sample of **Fuchsia**, a good color:
<table>
<tr>
<th>Connected </th>
<th>Disconnected</th>
</tr>
<tr>
<td>
<img width="100%" height="70%" alt="Screenshot 2026-02-08 at 10 35 06 PM" src="https://github.com/user-attachments/assets/484ff6c5-c143-47ab-ba82-bcdd3092d5f9" />
</td>
<td>
<img width="100%" height="70%" alt="Screenshot 2026-02-08 at 10 35 19 PM" src="https://github.com/user-attachments/assets/17999be5-c96c-488e-a139-eface0f6968f" />
</td>
</tr>
</table>

...and **Yellow**, which is less good but still better than it was:
<table>
<tr>
<th>Connected </th>
<th>Disconnected</th>
</tr>
<tr>
<td>
<img width="568" height="484" alt="Screenshot 2026-02-08 at 10 40 01 PM" src="https://github.com/user-attachments/assets/51bcf99b-f68c-462f-9802-8f92103c8f66" />

</td>
<td>
<img width="565" height="482" alt="Screenshot 2026-02-08 at 10 39 47 PM" src="https://github.com/user-attachments/assets/7f6b7678-28c1-45d3-91db-57a63977314b" />

</td>
</tr>
</table>

## Black and White
<table>
<tr>
<th>Description</th>
<th>Before Additional Tweaks</th>
<th>After Tweaks</th>
</tr>
<tr>
<td>Black cable, connected
<td>
<img width="565" height="481" alt="black, connected (before)" src="https://github.com/user-attachments/assets/34942e3a-9fd8-4221-855f-be6859b5bd97" />
</td>
<td>
<img width="565" height="483" alt="black, connected (after)" src="https://github.com/user-attachments/assets/5b793764-82fe-4dc9-a801-3d88e47d93e0" />
</td>
</tr>

<tr>
<td>Black cable, disconnected
<td>
<img width="568" height="483" alt="black, disconnected (before)" src="https://github.com/user-attachments/assets/0073926d-5476-4aec-98d6-49cef5c24ea9" />
</td>
<td>
<img width="565" height="480" alt="black, disconnected (after)" src="https://github.com/user-attachments/assets/59c50c4e-8ed3-4c03-9185-27b75d1afa7f" />
</td>
</tr>

<tr>
<td>White cable, connected
<td>
<img width="567" height="484" alt="white, connected (before)" src="https://github.com/user-attachments/assets/b662f23a-54f7-40e9-a21f-9cdeabbadb89" />
</td>
<td>
<img width="563" height="484" alt="white, connected (after)" src="https://github.com/user-attachments/assets/8c090ca4-f418-4f97-aa28-7deb651717ac" />

</td>
</tr>

<tr>
<td>White cable, disconnected
<td>
<img width="564" height="483" alt="white, disconnected (before)" src="https://github.com/user-attachments/assets/6323a295-d309-40b9-9088-fa74481a9ac1" />
</td>
<td>
<img width="565" height="479" alt="white, disconnected (after)" src="https://github.com/user-attachments/assets/266bb4ba-32a1-47a4-8d9f-efa8ca65963c" />
</td>
</tr>
</table>

One thing I draw your attention to: note that the `border-left-width` of the black disconnected cable is 6px rather than the 4 seen most other places. This is the same behavior seen by white cables in the light theme. This may well be a bug in the light theme, but I opted for consistency as I don't know the history there. Side note: it has the extra width in `develop` and `next` as well. Here are screenshots of an unconnected cable in next:

<table>
<tr>
<th>No color assigned</th>
<th>White cable</th>
</tr>
<tr>
<td>
<img width="363" height="222" alt="disconnected colorless (next)" src="https://github.com/user-attachments/assets/4a0c86f7-086d-42b3-bed4-bf758074ebf0" />
</td>
<td>
<img width="368" height="223" alt="disconnected white (next)" src="https://github.com/user-attachments/assets/75ec10c2-4e13-4a57-becd-e2a1f249ed26" />
</td>
</tr>
</table>

Assuming that's not by design, it felt to me like a separate issue warranting its own patch so this patch doesn't attempt to alter that behavior and, in fact, reproduces it. Certainly happy to tweak the width in this patch if you'd like, or I can open a new issue.


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design