### PR TITLE
fix: use termination.parent in cable_termination.html to support module interfaces

### DIFF
--- a/changes/8465.fixed
+++ b/changes/8465.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where cable terminations for module interfaces incorrectly displayed as "Circuit" instead of showing the device, type, and component fields.

--- a/nautobot/dcim/templates/dcim/inc/cable_termination.html
+++ b/nautobot/dcim/templates/dcim/inc/cable_termination.html
@@ -1,10 +1,10 @@
 {% load helpers %}
 <table class="table table-hover card-body attr-table">
-    {% if termination.device %}
-        {# Device component #}
+    {% if termination.parent %}
+        {# Device component (including module components) #}
         <tr>
             <td>Device</td>
-            <td>{{ termination.device|hyperlinked_object }}</td>
+            <td>{{ termination.parent|hyperlinked_object }}</td>
         </tr>
         <tr>
             <td>Type</td>


### PR DESCRIPTION
## Summary

Fixes #8465

### Problem

When viewing a cable connected to a module's interface, the Termination section displayed it as a "Circuit" instead of showing the Device, Type, and Component fields.

This happened because `cable_termination.html` checked `termination.device`, which is `None` for module components (they use a `module` FK instead). The template then fell through to the `{% else %}` circuit block.

### Fix

Replace `termination.device` with `termination.parent` on lines 3 and 7 of `cable_termination.html`.

The `parent` property on `ModularComponentModel` already handles this correctly:
- Returns `module.device` when the component belongs to a module
- Returns `device` for regular device components

This is consistent with how `cable_trace.html` already uses `termination.parent`.

### Changes

- `nautobot/dcim/templates/dcim/inc/cable_termination.html`: Replace `termination.device` with `termination.parent`