### PR TITLE
Fixed nested job kwarg serialization for kubernetes bulk edit

### DIFF
--- a/changes/8725.fixed
+++ b/changes/8725.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where nested job kwargs were not being serialized correctly which caused problems when using Kubernetes jobs.

--- a/nautobot/core/tests/test_jobs.py
+++ b/nautobot/core/tests/test_jobs.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 import yaml
 
 from nautobot.circuits.models import Circuit, CircuitType, Provider
+from nautobot.core.celery.encoders import NautobotKombuJSONEncoder
 from nautobot.core.jobs import ExportObjectList
 from nautobot.core.jobs.cleanup import CleanupTypes
 from nautobot.core.testing import create_job_result_and_run_job, TransactionTestCase
@@ -933,6 +934,58 @@ class BulkEditTestCase(TransactionTestCase):
         for namespace in namespaces[3:]:
             self.assertFalse(namespace.tags.filter(pk__in=[self.tags[0].pk]).exists())
             self.assertTrue(namespace.tags.filter(pk__in=[self.tags[-1].pk]).exists())
+
+    def test_bulk_edit_objects_kubernetes_serialization_nested_models(self):
+        """
+        Regression test for Kubernetes job execution.
+
+        Kubernetes stores job kwargs (including BulkEdit `form_data`) in a JSONField, which uses
+        NautobotKombuJSONEncoder to serialize Django model instances into `__nautobot_type__` dicts.
+        `BulkEditObjects.serialize_data()` must recursively pre-flatten any nested models into primitive PK values,
+        otherwise BulkEdit's form validation will fail with `invalid_list`.
+        """
+
+        self.add_permissions("ipam.change_namespace", "ipam.view_namespace", "extras.change_tag", "extras.view_tag")
+
+        namespaces = [Namespace.objects.create(name=f"Sample Namespace {x}") for x in range(2)]
+        for namespace in namespaces:
+            namespace.tags.set(self.tags[2:])
+
+        pk_list = [str(ns.pk) for ns in namespaces]
+        add_tags = self.tags[:2]
+
+        # Mimic the UI job enqueue payload: include actual model instances inside form_data.
+        job_kwargs = {
+            "content_type": self.namespace_ct,
+            "edit_all": False,
+            "filter_query_params": {},
+            "pk_list": pk_list,
+            "form_data": {"pk": namespaces, "add_tags": add_tags},
+        }
+
+        from nautobot.core.jobs.bulk_actions import BulkEditObjects
+
+        serialized_job_kwargs = BulkEditObjects.serialize_data(job_kwargs)
+        # Mimic the Kubernetes JSONField encoding of task_kwargs.
+        encoded_job_kwargs = json.loads(json.dumps(serialized_job_kwargs, cls=NautobotKombuJSONEncoder))
+
+        job_result = create_job_result_and_run_job(
+            "nautobot.core.jobs.bulk_actions",
+            "BulkEditObjects",
+            content_type=encoded_job_kwargs["content_type"],
+            edit_all=encoded_job_kwargs["edit_all"],
+            filter_query_params=encoded_job_kwargs["filter_query_params"],
+            pk_list=encoded_job_kwargs["pk_list"],
+            form_data=encoded_job_kwargs["form_data"],
+            username=self.user.username,
+        )
+
+        self._common_no_error_test_assertion(Namespace, job_result, 2, pk__in=pk_list)
+
+        # Assert namespaces received the added tags.
+        add_tag_pks = [tag.pk for tag in add_tags]
+        for namespace in namespaces:
+            self.assertTrue(namespace.tags.filter(pk__in=add_tag_pks).exists())
 
     def test_bulk_edit_objects_filter_all(self):
         """

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -582,25 +582,40 @@ class BaseJob:
         These are converted back during job execution.
         """
 
-        return_data = {}
-        for field_name, value in data.items():
+        def _serialize_value(value):
+            """Recursively convert job kwargs into JSON-serializable primitives.
+
+            This is particularly important for Kubernetes job execution where `task_kwargs` is stored as JSON and
+            Django's JSON encoder will otherwise convert Django model instances into `__nautobot_type__` dicts.
+            """
+
             # MultiObjectVar
             if isinstance(value, QuerySet):
-                return_data[field_name] = list(value.values_list("pk", flat=True))
-            # ObjectVar
-            elif isinstance(value, Model):
-                return_data[field_name] = value.pk
-            # FileVar (Save each FileVar as a FileProxy)
-            elif isinstance(value, UploadedFile):
-                return_data[field_name] = BaseJob._save_file_to_proxy(value)
-            # IPAddressVar, IPAddressWithMaskVar, IPNetworkVar
-            elif isinstance(value, netaddr.ip.BaseIP):
-                return_data[field_name] = str(value)
-            # Everything else...
-            else:
-                return_data[field_name] = value
+                return list(value.values_list("pk", flat=True))
 
-        return return_data
+            # ObjectVar
+            if isinstance(value, Model):
+                return value.pk
+
+            # FileVar (Save each FileVar as a FileProxy)
+            if isinstance(value, UploadedFile):
+                return BaseJob._save_file_to_proxy(value)
+
+            # IPAddressVar, IPAddressWithMaskVar, IPNetworkVar
+            if isinstance(value, netaddr.ip.BaseIP):
+                return str(value)
+
+            # Recurse into containers/dicts to handle nested Model instances (e.g. BulkEdit `form_data`).
+            if isinstance(value, dict):
+                return {k: _serialize_value(v) for k, v in value.items()}
+
+            if isinstance(value, (list, tuple, set)):
+                return [_serialize_value(v) for v in value]
+
+            # Everything else...
+            return value
+
+        return {field_name: _serialize_value(value) for field_name, value in data.items()}
 
     # TODO: can the deserialize_data logic be moved to NautobotKombuJSONEncoder?
     @classmethod


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8725
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
The root cause of the issue for kubernetes bulk edit is here:
https://github.com/nautobot/nautobot/blob/9cbf4e8fd5f9965e03ee071ebdafc65c40080449/nautobot/extras/jobs.py#L586-L601

We are only performing surface level serialization on the job kwargs. This results in the following celery kwargs being sent to the bulk edit job:

```json
{
    "content_type": 3,
    "edit_all": false,
    "filter_query_params": {
        "saved_view": [
            "e28dd310-a81f-4baf-8a78-676d976d03f9"
        ]
    },
    "form_data": {
        "add_tags": [
            {
                "__nautobot_type__": "nautobot.extras.models.tags.Tag",
                "display": "coolkitt",
                "id": "d34d6878-2ebd-43a3-97eb-4fbc9f72d0a9"
            }
        ],
        ...
        "pk": [
            {
                "__nautobot_type__": "nautobot.dcim.models.devices.Device",
                "display": "ang01-asw-01",
                "id": "7a1375de-3581-4d8b-af16-33a45fb8d8c7"
            }
        ],
        ...
}
```

This PR simply adds a bit of recursion to the process so we continue to serialize inside of nested lists and dicts:

```json
{
    "content_type": 3,
    "edit_all": false,
    "filter_query_params": {
        "saved_view": [
            "e28dd310-a81f-4baf-8a78-676d976d03f9"
        ]
    },
    "form_data": {
        "add_tags": [
            "d34d6878-2ebd-43a3-97eb-4fbc9f72d0a9"
        ],
        ...
        "pk": [
            "7a1375de-3581-4d8b-af16-33a45fb8d8c7"
        ...
}
```

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Successful test in my k3s dev after the fix was applied:

<img width="1064" height="403" alt="Screenshot 2026-03-20 at 10 40 57 AM" src="https://github.com/user-attachments/assets/d3fe25f3-f26d-4702-bcbc-259ed953256b" />


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests