### PR TITLE
Fixes 6111 for contact association.

### DIFF
--- a/changes/6111.fixed
+++ b/changes/6111.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where Contact and Team objects could not be looked up by name alone when creating a ContactAssociation via the REST API.

--- a/nautobot/extras/models/contacts.py
+++ b/nautobot/extras/models/contacts.py
@@ -22,6 +22,8 @@ class ContactTeamSharedBase(PrimaryModel):
     is_contact_associable_model = False
     is_data_compliance_model = False
 
+    natural_key_field_names = ["name"]
+
     class Meta:
         abstract = True
         ordering = ("name",)

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1377,6 +1377,86 @@ class ContactAssociationTestCase(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
         self.assertEqual(response.data["team"]["id"], team.pk)
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_create_contact_association_by_duplicate_contact_name_only(self):
+        """Test that creating a ContactAssociation with only a duplicated Contact name fails gracefully (issue #6111)."""
+        self.add_permissions("extras.add_contactassociation")
+        Contact.objects.create(name="Duplicate Contact", phone="555-0001", email="dup1@example.com")
+        Contact.objects.create(name="Duplicate Contact", phone="555-0002", email="dup2@example.com")
+        roles = Role.objects.get_for_model(ContactAssociation)
+        statuses = Status.objects.get_for_model(ContactAssociation)
+        device = Device.objects.first()
+        data = {
+            "contact": "Duplicate Contact",
+            "associated_object_type": "dcim.device",
+            "associated_object_id": str(device.pk),
+            "role": roles[0].pk,
+            "status": statuses[0].pk,
+        }
+        response = self.client.post(reverse("extras-api:contactassociation-list"), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("contact", response.data)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_create_contact_association_by_duplicate_contact_with_attrs(self):
+        """Test that a ContactAssociation can be created with a duplicated Contact name when disambiguating attributes are provided (issue #6111)."""
+        self.add_permissions("extras.add_contactassociation")
+        contact = Contact.objects.create(name="Duplicate Contact", phone="555-0001", email="dup1@example.com")
+        Contact.objects.create(name="Duplicate Contact", phone="555-0002", email="dup2@example.com")
+        roles = Role.objects.get_for_model(ContactAssociation)
+        statuses = Status.objects.get_for_model(ContactAssociation)
+        device = Device.objects.first()
+        data = {
+            "contact": {"name": "Duplicate Contact", "phone": "555-0001", "email": "dup1@example.com"},
+            "associated_object_type": "dcim.device",
+            "associated_object_id": str(device.pk),
+            "role": roles[0].pk,
+            "status": statuses[0].pk,
+        }
+        response = self.client.post(reverse("extras-api:contactassociation-list"), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["contact"]["id"], contact.pk)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_create_contact_association_by_duplicate_team_name_only(self):
+        """Test that creating a ContactAssociation with only a duplicated Team name fails gracefully (issue #6111)."""
+        self.add_permissions("extras.add_contactassociation")
+        Team.objects.create(name="Duplicate Team", phone="555-0001", email="dup1@example.com")
+        Team.objects.create(name="Duplicate Team", phone="555-0002", email="dup2@example.com")
+        roles = Role.objects.get_for_model(ContactAssociation)
+        statuses = Status.objects.get_for_model(ContactAssociation)
+        device = Device.objects.first()
+        data = {
+            "team": "Duplicate Team",
+            "associated_object_type": "dcim.device",
+            "associated_object_id": str(device.pk),
+            "role": roles[0].pk,
+            "status": statuses[0].pk,
+        }
+        response = self.client.post(reverse("extras-api:contactassociation-list"), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("team", response.data)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_create_contact_association_by_duplicate_team_with_attrs(self):
+        """Test that a ContactAssociation can be created with a duplicated Team name when disambiguating attributes are provided (issue #6111)."""
+        self.add_permissions("extras.add_contactassociation")
+        team = Team.objects.create(name="Duplicate Team", phone="555-0001", email="dup1@example.com")
+        Team.objects.create(name="Duplicate Team", phone="555-0002", email="dup2@example.com")
+        roles = Role.objects.get_for_model(ContactAssociation)
+        statuses = Status.objects.get_for_model(ContactAssociation)
+        device = Device.objects.first()
+        data = {
+            "team": {"name": "Duplicate Team", "phone": "555-0001", "email": "dup1@example.com"},
+            "associated_object_type": "dcim.device",
+            "associated_object_id": str(device.pk),
+            "role": roles[0].pk,
+            "status": statuses[0].pk,
+        }
+        response = self.client.post(reverse("extras-api:contactassociation-list"), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["team"]["id"], team.pk)
+
 
 class CreatedUpdatedFilterTest(APITestCase):
     @classmethod

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -1339,6 +1339,44 @@ class ContactAssociationTestCase(APIViewTestCases.APIViewTestCase):
             "status": statuses[1].pk,
         }
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_create_contact_association_by_contact_name(self):
+        """Test that a ContactAssociation can be created by referencing a Contact by name (issue #6111)."""
+        self.add_permissions("extras.add_contactassociation")
+        contact = Contact.objects.create(name="Issue 6111 Test Contact", phone="555-6111", email="test6111@example.com")
+        roles = Role.objects.get_for_model(ContactAssociation)
+        statuses = Status.objects.get_for_model(ContactAssociation)
+        device = Device.objects.first()
+        data = {
+            "contact": contact.name,
+            "associated_object_type": "dcim.device",
+            "associated_object_id": str(device.pk),
+            "role": roles[0].pk,
+            "status": statuses[0].pk,
+        }
+        response = self.client.post(reverse("extras-api:contactassociation-list"), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["contact"]["id"], contact.pk)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_create_contact_association_by_team_name(self):
+        """Test that a ContactAssociation can be created by referencing a Team by name (issue #6111)."""
+        self.add_permissions("extras.add_contactassociation")
+        team = Team.objects.create(name="Issue 6111 Test Team", phone="555-6111", email="team6111@example.com")
+        roles = Role.objects.get_for_model(ContactAssociation)
+        statuses = Status.objects.get_for_model(ContactAssociation)
+        device = Device.objects.first()
+        data = {
+            "team": team.name,
+            "associated_object_type": "dcim.device",
+            "associated_object_id": str(device.pk),
+            "role": roles[0].pk,
+            "status": statuses[0].pk,
+        }
+        response = self.client.post(reverse("extras-api:contactassociation-list"), data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["team"]["id"], team.pk)
+
 
 class CreatedUpdatedFilterTest(APITestCase):
     @classmethod


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6111
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
- Adds `natural_key_field_names` to the ContactTeamSharedBase() class to have a connection.

# Screenshots

- Created a test script to also verify from what Joe had demonstrated.

```python
"""
Verification script for GitHub issue #6111:
  "Related object Contact/Team not able to be looked up by name alone"

Reproduces the exact scenario from Joe's report:
  - Create a contact and a team
  - Get a device
  - Create a ContactAssociation by passing the contact/team name as a string

Run against the local dev environment:
  python verify_6111.py
"""

import pynautobot

URL = "http://localhost:8080"
TOKEN = "0123456789abcdef0123456789abcdef01234567"

nb = pynautobot.api(url=URL, token=TOKEN)

print("Connecting to Nautobot at", URL)

# --- Setup: get a device to associate with ---
devices = nb.dcim.devices.filter(limit=1)
if not devices:
    print("ERROR: No devices found. Load some fixture data first.")
    raise SystemExit(1)
device = devices[0]
print(f"Using device: {device.name} ({device.id})")

# --- Setup: get role and status for ContactAssociation ---
roles = nb.extras.roles.filter(content_types=["extras.contactassociation"], limit=1)
if not roles:
    print("ERROR: No roles found for ContactAssociation.")
    raise SystemExit(1)
role = roles[0]

statuses = nb.extras.statuses.filter(content_types=["extras.contactassociation"], limit=1)
if not statuses:
    print("ERROR: No statuses found for ContactAssociation.")
    raise SystemExit(1)
status = statuses[0]

print(f"Using role: {role.name}, status: {status.name}")

# --- Cleanup: remove any existing test objects ---
for contact in nb.extras.contacts.filter(name="Issue 6111 Test Contact"):
    contact.delete()
for team in nb.extras.teams.filter(name="Issue 6111 Test Team"):
    team.delete()

# --- Test 1: Create a ContactAssociation by contact name ---
print("\n[Test 1] Creating contact...")
contact = nb.extras.contacts.create(name="Issue 6111 Test Contact", phone="555-6111", email="test6111@example.com")
print(f"  Created contact: {contact.name} ({contact.id})")

print("[Test 1] Creating ContactAssociation by contact name (not UUID)...")
try:
    association = nb.extras.contact_associations.create(
        associated_object_type="dcim.device",
        associated_object_id=str(device.id),
        contact="Issue 6111 Test Contact",
        role=str(role.id),
        status=str(status.id),
    )
    print(f"  SUCCESS: ContactAssociation created ({association.id})")
    association.delete()
except Exception as e:
    print(f"  FAIL: {e}")

# --- Test 2: Create a ContactAssociation by team name ---
print("\n[Test 2] Creating team...")
team = nb.extras.teams.create(name="Issue 6111 Test Team", phone="555-6111", email="team6111@example.com")
print(f"  Created team: {team.name} ({team.id})")

print("[Test 2] Creating ContactAssociation by team name (not UUID)...")
try:
    association = nb.extras.contact_associations.create(
        associated_object_type="dcim.device",
        associated_object_id=str(device.id),
        team="Issue 6111 Test Team",
        role=str(role.id),
        status=str(status.id),
    )
    print(f"  SUCCESS: ContactAssociation created ({association.id})")
    association.delete()
except Exception as e:
    print(f"  FAIL: {e}")

# --- Cleanup ---
contact.delete()
team.delete()
print("\nDone.")

```

## Result of Test Script at start:

```bash
[Test 1] Creating contact...
  Created contact: Issue 6111 Test Contact (090be62a-8196-4a0b-a006-cb091630b76c)
[Test 1] Creating ContactAssociation by contact name (not UUID)...
  FAIL: The request failed with code 400 Bad Request: {'contact': ["Related object not found using the provided attributes: {'name': 'Issue 6111 Test Contact', 'phone': None, 'email': None}"]}

[Test 2] Creating team...
  Created team: Issue 6111 Test Team (03f5f587-0d43-49a2-9cc0-400a5d787172)
[Test 2] Creating ContactAssociation by team name (not UUID)...
  FAIL: The request failed with code 400 Bad Request: {'team': ["Related object not found using the provided attributes: {'name': 'Issue 6111 Test Team', 'phone': None, 'email': None}"]}
```

## After Fix

```bash
Using device: verify-device-6111 (5f798cec-e501-4b03-8239-050cdcded82b)
Using role: Administrative, status: Active

[Test 1] Creating contact...
  Created contact: Issue 6111 Test Contact (862d8604-bfb3-4099-957b-894fc4fc79d6)
[Test 1] Creating ContactAssociation by contact name (not UUID)...
  SUCCESS: ContactAssociation created (c2cc2a5d-6fe0-4bac-a20f-5b3055a6066f)

[Test 2] Creating team...
  Created team: Issue 6111 Test Team (42609428-264b-4124-9f45-47a84cb4125e)
[Test 2] Creating ContactAssociation by team name (not UUID)...
  SUCCESS: ContactAssociation created (20a69e25-8233-4c53-82ea-f850298b78a5)

Done.
```


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
