### PR TITLE
ConfigUIviewSet - NBOTQA-38

### DIFF
--- a/changes/8688.added
+++ b/changes/8688.added
@@ -1,0 +1,1 @@
+Implemented Config UI ViewSet using a custom Django FormView with a low-level mixin-based approach.

--- a/nautobot/core/tests/test_navigations.py
+++ b/nautobot/core/tests/test_navigations.py
@@ -57,7 +57,13 @@ class NavMenuTestCase(TestCase):
                             # Not a model view?
                             self.assertIn(
                                 item_details["name"],
-                                {"Apps Marketplace", "Installed Apps", "Interface Connections", "Device Constraints"},
+                                {
+                                    "Apps Marketplace",
+                                    "Installed Apps",
+                                    "Interface Connections",
+                                    "Device Constraints",
+                                    "Config",
+                                },
                             )
 
                     for button, button_details in item_details["buttons"].items():

--- a/nautobot/core/ui/choices.py
+++ b/nautobot/core/ui/choices.py
@@ -133,6 +133,7 @@ class NavigationIconChoices(ChoiceSet):
     CLOUD = "cloud"
     DESIGN = "hammer"
     APPROVAL_WORKFLOWS = "checkbox-circle"
+    ADMINISTRATION = "transform"
     EXTENSIBILITY = "extensibility"
     GOLDEN_CONFIG = "sliders-vert-2"
     JOBS = "share"
@@ -188,6 +189,7 @@ class NavigationWeightChoices(ChoiceSet):
     # since it the default weight for NavMenuTab if none is specified.
     DESIGN = 1100
     APPROVAL_WORKFLOWS = 1200
+    ADMINISTRATION = 1250
     EXTENSIBILITY = 1300
     # look to keep these last few items at the end of the nav for easy access
     GOLDEN_CONFIG = 2000
@@ -211,6 +213,7 @@ class NavigationWeightChoices(ChoiceSet):
         (CLOUD, "Cloud"),
         (DESIGN, "Design"),
         (APPROVAL_WORKFLOWS, "Approval Workflows"),
+        (ADMINISTRATION, "Administration"),
         (EXTENSIBILITY, "Extensibility"),
         (GOLDEN_CONFIG, "Golden Config"),
         (JOBS, "Jobs"),

--- a/nautobot/users/navigation.py
+++ b/nautobot/users/navigation.py
@@ -1,0 +1,28 @@
+from nautobot.core.apps import (
+    NavMenuGroup,
+    NavMenuItem,
+    NavMenuTab,
+)
+from nautobot.core.ui.choices import NavigationIconChoices, NavigationWeightChoices
+
+menu_items = (
+    NavMenuTab(
+        name="Administration",
+        icon=NavigationIconChoices.ADMINISTRATION,
+        weight=NavigationWeightChoices.ADMINISTRATION,
+        groups=(
+            NavMenuGroup(
+                name="Administration",
+                weight=100,
+                items=(
+                    NavMenuItem(
+                        link="users:config_edit",
+                        name="Config",
+                        weight=100,
+                        permissions=["users.view_user"],
+                    ),
+                ),
+            ),
+        ),
+    ),
+)

--- a/nautobot/users/templates/users/config_edit.html
+++ b/nautobot/users/templates/users/config_edit.html
@@ -44,21 +44,54 @@
 
                 <div class="row">
                     {% for title, fields in fieldsets.items %}
-                    <div class="card">
-                        <div class="card-header"><strong>{{ title }}</strong></div>
-                        <div class="card-body">
-                            {% for item in config_values %}
-                                {% if item.name in fields %}
+                        <div class="card">
+                            <div class="card-header"><strong>{{ title }}</strong></div>
+                            <div class="card-body">
+                                {% for item in config_values %}
+                                    {% if item.name in fields %}
                                 {# Handle App Configuration #}
-                                    {% if "__" in item.name %}
-                                        {% with app_name=item.name|split:"__"|first name=item.name|split:"__"|last %}
-                                            {% get_attr settings "PLUGINS_CONFIG" as app_settings %}
-                                            {% if app_settings|get_item:app_name|get_item:name is not None %}
+                                        {% if "__" in item.name %}
+                                            {% with app_name=item.name|split:"__"|first name=item.name|split:"__"|last %}
+                                                {% get_attr settings "PLUGINS_CONFIG" as app_settings %}
+                                                {% if app_settings|get_item:app_name|get_item:name is not None %}
+                                                    <div class="alert alert-warning" role="alert">
+                                                        <code>{{ name }} = {{ app_settings|get_item:app_name|get_item:name | quote_string }}</code>
+                                                        is set via an environment variable or otherwise explicitly
+                                                        set in <code>{{ settings.SETTINGS_PATH }}</code>
+                                                        under PLUGINS_CONFIG[{{app_name}}],
+                                                        therefore it is not currently editable here.
+                                                        <br>Remove that environment variable and/or the declaration in
+                                                        <code>{{ settings.SETTINGS_PATH }}</code>
+                                                        if you want to manage it via this interface instead.
+                                                    </div>
+                                                    {{ item.form_field.as_hidden }}
+                                                {% else %}
+                                                    <div class="mb-10 d-md-flex align-content-start justify-content-between{% if form_errors %} has-error{% endif %}">
+                                                        <label class="col-12 col-md-3 col-form-label" for="{{ item.form_field.id_for_label }}">
+                                                            {{ name | split:"_" | join:" " }}
+                                                            <span class="form-text ps-2">
+                                                                (default: <code>{{ item.default }}</code>)
+                                                            </span>
+                                                        </label>
+                                                        <div class="col-12 col-md-9">
+
+                                                        <!-- {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %} -->
+                                                            {{ item.form_field }}
+                                                            <div class="text-danger">
+                                                                {{ item.form_field.errors }}
+                                                            </div>
+                                                            <span class="form-text">{{ item.help_text | linebreaksbr }}</span>
+                                                        </div>
+                                                    </div>
+                                                {% endif %}
+                                            {% endwith %}
+                                        {% else %}
+                                            {% get_attr settings item.name as settings_value %}
+                                            {% if settings_value is not None %}
                                                 <div class="alert alert-warning" role="alert">
-                                                    <code>{{ name }} = {{ app_settings|get_item:app_name|get_item:name | quote_string }}</code>
+                                                    <code>{{ item.name }} = {{ settings_value | quote_string }}</code>
                                                     is set via an environment variable or otherwise explicitly
-                                                    set in <code>{{ settings.SETTINGS_PATH }}</code>
-                                                    under PLUGINS_CONFIG[{{app_name}}],
+                                                    set in <code>{{ settings.SETTINGS_PATH }}</code>,
                                                     therefore it is not currently editable here.
                                                     <br>Remove that environment variable and/or the declaration in
                                                     <code>{{ settings.SETTINGS_PATH }}</code>
@@ -67,15 +100,15 @@
                                                 {{ item.form_field.as_hidden }}
                                             {% else %}
                                                 <div class="mb-10 d-md-flex align-content-start justify-content-between{% if form_errors %} has-error{% endif %}">
-                                                    <label class="col-12 col-md-3 col-form-label" for="{{ item.form_field.id_for_label }}">
-                                                        {{ name | split:"_" | join:" " }}
+                                                    <label class="col-12 col-md-3 d-flex d-md-block col-form-label" for="{{ item.form_field.id_for_label }}">
+                                                        {{ item.name | split:"_" | join:" " }}
                                                         <span class="form-text ps-2">
                                                             (default: <code>{{ item.default }}</code>)
                                                         </span>
                                                     </label>
                                                     <div class="col-12 col-md-9">
-                                                        
-                                                        <!-- {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %} -->
+
+                                                    <!-- {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %} -->
                                                         {{ item.form_field }}
                                                         <div class="text-danger">
                                                             {{ item.form_field.errors }}
@@ -84,41 +117,8 @@
                                                     </div>
                                                 </div>
                                             {% endif %}
-                                        {% endwith %}
-                                    {% else %}
-                                        {% get_attr settings item.name as settings_value %}
-                                        {% if settings_value is not None %}
-                                            <div class="alert alert-warning" role="alert">
-                                                <code>{{ item.name }} = {{ settings_value | quote_string }}</code>
-                                                is set via an environment variable or otherwise explicitly
-                                                set in <code>{{ settings.SETTINGS_PATH }}</code>,
-                                                therefore it is not currently editable here.
-                                                <br>Remove that environment variable and/or the declaration in
-                                                <code>{{ settings.SETTINGS_PATH }}</code>
-                                                if you want to manage it via this interface instead.
-                                            </div>
-                                            {{ item.form_field.as_hidden }}
-                                        {% else %}
-                                            <div class="mb-10 d-md-flex align-content-start justify-content-between{% if form_errors %} has-error{% endif %}">
-                                                <label class="col-12 col-md-3 d-flex d-md-block col-form-label" for="{{ item.form_field.id_for_label }}">
-                                                    {{ item.name | split:"_" | join:" " }}
-                                                    <span class="form-text ps-2">
-                                                        (default: <code>{{ item.default }}</code>)
-                                                    </span>
-                                                </label>
-                                                <div class="col-12 col-md-9">
-                                                    
-                                                    <!-- {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %} -->
-                                                    {{ item.form_field }}
-                                                    <div class="text-danger">
-                                                        {{ item.form_field.errors }}
-                                                    </div>
-                                                    <span class="form-text">{{ item.help_text | linebreaksbr }}</span>
-                                                </div>
-                                            </div>
                                         {% endif %}
                                     {% endif %}
-                                {% endif %}
                                 {% endfor %}
                             </div>
                         </div>
@@ -126,7 +126,7 @@
                 </div>
             </div>
         </div>
-       
+
         <div class="row justify-content-center">
             <div class="col-lg-8 text-end">
                 <input type="submit" name="_save" class="btn btn-primary" value="Save"/>

--- a/nautobot/users/templates/users/config_edit.html
+++ b/nautobot/users/templates/users/config_edit.html
@@ -21,11 +21,11 @@
         {% csrf_token %}
         <div class="row justify-content-center">
             <div class="col-lg-8">
-                {% if form.non_field_errors %}
+                {% if form_errors %}
                     <div class="card border-danger">
                         <div class="card-header bg-danger-subtle border-danger text-body"><strong>Errors</strong></div>
                         <div class="card-body">
-                            {{ form.non_field_errors }}
+                            {{ form_errors }}
                         </div>
                     </div>
                 {% endif %}
@@ -66,7 +66,7 @@
                                                 </div>
                                                 {{ item.form_field.as_hidden }}
                                             {% else %}
-                                                <div class="mb-10 d-md-flex align-content-start justify-content-between{% if item.form_field.errors %} has-error{% endif %}">
+                                                <div class="mb-10 d-md-flex align-content-start justify-content-between{% if form_errors %} has-error{% endif %}">
                                                     <label class="col-12 col-md-3 col-form-label" for="{{ item.form_field.id_for_label }}">
                                                         {{ name | split:"_" | join:" " }}
                                                         <span class="form-text ps-2">
@@ -74,9 +74,12 @@
                                                         </span>
                                                     </label>
                                                     <div class="col-12 col-md-9">
-                                                        {{ item.form_field.errors }}
-                                                        {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
+                                                        
+                                                        <!-- {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %} -->
                                                         {{ item.form_field }}
+                                                        <div class="text-danger">
+                                                            {{ item.form_field.errors }}
+                                                        </div>
                                                         <span class="form-text">{{ item.help_text | linebreaksbr }}</span>
                                                     </div>
                                                 </div>
@@ -96,7 +99,7 @@
                                             </div>
                                             {{ item.form_field.as_hidden }}
                                         {% else %}
-                                            <div class="mb-10 d-md-flex align-content-start justify-content-between{% if item.form_field.errors %} has-error{% endif %}">
+                                            <div class="mb-10 d-md-flex align-content-start justify-content-between{% if form_errors %} has-error{% endif %}">
                                                 <label class="col-12 col-md-3 d-flex d-md-block col-form-label" for="{{ item.form_field.id_for_label }}">
                                                     {{ item.name | split:"_" | join:" " }}
                                                     <span class="form-text ps-2">
@@ -104,9 +107,12 @@
                                                     </span>
                                                 </label>
                                                 <div class="col-12 col-md-9">
-                                                    {{ item.form_field.errors }}
-                                                    {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
+                                                    
+                                                    <!-- {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %} -->
                                                     {{ item.form_field }}
+                                                    <div class="text-danger">
+                                                        {{ item.form_field.errors }}
+                                                    </div>
                                                     <span class="form-text">{{ item.help_text | linebreaksbr }}</span>
                                                 </div>
                                             </div>

--- a/nautobot/users/templates/users/config_edit.html
+++ b/nautobot/users/templates/users/config_edit.html
@@ -76,7 +76,7 @@
                                                         </label>
                                                         <div class="col-12 col-md-9">
 
-                                                        {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
+                                                            {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
                                                             {{ item.form_field }}
                                                             <div class="text-danger">
                                                                 {{ item.form_field.errors }}
@@ -109,7 +109,7 @@
                                                     </label>
                                                     <div class="col-12 col-md-9">
 
-                                                    {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
+                                                        {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
                                                         {{ item.form_field }}
                                                         <div class="text-danger">
                                                             {{ item.form_field.errors }}

--- a/nautobot/users/templates/users/config_edit.html
+++ b/nautobot/users/templates/users/config_edit.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/constance/change_list.html" %}
 {% load admin_list static i18n %}
 {% load helpers %}
 {% if messages %}
@@ -12,7 +12,7 @@
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item">Administration</li>
-        <li class="breadcrumb-item active" aria-current="page">Configuration</li>
+        <li class="breadcrumb-item active" aria-current="page">Config</li>
     </ol>
 {% endblock %}
 

--- a/nautobot/users/templates/users/config_edit.html
+++ b/nautobot/users/templates/users/config_edit.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container">
+
+    <h2>Configuration Settings</h2>
+
+    <form method="post" action="{% url 'user:config_edit' %}">
+    {% csrf_token %}
+
+    {% for field in form %}
+        <div class="form-group">
+            {{ field.label_tag }}
+            {{ field }}
+
+            {% if field.help_text %}
+                <small class="form-text text-muted">
+                    {{ field.help_text }}
+                </small>
+            {% endif %}
+
+            {{ field.errors }}
+        </div>
+    {% endfor %}
+
+    <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+
+    </form>
+
+</div>
+{% endblock %}

--- a/nautobot/users/templates/users/config_edit.html
+++ b/nautobot/users/templates/users/config_edit.html
@@ -1,32 +1,130 @@
-{% extends "base.html" %}
-
-{% block content %}
-<div class="container">
-
-    <h2>Configuration Settings</h2>
-
-    <form method="post" action="{% url 'user:config_edit' %}">
-    {% csrf_token %}
-
-    {% for field in form %}
-        <div class="form-group">
-            {{ field.label_tag }}
-            {{ field }}
-
-            {% if field.help_text %}
-                <small class="form-text text-muted">
-                    {{ field.help_text }}
-                </small>
-            {% endif %}
-
-            {{ field.errors }}
+{% extends "admin/base.html" %}
+{% load admin_list static i18n %}
+{% load helpers %}
+{% if messages %}
+    {% for message in messages %}
+        <div class="alert alert-{{ message.tags }} mb-3">
+            {{ message }}
         </div>
     {% endfor %}
+{% endif %}
 
-    <button type="submit" class="btn btn-primary">Save</button>
-    </form>
-
-    </form>
-
-</div>
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'admin:index' %}">{% trans 'Admin Home' %}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Configuration</li>
+    </ol>
 {% endblock %}
+
+{% block content %}
+    <form action="{% url 'user:config_edit' %}" method="post" enctype="multipart/form-data" class="form form-horizontal">
+        {% csrf_token %}
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                {% if form.non_field_errors %}
+                    <div class="card border-danger">
+                        <div class="card-header bg-danger-subtle border-danger text-body"><strong>Errors</strong></div>
+                        <div class="card-body">
+                            {{ form.non_field_errors }}
+                        </div>
+                    </div>
+                {% endif %}
+                {% if form.errors %}
+                    <ul class="errorlist">
+                {% endif %}
+                {% for field in form.hidden_fields %}
+                    {% for error in field.errors %}
+                        <li>{{ error }}</li>
+                    {% endfor %}
+                    {{ field }}
+                {% endfor %}
+                {% if form.errors %}
+                    </ul>
+                {% endif %}
+
+                <div class="row">
+                    {% for title, fields in fieldsets.items %}
+                    <div class="card">
+                        <div class="card-header"><strong>{{ title }}</strong></div>
+                        <div class="card-body">
+                            {% for item in config_values %}
+                                {% if item.name in fields %}
+                                {# Handle App Configuration #}
+                                    {% if "__" in item.name %}
+                                        {% with app_name=item.name|split:"__"|first name=item.name|split:"__"|last %}
+                                            {% get_attr settings "PLUGINS_CONFIG" as app_settings %}
+                                            {% if app_settings|get_item:app_name|get_item:name is not None %}
+                                                <div class="alert alert-warning" role="alert">
+                                                    <code>{{ name }} = {{ app_settings|get_item:app_name|get_item:name | quote_string }}</code>
+                                                    is set via an environment variable or otherwise explicitly
+                                                    set in <code>{{ settings.SETTINGS_PATH }}</code>
+                                                    under PLUGINS_CONFIG[{{app_name}}],
+                                                    therefore it is not currently editable here.
+                                                    <br>Remove that environment variable and/or the declaration in
+                                                    <code>{{ settings.SETTINGS_PATH }}</code>
+                                                    if you want to manage it via this interface instead.
+                                                </div>
+                                                {{ item.form_field.as_hidden }}
+                                            {% else %}
+                                                <div class="mb-10 d-md-flex align-content-start justify-content-between{% if item.form_field.errors %} has-error{% endif %}">
+                                                    <label class="col-12 col-md-3 col-form-label" for="{{ item.form_field.id_for_label }}">
+                                                        {{ name | split:"_" | join:" " }}
+                                                        <span class="form-text ps-2">
+                                                            (default: <code>{{ item.default }}</code>)
+                                                        </span>
+                                                    </label>
+                                                    <div class="col-12 col-md-9">
+                                                        {{ item.form_field.errors }}
+                                                        {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
+                                                        {{ item.form_field }}
+                                                        <span class="form-text">{{ item.help_text | linebreaksbr }}</span>
+                                                    </div>
+                                                </div>
+                                            {% endif %}
+                                        {% endwith %}
+                                    {% else %}
+                                        {% get_attr settings item.name as settings_value %}
+                                        {% if settings_value is not None %}
+                                            <div class="alert alert-warning" role="alert">
+                                                <code>{{ item.name }} = {{ settings_value | quote_string }}</code>
+                                                is set via an environment variable or otherwise explicitly
+                                                set in <code>{{ settings.SETTINGS_PATH }}</code>,
+                                                therefore it is not currently editable here.
+                                                <br>Remove that environment variable and/or the declaration in
+                                                <code>{{ settings.SETTINGS_PATH }}</code>
+                                                if you want to manage it via this interface instead.
+                                            </div>
+                                            {{ item.form_field.as_hidden }}
+                                        {% else %}
+                                            <div class="mb-10 d-md-flex align-content-start justify-content-between{% if item.form_field.errors %} has-error{% endif %}">
+                                                <label class="col-12 col-md-3 d-flex d-md-block col-form-label" for="{{ item.form_field.id_for_label }}">
+                                                    {{ item.name | split:"_" | join:" " }}
+                                                    <span class="form-text ps-2">
+                                                        (default: <code>{{ item.default }}</code>)
+                                                    </span>
+                                                </label>
+                                                <div class="col-12 col-md-9">
+                                                    {{ item.form_field.errors }}
+                                                    {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
+                                                    {{ item.form_field }}
+                                                    <span class="form-text">{{ item.help_text | linebreaksbr }}</span>
+                                                </div>
+                                            </div>
+                                        {% endif %}
+                                    {% endif %}
+                                {% endif %}
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+       
+        <div class="row justify-content-center">
+            <div class="col-lg-8 text-end">
+                <input type="submit" name="_save" class="btn btn-primary" value="Save"/>
+            </div>
+        </div>
+    </form>
+{% endblock content %}

--- a/nautobot/users/templates/users/config_edit.html
+++ b/nautobot/users/templates/users/config_edit.html
@@ -11,10 +11,11 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="{% url 'admin:index' %}">{% trans 'Admin Home' %}</a></li>
+        <li class="breadcrumb-item">Administration</li>
         <li class="breadcrumb-item active" aria-current="page">Configuration</li>
     </ol>
 {% endblock %}
+
 
 {% block content %}
     <form action="{% url 'user:config_edit' %}" method="post" enctype="multipart/form-data" class="form form-horizontal">
@@ -75,7 +76,7 @@
                                                         </label>
                                                         <div class="col-12 col-md-9">
 
-                                                        <!-- {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %} -->
+                                                        {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
                                                             {{ item.form_field }}
                                                             <div class="text-danger">
                                                                 {{ item.form_field.errors }}
@@ -108,7 +109,7 @@
                                                     </label>
                                                     <div class="col-12 col-md-9">
 
-                                                    <!-- {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %} -->
+                                                    {% if item.is_file %}{% trans "Current file" %}: <a href="{% get_media_prefix as MEDIA_URL %}{{ MEDIA_URL }}{{ item.value }}" target="_blank">{{ item.value }}</a>{% endif %}
                                                         {{ item.form_field }}
                                                         <div class="text-danger">
                                                             {{ item.form_field.errors }}

--- a/nautobot/users/tests/test_views.py
+++ b/nautobot/users/tests/test_views.py
@@ -1,6 +1,7 @@
 import json
 from unittest import mock
 
+from constance import config
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -9,6 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 from social_django.utils import load_backend, load_strategy
 
+from nautobot.core.settings import CONSTANCE_CONFIG, CONSTANCE_CONFIG_FIELDSETS
 from nautobot.core.testing import TestCase, utils
 from nautobot.core.testing.context import load_event_broker_override_settings
 from nautobot.core.testing.utils import post_data
@@ -190,3 +192,84 @@ class PreferenceTestCase(TestCase):
         self.assertEqual(timezone.get_current_timezone_name(), new_timezone_name)
         self.assertNotEqual(timezone_name, new_timezone_name)
         self.assertHttpStatus(response, 200)
+
+
+class ConfigUIViewSetTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Create an admin user and a regular user for testing permissions
+        cls.admin_user = User.objects.create_superuser(username="admin", email="admin@example.com")
+        cls.regular_user = User.objects.create_user(username="normal", email="normal@example.com")
+        cls.url = reverse("user:config_edit")
+
+    def setUp(self):
+        # Log in as the admin user for each test by default
+        self.client.force_login(self.admin_user)
+
+    def test_get_config_page(self):
+        # Test that the config edit page loads successfully and contains the expected context data
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "users/config_edit.html")
+        self.assertIn("form", response.context)
+        self.assertIn("config_values", response.context)
+        self.assertIn("fieldsets", response.context)
+
+    def test_get_initial_values_from_constance(self):
+        # Test that the initial form values are populated from the current Constance config
+        response = self.client.get(self.url)
+        form = response.context["form"]
+        for key in CONSTANCE_CONFIG:
+            self.assertIn(key, form.initial)
+            self.assertEqual(form.initial[key], getattr(config, key))
+
+    def test_context_data_populates_config_values(self):
+        # Test that the config_values context variable contains all Constance config items with their current values
+        response = self.client.get(self.url)
+        config_values = response.context["config_values"]
+        # each fieldset item exists
+        for _, names in CONSTANCE_CONFIG_FIELDSETS.items():
+            for name in names:
+                self.assertTrue(any(item["name"] == name for item in config_values))
+
+    def test_post_valid_config_updates_values(self):
+        # test updating a single value, but the form requires all values to be present so we need to include them all in the post data
+        name = "PAGINATE_COUNT"
+        old_value = getattr(config, name)
+        print(f"Old value of {name}: {old_value}")
+        new_value = old_value + 1 if isinstance(old_value, int) else 10
+        # get the form to obtain the version and full initial data
+        response = self.client.get(self.url)
+        data = response.context["form"].initial.copy()
+        for key in CONSTANCE_CONFIG:
+            value = getattr(config, key)
+            data[key] = json.dumps(value) if isinstance(value, dict) else value
+        data["PAGINATE_COUNT"] = new_value
+        # include the version to avoid required field error
+        data["version"] = response.context["form"]["version"].value()
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(getattr(config, name), new_value)
+
+    def test_post_invalid_config_shows_form_errors(self):
+        # test that posting invalid data (e.g. a string for an integer field) results in form errors and does not update the config value
+        response = self.client.post(self.url, {"PAGINATE_COUNT": "not-an-int"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("form", response.context)
+        self.assertTrue(response.context["form"].errors)
+        self.assertIn("PAGINATE_COUNT", response.context["form"].errors)
+        # page still contains fieldset context
+        self.assertIn("config_values", response.context)
+        self.assertIn("fieldsets", response.context)
+
+    def test_admin_only_permissions(self):
+        # Test that only admin users can access the config edit page
+        self.client.logout()
+        self.client.force_login(self.regular_user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+        self.client.logout()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)  # redirect to login

--- a/nautobot/users/tests/test_views.py
+++ b/nautobot/users/tests/test_views.py
@@ -228,7 +228,7 @@ class ConfigUIViewSetTestCase(TestCase):
         response = self.client.get(self.url)
         config_values = response.context["config_values"]
         # each fieldset item exists
-        for _, names in CONSTANCE_CONFIG_FIELDSETS.items():
+        for names in CONSTANCE_CONFIG_FIELDSETS.values():
             for name in names:
                 self.assertTrue(any(item["name"] == name for item in config_values))
 

--- a/nautobot/users/urls.py
+++ b/nautobot/users/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
         name="token_delete",
     ),
     path("advanced-settings/", views.AdvancedProfileSettingsEditView.as_view(), name="advanced_settings_edit"),
+    path("config/edit/", views.ConfigUIViewSet.as_view(), name="config_edit"),
 ]
 
 urlpatterns += router.urls

--- a/nautobot/users/views.py
+++ b/nautobot/users/views.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 import logging
 
+from constance.admin import ConstanceForm
 from django.contrib import messages
 from django.contrib.auth import (
     BACKEND_SESSION_KEY,
@@ -10,18 +11,23 @@ from django.contrib.auth import (
 )
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.utils.encoding import iri_to_uri
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.timezone import get_default_timezone_name
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import View
+from django.views.generic.edit import FormView
 
 from nautobot.core.events import publish_event
 from nautobot.core.forms import ConfirmationForm
+from nautobot.core.forms.forms import BootstrapMixin
 from nautobot.core.ui.titles import Titles
 from nautobot.core.views.generic import GenericView
+from nautobot.core.views.mixins import (
+    AdminRequiredMixin,
+)
 from nautobot.users.utils import serialize_user_without_config_and_views
 
 from ..core.views.mixins import GetReturnURLMixin
@@ -486,3 +492,17 @@ class AdvancedProfileSettingsEditView(GenericView):
                 "is_django_auth_user": is_django_auth_user(request),
             },
         )
+
+
+class ConfigForm(BootstrapMixin, ConstanceForm):
+    """Apply Bootstrap styling to ConstanceForm."""
+
+
+class ConfigUIViewSet(AdminRequiredMixin, FormView):
+    template_name = "users/config_edit.html"
+    form_class = ConfigForm
+    success_url = reverse_lazy("user:config_edit")
+
+    def form_valid(self, form):
+        form.save()
+        return super().form_valid(form)

--- a/nautobot/users/views.py
+++ b/nautobot/users/views.py
@@ -508,6 +508,7 @@ class ConfigUIViewSet(AdminRequiredMixin, SuccessMessageMixin, FormView):
     success_message = "Live settings updated successfully."
 
     def get_initial(self):
+        # Populate the form's initial values from the current Constance config
         initial = {}
         for name in CONSTANCE_CONFIG:
             initial[name] = getattr(config, name)
@@ -518,16 +519,18 @@ class ConfigUIViewSet(AdminRequiredMixin, SuccessMessageMixin, FormView):
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
+        # Build a list of config items with their current values and metadata for display in the template
         fieldsets = CONSTANCE_CONFIG_FIELDSETS
         constance_config = CONSTANCE_CONFIG
         context = super().get_context_data(**kwargs)
+        # Sort fieldsets by key to ensure consistent ordering
         fieldsets = {k: CONSTANCE_CONFIG_FIELDSETS[k] for k in sorted(CONSTANCE_CONFIG_FIELDSETS)}
         form = context["form"]
         config_values = []
-
-        for fieldset, fields in fieldsets.items():
+        for _, fields in fieldsets.items():
             for name in fields:  # order comes from fieldset list
                 item = constance_config[name]
+                print(form[name], "form field for", name)
                 config_values.append(
                     {
                         "name": name,
@@ -535,11 +538,13 @@ class ConfigUIViewSet(AdminRequiredMixin, SuccessMessageMixin, FormView):
                         "help_text": item.help_text,
                         "value": getattr(config, name),
                         "form_field": form[name],
-                        "is_file": False,  # adjust if file fields exist
+                        "is_file": True,  # adjust if file fields exist
                     }
                 )
 
         context["config_values"] = config_values
         context["fieldsets"] = fieldsets
-
+        context["title"] = "Configuration"
+        if form.errors:
+            context["form_errors"] = form.errors
         return context

--- a/nautobot/users/views.py
+++ b/nautobot/users/views.py
@@ -527,10 +527,9 @@ class ConfigUIViewSet(AdminRequiredMixin, SuccessMessageMixin, FormView):
         fieldsets = {k: CONSTANCE_CONFIG_FIELDSETS[k] for k in sorted(CONSTANCE_CONFIG_FIELDSETS)}
         form = context["form"]
         config_values = []
-        for _, fields in fieldsets.items():
+        for fields in fieldsets.values():
             for name in fields:  # order comes from fieldset list
                 item = constance_config[name]
-                print(form[name], "form field for", name)
                 config_values.append(
                     {
                         "name": name,
@@ -538,7 +537,7 @@ class ConfigUIViewSet(AdminRequiredMixin, SuccessMessageMixin, FormView):
                         "help_text": item.help_text,
                         "value": getattr(config, name),
                         "form_field": form[name],
-                        "is_file": True,  # adjust if file fields exist
+                        "is_file": False,  # adjust if file fields exist
                     }
                 )
 

--- a/nautobot/users/views.py
+++ b/nautobot/users/views.py
@@ -537,7 +537,6 @@ class ConfigUIViewSet(AdminRequiredMixin, SuccessMessageMixin, FormView):
                         "help_text": item.help_text,
                         "value": getattr(config, name),
                         "form_field": form[name],
-                        "is_file": False,  # adjust if file fields exist
                     }
                 )
 

--- a/nautobot/users/views.py
+++ b/nautobot/users/views.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 import logging
 
+from constance import config
 from constance.admin import ConstanceForm
 from django.contrib import messages
 from django.contrib.auth import (
@@ -9,6 +10,7 @@ from django.contrib.auth import (
     logout as auth_logout,
     update_session_auth_hash,
 )
+from django.contrib.messages.views import SuccessMessageMixin
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
@@ -23,6 +25,7 @@ from django.views.generic.edit import FormView
 from nautobot.core.events import publish_event
 from nautobot.core.forms import ConfirmationForm
 from nautobot.core.forms.forms import BootstrapMixin
+from nautobot.core.settings import CONSTANCE_CONFIG, CONSTANCE_CONFIG_FIELDSETS
 from nautobot.core.ui.titles import Titles
 from nautobot.core.views.generic import GenericView
 from nautobot.core.views.mixins import (
@@ -498,11 +501,45 @@ class ConfigForm(BootstrapMixin, ConstanceForm):
     """Apply Bootstrap styling to ConstanceForm."""
 
 
-class ConfigUIViewSet(AdminRequiredMixin, FormView):
+class ConfigUIViewSet(AdminRequiredMixin, SuccessMessageMixin, FormView):
     template_name = "users/config_edit.html"
     form_class = ConfigForm
     success_url = reverse_lazy("user:config_edit")
+    success_message = "Live settings updated successfully."
+
+    def get_initial(self):
+        initial = {}
+        for name in CONSTANCE_CONFIG:
+            initial[name] = getattr(config, name)
+        return initial
 
     def form_valid(self, form):
         form.save()
         return super().form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        fieldsets = CONSTANCE_CONFIG_FIELDSETS
+        constance_config = CONSTANCE_CONFIG
+        context = super().get_context_data(**kwargs)
+        fieldsets = {k: CONSTANCE_CONFIG_FIELDSETS[k] for k in sorted(CONSTANCE_CONFIG_FIELDSETS)}
+        form = context["form"]
+        config_values = []
+
+        for fieldset, fields in fieldsets.items():
+            for name in fields:  # order comes from fieldset list
+                item = constance_config[name]
+                config_values.append(
+                    {
+                        "name": name,
+                        "default": item.default,
+                        "help_text": item.help_text,
+                        "value": getattr(config, name),
+                        "form_field": form[name],
+                        "is_file": False,  # adjust if file fields exist
+                    }
+                )
+
+        context["config_values"] = config_values
+        context["fieldsets"] = fieldsets
+
+        return context


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes 
https://networktocode.atlassian.net/browse/NBOTQA-38
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

1. ConfigUIViewSet is a custom FormView, not a standard model-based Nautobot object view.
2. It does not operate on a Django model or queryset, so it does not use the usual ObjectListView/ObjectEditView patterns.
3. The form is built from ConstanceForm, so the fields are generated from CONSTANCE_CONFIG, not from model fields.
4. Initial values are loaded dynamically from the live Constance backend in get_initial().
5. On submit, form_valid() calls form.save(), which writes updated values back to the Constance-backed configuration store.
6. The page context is assembled manually in get_context_data(), including fieldsets, config_values, and title data.
7. config_values is derived from CONSTANCE_CONFIG and CONSTANCE_CONFIG_FIELDSETS, so the template renders settings metadata such as default, help text, current value, and generated form field.
8. Because these settings may also be overridden in settings.py or environment variables, the template includes logic to detect non-editable values and show them as read-only warnings.
9. Access control is handled at the view level with AdminRequiredMixin, since this is an administrative configuration page.


# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
| View                   | Before                                                                                                                                                                                                                                     | After                                                                                                                                                                                                                                      |
| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **Update View**    | <img width="1615" height="850" alt="image" src="https://github.com/user-attachments/assets/22e39406-fa06-4eac-9fef-27487a128ef8" /><br><img width="1142" height="691" alt="image" src="https://github.com/user-attachments/assets/1f358bd0-5d14-4a3a-a7d5-e1f3392f0556" /><br><img width="1130" height="867" alt="image" src="https://github.com/user-attachments/assets/442ea332-7c5d-430e-b7ce-6997580fedd3" /><br><img width="1161" height="778" alt="image" src="https://github.com/user-attachments/assets/95f1de2a-1c8f-4fc7-9270-d80d178585ad" /><br><img width="1147" height="730" alt="image" src="https://github.com/user-attachments/assets/540865d3-1345-4d80-9b29-b152a361196a" /><br><img width="1152" height="371" alt="image" src="https://github.com/user-attachments/assets/4b579382-0689-4217-82e1-88d29fc85347" /><br><img width="1617" height="821" alt="image" src="https://github.com/user-attachments/assets/64c7e396-cb07-42bc-84c6-5431161ee7cb" />| ![image](https://github.com/user-attachments/assets/7fa67fcc-4e12-4dcf-bd2c-cdec26a39bc6)<br><img width="1127" height="701" alt="image" src="https://github.com/user-attachments/assets/5feeddc5-4496-4d8a-9612-bb7992cb7fb4" /><br><img width="1260" height="865" alt="image" src="https://github.com/user-attachments/assets/0f6c8ac7-5446-46f9-bfcd-0ed17a5c7ab7" /><br><img width="1187" height="786" alt="image" src="https://github.com/user-attachments/assets/1a85a0eb-c3b9-4775-9349-69ea8bde4d80" /><br><img width="1215" height="730" alt="image" src="https://github.com/user-attachments/assets/3d1f7b6b-b361-4242-83ec-a752b2743451" /><br><img width="1145" height="367" alt="image" src="https://github.com/user-attachments/assets/00e525cc-0e58-4ed5-8f69-374823c89d13" /><br><img width="1623" height="822" alt="image" src="https://github.com/user-attachments/assets/b09a509c-d247-45e3-95f3-282a99d66f68" />|
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->

- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
