### PR TITLE
Added thread locks when refreshing jobs

### DIFF
--- a/changes/8614.fixed
+++ b/changes/8614.fixed
@@ -1,0 +1,1 @@
+Fixed a race condition when running jobs concurrently that could cause multiple threads to modify the `jobs` registry at the same time.

--- a/nautobot/core/celery/__init__.py
+++ b/nautobot/core/celery/__init__.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 import shutil
 import sys
-
 from celery import bootsteps, Celery, shared_task, signals
 from celery.app.log import TaskFormatter
 from celery.utils.log import get_logger
@@ -21,7 +20,7 @@ from nautobot.core.celery.control import discard_git_repository, refresh_git_rep
 from nautobot.core.celery.encoders import NautobotKombuJSONEncoder
 from nautobot.core.celery.log import NautobotDatabaseHandler
 from nautobot.core.utils.module_loading import import_modules_privately, import_string_optional
-from nautobot.extras.registry import registry
+from nautobot.extras.registry import registry, registry_jobs_lock
 
 logger = logging.getLogger(__name__)
 
@@ -53,19 +52,20 @@ def import_jobs(sender=None, **kwargs):
 
     Note that app-provided jobs are automatically imported at startup time via NautobotAppConfig.ready()
     """
-    import nautobot.core.jobs
-    import nautobot.ipam.jobs  # noqa: F401
+    with registry_jobs_lock:
+        import nautobot.core.jobs
+        import nautobot.ipam.jobs  # noqa: F401
 
-    _import_jobs_from_jobs_root()
-    _import_dynamic_jobs_from_apps()
+        _import_jobs_from_jobs_root()
+        _import_dynamic_jobs_from_apps()
 
-    try:
-        _import_jobs_from_git_repositories()
-    except (
-        OperationalError,  # Database not present, as may be the case when running pylint-nautobot
-        ProgrammingError,  # Database not ready yet, as may be the case on initial startup and migration
-    ):
-        pass
+        try:
+            _import_jobs_from_git_repositories()
+        except (
+            OperationalError,  # Database not present, as may be the case when running pylint-nautobot
+            ProgrammingError,  # Database not ready yet, as may be the case on initial startup and migration
+        ):
+            pass
 
 
 def _import_jobs_from_jobs_root():
@@ -95,7 +95,7 @@ def _import_jobs_from_jobs_root():
         except ProgrammingError:  # Database not ready yet, as may be the case on initial startup and migration
             pass
         # Else, it's presumably a JOBS_ROOT job
-        del registry["jobs"][job_class_path]
+        registry["jobs"].pop(job_class_path, None)
 
     # Load all modules in JOBS_ROOT
     import_modules_privately(path=os.path.realpath(settings.JOBS_ROOT))

--- a/nautobot/core/celery/__init__.py
+++ b/nautobot/core/celery/__init__.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import shutil
 import sys
+
 from celery import bootsteps, Celery, shared_task, signals
 from celery.app.log import TaskFormatter
 from celery.utils.log import get_logger

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -756,7 +756,9 @@ def refresh_job_code_from_repository(repository_slug, skip_reimport=False, ignor
                         raise FileNotFoundError(f"No `jobs` submodule found in Git repository {repository}")
                 else:
                     import_modules_privately(
-                        settings.GIT_ROOT, module_path=[repository_slug, "jobs"], ignore_import_errors=ignore_import_errors
+                        settings.GIT_ROOT,
+                        module_path=[repository_slug, "jobs"],
+                        ignore_import_errors=ignore_import_errors,
                     )
         except GitRepository.DoesNotExist as exc:
             logger.error("Unable to reload Jobs from %s.jobs: %s", repository_slug, exc)

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -37,7 +37,7 @@ from nautobot.extras.models import (
     Role,
     Tag,
 )
-from nautobot.extras.registry import DatasourceContent, register_datasource_contents, registry
+from nautobot.extras.registry import DatasourceContent, register_datasource_contents, registry, registry_jobs_lock
 from nautobot.extras.utils import refresh_job_model_from_job_class
 from nautobot.tenancy.models import Tenant, TenantGroup
 from nautobot.virtualization.models import Cluster, ClusterGroup, VirtualMachine
@@ -735,32 +735,33 @@ def refresh_job_code_from_repository(repository_slug, skip_reimport=False, ignor
             return
         raise ValueError(f"The repository_slug {repository_slug!r} is invalid as it is {reason}")
 
-    # Unload any previous version of this module and its submodules if present
-    for job_class_path in list(registry["jobs"]):
-        if job_class_path.startswith(f"{repository_slug}."):
-            del registry["jobs"][job_class_path]
+    with registry_jobs_lock:
+        # Unload any previous version of this module and its submodules if present
+        for job_class_path in list(registry["jobs"]):
+            if job_class_path.startswith(f"{repository_slug}."):
+                registry["jobs"].pop(job_class_path, None)
 
-    if skip_reimport:
-        return
+        if skip_reimport:
+            return
 
-    try:
-        repository = GitRepository.objects.get(slug=repository_slug)
-        if "extras.job" in repository.provided_contents:
-            if not (
-                os.path.isdir(os.path.join(repository.filesystem_path, "jobs"))
-                or os.path.isfile(os.path.join(repository.filesystem_path, "jobs.py"))
-            ):
-                logger.error("No `jobs` submodule found in Git repository %s", repository)
-                if not ignore_import_errors:
-                    raise FileNotFoundError(f"No `jobs` submodule found in Git repository {repository}")
-            else:
-                import_modules_privately(
-                    settings.GIT_ROOT, module_path=[repository_slug, "jobs"], ignore_import_errors=ignore_import_errors
-                )
-    except GitRepository.DoesNotExist as exc:
-        logger.error("Unable to reload Jobs from %s.jobs: %s", repository_slug, exc)
-        if not ignore_import_errors:
-            raise
+        try:
+            repository = GitRepository.objects.get(slug=repository_slug)
+            if "extras.job" in repository.provided_contents:
+                if not (
+                    os.path.isdir(os.path.join(repository.filesystem_path, "jobs"))
+                    or os.path.isfile(os.path.join(repository.filesystem_path, "jobs.py"))
+                ):
+                    logger.error("No `jobs` submodule found in Git repository %s", repository)
+                    if not ignore_import_errors:
+                        raise FileNotFoundError(f"No `jobs` submodule found in Git repository {repository}")
+                else:
+                    import_modules_privately(
+                        settings.GIT_ROOT, module_path=[repository_slug, "jobs"], ignore_import_errors=ignore_import_errors
+                    )
+        except GitRepository.DoesNotExist as exc:
+            logger.error("Unable to reload Jobs from %s.jobs: %s", repository_slug, exc)
+            if not ignore_import_errors:
+                raise
 
 
 def refresh_git_jobs(repository_record, job_result, delete=False):

--- a/nautobot/extras/registry.py
+++ b/nautobot/extras/registry.py
@@ -1,5 +1,5 @@
-import threading
 from collections import defaultdict
+import threading
 
 
 class Registry(dict):

--- a/nautobot/extras/registry.py
+++ b/nautobot/extras/registry.py
@@ -1,3 +1,4 @@
+import threading
 from collections import defaultdict
 
 
@@ -26,6 +27,8 @@ registry = Registry(
     datasource_contents=defaultdict(list),
     secrets_providers={},
 )
+
+registry_jobs_lock = threading.RLock()
 
 
 class DatasourceContent:

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -289,6 +289,56 @@ register_jobs(BadJob)
             # Clean up back to normal behavior
             get_jobs(reload=True)
 
+    def test_concurrent_import_jobs(self):
+        """
+        Test that concurrent calls to import_jobs() don't raise KeyError.
+
+        Regression test for https://github.com/nautobot/nautobot/issues/8614
+        """
+        import threading
+
+        from nautobot.core.celery import import_jobs
+
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                with override_settings(JOBS_ROOT=temp_dir):
+                    # Create a job file so there's something to flush/reload
+                    with open(os.path.join(temp_dir, "concurrent_test_jobs.py"), "w") as fd:
+                        fd.write(
+                            """\
+from nautobot.apps.jobs import Job, register_jobs
+class ConcurrentTestJob(Job):
+    def run(self):
+        pass
+register_jobs(ConcurrentTestJob)
+"""
+                        )
+                    # Initial load
+                    get_jobs(reload=True)
+                    self.assertIn("concurrent_test_jobs.ConcurrentTestJob", get_jobs().keys())
+
+                    errors = []
+                    num_threads = 4
+                    barrier = threading.Barrier(num_threads)
+
+                    def call_import_jobs():
+                        try:
+                            barrier.wait(timeout=5)
+                            import_jobs()
+                        except Exception as e:
+                            errors.append(e)
+
+                    threads = [threading.Thread(target=call_import_jobs) for _ in range(num_threads)]
+                    for t in threads:
+                        t.start()
+                    for t in threads:
+                        t.join(timeout=30)
+
+                    self.assertEqual(errors, [], f"Concurrent import_jobs() raised exceptions: {errors}")
+        finally:
+            # Clean up back to normal behavior
+            get_jobs(reload=True)
+
     @tag("example_app")
     def test_app_dynamic_jobs(self):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8614
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
This PR adds a thread lock to both `import_jobs` and `refresh_job_code_from_repository` to stop a race condition when multiple jobs are run at the same time (via any method). It also adds a second layer of protection of a safe `.pop` instead of `del` to fix the `KeyError` from the linked issue - just in case.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests

NTC-5120