### PR TITLE
Remove unused prefetch_related from CircuitUIViewSet

### DIFF
--- a/changes/6793.housekeeping
+++ b/changes/6793.housekeeping
@@ -1,0 +1,1 @@
+Removed unused `prefetch_related` class attribute from `CircuitUIViewSet`.

--- a/nautobot/circuits/views.py
+++ b/nautobot/circuits/views.py
@@ -187,8 +187,6 @@ class CircuitUIViewSet(NautobotUIViewSet):
     filterset_class = filters.CircuitFilterSet
     filterset_form_class = forms.CircuitFilterForm
     form_class = forms.CircuitForm
-    # v2 TODO(jathan): Replace prefetch_related with select_related
-    prefetch_related = ["provider", "circuit_type", "tenant", "circuit_termination_a", "circuit_termination_z"]
     queryset = Circuit.objects.all()
     serializer_class = serializers.CircuitSerializer
     table_class = tables.CircuitTable


### PR DESCRIPTION
## Summary

Remove the unused `prefetch_related` class attribute from `CircuitUIViewSet`.

## Changes

In `nautobot/circuits/views.py` (line 190-191), removed:
```python
# v2 TODO(jathan): Replace prefetch_related with select_related
prefetch_related = ["provider", "circuit_type", "tenant", "circuit_termination_a", "circuit_termination_z"]
```

This attribute was added in response to a review suggestion in PR #1902 but is not consumed by any `NautobotUIViewSet` base class - grep for `self.prefetch_related` across `nautobot/core/views/` returns no results.

## Testing

Verified no code in `nautobot/core/views/viewsets.py` or `nautobot/core/views/mixins.py` references `self.prefetch_related` or `cls.prefetch_related` as a class attribute.

Fixes #6793

This contribution was developed with AI assistance (Claude Code).