### PR TITLE
[LTM Backport] Fixed superfluous VRFDeviceAssignment validation

### DIFF
--- a/changes/8748.fixed
+++ b/changes/8748.fixed
@@ -1,0 +1,1 @@
+Fixed a performance issue where the `validated_save()` method was being called unnecessarily on all `VRFDeviceAssignment` objects when adding a new assignment to a VRF.

--- a/nautobot/ipam/signals.py
+++ b/nautobot/ipam/signals.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 from django.db.models.signals import m2m_changed, pre_delete, pre_save
 from django.dispatch import receiver
 
+from nautobot.dcim.models import Device, VirtualDeviceContext
 from nautobot.ipam.models import (
     IPAddress,
     IPAddressToInterface,
@@ -14,6 +15,7 @@ from nautobot.ipam.models import (
     VRFDeviceAssignment,
     VRFPrefixAssignment,
 )
+from nautobot.virtualization.models import VirtualMachine
 
 
 @receiver(pre_save, sender=VRFDeviceAssignment)
@@ -40,21 +42,74 @@ def vrf_prefix_associated(sender, instance, action, reverse, model, pk_set, **kw
             raise ValidationError({"prefixes": "Prefix must match namespace of VRF"})
 
 
+def _validate_vrf_device_assignments(sender, instance, pk_set, device_field):
+    """
+    Helper function to validate VRFDeviceAssignment instances when devices/VMs/VDCs are added to a VRF.
+
+    For example:
+        * vrf.devices.add(device)
+        * vrf.virtual_machines.add(virtual_machine)
+        * vrf.virtual_device_contexts.add(virtual_device_context)
+
+    Args:
+        sender: The through model class (VRFDeviceAssignment)
+        instance: The VRF instance
+        pk_set: Set of device/VM/VDC PKs being added
+        device_field: Field name to filter on ('device', 'virtual_machine', or 'virtual_device_context')
+    """
+    filter_kwargs = {"vrf": instance, device_field + "_id__in": pk_set}
+    for assignment in sender.objects.filter(**filter_kwargs):
+        assignment.validated_save()
+
+
+def _validate_device_vrf_assignments(sender, instance, pk_set, device_field):
+    """
+    Helper function to validate VRFDeviceAssignment instances when VRFs are added to a device/VM/VDC.
+
+    For example:
+        * device.vrfs.add(vrf)
+        * virtual_machine.vrfs.add(vrf)
+        * virtual_device_context.vrfs.add(vrf)
+
+    Args:
+        sender: The through model class (VRFDeviceAssignment)
+        instance: The Device/VirtualMachine/VirtualDeviceContext instance
+        pk_set: Set of VRF PKs being added
+        device_field: Field name to filter on ('device', 'virtual_machine', or 'virtual_device_context')
+    """
+    filter_kwargs = {device_field: instance, "vrf_id__in": pk_set}
+    for assignment in sender.objects.filter(**filter_kwargs):
+        assignment.validated_save()
+
+
 @receiver(m2m_changed, sender=VRFDeviceAssignment)
 def vrf_device_associated(sender, instance, action, reverse, model, pk_set, **kwargs):
     """
-    Assert validation on m2m when devices are associated with a VRF.
+    Assert validation on m2m when Devices, VMs, or VDCs are associated with a VRF.
     """
-
     # TODO(jathan): Temporary workaround until a formset to add/remove/update VRFs <-> Devices and
-    # optionally setting RD/name on assignment. k
-    if action == "post_add":
+    # optionally setting RD/name on assignment.
+    if action == "post_add" and pk_set:
         if isinstance(instance, VRF):
-            for assignment in instance.device_assignments.iterator():
-                assignment.validated_save()
+            if issubclass(model, Device):
+                device_field = "device"
+            elif issubclass(model, VirtualMachine):
+                device_field = "virtual_machine"
+            elif issubclass(model, VirtualDeviceContext):
+                device_field = "virtual_device_context"
+            else:
+                return
+            _validate_vrf_device_assignments(sender, instance, pk_set, device_field)
         else:
-            for assignment in instance.vrf_assignments.iterator():
-                assignment.validated_save()
+            if isinstance(instance, Device):
+                device_field = "device"
+            elif isinstance(instance, VirtualMachine):
+                device_field = "virtual_machine"
+            elif isinstance(instance, VirtualDeviceContext):
+                device_field = "virtual_device_context"
+            else:
+                return
+            _validate_device_vrf_assignments(sender, instance, pk_set, device_field)
 
 
 @receiver(pre_delete, sender=IPAddressToInterface)

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -10,7 +10,17 @@ import netaddr
 
 from nautobot.core.testing.models import ModelTestCases
 from nautobot.dcim import choices as dcim_choices
-from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Module, ModuleBay, ModuleType
+from nautobot.dcim.models import (
+    Device,
+    DeviceType,
+    Interface,
+    Location,
+    LocationType,
+    Module,
+    ModuleBay,
+    ModuleType,
+    VirtualDeviceContext,
+)
 from nautobot.extras.models import Role, Status
 from nautobot.ipam.choices import IPAddressTypeChoices, PrefixTypeChoices, ServiceProtocolChoices
 from nautobot.ipam.models import (
@@ -25,6 +35,7 @@ from nautobot.ipam.models import (
     VLAN,
     VLANGroup,
     VRF,
+    VRFDeviceAssignment,
 )
 from nautobot.virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
 
@@ -2275,6 +2286,127 @@ class TestVLAN(ModelTestCases.BaseModelTestCase):
                     VLAN.objects.exclude(**{f"location__{field_name}": value}),
                     VLAN.objects.exclude(**{f"locations__{field_name}": value}),
                 )
+
+
+class VRFDeviceAssignmentSignalTest(TestCase):
+    """Tests for the vrf_device_associated signal handler."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.namespace = Namespace.objects.first()
+        cls.vrf1 = VRF.objects.create(name="VRF Signal Test 1", rd="65000:100", namespace=cls.namespace)
+        cls.vrf2 = VRF.objects.create(name="VRF Signal Test 2", rd="65000:200", namespace=cls.namespace)
+        cls.device1 = Device.objects.create(
+            name="signal-test-device1",
+            role=Role.objects.get_for_model(Device).first(),
+            device_type=DeviceType.objects.first(),
+            location=Location.objects.get_for_model(Device).first(),
+            status=Status.objects.get_for_model(Device).first(),
+        )
+        cls.device2 = Device.objects.create(
+            name="signal-test-device2",
+            role=Role.objects.get_for_model(Device).first(),
+            device_type=DeviceType.objects.first(),
+            location=Location.objects.get_for_model(Device).first(),
+            status=Status.objects.get_for_model(Device).first(),
+        )
+        cluster_type = ClusterType.objects.create(name="VRF Signal Test Cluster Type")
+        cluster = Cluster.objects.create(name="VRF Signal Test Cluster", cluster_type=cluster_type)
+        vm_status = Status.objects.get_for_model(VirtualMachine).first()
+        vm_role = Role.objects.get_for_model(VirtualMachine).first()
+        cls.vm1 = VirtualMachine.objects.create(name="signal-test-vm1", cluster=cluster, status=vm_status, role=vm_role)
+        cls.vm2 = VirtualMachine.objects.create(name="signal-test-vm2", cluster=cluster, status=vm_status, role=vm_role)
+        vdc_status = Status.objects.get_for_model(VirtualDeviceContext).first()
+        cls.vdc1 = VirtualDeviceContext.objects.create(
+            device=cls.device1, name="signal-test-vdc1", status=vdc_status, identifier=100
+        )
+        cls.vdc2 = VirtualDeviceContext.objects.create(
+            device=cls.device2, name="signal-test-vdc2", status=vdc_status, identifier=200
+        )
+
+    def test_vrf_device_associated_signal_only_validates_new_assignments(self):
+        """Adding a device to a VRF should only validate the new assignment, not all existing ones."""
+        self.vrf1.devices.add(self.device1)
+        self.assertEqual(self.vrf1.device_assignments.count(), 1)
+
+        with patch.object(VRFDeviceAssignment, "validated_save", autospec=True) as mock_validated_save:
+            self.vrf1.devices.add(self.device2)
+            self.assertEqual(mock_validated_save.call_count, 1)
+
+    def test_device_vrf_associated_signal_only_validates_new_assignments(self):
+        """Adding a VRF to a device should only validate the new assignment, not all existing ones."""
+        self.device1.vrfs.add(self.vrf1)
+        self.assertEqual(self.device1.vrf_assignments.count(), 1)
+
+        with patch.object(VRFDeviceAssignment, "validated_save", autospec=True) as mock_validated_save:
+            self.device1.vrfs.add(self.vrf2)
+            self.assertEqual(mock_validated_save.call_count, 1)
+
+    def test_vrf_vm_associated_signal_only_validates_new_assignments(self):
+        """Adding a VM to a VRF should only validate the new assignment, not all existing ones."""
+        self.vrf1.virtual_machines.add(self.vm1)
+        self.assertEqual(self.vrf1.device_assignments.count(), 1)
+
+        with patch.object(VRFDeviceAssignment, "validated_save", autospec=True) as mock_validated_save:
+            self.vrf1.virtual_machines.add(self.vm2)
+            self.assertEqual(mock_validated_save.call_count, 1)
+
+    def test_vm_vrf_associated_signal_only_validates_new_assignments(self):
+        """Adding a VRF to a VM should only validate the new assignment, not all existing ones."""
+        self.vm1.vrfs.add(self.vrf1)
+        self.assertEqual(self.vm1.vrf_assignments.count(), 1)
+
+        with patch.object(VRFDeviceAssignment, "validated_save", autospec=True) as mock_validated_save:
+            self.vm1.vrfs.add(self.vrf2)
+            self.assertEqual(mock_validated_save.call_count, 1)
+
+    def test_vrf_vdc_associated_signal_only_validates_new_assignments(self):
+        """Adding a VDC to a VRF should only validate the new assignment, not all existing ones."""
+        self.vrf1.virtual_device_contexts.add(self.vdc1)
+        self.assertEqual(self.vrf1.device_assignments.count(), 1)
+
+        with patch.object(VRFDeviceAssignment, "validated_save", autospec=True) as mock_validated_save:
+            self.vrf1.virtual_device_contexts.add(self.vdc2)
+            self.assertEqual(mock_validated_save.call_count, 1)
+
+    def test_vdc_vrf_associated_signal_only_validates_new_assignments(self):
+        """Adding a VRF to a VDC should only validate the new assignment, not all existing ones."""
+        self.vdc1.vrfs.add(self.vrf1)
+        self.assertEqual(self.vdc1.vrf_assignments.count(), 1)
+
+        with patch.object(VRFDeviceAssignment, "validated_save", autospec=True) as mock_validated_save:
+            self.vdc1.vrfs.add(self.vrf2)
+            self.assertEqual(mock_validated_save.call_count, 1)
+
+    def test_vrf_device_associated_signal_ignores_unknown_model(self):
+        """Signal should return early when model is not Device, VirtualMachine, or VirtualDeviceContext."""
+        from nautobot.ipam.signals import vrf_device_associated
+
+        with patch.object(VRFDeviceAssignment, "validated_save", autospec=True) as mock_validated_save:
+            vrf_device_associated(
+                sender=VRFDeviceAssignment,
+                instance=self.vrf1,
+                action="post_add",
+                reverse=False,
+                model=VRF,  # unexpected model type
+                pk_set={self.device1.pk},
+            )
+            mock_validated_save.assert_not_called()
+
+    def test_vrf_device_associated_signal_ignores_unknown_instance(self):
+        """Signal should return early when instance is not VRF, Device, VirtualMachine, or VirtualDeviceContext."""
+        from nautobot.ipam.signals import vrf_device_associated
+
+        with patch.object(VRFDeviceAssignment, "validated_save", autospec=True) as mock_validated_save:
+            vrf_device_associated(
+                sender=VRFDeviceAssignment,
+                instance=Namespace.objects.first(),  # unexpected instance type
+                action="post_add",
+                reverse=False,
+                model=VRF,
+                pk_set={self.vrf1.pk},
+            )
+            mock_validated_save.assert_not_called()
 
 
 class TestVRF(ModelTestCases.BaseModelTestCase):


### PR DESCRIPTION
This is a copy/paste of #8749 to backport the changes into the LTM 2.4 branch.