### PR TITLE
Avoid ignoring relevant ImportErrors in import_string_optional

### DIFF
--- a/changes/8661.fixed
+++ b/changes/8661.fixed
@@ -1,0 +1,1 @@
+Enhanced `import_string_optional` to avoid ignoring certain exceptions unrelated to the specific import.

--- a/changes/xxxx.fixed
+++ b/changes/xxxx.fixed
@@ -1,1 +1,0 @@
-Enhanced `import_string_optional` to avoid ignoring `AttributeError` exceptions unrelated to the specific import.


### PR DESCRIPTION
# What's Changed

Address an issue reported by @itdependsnetworks in which certain categories of "legitimate" ImportError exceptions were being ignored by `import_string_optional`.  This patch is a workaround for https://code.djangoproject.com/ticket/36956 but will remain valid even once that issue is fixed (likely not before Django 6.x)