### PR TITLE
Fixed synchronous job status

### DIFF
--- a/changes/8560.fixed
+++ b/changes/8560.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where the `JobResult` status was not being set to `STARTED` when a job was run synchronously.

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -927,6 +927,7 @@ class JobResult(SavedViewMixin, BaseModel, CustomFieldModel):
             # the job must be added before calling `apply()`
             job_result.celery_kwargs = job_celery_kwargs
             job_result.date_started = timezone.now()
+            job_result.status = JobResultStatusChoices.STATUS_STARTED
             job_result.save()
 
             # setup synchronous task logging

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -457,6 +457,36 @@ class JobTransactionTest(TransactionTestCase):
             print(job_result.traceback)
             raise
 
+    def test_synchronous_enqueue_job_sets_started_before_run(self):
+        """
+        When enqueue_job is called with synchronous=True (e.g. runjob --local or Kubernetes job pod),
+        JobResult status and date_started must be set to STARTED before run_job.apply() executes,
+        so the UI shows "Running" instead of "Pending" until the job completes.
+        """
+        import nautobot.extras.jobs as jobs_module
+
+        real_run_job = jobs_module.run_job
+        with mock.patch("nautobot.extras.jobs.run_job") as mock_run_job:
+
+            def apply_wrapper(*args, **kwargs):
+                task_id = kwargs.get("task_id")
+                if task_id is not None:
+                    job_result = models.JobResult.objects.get(pk=task_id)
+                    self.assertEqual(
+                        job_result.status,
+                        JobResultStatusChoices.STATUS_STARTED,
+                        "JobResult should be STARTED before run_job.apply() when running synchronously",
+                    )
+                    self.assertIsNotNone(
+                        job_result.date_started,
+                        "date_started should be set before run_job.apply() when running synchronously",
+                    )
+                return real_run_job.apply(*args, **kwargs)
+
+            mock_run_job.apply = apply_wrapper
+            job_result = create_job_result_and_run_job("pass_job", "TestPassJob")
+            self.assertJobResultStatus(job_result)
+
     def test_job_result_manager_censor_sensitive_variables(self):
         """
         Job test with JobResult Censored Sensitive Variables.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8560
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
When a job runs **synchronously** (e.g. Kubernetes job pod or `runjob --local`), we call `run_job.apply()` (eager mode). In eager mode Celery **does not** send a STARTED state to the result backend, so the `JobResult` stays PENDING until the task finishes and the UI never shows "Running."

When a job runs on a **Celery worker** (via `apply_async`), the worker sends STARTED to the backend before executing the task, so the UI correctly shows "Running."

This change sets `job_result.status = STATUS_STARTED` in the synchronous branch of `enqueue_job` before calling `run_job.apply()`, so synchronous execution (Kubernetes jobs and `runjob --local`) also shows "Running" instead of "Pending" until the job completes.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests
