### PR TITLE
Fix ConfigContex QuerySets for subclasses of Device model

### DIFF
--- a/changes/8763.fixed
+++ b/changes/8763.fixed
@@ -1,0 +1,1 @@
+Fix get_config_context and ConfigContexModel annotation for subclasses of Device model

--- a/nautobot/extras/querysets.py
+++ b/nautobot/extras/querysets.py
@@ -54,7 +54,9 @@ class ConfigContextQuerySet(RestrictedQuerySet):
             query.append(Q(dynamic_groups__in=obj.dynamic_groups) | Q(dynamic_groups=None))
 
         # `clusters` for Device, `cluster` for VirtualMachine
-        if obj._meta.model_name == "device":
+        from nautobot.dcim.models import Device
+
+        if isinstance(obj, Device):
             query.append(Q(clusters__in=obj.clusters.all()) | Q(clusters=None))
             query.append(
                 Q(cluster_groups__in=obj.clusters.values_list("cluster_group", flat=True)) | Q(cluster_groups=None)
@@ -134,10 +136,10 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
         )
         base_query.add((Q(roles=OuterRef("role")) | Q(roles=None)), Q.AND)
 
-        from nautobot.dcim.models import Location
+        from nautobot.dcim.models import Device, Location
         from nautobot.tenancy.models import TenantGroup
 
-        if self.model._meta.model_name == "device":
+        if issubclass(self.model, Device):
             location_query_string = "location"
             base_query.add((Q(device_types=OuterRef("device_type")) | Q(device_types=None)), Q.AND)
             base_query.add((Q(device_families=OuterRef("device_type__device_family")) | Q(device_families=None)), Q.AND)

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -1361,6 +1361,27 @@ class ConfigContextTest(ModelTestCases.BaseModelTestCase):
         self.assertEqual(ctx1.get("device_family"), "Device Family 1")
         self.assertEqual(ctx2.get("device_family"), None)
 
+    def test_get_for_object_inheritance(self):
+        """
+        Verify that get_for_object handles models inheriting from Device.
+        """
+
+        # We use an existing device but mock its model_name to something else, to emulate inheritance.
+        with mock.patch.object(self.device._meta, "model_name", "proxy_device"):
+            self.assertEqual(self.device._meta.model_name, "proxy_device")
+            contexts = ConfigContext.objects.get_for_object(self.device)
+            self.assertEqual(contexts.count(), 1)
+
+    def test_annotate_config_context_data_inheritance(self):
+        """
+        Verify that annotate_config_context_data() works for models inheriting from Device.
+        """
+
+        # Mock the model_name at the class level to prove issubclass() is used.
+        with mock.patch.object(Device._meta, "model_name", "proxy_device"):
+            annotated_device = Device.objects.filter(pk=self.device.pk).annotate_config_context_data().first()
+            self.assertEqual(self.device.get_config_context(), annotated_device.get_config_context())
+
 
 class ConfigContextSchemaTestCase(ModelTestCases.BaseModelTestCase):
     """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8763
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Fix `get_config_context` and `ConfigContexModel` annotation for subclasses of Device model. The fix is moving away from checking `_meta.model_name == "device"`, towards checking for instance/model inheritance from the Device model, to support Proxy models.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
