### PR TITLE
[2.4] Fixed intermittent test failures (#8735)

### DIFF
--- a/changes/8734.housekeeping
+++ b/changes/8734.housekeeping
@@ -1,0 +1,1 @@
+Changed ObjectChangeFactory to use set start and end dates for deterministic timestamps for the `time` field for tests.

--- a/nautobot/core/tests/test_jobs.py
+++ b/nautobot/core/tests/test_jobs.py
@@ -9,6 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.files.base import ContentFile
 from django.utils import timezone
+import time_machine
 import yaml
 
 from nautobot.circuits.models import Circuit, CircuitType, Provider
@@ -675,63 +676,67 @@ class LogsCleanupTestCase(TransactionTestCase):
     )
     def test_cleanup_job_results(self):
         """With unconstrained permissions, all JobResults before the cutoff should be deleted."""
-        cutoff = timezone.now() - timedelta(days=60)
-        job_results_to_be_deleted = JobResult.objects.filter(date_done__lt=cutoff)
-        job_results_to_be_deleted_count = job_results_to_be_deleted.count()
-        job_log_entry_to_be_deleted_count = JobLogEntry.objects.filter(job_result__in=job_results_to_be_deleted).count()
-        objectmetadata_to_be_deleted_count = ObjectMetadata.objects.filter(
-            assigned_object_id__in=job_results_to_be_deleted,
-            assigned_object_type=ContentType.objects.get_for_model(JobResult),
-        ).count()
+        with time_machine.travel("2024-10-01 00:00 +0000"):
+            cutoff = timezone.now() - timedelta(days=60)
+            job_results_to_be_deleted = JobResult.objects.filter(date_done__lt=cutoff)
+            job_results_to_be_deleted_count = job_results_to_be_deleted.count()
+            job_log_entry_to_be_deleted_count = JobLogEntry.objects.filter(
+                job_result__in=job_results_to_be_deleted
+            ).count()
+            objectmetadata_to_be_deleted_count = ObjectMetadata.objects.filter(
+                assigned_object_id__in=job_results_to_be_deleted,
+                assigned_object_type=ContentType.objects.get_for_model(JobResult),
+            ).count()
 
-        with self.assertLogs("nautobot.events") as cm:
-            job_result = create_job_result_and_run_job(
-                "nautobot.core.jobs.cleanup",
-                "LogsCleanup",
-                cleanup_types=[CleanupTypes.JOB_RESULT],
-                max_age=60,
+            with self.assertLogs("nautobot.events") as cm:
+                job_result = create_job_result_and_run_job(
+                    "nautobot.core.jobs.cleanup",
+                    "LogsCleanup",
+                    cleanup_types=[CleanupTypes.JOB_RESULT],
+                    max_age=60,
+                )
+            self.assertFalse(JobResult.objects.filter(date_done__lt=cutoff).exists(), cm.output)
+            self.assertTrue(JobResult.objects.filter(date_done__gte=cutoff).exists(), cm.output)
+            self.assertTrue(ObjectChange.objects.filter(time__lt=cutoff).exists(), cm.output)
+            self.assertTrue(ObjectChange.objects.filter(time__gte=cutoff).exists(), cm.output)
+
+            started_logs = {
+                "job_result_id": str(job_result.id),
+                "job_name": "Logs Cleanup",
+                "user_name": job_result.user.username,
+                "job_kwargs": {"cleanup_types": ["extras.JobResult"], "max_age": 60},
+            }
+            self.assertEqual(
+                cm.output[0],
+                f"INFO:nautobot.events.nautobot.jobs.job.started:{json.dumps(started_logs, indent=4)}",
             )
-        self.assertFalse(JobResult.objects.filter(date_done__lt=cutoff).exists(), cm.output)
-        self.assertTrue(JobResult.objects.filter(date_done__gte=cutoff).exists(), cm.output)
-        self.assertTrue(ObjectChange.objects.filter(time__lt=cutoff).exists(), cm.output)
-        self.assertTrue(ObjectChange.objects.filter(time__gte=cutoff).exists(), cm.output)
 
-        started_logs = {
-            "job_result_id": str(job_result.id),
-            "job_name": "Logs Cleanup",
-            "user_name": job_result.user.username,
-            "job_kwargs": {"cleanup_types": ["extras.JobResult"], "max_age": 60},
-        }
-        self.assertEqual(
-            cm.output[0],
-            f"INFO:nautobot.events.nautobot.jobs.job.started:{json.dumps(started_logs, indent=4)}",
-        )
+            started_logs["job_output"] = {
+                "extras.JobResult": job_results_to_be_deleted_count,
+                "extras.JobLogEntry": job_log_entry_to_be_deleted_count,
+            }
+            if objectmetadata_to_be_deleted_count > 0:
+                started_logs["job_output"]["extras.ObjectMetadata"] = objectmetadata_to_be_deleted_count
 
-        started_logs["job_output"] = {
-            "extras.JobResult": job_results_to_be_deleted_count,
-            "extras.JobLogEntry": job_log_entry_to_be_deleted_count,
-        }
-        if objectmetadata_to_be_deleted_count > 0:
-            started_logs["job_output"]["extras.ObjectMetadata"] = objectmetadata_to_be_deleted_count
-
-        self.assertEqual(
-            cm.output[1],
-            f"INFO:nautobot.events.nautobot.jobs.job.completed:{json.dumps(started_logs, indent=4)}",
-        )
+            self.assertEqual(
+                cm.output[1],
+                f"INFO:nautobot.events.nautobot.jobs.job.completed:{json.dumps(started_logs, indent=4)}",
+            )
 
     def test_cleanup_object_changes(self):
         """With unconstrained permissions, all ObjectChanges before the cutoff should be deleted."""
-        cutoff = timezone.now() - timedelta(days=60)
-        create_job_result_and_run_job(
-            "nautobot.core.jobs.cleanup",
-            "LogsCleanup",
-            cleanup_types=[CleanupTypes.OBJECT_CHANGE],
-            max_age=60,
-        )
-        self.assertTrue(JobResult.objects.filter(date_done__lt=cutoff).exists())
-        self.assertTrue(JobResult.objects.filter(date_done__gte=cutoff).exists())
-        self.assertFalse(ObjectChange.objects.filter(time__lt=cutoff).exists())
-        self.assertTrue(ObjectChange.objects.filter(time__gte=cutoff).exists())
+        with time_machine.travel("2024-10-01 00:00 +0000"):
+            cutoff = timezone.now() - timedelta(days=60)
+            create_job_result_and_run_job(
+                "nautobot.core.jobs.cleanup",
+                "LogsCleanup",
+                cleanup_types=[CleanupTypes.OBJECT_CHANGE],
+                max_age=60,
+            )
+            self.assertTrue(JobResult.objects.filter(date_done__lt=cutoff).exists())
+            self.assertTrue(JobResult.objects.filter(date_done__gte=cutoff).exists())
+            self.assertFalse(ObjectChange.objects.filter(time__lt=cutoff).exists())
+            self.assertTrue(ObjectChange.objects.filter(time__gte=cutoff).exists())
 
 
 class BulkEditTestCase(TransactionTestCase):

--- a/nautobot/extras/factory.py
+++ b/nautobot/extras/factory.py
@@ -1,4 +1,4 @@
-from datetime import timezone
+from datetime import datetime, timedelta, timezone
 import json
 
 from django.contrib.auth import get_user_model
@@ -217,15 +217,15 @@ class JobResultFactory(BaseModelFactory):
             return
         if extracted:
             return
-        # Create a date_created in the past, but not too far in the past
-        self.date_created = faker.Faker().date_time_between(start_date="-1y", end_date="-1w", tzinfo=timezone.utc)
-        self.date_started = faker.Faker().date_time_between(
-            start_date=self.date_created, end_date="-1d", tzinfo=timezone.utc
+        # Fixed absolute dates with factory_boy's seeded random for full determinism.
+        # Avoids standalone faker (bypasses seed) and relative dates (faker#2149).
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        seconds_range = int((end - start).total_seconds())
+        timestamps = sorted(
+            start + timedelta(seconds=factory.random.randgen.randint(0, seconds_range)) for _ in range(3)
         )
-        # TODO, should we create "in progress" job results without a date_done value as well?
-        self.date_done = faker.Faker().date_time_between(
-            start_date=self.date_started, end_date="now", tzinfo=timezone.utc
-        )
+        self.date_created, self.date_started, self.date_done = timestamps
 
 
 class MetadataChoiceFactory(BaseModelFactory):
@@ -473,7 +473,12 @@ class ObjectChangeFactory(BaseModelFactory):
             if extracted:
                 self.time = extracted
             else:
-                self.time = faker.Faker().date_time_between(start_date="-1y", end_date="now", tzinfo=timezone.utc)
+                # Fixed absolute dates with factory_boy's seeded random for full determinism.
+                # Avoids standalone faker (bypasses seed) and relative dates (faker#2149).
+                start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+                end = datetime(2025, 1, 1, tzinfo=timezone.utc)
+                seconds_range = int((end - start).total_seconds())
+                self.time = start + timedelta(seconds=factory.random.randgen.randint(0, seconds_range))
 
 
 class RoleFactory(OrganizationalModelFactory):

--- a/nautobot/extras/tests/test_changelog.py
+++ b/nautobot/extras/tests/test_changelog.py
@@ -454,7 +454,7 @@ class ChangeLogAPITest(APITestCase):
         resp = execute_query(gql_payload, user=self.user).to_dict()
         self.assertFalse(resp["data"].get("error"))
         self.assertIsInstance(resp["data"].get("query"), list)
-        # ObjectChangeFactory creates records in the last year only; there shouldn't be any in this filtered response.
+        # ObjectChangeFactory creates records with fixed dates in 2024; there shouldn't be any in this filtered response.
         self.assertEqual(len(resp["data"].get("query")), 0)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])


### PR DESCRIPTION
Backport of #8735 to ltm-2.4 as we see failures there as well (e.g. https://github.com/nautobot/nautobot/actions/runs/23648323658/job/68887355728#step:5:521).

Patched cleanly except for the comment in test_changelog.py (which conflicted on other lines due to the graphene major version difference between 2.4 and 3.0).