### PR TITLE
Closes #8522: [develop] Adjusted the foreground color contrast threshold for color labels

### DIFF
--- a/changes/8522.fixed
+++ b/changes/8522.fixed
@@ -1,0 +1,1 @@
+Adjusted the foreground color contrast threshold used for color labels to improve readability.

--- a/nautobot/core/tests/test_templatetags_helpers.py
+++ b/nautobot/core/tests/test_templatetags_helpers.py
@@ -210,7 +210,7 @@ class NautobotTemplatetagsHelperTest(TestCase):
         # TODO add unit tests for tzoffset
 
     def test_fgcolor(self):
-        self.assertEqual(helpers.fgcolor("#999999"), "#ffffff")
+        self.assertEqual(helpers.fgcolor("#999999"), "#000000")
         self.assertEqual(helpers.fgcolor("#111111"), "#ffffff")
         self.assertEqual(helpers.fgcolor("#000000"), "#ffffff")
         self.assertEqual(helpers.fgcolor("#ffffff"), "#000000")

--- a/nautobot/core/utils/color.py
+++ b/nautobot/core/utils/color.py
@@ -19,9 +19,10 @@ def foreground_color(bg_color):
     """
     Return the ideal foreground color (black or white) for a given background color in hexadecimal RGB format.
     """
+    THRESHOLD = 150
     bg_color = bg_color.strip("#")
     r, g, b = hex_to_rgb(bg_color)
-    if r * 0.299 + g * 0.587 + b * 0.114 > 186:
+    if r * 0.299 + g * 0.587 + b * 0.114 > THRESHOLD:
         return "000000"
     else:
         return "ffffff"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8522
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

This patch makes a handful of color labels in the color selector dropdown (e.g. for `Cable` color) more readable. It also syncs up the luminance threshold [with Netbox](https://github.com/netbox-community/netbox/blob/main/netbox/utilities/html.py#L28-L41). The following colors are altered as a result:

- Fuchsia
- Aqua
- Light Green
- Orange
- Gray

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

<table>
<tr>
  <th>Before</th>
  <th>After</th>
</tr>
<tr>
<td>
<img width="625" height="182" alt="Screenshot 2026-02-09 at 3 23 03 PM" src="https://github.com/user-attachments/assets/c68f445e-000a-4826-b743-e3b7b38286e2" />
<img width="624" height="178" alt="Screenshot 2026-02-09 at 3 23 13 PM" src="https://github.com/user-attachments/assets/6857d0d0-8876-4515-900b-d8ad7325eef4" />
<img width="624" height="179" alt="Screenshot 2026-02-09 at 3 23 22 PM" src="https://github.com/user-attachments/assets/0f866bb8-ac14-41c7-8a25-5b8d3ba7a661" />
<img width="624" height="181" alt="Screenshot 2026-02-09 at 3 23 31 PM" src="https://github.com/user-attachments/assets/29d7b8de-8efe-41d3-a0f0-16a4bb7eac77" />
<img width="626" height="179" alt="Screenshot 2026-02-09 at 3 23 41 PM" src="https://github.com/user-attachments/assets/70bb4386-285a-45c6-aa10-8054a6f5c2a8" />
<img width="625" height="72" alt="Screenshot 2026-02-09 at 3 23 50 PM" src="https://github.com/user-attachments/assets/371ad372-b1e4-4d50-9c49-ab6248c5780a" />
</td>

<td>
<img width="626" height="180" alt="Screenshot 2026-02-09 at 3 25 06 PM" src="https://github.com/user-attachments/assets/c5b82482-76fe-4688-b21d-6bc4e2f46b8d" />
<img width="624" height="177" alt="Screenshot 2026-02-09 at 3 25 37 PM" src="https://github.com/user-attachments/assets/03ac9ad3-ddbc-4577-96d4-96a08ac93124" />
<img width="623" height="179" alt="Screenshot 2026-02-09 at 3 25 48 PM" src="https://github.com/user-attachments/assets/a21a4466-a348-415f-b4be-d97847afd5f8" />
<img width="624" height="179" alt="Screenshot 2026-02-09 at 3 25 57 PM" src="https://github.com/user-attachments/assets/9f8bed73-9eac-4119-adcc-a069aa7e64fa" />
<img width="623" height="179" alt="Screenshot 2026-02-09 at 3 26 07 PM" src="https://github.com/user-attachments/assets/9818dc5e-d8f5-48de-b392-823564516d8a" />
<img width="622" height="71" alt="Screenshot 2026-02-09 at 3 26 15 PM" src="https://github.com/user-attachments/assets/c4c75f05-5cb9-4cbe-b4f2-aa2f13f5a51d" />

</td>

</tr>
</table


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
