### PR TITLE
Fixed isolation of docker image digests by cache scope when building multiple images

### DIFF
--- a/.github/actions/build-nautobot-image/action.yaml
+++ b/.github/actions/build-nautobot-image/action.yaml
@@ -132,16 +132,17 @@ runs:
     - name: "Export digest"
       shell: "bash"
       run: |
-        mkdir -p ${{ runner.temp }}/digests
-        digest="${{ steps.build.outputs.digest }}"
-        touch "${{ runner.temp }}/digests/${digest#sha256:}"
         cache_scope="${{ inputs.cache-scope }}"
+        DIGEST_SCOPE="${cache_scope//\//-}"
         echo "DIGEST_SCOPE=${cache_scope//\//-}" >> $GITHUB_ENV
+        mkdir -p ${{ runner.temp }}/digests/$DIGEST_SCOPE
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/$DIGEST_SCOPE/${digest#sha256:}"
 
     - name: "Upload digest"
       uses: "actions/upload-artifact@v4"
       with:
         name: "digests-${{ env.DIGEST_SCOPE }}-${{ inputs.python-version }}-${{ inputs.arch }}"
-        path: "${{ runner.temp }}/digests/*"
+        path: "${{ runner.temp }}/digests/${{ env.DIGEST_SCOPE }}/*"
         if-no-files-found: error
         retention-days: 1

--- a/changes/8699.housekeeping
+++ b/changes/8699.housekeeping
@@ -1,0 +1,1 @@
+Fixed isolation of docker image digests by cache scope when building multiple images in a single workflow.


### PR DESCRIPTION
Followup to #8697. In integration CI we are building both `final` and `final-dev` images but the SHA256 image digests for both were being placed in the same `temp/digests/` directory, resulting in both image digests being uploaded incorrectly as the artifact from the second build. This *should* fix that by scoping the image digests to a subdirectory based on the specified cache scope (which is different for each image).