### PR TITLE
[Hackathon] [WIP] Kubernetes Job Manifest easy mode

### DIFF
--- a/nautobot/extras/exceptions.py
+++ b/nautobot/extras/exceptions.py
@@ -3,3 +3,7 @@ from django.core.exceptions import ValidationError
 
 class ApprovalRequiredScheduledJobsError(ValidationError):
     """Raised when scheduled jobs requiring approval are found during migration."""
+
+
+class KubernetesJobManifestError(ValidationError):
+    """Raised when we are unable to generate a kubernetes job manifest."""

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import logging
 import re
+import socket
 import sys
 from typing import Optional, TYPE_CHECKING, Union
 
@@ -33,6 +34,7 @@ from nautobot.extras.choices import (
     ApprovalWorkflowStateChoices,
     DynamicGroupTypeChoices,
     JobQueueTypeChoices,
+    JobResultStatusChoices,
     ObjectChangeActionChoices,
 )
 from nautobot.extras.constants import (
@@ -41,6 +43,7 @@ from nautobot.extras.constants import (
     JOB_MAX_NAME_LENGTH,
     JOB_OVERRIDABLE_FIELDS,
 )
+from nautobot.extras.exceptions import KubernetesJobManifestError
 from nautobot.extras.registry import registry
 
 if TYPE_CHECKING:
@@ -668,12 +671,123 @@ def refresh_job_model_from_job_class(job_model_class, job_class, job_queue_class
     return (job_model, created)
 
 
+def detect_current_kubernetes_image():
+    """Using the kubernetes API, detect the current image for the pod we are running in."""
+    configuration = kubernetes.client.Configuration()
+    configuration.host = settings.KUBERNETES_DEFAULT_SERVICE_ADDRESS
+    configuration.ssl_ca_cert = settings.KUBERNETES_SSL_CA_CERT_PATH
+    with open(settings.KUBERNETES_TOKEN_PATH, "r", encoding="utf-8") as token_file:
+        token = token_file.read().strip()
+    configuration.api_key_prefix["authorization"] = "Bearer"
+    configuration.api_key["authorization"] = token
+    namespace = settings.KUBERNETES_JOB_POD_NAMESPACE
+    hostname = socket.gethostname()
+    with kubernetes.client.ApiClient(configuration) as api_client:
+        api_instance = kubernetes.client.CoreV1Api(api_client)
+        try:
+            pods = api_instance.list_namespaced_pod(namespace, field_selector=f"metadata.name={hostname}")
+        except kubernetes.client.ApiException as err:
+            if err.status == 403:
+                raise KubernetesJobManifestError(
+                    "Permission error listing namespaced pod. Please verify the service account has the proper Role and RoleBinding."
+                ) from err
+            raise KubernetesJobManifestError("Error listing namespaced pod.") from err
+        if pods.items:
+            return pods.items[0].spec.containers[0].image
+        return None
+
+
+def easy_mode_kubernetes_job_manifest():
+    """Generate a kubernetes job manifest for a Nautobot job."""
+    container_image = detect_current_kubernetes_image()
+    if not container_image:
+        raise KubernetesJobManifestError("No container image found")
+    manifest = {
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {
+            "name": settings.KUBERNETES_JOB_POD_NAME,
+        },
+        "spec": {
+            "backoffLimit": 0,
+            "ttlSecondsAfterFinished": 5,
+            "template": {
+                "spec": {
+                    "restartPolicy": "Never",
+                    "containers": [
+                        {
+                            "name": "nautobot-job",
+                            "image": container_image,
+                            "tty": True,
+                            "ports": [
+                                {
+                                    "containerPort": 8080,
+                                    "protocol": "TCP",
+                                }
+                            ],
+                            "envFrom": [
+                                {
+                                    "configMapRef": {
+                                        "name": "nautobot-env",
+                                    }
+                                }
+                            ],
+                            "env": [
+                                {
+                                    "name": "NAUTOBOT_DB_PASSWORD",
+                                    "valueFrom": {
+                                        "secretKeyRef": {
+                                            "name": "nautobot-postgresql",
+                                            "key": "password",
+                                        }
+                                    },
+                                },
+                                {
+                                    "name": "NAUTOBOT_REDIS_PASSWORD",
+                                    "valueFrom": {
+                                        "secretKeyRef": {
+                                            "name": "nautobot-redis",
+                                            "key": "redis-password",
+                                        }
+                                    },
+                                },
+                            ],
+                            "volumeMounts": [
+                                {
+                                    "name": "nautobot-media",
+                                    "mountPath": "/opt/nautobot/media",
+                                }
+                            ],
+                        }
+                    ],
+                    "volumes": [
+                        {
+                            "name": "nautobot-media",
+                            "persistentVolumeClaim": {
+                                "claimName": "nautobot-media",
+                            },
+                        }
+                    ],
+                }
+            },
+        },
+    }
+    return manifest
+
+
+def get_kubernetes_job_manifest():
+    """Get the kubernetes job manifest."""
+    if settings.KUBERNETES_JOB_MANIFEST:
+        return copy.deepcopy(settings.KUBERNETES_JOB_MANIFEST)
+    return easy_mode_kubernetes_job_manifest()
+
+
 def run_kubernetes_job_and_return_job_result(job_result, job_kwargs):
     """
     Pass the job to a kubernetes pod and execute it there.
     """
     pod_namespace = settings.KUBERNETES_JOB_POD_NAMESPACE
-    pod_manifest = copy.deepcopy(settings.KUBERNETES_JOB_MANIFEST)
+    pod_manifest = get_kubernetes_job_manifest()
     pod_ssl_ca_cert = settings.KUBERNETES_SSL_CA_CERT_PATH
     pod_token = settings.KUBERNETES_TOKEN_PATH
 
@@ -701,7 +815,22 @@ def run_kubernetes_job_and_return_job_result(job_result, job_kwargs):
         with kubernetes.client.ApiClient(configuration) as api_client:
             api_instance = kubernetes.client.BatchV1Api(api_client)
             job_result.log(f"Creating job pod {pod_name} in namespace {pod_namespace}")
-            api_instance.create_namespaced_job(body=pod_manifest, namespace=pod_namespace)
+            try:
+                api_instance.create_namespaced_job(body=pod_manifest, namespace=pod_namespace)
+            except kubernetes.client.ApiException as err:
+                if err.status == 403:
+                    job_result.log(
+                        f"Permission denied creating a job in namespace {pod_namespace}. Please verify the service account has the proper Role and RoleBinding.",
+                        level_choice="error",
+                    )
+                else:
+                    job_result.log(
+                        f"Error creating job in namespace {pod_namespace}: {err}",
+                        level_choice="error",
+                    )
+                job_result.set_status(JobResultStatusChoices.STATUS_FAILURE)
+                job_result.save()
+                return
 
     transaction.on_commit(create_kubernetes_job)
     return job_result

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -83,10 +83,12 @@ from nautobot.dcim.tables import (
     VirtualDeviceContextTable,
 )
 from nautobot.extras.context_managers import deferred_change_logging_for_bulk_operation
+from nautobot.extras.exceptions import KubernetesJobManifestError
 from nautobot.extras.templatetags.approvals import render_approval_workflow_state
 from nautobot.extras.utils import (
     fixup_filterset_query_params,
     get_base_template,
+    get_kubernetes_job_manifest,
     get_pending_approval_workflow_stages,
     get_worker_count,
 )
@@ -2140,7 +2142,25 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
 
         job_class = get_job(job_model.class_path, reload=True)
         job_form = job_class.as_form(request.POST, request.FILES) if job_class is not None else None
+        if job_form is not None:
+            job_form_is_valid = job_form.is_valid()
+            job_queue = job_form.cleaned_data.pop("_job_queue", None)
+            if job_queue is None:
+                job_queue = job_model.default_job_queue
+            if job_queue.queue_type == JobQueueTypeChoices.TYPE_KUBERNETES:
+                try:
+                    get_kubernetes_job_manifest()
+                except KubernetesJobManifestError as err:
+                    messages.error(
+                        request, "Failed to generate kubernetes job manifest. Please see the logs for more details."
+                    )
+                    logger.error("Error getting kubernetes job manifest: %s", err, exc_info=True)
+                    job_form_is_valid = False
+        else:
+            job_form_is_valid = False
+
         schedule_form = forms.JobScheduleForm(request.POST)
+        schedule_form_is_valid = schedule_form.is_valid()
 
         return_url = request.POST.get("_return_url")
         if return_url is not None and url_has_allowed_host_and_scheme(url=return_url, allowed_hosts=request.get_host()):
@@ -2158,11 +2178,7 @@ class JobRunView(ObjectPermissionRequiredMixin, View):
             and request.POST.get("_schedule_type") != JobExecutionType.TYPE_IMMEDIATELY
         ):
             messages.error(request, "Unable to schedule job: Job may have sensitive input variables.")
-        elif job_form is not None and job_form.is_valid() and schedule_form.is_valid():
-            job_queue = job_form.cleaned_data.pop("_job_queue", None)
-            if job_queue is None:
-                job_queue = job_model.default_job_queue
-
+        elif job_form_is_valid and schedule_form_is_valid:
             if job_queue.queue_type == JobQueueTypeChoices.TYPE_CELERY and not get_worker_count(queue=job_queue):
                 messages.warning(
                     request,


### PR DESCRIPTION
This is a WIP draft of some changes that would make it so users of our Nautobot helm chart wouldn't need to provide a Kubernetes Job manifest in order to use a Kubernetes JobQueue instead of Celery. This would be coupled with a change that I have drafted for the helm charts to include the required Roles and RoleBindings needed to assure the nautobot service account has the proper permissions needed to read the current container image name and create the job.

Items of consideration/discussion:
- I have only tested this in my k3s environment. I need to expand and test in more distros to be thorough.
- I don't like that we set up the kubernetes client multiple times (once to read the pod info and then again to create the job). I'd like to maybe do that once and just reuse it. I need to figure out the best way to do that eventually.
- I added some error handling around the different scenarios that I ran into (e.g., missing permissions, wrong namespace, etc.). I'm hoping that this will have a better UX than jobs just failing silently like they do now.
  - This really doesn't satisfy #8489 since it's not on startup and we don't actually try the manifest until we start the job, but maybe it could be augmented to accomplish it.