### PR TITLE
Release/2.4.29

### DIFF
--- a/changes/8473.fixed
+++ b/changes/8473.fixed
@@ -1,1 +1,0 @@
-Fixed issue of not using the setting `KUBERNETES_JOB_POD_NAME`.

--- a/changes/8488.added
+++ b/changes/8488.added
@@ -1,1 +1,0 @@
-Added the ability to configure multiple Kubernetes job manifests via file-based configuration.

--- a/changes/8663.security
+++ b/changes/8663.security
@@ -1,1 +1,0 @@
-Updated dependency `Django` to `~4.2.29` to mitigate CVE-2026-25673 and CVE-2026-25674.

--- a/changes/8691.security
+++ b/changes/8691.security
@@ -1,1 +1,0 @@
-Updated dependency `pyjwt` to `2.12.1` to mitigate CVE-2026-32597. As this is not a direct dependency, it will not auto-update when upgrading; please be sure to upgrade your local environment.

--- a/nautobot/docs/release-notes/version-2.4.md
+++ b/nautobot/docs/release-notes/version-2.4.md
@@ -166,6 +166,21 @@ As Python 3.8 has reached end-of-life, Nautobot 2.4 requires a minimum of Python
 
 <!-- towncrier release notes start -->
 
+## v2.4.29 (2026-03-17)
+
+### Security in v2.4.29
+
+- [#8663](https://github.com/nautobot/nautobot/issues/8663) - Updated dependency `Django` to `~4.2.29` to mitigate CVE-2026-25673 and CVE-2026-25674.
+- [#8691](https://github.com/nautobot/nautobot/issues/8691) - Updated dependency `pyjwt` to `2.12.1` to mitigate CVE-2026-32597. As this is not a direct dependency, it will not auto-update when upgrading; please be sure to upgrade your local environment.
+
+### Added in v2.4.29
+
+- [#8488](https://github.com/nautobot/nautobot/issues/8488) - Added the ability to configure multiple Kubernetes job manifests via file-based configuration.
+
+### Fixed in v2.4.29
+
+- [#8473](https://github.com/nautobot/nautobot/issues/8473) - Fixed issue of not using the setting `KUBERNETES_JOB_POD_NAME`.
+
 ## v2.4.28 (2026-03-02)
 
 ### Fixed in v2.4.28

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "2.4.29b1"
+version = "2.4.29"
 description = "Source of truth and network automation platform."
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Security in v2.4.29

- [#8663](https://github.com/nautobot/nautobot/issues/8663) - Updated dependency `Django` to `~4.2.29` to mitigate CVE-2026-25673 and CVE-2026-25674.
- [#8691](https://github.com/nautobot/nautobot/issues/8691) - Updated dependency `pyjwt` to `2.12.1` to mitigate CVE-2026-32597. As this is not a direct dependency, it will not auto-update when upgrading; please be sure to upgrade your local environment.

### Added in v2.4.29

- [#8488](https://github.com/nautobot/nautobot/issues/8488) - Added the ability to configure multiple Kubernetes job manifests via file-based configuration.

### Fixed in v2.4.29

- [#8473](https://github.com/nautobot/nautobot/issues/8473) - Fixed issue of not using the setting `KUBERNETES_JOB_POD_NAME`.