### PR TITLE
Fix job logs DB connection to respect CONN_MAX_AGE and recover from errors

### DIFF
--- a/changes/8547.fixed
+++ b/changes/8547.fixed
@@ -1,0 +1,1 @@
+Resolves issues with the job logs DB connection. It now correctly respects `CONN_MAX_AGE` and can recover from errored connections.

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -1052,7 +1052,9 @@ class JobResult(SavedViewMixin, BaseModel, CustomFieldModel):
             # Some failure scenarios, such as a DB connection closed by the server, cannot be easily detected.
             # In these cases, we manually clear the connection and retry.
             except (InterfaceError, OperationalError):
-                conn.close()
+                # Explicitly clear the connection socket due to MySQL not playing nicely with conn.close()
+                conn.connection = None
+                conn.ensure_connection()
                 log.save(using=JOB_LOGS)
 
     log.alters_data = True

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
-from django.db import models, transaction
+from django.db import connections, InterfaceError, models, OperationalError, transaction
 from django.db.models import Count, ProtectedError, Q, signals
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -1042,7 +1042,18 @@ class JobResult(SavedViewMixin, BaseModel, CustomFieldModel):
         if not self.use_job_logs_db or not JOB_LOGS:
             log.save()
         else:
-            log.save(using=JOB_LOGS)
+            try:
+                conn = connections[JOB_LOGS]
+                # Close the existing connection if it has encountered errors or if the CONN_MAX_AGE is exceeded.
+                # Without this, job logs connections persist indefinitely, regardless of the CONN_MAX_AGE setting.
+                # A subsequent ORM call will automatically open a new connection.
+                conn.close_if_unusable_or_obsolete()
+                log.save(using=JOB_LOGS)
+            # Some failure scenarios, such as a DB connection closed by the server, cannot be easily detected.
+            # In these cases, we manually clear the connection and retry.
+            except (InterfaceError, OperationalError):
+                conn.close()
+                log.save(using=JOB_LOGS)
 
     log.alters_data = True
 

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import re
 import tempfile
+import time
 from unittest import mock
 import uuid
 
@@ -16,6 +17,8 @@ from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db import connections
+from django.db.utils import InterfaceError, OperationalError
 from django.test import override_settings, tag
 from django.test.client import RequestFactory
 from django.utils import timezone
@@ -38,8 +41,8 @@ from nautobot.extras.choices import (
 )
 from nautobot.extras.context_managers import change_logging, JobHookChangeContext, web_request_context
 from nautobot.extras.jobs import BaseJob, get_job, get_jobs
-from nautobot.extras.models import Job, JobQueue
-from nautobot.extras.models.jobs import JobLogEntry
+from nautobot.extras.models import Job, JobQueue, JobResult
+from nautobot.extras.models.jobs import JOB_LOGS, JobLogEntry
 
 
 class JobTest(TestCase):
@@ -1352,3 +1355,86 @@ class ScheduledJobIntervalTestCase(TestCase):
         schedule_day_of_week = next(iter(scheduled_job.schedule.day_of_week))
         scheduled_job_weekday = self.cron_days[schedule_day_of_week]
         self.assertEqual(scheduled_job_weekday, requested_weekday)
+
+
+class JobLogsDBConnectionTest(TransactionTestCase):
+    databases = {"default", JOB_LOGS}
+
+    def test_closed_connection_recovery(self):
+        """Test the job logs DB connection is recovered from the errors at the driver layer."""
+        conn = connections[JOB_LOGS]
+
+        # Ensure a job logs connection is open
+        conn.ensure_connection()
+        self.assertTrue(conn.is_usable())
+
+        jobs = Job.objects.all()[:2]
+        job_result = JobResult.objects.create(
+            name="irrelevant",
+            job_model=jobs[0],
+            date_done=timezone.now(),
+            user=None,
+            status=JobResultStatusChoices.STATUS_SUCCESS,
+            task_kwargs={},
+            scheduled_job=None,
+        )
+
+        # Forcefully close the connection through the underlying driver.
+        conn.connection.close()
+        self.assertFalse(conn.is_usable())
+
+        # Attempt a log message write. The connection should automatically recover.
+        try:
+            job_result.log("Hello")
+        except (InterfaceError, OperationalError) as ex:
+            self.fail(f"Job Logs DB Connection regression error. Caused by exception: {ex}")
+
+        # Confirm the log entry was created
+        log = JobLogEntry.objects.get(job_result=job_result)
+        self.assertEqual("Hello", log.message)
+        self.assertEqual(LogLevelChoices.LOG_INFO, log.log_level)
+        self.assertEqual("main", log.grouping)
+        self.assertEqual("", log.log_object)
+        self.assertEqual("", log.absolute_url)
+
+        # Set connection close_at time to 30s from now to make sure CONN_MAX_AGE time is not getting in the way
+        conn.close_at = time.monotonic() + 30
+        # This closes connections that had reported errors. Here, we're validating that the connection is NOT closed.
+        conn.close_if_unusable_or_obsolete()
+        self.assertTrue(conn.is_usable())
+
+    def test_close_if_unusable_or_obsolete(self):
+        """Test the job logs DB connection is refreshed when the connection's CONN_MAX_AGE is exceeded."""
+        conn = connections[JOB_LOGS]
+
+        # Ensure the DB connection is open
+        conn.ensure_connection()
+        self.assertTrue(conn.is_usable())
+
+        # Set close at_time to now, combined with time.sleep this will force the connection expiration.
+        conn.close_at = time.monotonic() - 1
+        original_conn_close_at = conn.close_at
+
+        jobs = Job.objects.all()[:2]
+        job_result = JobResult.objects.create(
+            name="irrelevant",
+            job_model=jobs[0],
+            date_done=timezone.now(),
+            user=None,
+            status=JobResultStatusChoices.STATUS_SUCCESS,
+            task_kwargs={},
+            scheduled_job=None,
+        )
+
+        # Confirm the log entry was created. This should also trigger the connection refresh confirming CONN_MAX_AGE is honored.
+        job_result.log("Hello")
+        log = JobLogEntry.objects.get(job_result=job_result)
+        self.assertEqual("Hello", log.message)
+        self.assertEqual(LogLevelChoices.LOG_INFO, log.log_level)
+        self.assertEqual("main", log.grouping)
+        self.assertEqual("", log.log_object)
+        self.assertEqual("", log.absolute_url)
+
+        # If the connection was reopened, a new close at value should be present.
+        new_conn_close_at = conn.close_at
+        self.assertGreater(new_conn_close_at, original_conn_close_at)

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta, timezone
 import os
 import shutil
 import tempfile
-import time
 from unittest import expectedFailure, mock
 import uuid
 from zoneinfo import ZoneInfo
@@ -13,9 +12,8 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.db import connections
 from django.db.models import ProtectedError
-from django.db.utils import IntegrityError, InterfaceError, OperationalError
+from django.db.utils import IntegrityError
 from django.test import override_settings, tag
 from django.utils.timezone import get_default_timezone, now
 from django_celery_beat.tzcrontab import TzAwareCrontab
@@ -25,7 +23,7 @@ import time_machine
 
 from nautobot.circuits.models import CircuitType
 from nautobot.core.choices import ColorChoices
-from nautobot.core.testing import TestCase, TransactionTestCase
+from nautobot.core.testing import TestCase
 from nautobot.core.testing.models import ModelTestCases
 from nautobot.dcim.models import (
     Device,
@@ -91,7 +89,6 @@ from nautobot.extras.models import (
     Team,
     Webhook,
 )
-from nautobot.extras.models.jobs import JOB_LOGS
 from nautobot.extras.registry import registry
 from nautobot.extras.secrets.exceptions import SecretParametersError, SecretProviderError, SecretValueNotFoundError
 from nautobot.extras.tests.git_helper import create_and_populate_git_repository
@@ -2379,91 +2376,6 @@ class ObjectChangeTest(ModelTestCases.BaseModelTestCase):
         self.assertEqual("Hi 2", log.message)
         self.assertEqual("a" * JOB_LOG_MAX_LOG_OBJECT_LENGTH, log.log_object)
         self.assertEqual("", log.absolute_url)
-
-
-class JobLogsDBConnectionTest(TransactionTestCase):
-    model = ObjectChange
-    databases = {"default", JOB_LOGS}
-
-    def test_closed_connection_recovery(self):
-        """Test the job logs DB connection is recovered from the errors at the driver layer."""
-        conn = connections[JOB_LOGS]
-
-        # Ensure a job logs connection is open
-        conn.ensure_connection()
-        self.assertTrue(conn.is_usable())
-
-        jobs = JobModel.objects.all()[:2]
-        job_result = JobResult.objects.create(
-            name="irrelevant",
-            job_model=jobs[0],
-            date_done=now(),
-            user=None,
-            status=JobResultStatusChoices.STATUS_SUCCESS,
-            task_kwargs={},
-            scheduled_job=None,
-        )
-
-        # Forcefully close the connection through the underlying driver.
-        conn.connection.close()
-        self.assertFalse(conn.is_usable())
-
-        # Attempt a log message write. The connection should automatically recover.
-        try:
-            job_result.log("Hello")
-        except (InterfaceError, OperationalError) as ex:
-            self.fail(f"Job Logs DB Connection regression error. Caused by exception: {ex}")
-
-        # Confirm the log entry was created
-        log = JobLogEntry.objects.get(job_result=job_result)
-        self.assertEqual("Hello", log.message)
-        self.assertEqual(LogLevelChoices.LOG_INFO, log.log_level)
-        self.assertEqual("main", log.grouping)
-        self.assertEqual("", log.log_object)
-        self.assertEqual("", log.absolute_url)
-
-        # Set connection close_at time to 30s from now to make sure CONN_MAX_AGE time is not getting in the way
-        conn.close_at = time.monotonic() + 30
-        # This closes connections that had reported errors. Here, we're validating that the connection is NOT closed.
-        conn.close_if_unusable_or_obsolete()
-        self.assertTrue(conn.is_usable())
-
-    def test_close_if_unusable_or_obsolete(self):
-        """Test the job logs DB connection is refreshed when the connection's CONN_MAX_AGE is exceeded."""
-        conn = connections[JOB_LOGS]
-
-        # Ensure the DB connection is open
-        conn.ensure_connection()
-        self.assertTrue(conn.is_usable())
-
-        # Set close at_time to now, combined with time.sleep this will force the connection expiration.
-        conn.close_at = time.monotonic()
-        original_conn_close_at = conn.close_at
-        time.sleep(2)
-
-        jobs = JobModel.objects.all()[:2]
-        job_result = JobResult.objects.create(
-            name="irrelevant",
-            job_model=jobs[0],
-            date_done=now(),
-            user=None,
-            status=JobResultStatusChoices.STATUS_SUCCESS,
-            task_kwargs={},
-            scheduled_job=None,
-        )
-
-        # Confirm the log entry was created. This should also trigger the connection refresh confirming CONN_MAX_AGE is honored.
-        job_result.log("Hello")
-        log = JobLogEntry.objects.get(job_result=job_result)
-        self.assertEqual("Hello", log.message)
-        self.assertEqual(LogLevelChoices.LOG_INFO, log.log_level)
-        self.assertEqual("main", log.grouping)
-        self.assertEqual("", log.log_object)
-        self.assertEqual("", log.absolute_url)
-
-        # If the connection was reopend, a new close at value should be present.
-        new_conn_close_at = conn.close_at
-        self.assertGreater(new_conn_close_at, original_conn_close_at)
 
 
 class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 import os
 import shutil
 import tempfile
+import time
 from unittest import expectedFailure, mock
 import uuid
 from zoneinfo import ZoneInfo
@@ -12,8 +13,9 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connections
 from django.db.models import ProtectedError
-from django.db.utils import IntegrityError
+from django.db.utils import IntegrityError, InterfaceError, OperationalError
 from django.test import override_settings, tag
 from django.utils.timezone import get_default_timezone, now
 from django_celery_beat.tzcrontab import TzAwareCrontab
@@ -23,7 +25,7 @@ import time_machine
 
 from nautobot.circuits.models import CircuitType
 from nautobot.core.choices import ColorChoices
-from nautobot.core.testing import TestCase
+from nautobot.core.testing import TestCase, TransactionTestCase
 from nautobot.core.testing.models import ModelTestCases
 from nautobot.dcim.models import (
     Device,
@@ -89,6 +91,7 @@ from nautobot.extras.models import (
     Team,
     Webhook,
 )
+from nautobot.extras.models.jobs import JOB_LOGS
 from nautobot.extras.registry import registry
 from nautobot.extras.secrets.exceptions import SecretParametersError, SecretProviderError, SecretValueNotFoundError
 from nautobot.extras.tests.git_helper import create_and_populate_git_repository
@@ -2376,6 +2379,92 @@ class ObjectChangeTest(ModelTestCases.BaseModelTestCase):
         self.assertEqual("Hi 2", log.message)
         self.assertEqual("a" * JOB_LOG_MAX_LOG_OBJECT_LENGTH, log.log_object)
         self.assertEqual("", log.absolute_url)
+
+
+class JobLogsDBConnectionTest(TransactionTestCase):
+    model = ObjectChange
+    databases = {"default", JOB_LOGS}
+
+    def test_closed_connection_recovery(self):
+        """Test the job logs DB connection is recovered from the errors at the driver layer."""
+        conn = connections[JOB_LOGS]
+
+        # Ensure a job logs connection is open
+        conn.ensure_connection()
+        self.assertTrue(conn.is_usable())
+
+        jobs = JobModel.objects.all()[:2]
+        job_result = JobResult.objects.create(
+            name="irrelevant",
+            job_model=jobs[0],
+            date_done=now(),
+            user=None,
+            status=JobResultStatusChoices.STATUS_SUCCESS,
+            task_kwargs={},
+            scheduled_job=None,
+        )
+
+        # Forcefully close the connection through the underlying driver.
+        conn.connection.close()
+        self.assertFalse(conn.is_usable())
+
+        # Attempt a log message write. The connection should automatically recover.
+        try:
+            job_result.log("Hello")
+        except (InterfaceError, OperationalError) as ex:
+            self.fail(f"Job Logs DB Connection regression error. Caused by execption: {ex}")
+
+        # Confirm the log entry was created
+        log = JobLogEntry.objects.get(job_result=job_result)
+        self.assertEqual("Hello", log.message)
+        self.assertEqual(LogLevelChoices.LOG_INFO, log.log_level)
+        self.assertEqual("main", log.grouping)
+        self.assertEqual("", log.log_object)
+        self.assertEqual("", log.absolute_url)
+
+        # Set connection close_at time to 30s from now to make sure CONN_MAX_AGE time is not getting in the way
+        conn.close_at = time.monotonic() + 30
+        # This closes connections that had reported errors. Here, we're validating that the connection is NOT closed.
+        conn.close_if_unusable_or_obsolete()
+        self.assertTrue(conn.is_usable())
+
+    def test_close_if_unusable_or_obsolete(self):
+        """Test the job logs DB connection is refreshed when the connection's CONN_MAX_AGE is exceeded."""
+        conn = connections[JOB_LOGS]
+
+        # Ensure the DB connection is open
+        conn.ensure_connection()
+        self.assertTrue(conn.is_usable())
+
+        # Set close at_time to now, combined with time.sleep this will force the connection expiration.
+        conn.close_at = time.monotonic()
+        original_conn_close_at = conn.close_at
+        time.sleep(2)
+
+        jobs = JobModel.objects.all()[:2]
+        job_result = JobResult.objects.create(
+            name="irrelevant",
+            job_model=jobs[0],
+            date_done=now(),
+            user=None,
+            status=JobResultStatusChoices.STATUS_SUCCESS,
+            task_kwargs={},
+            scheduled_job=None,
+        )
+
+        # Confirm the log entry was created. This should also trigger the connection refresh confirming CONN_MAX_AGE is honored.
+        job_result.log("Hello")
+        log = JobLogEntry.objects.get(job_result=job_result)
+        self.assertEqual("Hello", log.message)
+        self.assertEqual(LogLevelChoices.LOG_INFO, log.log_level)
+        self.assertEqual("main", log.grouping)
+        self.assertEqual("", log.log_object)
+        self.assertEqual("", log.absolute_url)
+
+        # If the connection was reopend, a new close at value should be present.
+        new_conn_close_at = conn.close_at
+        self.assertNotAlmostEqual(new_conn_close_at, original_conn_close_at, delta=0)
+        self.assertGreater(new_conn_close_at, original_conn_close_at)
 
 
 class ObjectMetadataTest(ModelTestCases.BaseModelTestCase):

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -2412,7 +2412,7 @@ class JobLogsDBConnectionTest(TransactionTestCase):
         try:
             job_result.log("Hello")
         except (InterfaceError, OperationalError) as ex:
-            self.fail(f"Job Logs DB Connection regression error. Caused by execption: {ex}")
+            self.fail(f"Job Logs DB Connection regression error. Caused by exception: {ex}")
 
         # Confirm the log entry was created
         log = JobLogEntry.objects.get(job_result=job_result)
@@ -2463,7 +2463,6 @@ class JobLogsDBConnectionTest(TransactionTestCase):
 
         # If the connection was reopend, a new close at value should be present.
         new_conn_close_at = conn.close_at
-        self.assertNotAlmostEqual(new_conn_close_at, original_conn_close_at, delta=0)
         self.assertGreater(new_conn_close_at, original_conn_close_at)
 
 

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -2382,7 +2382,6 @@ class ObjectChangeTest(ModelTestCases.BaseModelTestCase):
 
 
 class JobLogsDBConnectionTest(TransactionTestCase):
-    model = ObjectChange
     databases = {"default", JOB_LOGS}
 
     def test_closed_connection_recovery(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8547
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Updated the `log` method in the `JobResult` class to:

- Make proactive job logs DB connection check via Django's `close_if_unusable_or_obsolete()`. This executes several checks on the connection, including the check for `CONN_MAX_AGE` expiration.
- Call `close()` on the the job logs DB connection if one of the `InterfaceError`, `OperationalError` exceptions is raised. This allows recovering from the underlying errors, such as server closing the connection.

Added tests to:

- Validate that the `CONN_MAX_AGE` value is respected and connections are re-opened upon expiration.
- Validate the connection is automatically recovered when underlying connection errors are encountered.