### PR TITLE
Added `HYPERLINKED_OBJECT` render option to ObjectTextPanel

### DIFF
--- a/changes/8575.added
+++ b/changes/8575.added
@@ -1,0 +1,1 @@
+Added `HYPERLINKED_OBJECT` option to `ObjectTextPanel.RenderOptions` to automatically render the value as a hyperlink to the related object.

--- a/nautobot/core/templates/components/panel/body_content_text.html
+++ b/nautobot/core/templates/components/panel/body_content_text.html
@@ -7,6 +7,8 @@
     {{ value | render_markdown }}
 {% elif render_as == 'code' %}
     <pre>{{ value }}</pre>
+{% elif render_as == 'hyperlinked_object' %}
+    {{ value | hyperlinked_object }}
 {% else %}
     {{ value }}
 {% endif %}

--- a/nautobot/core/tests/test_ui.py
+++ b/nautobot/core/tests/test_ui.py
@@ -28,6 +28,7 @@ from nautobot.core.ui.object_detail import (
     ObjectDetailContent,
     ObjectFieldsPanel,
     ObjectsTablePanel,
+    ObjectTextPanel,
     Panel,
     SectionChoices,
 )
@@ -190,6 +191,20 @@ class BaseTextPanelTest(TestCase):
         panel = BaseTextPanel(weight=100)
         with self.assertRaises(NotImplementedError):
             panel.get_value({})
+
+
+class ObjectTextPanelTest(TestCase):
+    def test_render_body_content_hyperlinked_object(self):
+        device = Device.objects.first()
+        location = device.location
+        panel = ObjectTextPanel(
+            weight=100, render_as=ObjectTextPanel.RenderOptions.HYPERLINKED_OBJECT, object_field="location"
+        )
+        context = Context({"object": device})
+        result = panel.render_body_content(context)
+        self.assertHTMLEqual(
+            result, f'<a href="{location.get_absolute_url()}" title="{location.description}">{location.display}</a>'
+        )
 
 
 class ObjectsTablePanelTest(TestCase):

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -1677,6 +1677,7 @@ class BaseTextPanel(Panel):
             YAML (str): Dict will be displayed as pretty-formatted yaml (value: "yaml")
             MARKDOWN (str): Markdown format (value: "markdown").
             CODE (str): Code format. Just wraps content within <pre> tags (value: "code").
+            HYPERLINKED_OBJECT (str): Attempts to render the value as a hyperlink to the related object.
         """
 
         PLAINTEXT = "plaintext"
@@ -1684,6 +1685,7 @@ class BaseTextPanel(Panel):
         YAML = "yaml"
         MARKDOWN = "markdown"
         CODE = "code"
+        HYPERLINKED_OBJECT = "hyperlinked_object"
 
     def __init__(
         self,

--- a/nautobot/docs/development/core/ui-component-framework.md
+++ b/nautobot/docs/development/core/ui-component-framework.md
@@ -480,6 +480,8 @@ ObjectTextPanel(
 )
 ```
 
+If the field is a single related object, you can use `render_as=ObjectTextPanel.RenderOptions.HYPERLINKED_OBJECT` to automatically render the value as a hyperlink to the related object.
+
 ### TextPanel
 
 `TextPanel` renders content from a specified context field. It provides a simple way to display text content in various formats (Markdown, JSON, YAML, plaintext, or code) from the rendering context.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8575
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
This PR adds the option `HYPERLINKED_OBJECT` to `ObjectTextPanel.RenderOptions` to allow for rendering related objects as hyperlinks.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
|Before|After|
|-|-|
|<img width="216" height="99" alt="Screenshot 2026-02-16 at 11 39 27 AM" src="https://github.com/user-attachments/assets/593daf99-b304-4541-8914-b89f6016289f" />|<img width="220" height="103" alt="Screenshot 2026-02-16 at 11 36 33 AM" src="https://github.com/user-attachments/assets/8ff80443-94e3-4266-aca8-5828adf3f188" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
