### PR TITLE
Add explicit chunk_size when iterating a queryset that might prefetch_related

### DIFF
--- a/changes/8570.fixed
+++ b/changes/8570.fixed
@@ -1,0 +1,1 @@
+Fixed an exception under Django 5.2 when bulk-editing or bulk-deleting certain types of records.

--- a/nautobot/core/jobs/bulk_actions.py
+++ b/nautobot/core/jobs/bulk_actions.py
@@ -63,7 +63,7 @@ class BulkEditObjects(Job):
             ]
 
             self.logger.debug(f"Performing update on {queryset.count()} {model._meta.verbose_name_plural}")
-            for obj in queryset.iterator():
+            for obj in queryset.iterator(chunk_size=1000):
                 # Update standard fields. If a field is listed in _nullify, delete its value.
                 for field_name in standard_fields:
                     try:

--- a/nautobot/core/tests/test_jobs.py
+++ b/nautobot/core/tests/test_jobs.py
@@ -843,6 +843,25 @@ class BulkEditTestCase(TransactionTestCase):
         )
         self._common_no_error_test_assertion(Role, job_result, Role.objects.all().count(), color="aa1409")
 
+    def test_bulk_edit_objects_select_all_prefetch_related(self):
+        """
+        Bulk edit all DeviceType instances (https://github.com/nautobot/nautobot/issues/8570).
+        """
+        self.add_permissions("dcim.change_devicetype", "dcim.view_devicetype")
+        mfr = Manufacturer.objects.create(name="Cisco")
+        for x in range(3):
+            DeviceType.objects.create(manufacturer=mfr, model=f"Cisco CSR{x}000v")
+        job_result = create_job_result_and_run_job(
+            "nautobot.core.jobs.bulk_actions",
+            "BulkEditObjects",
+            content_type=ContentType.objects.get_for_model(DeviceType).id,
+            edit_all=True,
+            filter_query_params={},
+            form_data={"u_height": 0},
+            username=self.user.username,
+        )
+        self._common_no_error_test_assertion(DeviceType, job_result, DeviceType.objects.all().count(), u_height=0)
+
     def test_bulk_edit_objects_nullify(self):
         """
         Bulk edit Role instances to nullify their weight.
@@ -1248,6 +1267,26 @@ class BulkDeleteTestCase(TransactionTestCase):
             saved_view_id=None,
         )
         self._common_no_error_test_assertion(Circuit, job_result)
+
+    def test_bulk_delete_objects_select_all_prefetch_related(self):
+        """
+        Delete all DeviceType objects (https://github.com/nautobot/nautobot/issues/8570).
+        """
+        self.add_permissions("dcim.delete_devicetype", "dcim.view_devicetype")
+        mfr = Manufacturer.objects.create(name="Cisco")
+        for x in range(3):
+            DeviceType.objects.create(manufacturer=mfr, model=f"Cisco CSR{x}000v")
+        job_result = create_job_result_and_run_job(
+            "nautobot.core.jobs.bulk_actions",
+            "BulkDeleteObjects",
+            username=self.user.username,
+            content_type=ContentType.objects.get_for_model(DeviceType).id,
+            delete_all=True,
+            filter_query_params={"per_page": [10]},
+            pk_list=[],
+            saved_view_id=None,
+        )
+        self._common_no_error_test_assertion(DeviceType, job_result)
 
     def test_bulk_delete_objects_select_some(self):
         """

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -886,7 +886,7 @@ def bulk_delete_with_bulk_change_logging(qs, batch_size=1000):
         try:
             queued_object_changes = []
             change_context.defer_object_changes = True
-            for obj in qs.iterator():
+            for obj in qs.iterator(chunk_size=1000):
                 if not hasattr(obj, "to_objectchange"):
                     break
                 if len(queued_object_changes) >= batch_size:


### PR DESCRIPTION
# Closes #8570
# What's Changed

Problem:

- In Django 5.x, `queryset.prefetch_related().iterator()` calls require specifying an explicit `chunk_size` to the `iterator()` call, which was not the case in Django 4.2 and earlier. 
- As reported in #8570, some (but not all) model/view querysets used in the bulk-edit and bulk-delete jobs have a `prefetch_related()`, but those jobs were using `iterator()` with no explicit `chunk_size` - valid in Django 4.2 but raising an exception in Django 5.2.
- Our existing tests didn't catch this because the specific models they were testing these jobs against happened to be ones that don't have a `prefetch_related` on their view querysets.

Solution:

- Add tests for bulk edit and bulk delete of DeviceType records specifically (because `DeviceTypeUIViewSet.queryset` has an explicit `.select_related().prefetch_related()` on it) and verify that they reproduce the reported issue.
- Add explicit `chunk_size` to the respective `iterator()` calls for bulk-edit and bulk-delete.

Note that while there are other cases in core where we are using `iterator()`, at a quick glance I didn't find any others that appeared to be using a queryset with `prefetch_related()` applied to it, so in these cases the implied default `chunk_size` of 2000 remains valid.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
