### PR TITLE
Job profiling results as file downloads

### DIFF
--- a/changes/8747.changed
+++ b/changes/8747.changed
@@ -1,0 +1,1 @@
+Job profiling results are now available for download as a file attached to the Job Result, rather than only being written to the worker's local filesystem.

--- a/nautobot/core/tests/test_cli.py
+++ b/nautobot/core/tests/test_cli.py
@@ -1,25 +1,159 @@
-"""Initial testing of cli.py"""
+import importlib.util
+import os.path
+import sys
+from unittest import mock
 
-from nautobot.core import cli
+from nautobot.core.cli import _preprocess_settings, migrate_deprecated_templates
+from nautobot.core.testing import TestCase
 
 
-class TestCli:
-    def test_cli_setting_monkey_patch_return_value(self):
-        """Validate _setting works provides the expected return value."""
-        storages_config = {
-            "AWS_ACCESS_KEY_ID": "ASFWDAMWWOQMEOQMWPMDA<WPDA",
-            "AWS_SECRET_ACCESS_KEY": "ASFKMWADMsacasdaw/dawrt1231541231231",
-            "AWS_STORAGE_BUCKET_NAME": "nautobot",
-            "AWS_S3_REGION_NAME": "us-west-1",
-        }
-        global_config = {"USE_TZ": True}
-        configs = storages_config.update(global_config)
-        for setting, value in configs.items():
-            result = cli._configure_settings._setting(setting)
-            assert result == value
+class TestMigrateTemplates(TestCase):
+    def test_template_replacements(self):
+        """Verify that all old templates are replaced by a single new template."""
+        audit_dict = {}
+        for new_template, old_templates in migrate_deprecated_templates.TEMPLATE_REPLACEMENTS.items():
+            for old_template in old_templates:
+                self.assertNotIn(old_template, audit_dict)
+                audit_dict[old_template] = new_template
 
-    def test_cli_setting_monkey_patch_return_none(self):
-        """Validate _setting returns none for non-existent setting."""
-        configs = ("AWS_NON_EXISTENT_KEY", "STORAGE_NON_EXISTENT_KEY")
-        for setting in configs:
-            assert not cli._configure_settings._setting(setting)
+    def test_replace_template_references_no_change(self):
+        content = """
+        {% extends "base.html" %}
+        {% block content %}
+        <h1>Hello, World!</h1>
+        {% endblock %}
+        """
+        replaced_content, was_updated = migrate_deprecated_templates.replace_template_references(content)
+        self.assertFalse(was_updated)
+        self.assertEqual(replaced_content, content)
+
+    def test_replace_template_references(self):
+        original_content = """
+        {% extends "generic/object_bulk_import.html" %}
+        {% block content %}
+        <h1>Hello, World!</h1>
+        {% endblock %}
+        """
+        new_content = """
+        {% extends "generic/object_bulk_create.html" %}
+        {% block content %}
+        <h1>Hello, World!</h1>
+        {% endblock %}
+        """
+        replaced_content, was_updated = migrate_deprecated_templates.replace_template_references(original_content)
+        self.assertTrue(was_updated)
+        self.assertEqual(replaced_content, new_content)
+
+
+@mock.patch("nautobot.core.cli.load_plugins")
+@mock.patch("nautobot.core.cli.load_event_brokers")
+class TestPreprocessSettings(TestCase):
+    """Tests for the `_preprocess_settings` function in nautobot.core.cli, as it's important to Nautobot startup."""
+
+    def load_settings_module(self):
+        # Load the testing nautobot_config.py as a self-contained module
+        config_path = os.path.join(os.path.dirname(__file__), "nautobot_config.py")
+        spec = importlib.util.spec_from_file_location("test_nautobot_config", config_path)
+        settings_module = importlib.util.module_from_spec(spec)
+        # nautobot.core.cli.load_settings would do the below, but obviously we don't want to do that here:
+        # sys.modules["nautobot_config"] = settings_module
+        spec.loader.exec_module(settings_module)
+        return settings_module, config_path
+
+    def test_basic_path(self, mock_load_event_brokers, mock_load_plugins):
+        """Basic operation of the function."""
+        settings_module, config_path = self.load_settings_module()
+
+        # Process the settings module
+        _preprocess_settings(settings_module, config_path)
+
+        # _preprocess_settings should have set SETTINGS_PATH on the module
+        self.assertEqual(settings_module.SETTINGS_PATH, config_path)
+
+        # the default test settings have no EXTRA_* settings to handle
+
+        # all media paths should exist
+        self.assertTrue(os.path.isdir(settings_module.GIT_ROOT))
+        self.assertTrue(os.path.isdir(settings_module.JOBS_ROOT))
+        self.assertTrue(os.path.isdir(settings_module.MEDIA_ROOT))
+        self.assertTrue(os.path.isdir(os.path.join(settings_module.MEDIA_ROOT, "devicetype-images")))
+        self.assertTrue(os.path.isdir(os.path.join(settings_module.MEDIA_ROOT, "image-attachments")))
+        self.assertTrue(os.path.isdir(settings_module.STATIC_ROOT))
+
+        # databases should be using the prometheus backends
+        self.assertTrue(settings_module.METRICS_ENABLED)
+        self.assertIn("django_prometheus.db.backends", settings_module.DATABASES["default"]["ENGINE"])
+
+        # job_logs database connection should exist
+        self.assertIn("job_logs", settings_module.DATABASES)
+        self.assertIn("TEST", settings_module.DATABASES["job_logs"])
+        self.assertEqual(settings_module.DATABASES["job_logs"]["TEST"], {"MIRROR": "default"})
+        for key, value in settings_module.DATABASES["default"].items():
+            if key == "TEST":
+                continue
+            self.assertEqual(value, settings_module.DATABASES["job_logs"][key])
+
+        # STORAGES should remain as default
+        self.assertEqual(
+            settings_module.STORAGES,
+            {
+                "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+                "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
+                "nautobotjobfiles": {"BACKEND": "db_file_storage.storage.DatabaseFileStorage"},
+            },
+        )
+
+        mock_load_plugins.assert_called_with(settings_module)
+        mock_load_event_brokers.assert_called_with(settings_module.EVENT_BROKERS)
+
+    def test_EXTRA_behavior(self, *args):
+        """Handling of special settings like EXTRA_INSTALLED_APPS and EXTRA_MIDDLEWARE."""
+        settings_module, config_path = self.load_settings_module()
+
+        # Inject EXTRA_INSTALLED_APPS and EXTRA_MIDDLEWARE to the settings module for test purposes
+        settings_module.EXTRA_INSTALLED_APPS = ["foo.bar"]
+        settings_module.EXTRA_MIDDLEWARE = ("baz.bat",)
+
+        # Process the settings module
+        _preprocess_settings(settings_module, config_path)
+
+        self.assertIn("foo.bar", settings_module.INSTALLED_APPS)
+        # more specifically:
+        self.assertEqual("foo.bar", settings_module.INSTALLED_APPS[-1])
+        self.assertIn("baz.bat", settings_module.MIDDLEWARE)
+        # more specifically:
+        self.assertEqual("baz.bat", settings_module.MIDDLEWARE[-1])
+
+    def test_legacy_storage_behavior(self, *args):
+        """Handling legacy storage settings."""
+        settings_module, config_path = self.load_settings_module()
+
+        settings_module.DEFAULT_FILE_STORAGE = "storages.some_custom_backend"
+        settings_module.JOB_FILE_IO_STORAGE = "some_custom_job_file_storage"
+        settings_module.STATICFILES_STORAGE = "some_custom_static_storage"
+        settings_module.STORAGE_BACKEND = "storages.some_custom_backend"
+        settings_module.STORAGE_CONFIG = {"MY_BACKEND_OPTION": "some_value"}
+
+        import storages.utils
+
+        original_setting = storages.utils.setting
+        del sys.modules["storages.utils"]
+        del storages.utils
+
+        try:
+            # Process the settings module
+            _preprocess_settings(settings_module, config_path)
+
+            self.assertFalse(hasattr(settings_module, "DEFAULT_FILE_STORAGE"))  # unset to avoid a Django exception
+            self.assertEqual("storages.some_custom_backend", settings_module.STORAGES["default"]["BACKEND"])
+            self.assertEqual("some_custom_job_file_storage", settings_module.STORAGES["nautobotjobfiles"]["BACKEND"])
+            self.assertFalse(hasattr(settings_module, "STATICFILES_STORAGE"))  # unset to avoid a Django exception
+            self.assertEqual("some_custom_static_storage", settings_module.STORAGES["staticfiles"]["BACKEND"])
+
+            self.assertEqual("some_value", storages.utils.setting("MY_BACKEND_OPTION"))
+        finally:
+            # Clean up the STORAGE_CONFIG monkeypatch
+            import storages.utils  # pylint: disable=reimported
+
+            storages.utils.setting = original_setting
+            self.assertIsNone(storages.utils.setting("MY_BACKEND_OPTION"))

--- a/nautobot/core/tests/test_cli.py
+++ b/nautobot/core/tests/test_cli.py
@@ -1,159 +1,25 @@
-import importlib.util
-import os.path
-import sys
-from unittest import mock
+"""Initial testing of cli.py"""
 
-from nautobot.core.cli import _preprocess_settings, migrate_deprecated_templates
-from nautobot.core.testing import TestCase
+from nautobot.core import cli
 
 
-class TestMigrateTemplates(TestCase):
-    def test_template_replacements(self):
-        """Verify that all old templates are replaced by a single new template."""
-        audit_dict = {}
-        for new_template, old_templates in migrate_deprecated_templates.TEMPLATE_REPLACEMENTS.items():
-            for old_template in old_templates:
-                self.assertNotIn(old_template, audit_dict)
-                audit_dict[old_template] = new_template
+class TestCli:
+    def test_cli_setting_monkey_patch_return_value(self):
+        """Validate _setting works provides the expected return value."""
+        storages_config = {
+            "AWS_ACCESS_KEY_ID": "ASFWDAMWWOQMEOQMWPMDA<WPDA",
+            "AWS_SECRET_ACCESS_KEY": "ASFKMWADMsacasdaw/dawrt1231541231231",
+            "AWS_STORAGE_BUCKET_NAME": "nautobot",
+            "AWS_S3_REGION_NAME": "us-west-1",
+        }
+        global_config = {"USE_TZ": True}
+        configs = storages_config.update(global_config)
+        for setting, value in configs.items():
+            result = cli._configure_settings._setting(setting)
+            assert result == value
 
-    def test_replace_template_references_no_change(self):
-        content = """
-        {% extends "base.html" %}
-        {% block content %}
-        <h1>Hello, World!</h1>
-        {% endblock %}
-        """
-        replaced_content, was_updated = migrate_deprecated_templates.replace_template_references(content)
-        self.assertFalse(was_updated)
-        self.assertEqual(replaced_content, content)
-
-    def test_replace_template_references(self):
-        original_content = """
-        {% extends "generic/object_bulk_import.html" %}
-        {% block content %}
-        <h1>Hello, World!</h1>
-        {% endblock %}
-        """
-        new_content = """
-        {% extends "generic/object_bulk_create.html" %}
-        {% block content %}
-        <h1>Hello, World!</h1>
-        {% endblock %}
-        """
-        replaced_content, was_updated = migrate_deprecated_templates.replace_template_references(original_content)
-        self.assertTrue(was_updated)
-        self.assertEqual(replaced_content, new_content)
-
-
-@mock.patch("nautobot.core.cli.load_plugins")
-@mock.patch("nautobot.core.cli.load_event_brokers")
-class TestPreprocessSettings(TestCase):
-    """Tests for the `_preprocess_settings` function in nautobot.core.cli, as it's important to Nautobot startup."""
-
-    def load_settings_module(self):
-        # Load the testing nautobot_config.py as a self-contained module
-        config_path = os.path.join(os.path.dirname(__file__), "nautobot_config.py")
-        spec = importlib.util.spec_from_file_location("test_nautobot_config", config_path)
-        settings_module = importlib.util.module_from_spec(spec)
-        # nautobot.core.cli.load_settings would do the below, but obviously we don't want to do that here:
-        # sys.modules["nautobot_config"] = settings_module
-        spec.loader.exec_module(settings_module)
-        return settings_module, config_path
-
-    def test_basic_path(self, mock_load_event_brokers, mock_load_plugins):
-        """Basic operation of the function."""
-        settings_module, config_path = self.load_settings_module()
-
-        # Process the settings module
-        _preprocess_settings(settings_module, config_path)
-
-        # _preprocess_settings should have set SETTINGS_PATH on the module
-        self.assertEqual(settings_module.SETTINGS_PATH, config_path)
-
-        # the default test settings have no EXTRA_* settings to handle
-
-        # all media paths should exist
-        self.assertTrue(os.path.isdir(settings_module.GIT_ROOT))
-        self.assertTrue(os.path.isdir(settings_module.JOBS_ROOT))
-        self.assertTrue(os.path.isdir(settings_module.MEDIA_ROOT))
-        self.assertTrue(os.path.isdir(os.path.join(settings_module.MEDIA_ROOT, "devicetype-images")))
-        self.assertTrue(os.path.isdir(os.path.join(settings_module.MEDIA_ROOT, "image-attachments")))
-        self.assertTrue(os.path.isdir(settings_module.STATIC_ROOT))
-
-        # databases should be using the prometheus backends
-        self.assertTrue(settings_module.METRICS_ENABLED)
-        self.assertIn("django_prometheus.db.backends", settings_module.DATABASES["default"]["ENGINE"])
-
-        # job_logs database connection should exist
-        self.assertIn("job_logs", settings_module.DATABASES)
-        self.assertIn("TEST", settings_module.DATABASES["job_logs"])
-        self.assertEqual(settings_module.DATABASES["job_logs"]["TEST"], {"MIRROR": "default"})
-        for key, value in settings_module.DATABASES["default"].items():
-            if key == "TEST":
-                continue
-            self.assertEqual(value, settings_module.DATABASES["job_logs"][key])
-
-        # STORAGES should remain as default
-        self.assertEqual(
-            settings_module.STORAGES,
-            {
-                "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
-                "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
-                "nautobotjobfiles": {"BACKEND": "db_file_storage.storage.DatabaseFileStorage"},
-            },
-        )
-
-        mock_load_plugins.assert_called_with(settings_module)
-        mock_load_event_brokers.assert_called_with(settings_module.EVENT_BROKERS)
-
-    def test_EXTRA_behavior(self, *args):
-        """Handling of special settings like EXTRA_INSTALLED_APPS and EXTRA_MIDDLEWARE."""
-        settings_module, config_path = self.load_settings_module()
-
-        # Inject EXTRA_INSTALLED_APPS and EXTRA_MIDDLEWARE to the settings module for test purposes
-        settings_module.EXTRA_INSTALLED_APPS = ["foo.bar"]
-        settings_module.EXTRA_MIDDLEWARE = ("baz.bat",)
-
-        # Process the settings module
-        _preprocess_settings(settings_module, config_path)
-
-        self.assertIn("foo.bar", settings_module.INSTALLED_APPS)
-        # more specifically:
-        self.assertEqual("foo.bar", settings_module.INSTALLED_APPS[-1])
-        self.assertIn("baz.bat", settings_module.MIDDLEWARE)
-        # more specifically:
-        self.assertEqual("baz.bat", settings_module.MIDDLEWARE[-1])
-
-    def test_legacy_storage_behavior(self, *args):
-        """Handling legacy storage settings."""
-        settings_module, config_path = self.load_settings_module()
-
-        settings_module.DEFAULT_FILE_STORAGE = "storages.some_custom_backend"
-        settings_module.JOB_FILE_IO_STORAGE = "some_custom_job_file_storage"
-        settings_module.STATICFILES_STORAGE = "some_custom_static_storage"
-        settings_module.STORAGE_BACKEND = "storages.some_custom_backend"
-        settings_module.STORAGE_CONFIG = {"MY_BACKEND_OPTION": "some_value"}
-
-        import storages.utils  # pylint: disable=import-error
-
-        original_setting = storages.utils.setting
-        del sys.modules["storages.utils"]
-        del storages.utils
-
-        try:
-            # Process the settings module
-            _preprocess_settings(settings_module, config_path)
-
-            self.assertFalse(hasattr(settings_module, "DEFAULT_FILE_STORAGE"))  # unset to avoid a Django exception
-            self.assertEqual("storages.some_custom_backend", settings_module.STORAGES["default"]["BACKEND"])
-            self.assertEqual("some_custom_job_file_storage", settings_module.STORAGES["nautobotjobfiles"]["BACKEND"])
-            self.assertFalse(hasattr(settings_module, "STATICFILES_STORAGE"))  # unset to avoid a Django exception
-            self.assertEqual("some_custom_static_storage", settings_module.STORAGES["staticfiles"]["BACKEND"])
-
-            self.assertEqual("some_value", storages.utils.setting("MY_BACKEND_OPTION"))
-        finally:
-            # Clean up the STORAGE_CONFIG monkeypatch
-            import storages.utils  # pylint: disable=reimported,import-error
-
-            storages.utils.setting = original_setting
-            self.assertIsNone(storages.utils.setting("MY_BACKEND_OPTION"))
+    def test_cli_setting_monkey_patch_return_none(self):
+        """Validate _setting returns none for non-existent setting."""
+        configs = ("AWS_NON_EXISTENT_KEY", "STORAGE_NON_EXISTENT_KEY")
+        for setting in configs:
+            assert not cli._configure_settings._setting(setting)

--- a/nautobot/core/tests/test_cli.py
+++ b/nautobot/core/tests/test_cli.py
@@ -134,7 +134,7 @@ class TestPreprocessSettings(TestCase):
         settings_module.STORAGE_BACKEND = "storages.some_custom_backend"
         settings_module.STORAGE_CONFIG = {"MY_BACKEND_OPTION": "some_value"}
 
-        import storages.utils
+        import storages.utils  # pylint: disable=import-error
 
         original_setting = storages.utils.setting
         del sys.modules["storages.utils"]
@@ -153,7 +153,7 @@ class TestPreprocessSettings(TestCase):
             self.assertEqual("some_value", storages.utils.setting("MY_BACKEND_OPTION"))
         finally:
             # Clean up the STORAGE_CONFIG monkeypatch
-            import storages.utils  # pylint: disable=reimported
+            import storages.utils  # pylint: disable=reimported,import-error
 
             storages.utils.setting = original_setting
             self.assertIsNone(storages.utils.setting("MY_BACKEND_OPTION"))

--- a/nautobot/docs/development/jobs/testing.md
+++ b/nautobot/docs/development/jobs/testing.md
@@ -63,19 +63,20 @@ The test files should be placed under the `tests` folder in the app's directory 
 
 Debugging the performance of Nautobot Jobs can be tricky, because they are executed in the Celery worker context. In order to gain extra visibility, [cProfile](https://docs.python.org/3/library/profile.html) can be used to profile the Job execution.
 
-The 'profile' form field on Jobs is automatically available when the `DEBUG` settings is `True`. When you select that checkbox, a profiling report in the pstats format will be written to the file system of the environment where the Job runs. Normally, this is on the file system of the worker process, but if you are using the `nautobot-server runjob` command with `--local`, it will end up in the file system of the web application itself. The path of the written file will be logged in the Job.
+The 'profile' form field on Jobs is automatically available when the `DEBUG` setting is `True`. When you select that checkbox, a profiling report in the pstats format will be attached to the Job Result and can be downloaded directly from the Job Result detail view in the GUI.
 
 !!! note
     If you need to run this in an environment where `DEBUG` is `False`, you have the option of using `nautobot-server runjob` with the `--profile` flag. According to the docs, `cProfile` should have minimal impact on the performance of the Job; still, proceed with caution when using this in a production environment.
 
 ## Reading Profiling Reports
 
-Profiling files are saved in the format expected by Python's `pstats` module. A full description on how to deal with the output of `cProfile` can be found in the [Instant User's Manual](https://docs.python.org/3/library/profile.html#instant-user-s-manual). You can analyze them as follows:
+Profiling files are saved in the format expected by Python's `pstats` module. A full description on how to deal with the output of `cProfile` can be found in the [Instant User's Manual](https://docs.python.org/3/library/profile.html#instant-user-s-manual).
+
+Download the `.pstats` file from the Job Result detail view and analyze it locally:
 
 ```python
 import pstats
-job_result_uuid = "66b70231-002f-412b-8cc4-1cc9609c2c9b"
-stats = pstats.Stats(f"/tmp/nautobot-jobresult-{job_result_uuid}.pstats")
+stats = pstats.Stats("/path/to/downloaded/nautobot-jobresult-<uuid>.pstats")
 stats.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(10)
 ```
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -166,22 +166,37 @@ class BaseJob:
             if self.celery_kwargs.get("nautobot_job_profile", False) is True:
                 import cProfile
 
-                # TODO: This should probably be available as a file download rather than dumped to the hard drive.
-                # Pending this: https://github.com/nautobot/nautobot/issues/3352
-                profiling_path = f"{tempfile.gettempdir()}/nautobot-jobresult-{self.job_result.id}.pstats"
+                profile_filename = f"nautobot-jobresult-{self.job_result.id}.pstats"
                 self.logger.info(
-                    "Writing profiling information to %s.", profiling_path, extra={"grouping": "initialization"}
+                    "Profiling job execution; results will be available for download upon completion.",
+                    extra={"grouping": "initialization"},
                 )
 
                 with cProfile.Profile() as pr:
                     try:
                         output = self.run(*args, **deserialized_kwargs)
-                    except Exception as err:
-                        pr.dump_stats(profiling_path)
-                        raise err
+                    except Exception:
+                        raise
                     else:
-                        pr.dump_stats(profiling_path)
                         return output
+                    finally:
+                        import io
+                        import marshal
+
+                        pr.create_stats()
+                        buf = io.BytesIO()
+                        marshal.dump(pr.stats, buf)
+                        self.create_file(profile_filename, content=buf.getvalue())
+
+                        # TODO: Remove after deprecation
+                        profiling_path = f"{tempfile.gettempdir()}/{profile_filename}"
+                        warnings.warn(
+                            f"Writing profiling stats to {profiling_path} is deprecated and will be removed in a "
+                            "future release. Download the profiling file directly from the Job Result in the GUI.",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
+                        pr.dump_stats(profiling_path)
             else:
                 return self.run(*args, **deserialized_kwargs)
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -487,7 +487,7 @@ class BaseJob:
             required=False,
             initial=False,
             label="Profile job execution",
-            help_text="Profiles the job execution using cProfile and outputs a report to /tmp/",
+            help_text="Profiles the job execution using cProfile and attaches a report to the job result",
         )
         form.fields["_profile"].widget.attrs["class"] = "form-check-input"
         # If the class already exists there may be overrides, so we have to check this.

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import sys
-import tempfile
 from textwrap import dedent
 from typing import final
 import warnings
@@ -172,28 +171,16 @@ class BaseJob:
                     extra={"grouping": "initialization"},
                 )
 
-                with cProfile.Profile() as pr:
-                    try:
-                        output = self.run(*args, **deserialized_kwargs)
-                    finally:
-                        import io
+                pr = None
+                try:
+                    with cProfile.Profile() as pr:
+                        return self.run(*args, **deserialized_kwargs)
+                finally:
+                    if pr:
                         import marshal
 
                         pr.create_stats()
-                        buf = io.BytesIO()
-                        marshal.dump(pr.stats, buf)
-                        self.create_file(profile_filename, content=buf.getvalue())
-
-                        # TODO: Remove after deprecation
-                        profiling_path = f"{tempfile.gettempdir()}/{profile_filename}"
-                        warnings.warn(
-                            f"Writing profiling stats to {profiling_path} is deprecated and will be removed in a "
-                            "future release. Download the profiling file directly from the Job Result in the GUI.",
-                            DeprecationWarning,
-                            stacklevel=2,
-                        )
-                        pr.dump_stats(profiling_path)
-                return output
+                        self.create_file(profile_filename, content=marshal.dumps(pr.stats))
             else:
                 return self.run(*args, **deserialized_kwargs)
 

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -175,10 +175,6 @@ class BaseJob:
                 with cProfile.Profile() as pr:
                     try:
                         output = self.run(*args, **deserialized_kwargs)
-                    except Exception:
-                        raise
-                    else:
-                        return output
                     finally:
                         import io
                         import marshal
@@ -197,6 +193,7 @@ class BaseJob:
                             stacklevel=2,
                         )
                         pr.dump_stats(profiling_path)
+                return output
             else:
                 return self.run(*args, **deserialized_kwargs)
 

--- a/nautobot/extras/test_jobs/profiling.py
+++ b/nautobot/extras/test_jobs/profiling.py
@@ -1,6 +1,3 @@
-import pstats
-import tempfile
-
 from nautobot.core.celery import register_jobs
 from nautobot.extras.jobs import get_task_logger, Job
 
@@ -22,10 +19,6 @@ class TestProfilingJob(Job):
         logger.info("Profiling test.")
 
         return []
-
-    def after_return(self, status, retval, task_id, args, kwargs, einfo):
-        super().after_return(status, retval, task_id, args, kwargs, einfo=einfo)
-        pstats.Stats(f"{tempfile.gettempdir()}/nautobot-jobresult-{self.job_result.id}.pstats")
 
 
 register_jobs(TestProfilingJob)

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -774,11 +774,20 @@ class JobTransactionTest(TransactionTestCase):
         module = "profiling"
         name = "TestProfilingJob"
 
-        # The job itself contains the 'assert' by loading the resulting profiling file from the workers filesystem
-        job_result = create_job_result_and_run_job(module, name, profile=True)
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated"):
+            job_result = create_job_result_and_run_job(module, name, profile=True)
 
         self.assertJobResultStatus(job_result)
 
+        # New behaviour: profiling data is available as a downloadable FileProxy linked to the JobResult
+        job_result.refresh_from_db()
+        self.assertEqual(job_result.files.count(), 1)
+        file_proxy = job_result.files.first()
+        self.assertEqual(file_proxy.name, f"nautobot-jobresult-{job_result.id}.pstats")
+        self.assertGreater(len(file_proxy.file.read()), 0)
+
+        # Old (deprecated) behaviour: stats are still written to /tmp for backward compatibility
+        # TODO: Remove after deprecation
         profiling_result = Path(f"{tempfile.gettempdir()}/nautobot-jobresult-{job_result.id}.pstats")
         self.assertTrue(profiling_result.exists())
         profiling_result.unlink()

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -774,23 +774,16 @@ class JobTransactionTest(TransactionTestCase):
         module = "profiling"
         name = "TestProfilingJob"
 
-        with self.assertWarnsRegex(DeprecationWarning, "deprecated"):
-            job_result = create_job_result_and_run_job(module, name, profile=True)
+        job_result = create_job_result_and_run_job(module, name, profile=True)
 
         self.assertJobResultStatus(job_result)
 
-        # New behaviour: profiling data is available as a downloadable FileProxy linked to the JobResult
+        # Profiling data is available as a downloadable FileProxy linked to the JobResult
         job_result.refresh_from_db()
         self.assertEqual(job_result.files.count(), 1)
         file_proxy = job_result.files.first()
         self.assertEqual(file_proxy.name, f"nautobot-jobresult-{job_result.id}.pstats")
         self.assertGreater(len(file_proxy.file.read()), 0)
-
-        # Old (deprecated) behaviour: stats are still written to /tmp for backward compatibility
-        # TODO: Remove after deprecation
-        profiling_result = Path(f"{tempfile.gettempdir()}/nautobot-jobresult-{job_result.id}.pstats")
-        self.assertTrue(profiling_result.exists())
-        profiling_result.unlink()
 
     def test_job_singleton(self):
         module = "singleton"


### PR DESCRIPTION
# Closes DNE - only in the code

_Disclaimer_: This PR was created with the help of GitHub Copilot. I was going to include the prompt, but it is in German, so that probably doesn't aid much. I did, however, test the changes manually (in addition to Copilot amending the unit tests).

# What's Changed

Job profiling results are now available for download as a file attached to the Job Result, rather than only being written to the worker's local filesystem.

# Screenshots

<img width="1629" height="640" alt="Bildschirmfoto 2026-03-25 um 14 49 28" src="https://github.com/user-attachments/assets/5eb48ace-9f66-490a-a6d2-cf5399a10b78" />

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
