### PR TITLE
Fixing GraphQL nested FK optimization

### DIFF
--- a/changes/8706.fixed
+++ b/changes/8706.fixed
@@ -1,0 +1,1 @@
+Fixed a bug where GraphQL queries that included related objects were not being optimized correctly since upgrading to graphene-django v3.x.

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -21,7 +21,6 @@ from nautobot.core.graphql.generators import (
     generate_list_search_parameters,
     generate_null_choices_resolver,
     generate_relationship_resolver,
-    generate_restricted_queryset,
     generate_schema_type,
 )
 from nautobot.core.graphql.types import ContentTypeType, DateType, JSON
@@ -103,7 +102,6 @@ def extend_schema_type(schema_type):
     """Extend an existing schema type to add fields dynamically.
 
     The following type of dynamic fields/functions are currently supported:
-     - Queryset, ensure a restricted queryset is always returned.
      - Custom Field, all custom field will be defined as a first level attribute.
      - Tags, Tags will automatically be resolvable.
      - Config Context, add a config_context attribute and resolver.
@@ -115,11 +113,6 @@ def extend_schema_type(schema_type):
     """
 
     model = schema_type._meta.model
-
-    #
-    # Queryset
-    #
-    setattr(schema_type, "get_queryset", classmethod(generate_restricted_queryset()))
 
     #
     # Custom Fields

--- a/nautobot/core/graphql/types.py
+++ b/nautobot/core/graphql/types.py
@@ -3,20 +3,24 @@ import datetime
 from django.contrib.contenttypes.models import ContentType
 import graphene
 from graphene_django import DjangoObjectType
-import graphene_django_optimizer as gql_optimizer
 from graphql import GraphQLError
 
 
-class OptimizedNautobotObjectType(gql_optimizer.OptimizedDjangoObjectType):
+class OptimizedNautobotObjectType(DjangoObjectType):
     url = graphene.String()
 
-    # Reset get_queryset to DjangoObjectType's base implementation.
-    # OptimizedDjangoObjectType overrides get_queryset for auto-optimization, but in graphene-django 3.x
-    # any get_queryset override causes FK field resolvers to be wrapped in a custom_resolver that the
-    # optimizer cannot introspect, preventing it from adding select_related for FK fields and causing
-    # N+1 query regressions. Query optimization is handled explicitly via gql_optimizer.query() calls
-    # in the list and single-item resolvers, so this auto-optimization is not needed.
-    get_queryset = classmethod(DjangoObjectType.get_queryset.__func__)
+    # IMPORTANT:
+    # Do NOT override get_queryset here.
+    #
+    # In graphene-django 3.1.15 and later, customizing get_queryset changes how forward FK/1:1 fields are resolved
+    # internally (it wraps FK resolvers in a custom resolver path that defeats gql optimizer hints),
+    # which can re-introduce FK N+1 query regressions.
+    #
+    # Nautobot query optimization is handled explicitly by wrapping the *root* queryset with
+    # `graphene_django_optimizer.query(...)` in our GraphQL resolvers.
+    # See nautobot/core/graphql/generators.py for more details.
+    #
+    # Permission enforcement for ID/node lookups is handled in get_node().
 
     @classmethod
     def get_node(cls, info, id):  # pylint: disable=redefined-builtin

--- a/nautobot/core/graphql/types.py
+++ b/nautobot/core/graphql/types.py
@@ -2,12 +2,37 @@ import datetime
 
 from django.contrib.contenttypes.models import ContentType
 import graphene
+from graphene_django import DjangoObjectType
 import graphene_django_optimizer as gql_optimizer
 from graphql import GraphQLError
 
 
 class OptimizedNautobotObjectType(gql_optimizer.OptimizedDjangoObjectType):
     url = graphene.String()
+
+    # Reset get_queryset to DjangoObjectType's base implementation.
+    # OptimizedDjangoObjectType overrides get_queryset for auto-optimization, but in graphene-django 3.x
+    # any get_queryset override causes FK field resolvers to be wrapped in a custom_resolver that the
+    # optimizer cannot introspect, preventing it from adding select_related for FK fields and causing
+    # N+1 query regressions. Query optimization is handled explicitly via gql_optimizer.query() calls
+    # in the list and single-item resolvers, so this auto-optimization is not needed.
+    get_queryset = classmethod(DjangoObjectType.get_queryset.__func__)
+
+    @classmethod
+    def get_node(cls, info, id):  # pylint: disable=redefined-builtin
+        """Override get_node to enforce object-level permissions.
+
+        We intentionally do NOT override get_queryset (see above), so permission
+        enforcement for Relay-style node lookups and any plugin code that calls
+        get_node() is handled here instead.
+        """
+        queryset = cls._meta.model.objects.all()
+        if hasattr(queryset, "restrict"):
+            queryset = queryset.restrict(info.context.user, "view")
+        try:
+            return queryset.get(pk=id)
+        except cls._meta.model.DoesNotExist:
+            return None
 
     def resolve_url(self, info):
         return self.get_absolute_url(api=True)  # pylint: disable=no-member

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -65,6 +65,7 @@ from nautobot.dcim.models import (
     RearPort,
 )
 from nautobot.extras.choices import CustomFieldTypeChoices
+from nautobot.extras.graphql.types import StatusType
 from nautobot.extras.models import (
     ChangeLoggedModel,
     ConfigContext,
@@ -239,6 +240,48 @@ class GraphQLGenerateSchemaTypeTestCase(GraphQLTestCaseBase):
         self.assertIn(OptimizedNautobotObjectType, schema.__bases__)
         self.assertEqual(schema._meta.model, ChangeLoggedModel)
         self.assertIsNone(schema._meta.filterset_class)
+
+
+class GraphQLGetNodePermissionTest(GraphQLTestCaseBase):
+    """Direct tests for `OptimizedNautobotObjectType.get_node()`.
+
+    These ensure that our object-level permission enforcement for ID/node
+    lookups is covered even when nested FK optimization behavior changes.
+    """
+
+    def test_get_node_enforces_object_permissions(self):
+        user = create_test_user("graphql_get_node_user")
+
+        # Status objects are associated with "content_types"; we include one here so the
+        # Status model is fully valid for GraphQL usage.
+        interface_ct = ContentType.objects.get_for_model(Interface)
+        status_ct = ContentType.objects.get_for_model(Status)
+
+        allowed_status = Status.objects.create(name="AllowedStatusForGetNodeTest")
+        allowed_status.content_types.add(interface_ct)
+
+        denied_status = Status.objects.create(name="DeniedStatusForGetNodeTest")
+        denied_status.content_types.add(interface_ct)
+
+        allowed_status_perm = ObjectPermission.objects.create(
+            name="View Status allowed (get_node test)",
+            actions=["view"],
+            constraints={"name": allowed_status.name},
+        )
+        allowed_status_perm.object_types.add(status_ct)
+        allowed_status_perm.users.add(user)
+
+        info = types.SimpleNamespace(context=types.SimpleNamespace(user=user))
+
+        allowed_node = StatusType.get_node(info, str(allowed_status.pk))
+        self.assertIsNotNone(allowed_node)
+        self.assertEqual(allowed_node.name, allowed_status.name)
+
+        denied_node = StatusType.get_node(info, str(denied_status.pk))
+        self.assertIsNone(denied_node)
+
+        nonexistent_node = StatusType.get_node(info, str(uuid.uuid4()))
+        self.assertIsNone(nonexistent_node)
 
 
 class GraphQLExtendSchemaType(GraphQLTestCaseBase):

--- a/nautobot/dcim/tests/test_graphql.py
+++ b/nautobot/dcim/tests/test_graphql.py
@@ -15,6 +15,7 @@ from nautobot.dcim.models import (
     Platform,
 )
 from nautobot.extras.models import DynamicGroup, Role, Status
+from nautobot.users.models import ObjectPermission
 
 
 class GraphQLTestCase(TestCase):
@@ -174,3 +175,104 @@ class GraphQLTestCase(TestCase):
             names = {i["name"] for i in resp.data["interfaces"]}
             self.assertIn("eth2", names)
             self.assertNotIn("eth3", names)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_query_optimizer_fk_resolution(self):
+        """Test that nested forward FK fields don't cause N+1 queries.
+
+        Regression test for graphene-django 3.x changes around FK resolution.
+        """
+        interface_status = Status.objects.get_for_model(Interface).first()
+
+        # Amplify the N+1 issue by creating many interfaces with the same status object.
+        for i in range(30):
+            interface = Interface(
+                device=self.device,
+                name=f"eth_perf_{i}",
+                status=interface_status,
+                type=InterfaceTypeChoices.TYPE_VIRTUAL,
+                mac_address=f"00:00:00:00:00:{i:02x}",
+            )
+            interface.validated_save()
+
+        query = "query { interfaces { name status { name } } }"
+        execute_query(query, user=self.user)  # prewarm
+
+        with self.assertApproximateNumQueries(minimum=1, maximum=20):
+            result = execute_query(query, user=self.user)
+
+        self.assertIsNone(result.errors)
+
+
+class GraphQLFKPermissionTest(GraphQLTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.interface_content_type = ContentType.objects.get_for_model(Interface)
+        self.status_content_type = ContentType.objects.get_for_model(Status)
+
+        interface_statuses = list(Status.objects.get_for_model(Interface).order_by("name"))
+        self.allowed_status = interface_statuses[0]
+        if len(interface_statuses) > 1:
+            self.denied_status = interface_statuses[1]
+        else:
+            # Ensure we have a distinct status object we can explicitly deny via ObjectPermission constraints.
+            self.denied_status = Status.objects.create(name="DeniedStatusForGraphQLFKTest")
+            self.denied_status.content_types.add(self.interface_content_type)
+
+        self.allowed_interface = Interface(
+            device=self.device,
+            name="eth_allowed",
+            status=self.allowed_status,
+            type=InterfaceTypeChoices.TYPE_VIRTUAL,
+            mac_address="00:00:00:00:aa:aa",
+        )
+        self.allowed_interface.validated_save()
+
+        self.denied_interface = Interface(
+            device=self.device,
+            name="eth_denied",
+            status=self.denied_status,
+            type=InterfaceTypeChoices.TYPE_VIRTUAL,
+            mac_address="00:00:00:00:bb:bb",
+        )
+        self.denied_interface.validated_save()
+
+        # Grant view permission for the two interfaces, but only grant view permission
+        # for the allowed status object. The denied status should come back as null.
+        allowed_iface_perm = ObjectPermission.objects.create(
+            name="View Interface eth_allowed",
+            actions=["view"],
+            constraints={"name": self.allowed_interface.name},
+        )
+        allowed_iface_perm.object_types.add(self.interface_content_type)
+        allowed_iface_perm.users.add(self.user)
+
+        denied_iface_perm = ObjectPermission.objects.create(
+            name="View Interface eth_denied",
+            actions=["view"],
+            constraints={"name": self.denied_interface.name},
+        )
+        denied_iface_perm.object_types.add(self.interface_content_type)
+        denied_iface_perm.users.add(self.user)
+
+        allowed_status_perm = ObjectPermission.objects.create(
+            name="View Status allowed",
+            actions=["view"],
+            constraints={"name": self.allowed_status.name},
+        )
+        allowed_status_perm.object_types.add(self.status_content_type)
+        allowed_status_perm.users.add(self.user)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
+    def test_status_id_lookup_enforces_object_permissions(self):
+        query = "query ($id: ID!) { status(id: $id) { name } }"
+
+        allowed_result = execute_query(query, user=self.user, variables={"id": str(self.allowed_status.pk)})
+        self.assertIsNone(allowed_result.errors)
+        self.assertIsNotNone(allowed_result.data["status"])
+        self.assertEqual(allowed_result.data["status"]["name"], self.allowed_status.name)
+
+        denied_result = execute_query(query, user=self.user, variables={"id": str(self.denied_status.pk)})
+        self.assertIsNone(denied_result.errors)
+        self.assertIsNone(denied_result.data["status"])

--- a/nautobot/dcim/tests/test_graphql.py
+++ b/nautobot/dcim/tests/test_graphql.py
@@ -198,7 +198,7 @@ class GraphQLTestCase(TestCase):
         query = "query { interfaces { name status { name } } }"
         execute_query(query, user=self.user)  # prewarm
 
-        with self.assertApproximateNumQueries(minimum=1, maximum=20):
+        with self.assertApproximateNumQueries(minimum=1, maximum=10):
             result = execute_query(query, user=self.user)
 
         self.assertIsNone(result.errors)
@@ -219,42 +219,6 @@ class GraphQLFKPermissionTest(GraphQLTestCase):
             # Ensure we have a distinct status object we can explicitly deny via ObjectPermission constraints.
             self.denied_status = Status.objects.create(name="DeniedStatusForGraphQLFKTest")
             self.denied_status.content_types.add(self.interface_content_type)
-
-        self.allowed_interface = Interface(
-            device=self.device,
-            name="eth_allowed",
-            status=self.allowed_status,
-            type=InterfaceTypeChoices.TYPE_VIRTUAL,
-            mac_address="00:00:00:00:aa:aa",
-        )
-        self.allowed_interface.validated_save()
-
-        self.denied_interface = Interface(
-            device=self.device,
-            name="eth_denied",
-            status=self.denied_status,
-            type=InterfaceTypeChoices.TYPE_VIRTUAL,
-            mac_address="00:00:00:00:bb:bb",
-        )
-        self.denied_interface.validated_save()
-
-        # Grant view permission for the two interfaces, but only grant view permission
-        # for the allowed status object. The denied status should come back as null.
-        allowed_iface_perm = ObjectPermission.objects.create(
-            name="View Interface eth_allowed",
-            actions=["view"],
-            constraints={"name": self.allowed_interface.name},
-        )
-        allowed_iface_perm.object_types.add(self.interface_content_type)
-        allowed_iface_perm.users.add(self.user)
-
-        denied_iface_perm = ObjectPermission.objects.create(
-            name="View Interface eth_denied",
-            actions=["view"],
-            constraints={"name": self.denied_interface.name},
-        )
-        denied_iface_perm.object_types.add(self.interface_content_type)
-        denied_iface_perm.users.add(self.user)
 
         allowed_status_perm = ObjectPermission.objects.create(
             name="View Status allowed",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8706
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
This PR changes the way we pass querysets to Graphene Django to reimplement query optimizations.

## Root Cause

In [graphene-django v3.1.5+](https://github.com/graphql-python/graphene-django/pull/1411), a change was made to improve security around leaking permissions. This caused a negative effect on any classes that are overriding the `get_queryset` method from the `graphene_django.DjangoObjectType` class. This was seen as a necessary downgrade for graphene-django in order to maintain security and a note about the limitation was [added to the docs](https://github.com/graphql-python/graphene-django/blob/main/docs/authorization.rst#global-filtering) (although I don't see the warning on the docs page for some reason).

We are actually overriding this method in 2 locations:
- By inheriting from [graphene_django_optimizer.OptimizedDjangoObjectType](https://github.com/nautobot/nautobot/blob/97c9c114a50e4ab1d6f7c6bb3fd2c26ce91c9407/nautobot/core/graphql/types.py#L9)
- Dynamically replacing `get_queryset` as part of the [extend_schema_type](https://github.com/nautobot/nautobot/blob/97c9c114a50e4ab1d6f7c6bb3fd2c26ce91c9407/nautobot/core/graphql/schema.py#L122) function to ensure we provide a restricted queryset
  - This, as it turns out, is legacy code from the original implementation and is redundant since we also restrict permissions when we generate the resolvers for top level items ([single item](https://github.com/nautobot/nautobot/blob/97c9c114a50e4ab1d6f7c6bb3fd2c26ce91c9407/nautobot/core/graphql/generators.py#L294) and [list items](https://github.com/nautobot/nautobot/blob/97c9c114a50e4ab1d6f7c6bb3fd2c26ce91c9407/nautobot/core/graphql/generators.py#L345)).

## Remediation

In order to remediate this issue, we need to make sure that `DjangoObjectType.get_queryset.__func__` resolves to the original function so that we don't need to monkey patch it. We can do this by removing the redundant dynamic `get_queryset` when we extend the schema and by skipping over the `graphene_django_optimizer.OptimizedDjangoObjectType` implementation of `get_queryset` and directly call it from `graphene_django.DjangoObjectType`.

## Edge Case

Since we are no longer doing the restriction as part of `get_queryset`, if any downstream App directly calls `get_node` (for example via `DjangoListField`) instead of using the custom resolvers provided and expects permission filtering to already happen, it would no longer apply. As such, I have also overridden `get_node` to apply the restriction as well - just in case.

# Results

The number of queries has dropped back down to the 2.4 amount:

137ms overall
12ms on queries
4 queries

<details>
    <summary>Fixed SQL Details</summary>

|At | Action|  Tables|  Num. Joins|  Execution Time (ms)|
|-|-|-|-|-|
|+0:00:00.130668|SELECT|  "extras_objectchange", "auth_user", "django_content_type" |  2|   2.259000|
|+0:00:00.117118|SELECT|  "dcim_interface", "dcim_device", "extras_status" |   2|   3.222000|
|+0:00:00.108915|SELECT|  "dcim_device" |  0|   3.782000|
|+0:00:00.007060|SELECT|  "auth_user" |0|   2.384000|

</details>


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests

NTC-4985