### PR TITLE
Fix #8723 - add a note on Job form if there are no user inputs

### DIFF
--- a/changes/8723.added
+++ b/changes/8723.added
@@ -1,0 +1,1 @@
+Added a note to Job forms when the job has no user inputs to avoid rendering an empty card.

--- a/nautobot/extras/templates/extras/job.html
+++ b/nautobot/extras/templates/extras/job.html
@@ -35,7 +35,7 @@
                     {% endif %}
                     {% if job_model.read_only %}
                         <div class="alert alert-info">
-                            <span aria-hidden="true" class="mdi mdi-info"></span>This job is read-only in its operation.
+                            <span aria-hidden="true" class="mdi mdi-info"></span> This job is read-only in its operation.
                         </div>
                     {% endif %}
                     {% if job_form.non_field_errors or schedule_form.non_field_errors %}
@@ -57,6 +57,9 @@
                             <div class="card-body">
                                 {% block job_form %}
                                     {% render_form job_form excluded_fields="[]" %}
+                                    {% if not job_form.visible_fields %}
+                                        <small class="text-secondary">This job does not take any user inputs.</small>
+                                    {% endif %}
                                 {% endblock %}
                             </div>
                         </div>

--- a/nautobot/extras/templates/extras/job.html
+++ b/nautobot/extras/templates/extras/job.html
@@ -58,7 +58,10 @@
                                 {% block job_form %}
                                     {% render_form job_form excluded_fields="[]" %}
                                     {% if not job_form.visible_fields %}
-                                        <small class="text-secondary">This job does not take any user inputs.</small>
+                                        <span class="form-text w-100">
+                                            <span class="mdi mdi-information-outline"></span>
+                                            This job does not take any user inputs.
+                                        </span>
                                     {% endif %}
                                 {% endblock %}
                             </div>


### PR DESCRIPTION

# Closes #8723 
# What's Changed

If a Job form has no visible fields, render a note instead of just an empty card. I went with this approach because in theory the form (like any Django form) may still have hidden inputs, and we'd want to render them still.

# Screenshots

<img width="909" height="527" alt="Screenshot 2026-03-20 at 12 38 41 PM" src="https://github.com/user-attachments/assets/db25bdf5-1d3e-45c2-a809-63b104569db5" />


<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
