### PR TITLE
Adding reload=True to ScheduledJobView get_job() call

### DIFF
--- a/changes/8629.fixed
+++ b/changes/8629.fixed
@@ -1,1 +1,1 @@
-Fixed a scenario where rendering a Jobs "Scheduled Job View" would sometimes show the Job as not installed
+Fixed a scenario where rendering a GitRepository related Jobs "Scheduled Job View" would sometimes show the Job as not installed

--- a/changes/8629.fixed
+++ b/changes/8629.fixed
@@ -1,0 +1,1 @@
+Fixed a scenario where rendering a Jobs "Scheduled Job View" would sometimes show the Job as not installed

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2684,7 +2684,7 @@ class ScheduledJobView(generic.ObjectView):
         context = super().get_extra_context(request, instance)
 
         # Add job class labels
-        job_class = get_job(instance.task)
+        job_class = get_job(instance.task, reload=True)
         labels = {}
         if job_class is not None:
             for name, var in job_class._get_vars().items():


### PR DESCRIPTION
# Closes #8629 
# What's Changed

Addition of reload=True to the get_job() call when rendering the Scheduled Job View.

# Screenshots

Before Bug Fix:

<img width="1918" height="917" alt="image" src="https://github.com/user-attachments/assets/e659ff8b-63e1-48c2-b916-a61462a488a9" />

As seen above, a confirmed installed Job from a git repostiory on the demo nautobot site shows "This job source for this scheduled job is no longer installed. This scheduled job will fail to run unless reinstalled at the original location."

With fixes, each time the page is rendered it will discover the job:

<img width="1918" height="918" alt="image" src="https://github.com/user-attachments/assets/acbd72f1-2861-4fe5-a589-976c984c9136" />

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example