### PR TITLE
Update release CI and add prepare-release action

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,180 @@
+---
+name: "Prepare Release"
+on: # yamllint disable-line rule:truthy rule:comments
+  workflow_dispatch:
+    inputs:
+      bump_rule:
+        description: "Select the version bump type"
+        required: true
+        default: "patch"
+        type: "choice"
+        options:
+          - "prerelease"
+          - "patch"
+          - "minor"
+          - "major"
+      target_branch:
+        description: "Create the release from this branch (default: main)."
+        required: true
+        default: "main"
+      date:
+        description: "Date of the release YYYY-MM-DD (defaults to today's date in the US Eastern TZ)."
+        required: false
+        default: ""
+
+jobs:
+  prepare-release:
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Prepare Release"
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v4"
+        with:
+          # If target_branch is 'main', use 'develop' as the source branch. Otherwise, the source and target branch are the same.
+          ref: "${{ github.event.inputs['target_branch'] == 'main' && 'develop' || github.event.inputs['target_branch'] }}"
+          fetch-depth: 0  # Fetch all history for git tags
+
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-install-options: "--with dev"
+          poetry-version: "2.1.4"
+
+      - name: "Validate Branch and Tags"
+        run: |
+          # 1. Verify branch exists
+          if ! git rev-parse --verify origin/${{ github.event.inputs.target_branch }} > /dev/null 2>&1; then
+            echo "Error: Branch ${{ github.event.inputs.target_branch }} does not exist."
+            exit 1
+          fi
+
+          # 2. Try to get the previous version tag
+          # If it fails (no tags), get the hash of the first commit
+          if PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
+            echo "PREVIOUS_TAG=$PREV_TAG" >> $GITHUB_ENV
+            echo "Found previous tag: $PREV_TAG"
+          else
+            # Fallback to the first commit in the repository
+            FIRST_COMMIT=$(git rev-list --max-parents=0 HEAD)
+            echo "PREVIOUS_TAG=$FIRST_COMMIT" >> $GITHUB_ENV
+            echo "No tags found. Falling back to initial commit: $FIRST_COMMIT"
+          fi
+
+      - name: "Determine New Version"
+        id: "versioning"
+        run: |
+          if [[ "${{ github.event.inputs.bump_rule }}" != "prerelease" ]]; then
+            # Perform the bump based on the user input
+            poetry version ${{ github.event.inputs.bump_rule }}
+          fi
+
+          # Capture the New version string for use in other steps
+          NEW_VER=$(poetry version --short)
+          echo "NEW_VERSION=$NEW_VER" >> $GITHUB_ENV
+          echo "RELEASE_BRANCH=release/$NEW_VER" >> $GITHUB_ENV
+
+      - name: "Set Date Variable"
+        run: |
+          if [ -z "${{ github.event.inputs.date }}" ]; then
+            RELEASE_DATE=$(TZ=America/New_York date +%Y-%m-%d)
+          else
+            RELEASE_DATE="${{ github.event.inputs.date }}"
+          fi
+          echo "RELEASE_DATE=$RELEASE_DATE" >> $GITHUB_ENV
+
+      - name: "Create Release Branch"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          # Ensure release branch doesn't already exist
+          if git rev-parse --verify origin/${{ env.RELEASE_BRANCH }} > /dev/null 2>&1; then
+            echo "Error: Release branch ${{ env.RELEASE_BRANCH }} already exists."
+            exit 1
+          fi
+
+          # Create a new branch for the release
+          git checkout -b "${{ env.RELEASE_BRANCH }}"
+
+      - name: "Regenerate poetry.lock"
+        run: "poetry lock --regenerate"
+
+      - name: "Generate Github Release Notes"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          # 1. Get Towncrier Draft
+          TOWNCRIER_NOTES=$(poetry run towncrier build --version "${{ env.NEW_VERSION }}" --date "${{ env.RELEASE_DATE }}" --draft)
+
+          # 2. Call GitHub API to generate raw notes
+          RAW_GH_NOTES=$(gh api /repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name="v${{ env.NEW_VERSION }}" \
+            -f target_commitish="${{ github.event.inputs['target_branch'] == 'main' && 'develop' || github.event.inputs['target_branch'] }}" \
+            -f previous_tag_name="${{ env.PREVIOUS_TAG }}" --jq '.body')
+
+          # 3. Parse usernames (Regex match)
+          # We use grep to find "@user" patterns, sort, and uniq them
+          USERNAMES=$(echo "$RAW_GH_NOTES" | grep -oP 'by @\K[a-zA-Z0-9-]+' | sort -u | grep -vE 'dependabot|nautobot-bot|github-actions' || true)
+
+          # 4. Format the Contributors section
+          CONTRIBUTORS_SECTION="## Contributors"
+          for user in $USERNAMES; do
+            CONTRIBUTORS_SECTION="$CONTRIBUTORS_SECTION"$'\n'"* @$user"
+          done
+
+          # 5. Extract the "Full Changelog" or "New Contributors" part
+          # Using awk to grab everything from '## New Contributors' or '**Full Changelog**' to the end
+          GH_FOOTER=$(echo "$RAW_GH_NOTES" | awk '/## New Contributors/ || /\*\*Full Changelog\*\*/ {found=1} found {print}')
+          if [ -z "$GH_FOOTER" ]; then
+            GH_FOOTER=$(echo "$RAW_GH_NOTES" | sed -n '/**Full Changelog**/,$p')
+          fi
+
+          # 6. Combine everything
+          FINAL_NOTES="$TOWNCRIER_NOTES"$'\n\n'"$CONTRIBUTORS_SECTION"$'\n\n'"$GH_FOOTER"
+
+          # 7. Save to a temporary file to avoid shell argument length limits
+          echo "$FINAL_NOTES" > ../consolidated_notes.md
+
+      - name: "Generate App Release Notes and update mkdocs.yml"
+        run: "poetry run inv generate-release-notes --version '${{ env.NEW_VERSION }}' --date '${{ env.RELEASE_DATE }}'"
+
+      - name: "Commit Changes and Push"
+        run: |
+          # Add all changes (pyproject.toml, poetry.lock, etc.)
+          git add .
+          git commit -m "prepare release v${{ env.NEW_VERSION }}"
+          git push origin "${{ env.RELEASE_BRANCH }}"
+
+      - name: "Create Pull Request"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          gh pr create \
+            --title "Release v${{ env.NEW_VERSION }}" \
+            --body-file "../consolidated_notes.md" \
+            --base "${{ github.event.inputs.target_branch }}" \
+            --head "${{ env.RELEASE_BRANCH }}"
+
+      - name: "Create Draft Release"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          if [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" ]]; then
+            RELEASE_FLAGS="--prerelease"
+          elif [[ "${{ github.event.inputs.target_branch }}" == "main" ]]; then
+            RELEASE_FLAGS="--latest"
+          else
+            RELEASE_FLAGS="--latest=false"
+          fi
+
+          gh release create "v${{ env.NEW_VERSION }}" \
+            --draft \
+            $RELEASE_FLAGS \
+            --title "v${{ env.NEW_VERSION }} - ${{ env.RELEASE_DATE }}" \
+            --notes-file "../consolidated_notes.md" \
+            --target "${{ github.event.inputs.target_branch }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,9 @@ on:
     types: ["published"]  # covers releases, prereleases, and drafts
 
 jobs:
-  # Publish to GitHub followed by pypi
-  publish_python:
+  build:
     if: ${{ ! github.event.release.draft }}
-    name: "Publish Python Packages"
+    name: "Build Python Packages"
     runs-on: "ubuntu-24.04"
     steps:
       - name: "Check out repository code"
@@ -19,22 +18,53 @@ jobs:
           poetry-version: "2.1.4"
           python-version: "3.14"
       - name: "Build Documentation"
-        run: "poetry run mkdocs build --no-directory-urls --strict"
+        run: "poetry run invoke build-and-check-docs"
       - name: "Run Poetry Build"
         run: "poetry build"
       - name: "Upload binaries to release"
-        uses: "svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd" # v2
+        uses: "actions/upload-artifact@v4"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          file: "dist/*"
-          tag: "${{ github.ref }}"
-          overwrite: true
-          file_glob: true
+          name: "distfiles"
+          path: "dist/"
+          if-no-files-found: "error"
+
+  publish_github:
+    if: ${{ ! github.event.release.draft }}
+    name: "Publish to GitHub"
+    runs-on: "ubuntu-24.04"
+    permissions:
+      contents: "write"
+    needs: "build"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Retrieve built package from cache"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "distfiles"
+          path: "dist/"
+      - name: "Upload binaries to release"
+        run: "gh release upload ${{ github.ref_name }} dist/*.{tar.gz,whl}"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  publish_pypi:
+    if: ${{ ! github.event.release.draft }}
+    name: "Publish to PyPI"
+    runs-on: "ubuntu-24.04"
+    needs: "build"
+    environment: "pypi"
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: "write"
+    steps:
+      - name: "Retrieve built package from cache"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "distfiles"
+          path: "dist/"
       - name: "Push to PyPI"
-        uses: "pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc" # release/v1
-        with:
-          user: "__token__"
-          password: "${{ secrets.PYPI_API_TOKEN }}"
+        uses: "pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e" # v1.13.0
 
   publish_containers:
     if: ${{ ! github.event.release.draft }}
@@ -181,11 +211,13 @@ jobs:
   slack-notify:
     if: ${{ ! github.event.release.draft }}
     needs:
-      - "publish_python"
+      - "publish_github"
+      - "publish_pypi"
       - "merge_containers"
     runs-on: "ubuntu-24.04"
     env:
       SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
+      SLACK_WEBHOOK_TYPE: "INCOMING_WEBHOOK"
       SLACK_MESSAGE: >-
         *NOTIFICATION: NEW-RELEASE-PUBLISHED*\n
         Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\n
@@ -196,7 +228,7 @@ jobs:
         # ENVs cannot be used directly in job.if. This is a workaround to check
         # if SLACK_WEBHOOK_URL is present.
         if: ${{ env.SLACK_WEBHOOK_URL != '' }}
-        uses: "slackapi/slack-github-action@8157a0f4d70c5099e42dcff1258b19bdaabb030b" # v1.17.0
+        uses: "slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3" # v1.27.1
         with:
           payload: |
             {
@@ -218,7 +250,8 @@ jobs:
   deploy-sandbox:
     if: ${{ ! github.event.release.draft && ! github.event.release.prerelease }}
     needs:
-      - "publish_python"
+      - "publish_github"
+      - "publish_pypi"
       - "merge_containers"
     runs-on: "ubuntu-24.04"
     steps:
@@ -226,3 +259,63 @@ jobs:
         run: "gh workflow run deploy_sandbox.yml -R nautobot/sandboxes -f sandbox_environment=demo.nautobot.com"
         env:
           GH_TOKEN: "${{ secrets.GH_NAUTOBOT_BOT_TOKEN }}"
+
+  create-pr-to-develop:
+    if: "github.event.release.target_commitish == 'main'"
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Create a PR from main into develop"
+    needs:
+      - "publish_github"
+      - "publish_pypi"
+      - "merge_containers"
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "Checkout main"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "main"
+          fetch-depth: 0
+
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-version: "2.1.4"
+          poetry-install-options: "--no-root"
+
+      - name: "Create release branch from main"
+        id: "branch"
+        run: |
+
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME#v}"
+
+          BRANCH_NAME="release-${VERSION}-to-develop"
+
+          # Ensure release branch doesn't already exist
+          if git rev-parse --verify origin/$BRANCH_NAME > /dev/null 2>&1; then
+            echo "Error: Release branch $BRANCH_NAME already exists."
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH_NAME"
+
+          poetry version prepatch
+          git add pyproject.toml && git commit -m "Bump version"
+          git push origin "$BRANCH_NAME"
+
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: "Create Pull Request to develop"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          gh pr create \
+            --title "Post release ${{ github.event.release.tag_name }} to develop" \
+            --body "Please do a merge commit." \
+            --base "develop" \
+            --head "${{ steps.branch.outputs.branch_name }}"

--- a/changes/4806.housekeeping
+++ b/changes/4806.housekeeping
@@ -1,1 +1,0 @@
-Updated and/or replaced GitHub actions in release CI that were using deprecated commands.

--- a/changes/4806.housekeeping
+++ b/changes/4806.housekeeping
@@ -1,0 +1,1 @@
+Updated and/or replaced GitHub actions in release CI that were using deprecated commands.

--- a/changes/6267.housekeeping
+++ b/changes/6267.housekeeping
@@ -1,0 +1,1 @@
+Replaced third-party GitHub action in release CI.

--- a/changes/8774.documentation
+++ b/changes/8774.documentation
@@ -1,0 +1,1 @@
+Updated release process documentation to reflect available automation.

--- a/changes/8774.housekeeping
+++ b/changes/8774.housekeeping
@@ -1,0 +1,1 @@
+Updated PyPI publication to use Trusted Publisher.

--- a/nautobot/docs/development/core/docker-compose-advanced-use-cases.md
+++ b/nautobot/docs/development/core/docker-compose-advanced-use-cases.md
@@ -11,7 +11,7 @@ The Invoke tasks have some default [configuration](http://docs.pyinvoke.org/en/s
 - `local`: run the commands in the local environment vs the Docker container (default: `False`)
 - `compose_dir`: the full path to the directory containing the Docker Compose YAML files (default: `"<nautobot source directory>/development"`)
 - `compose_files`: the Docker Compose YAML file(s) to use (default: `["docker-compose.yml", "docker-compose.postgres.yml", "docker-compose.dev.yml"]`)
-- `docker_image_names_main` and `docker_image_names_develop`: Used when [building Docker images for publication](release-checklist.md#publish-docker-images-manually-if-needed); you shouldn't generally need to change these.
+- `docker_image_names_main` and `docker_image_names_develop`: Used when [building Docker images for publication](release-checklist.md#publish-release-to-pypi-and-docker-registries); you shouldn't generally need to change these.
 - `ephemeral_ports`: Setting this value to `True` and not using any custom compose files will make all Nautobot containers with published ports expose themselves with dynamic ports. This is useful when running multiple Nautobot versions at the same time on the same machine so you won't experience system port conflicts. If setting `compose_files`, this will have no effect so please ensure to manually add the `docker-compose.ephemeral-ports.yml` to your list.
 
 These setting may be overridden several different ways (from highest to lowest precedence):

--- a/nautobot/docs/development/core/getting-started.md
+++ b/nautobot/docs/development/core/getting-started.md
@@ -190,6 +190,7 @@ Available tasks:
   dump-service-ports-to-disk   Useful for downstream utilities without direct docker access to determine ports.
   dumpdata                     Dump data from database to db_output file.
   eslint                       Run ESLint to perform JavaScript code linting. Optionally, make an attempt to fix found issues with `--fix` flag.
+  generate-release-notes       Generate Release Notes using Towncrier.
   hadolint                     Check Dockerfile for hadolint compliance and other style issues.
   lint                         Run all linters.
   loaddata                     Load data from file.

--- a/nautobot/docs/development/core/release-checklist.md
+++ b/nautobot/docs/development/core/release-checklist.md
@@ -148,7 +148,7 @@ Ensure that continuous integration testing on the `develop` branch is completing
 
     <h4>Update the Changelog</h4>
 
-    Generate release notes with `towncrier build --version <new-version-number>` and answer `yes` to the prompt `Is it okay if I remove those files? [Y/n]:`. This will update the release notes in `nautobot/docs/release-notes/version-<major.minor>.md`, stage that file in Git, and `git rm` all of the fragments that have now been incorporated into the release notes.
+    Generate release notes with `invoke generate-release-notes --version <new-version-number>`. This will update the release notes in `nautobot/docs/release-notes/version-<major.minor>.md`, stage that file in Git, and `git rm` all of the fragments that have now been incorporated into the release notes.
 
     Run `invoke markdownlint` to make sure the generated release notes pass the linter checks, and manually review them for completeness/correctness as well.
 

--- a/nautobot/docs/development/core/release-checklist.md
+++ b/nautobot/docs/development/core/release-checklist.md
@@ -10,17 +10,12 @@ This document is intended for Nautobot maintainers and covers the steps to perfo
     3. [Link to the New Release Notes Page](#link-to-the-new-release-notes-page)
     4. [Verify and Revise the Install Documentation](#verify-and-revise-the-install-documentation)
 2. [Verify CI Build Status](#verify-ci-build-status)
-3. [Create a Release Branch](#create-a-release-branch)
-4. [Bump the Version](#bump-the-version)
-5. [Update the Changelog](#update-the-changelog)
-6. [Submit Release Pull Request](#submit-release-pull-request)
-7. [Merge Release Pull Request](#merge-release-pull-request)
-8. [Create a New Release](#create-a-new-release)
-9. If needed due to CI failures:
-    1. [Publish to PyPI Manually (if needed)](#publish-to-pypi-manually-if-needed)
-    2. [Publish Docker Images Manually (if needed)](#publish-docker-images-manually-if-needed)
-10. [Bump the Development Version in `develop`](#bump-the-development-version-in-develop)
-11. [Sync Changes into `next`](#sync-changes-into-next)
+3. [Prepare Release Pull Request](#prepare-release-pull-request)
+4. [Merge Release Pull Request](#merge-release-pull-request)
+5. [Publish Release on GitHub](#publish-release-on-github)
+6. [Publish Release to PyPI and Docker Registries](#publish-release-to-pypi-and-docker-registries)
+7. [Bump the Development Version in `develop`](#bump-the-development-version-in-develop)
+8. [Sync Changes into `next`](#sync-changes-into-next)
 
 ## Prerequisites for New Minor or Major Versions
 
@@ -44,6 +39,10 @@ Use the [`poetry update`](https://python-poetry.org/docs/cli/#update) command as
 After making any changes to `pyproject.toml` or `poetry.lock` with the above commands, you should of course commit the changes and re-run Nautobot tests and CI to verify that the dependency updates have not broken anything before proceeding with the release preparation.
 
 ### Update UI Libraries
+
+As with Python dependencies, the UI-compilation dependencies managed by `npm` are generally kept up-to-date by Renovate,and before releasing a new minor or major version of Nautobot, you should review any open Renovate PRs for suitability and merge them if appropriate.
+
+#### Manually Updating UI Libraries
 
 Update UI libraries to their latest version (specified by the tag config) respecting the semver constraints of both package and its dependencies:
 
@@ -77,203 +76,228 @@ Commit any necessary changes to the documentation before proceeding with the rel
 
 Ensure that continuous integration testing on the `develop` branch is completing successfully.
 
-### Create a Release Branch
+### Prepare Release Pull Request
 
-Create a release branch off of `develop` (`git checkout -b release/3.0.1 develop`).
+=== "Automated Release Preparation"
 
-### Bump the Version
+    As of Nautobot 3.1 and later, preparation of a release pull request is automated and can be carried out by running the "prepare-release" GitHub Action. For release preparation from an older branch such as `ltm-2.4`, refer to "Manual Release Preparation" instead.
 
-Update the package version using `invoke version`. This command shows the current version of the project or bumps the version of the project and writes the new version back to `pyproject.toml` (for the Nautobot Python package) if a valid bump rule is provided.
+=== "Manual Release Preparation"
 
-The new version should ideally be a valid semver string or a valid bump rule: `patch`, `minor`, `major`, `prepatch`, `preminor`, `premajor`, `prerelease`. Always try to use a bump rule when you can.
+    <h4>Create a Release Branch</h4>
 
-Display the current version with no arguments:
+    Create a release branch off of `develop` (`git checkout -b release/3.0.1 develop`).
 
-```no-highlight
-invoke version
-```
+    <h4>Bump the Version</h4>
 
-Example output:
+    Update the package version using `invoke version`. This command shows the current version of the project or bumps the version of the project and writes the new version back to `pyproject.toml` (for the Nautobot Python package) if a valid bump rule is provided.
 
-```no-highlight
-3.0.1.b1
-```
+    The new version should ideally be a valid semver string or a valid bump rule: `patch`, `minor`, `major`, `prepatch`, `preminor`, `premajor`, `prerelease`. Always try to use a bump rule when you can.
 
-To prepare for a patch release, use `patch`:
+    Display the current version with no arguments:
 
-```no-highlight
-invoke version -v patch
-```
+    ```no-highlight
+    invoke version
+    ```
 
-Example output:
+    Example output:
 
-```no-highlight
-3.0.2
-```
+    ```no-highlight
+    3.0.1.b1
+    ```
 
-For minor versions, use `minor`:
+    To prepare for a patch release, use `patch`:
 
-```no-highlight
-invoke version -v minor
-```
+    ```no-highlight
+    invoke version -v patch
+    ```
 
-Example output:
+    Example output:
 
-```no-highlight
-3.1.0
-```
+    ```no-highlight
+    3.0.2
+    ```
 
-And for major versions, use `major`:
+    For minor versions, use `minor`:
 
-```no-highlight
-invoke version -v major
-```
+    ```no-highlight
+    invoke version -v minor
+    ```
 
-Example output:
+    Example output:
 
-```no-highlight
-4.0.0
-```
+    ```no-highlight
+    3.1.0
+    ```
 
-The `invoke version [-v <version>]` command internally runs the [`poetry version`](https://python-poetry.org/docs/cli/#version) command to handle the versioning process. However, there might be cases where you need to manually configure the version. Refer to the Poetry documentation linked above for detailed instructions. It provides information on how to set the version directly in the `pyproject.toml` file or update it using the `poetry version` command.
+    And for major versions, use `major`:
 
-After updating the version correctly, be sure to `git add pyproject.toml`. You'll commit it after the next step.
+    ```no-highlight
+    invoke version -v major
+    ```
 
-### Update the Changelog
+    Example output:
 
-Generate release notes with `towncrier build --version <new-version-number>` and answer `yes` to the prompt `Is it okay if I remove those files? [Y/n]:`. This will update the release notes in `nautobot/docs/release-notes/version-<major.minor>.md`, stage that file in Git, and `git rm` all of the fragments that have now been incorporated into the release notes.
+    ```no-highlight
+    4.0.0
+    ```
 
-Run `invoke markdownlint` to make sure the generated release notes pass the linter checks, and manually review them for completeness/correctness as well.
+    The `invoke version [-v <version>]` command internally runs the [`poetry version`](https://python-poetry.org/docs/cli/#version) command to handle the versioning process. However, there might be cases where you need to manually configure the version. Refer to the Poetry documentation linked above for detailed instructions. It provides information on how to set the version directly in the `pyproject.toml` file or update it using the `poetry version` command.
 
-!!! important
-    The changelog must adhere to the [Keep a Changelog](https://keepachangelog.com/) style guide.
+    After updating the version correctly, be sure to `git add pyproject.toml`. You'll commit it after the next step.
 
-Check the git diff to verify the changes are correct (`git diff --cached`). You should see:
+    <h4>Update the Changelog</h4>
 
-* a one-line change to `pyproject.toml` updating the version number (from the previous step)
-* release-notes added to `nautobot/docs/release-notes/version-<major.minor>.md`
-* all change fragments removed from the `changes/` folder
+    Generate release notes with `towncrier build --version <new-version-number>` and answer `yes` to the prompt `Is it okay if I remove those files? [Y/n]:`. This will update the release notes in `nautobot/docs/release-notes/version-<major.minor>.md`, stage that file in Git, and `git rm` all of the fragments that have now been incorporated into the release notes.
 
-Commit (the traditional commit message is "Towncrier and version bump" but that's not required) and push the staged changes upstream to GitHub.
+    Run `invoke markdownlint` to make sure the generated release notes pass the linter checks, and manually review them for completeness/correctness as well.
 
-### Submit Release Pull Request
+    !!! warning
+        The changelog must adhere to the [Keep a Changelog](https://keepachangelog.com/) style guide.
 
-Submit a pull request titled **"Release vX.Y.Z"** to merge your release branch into `main`. Copy the documented release notes into the pull request's body.
+    Check the git diff to verify the changes are correct (`git diff --cached`). You should see:
+
+    * a one-line change to `pyproject.toml` updating the version number (from the previous step)
+    * release-notes added to `nautobot/docs/release-notes/version-<major.minor>.md`
+    * all change fragments removed from the `changes/` folder
+
+    Commit (the traditional commit message is "Towncrier and version bump" but that's not required) and push the staged changes upstream to GitHub.
+
+    <h4>Submit Release Pull Request</h4>
+
+    Submit a pull request titled **"Release vX.Y.Z"** to merge your release branch into `main`. Copy the documented release notes into the pull request's body.
 
 ### Merge Release Pull Request
 
 Once CI has completed on the PR, and you have obtained the required approval(s), merge it.
 
-!!! important
+!!! warning
     Do not squash merge this branch into `main`. Make sure to select `Create a merge commit` when merging in GitHub.
 
-### Create a New Release
+### Publish Release on GitHub
 
-Draft a [new release](https://github.com/nautobot/nautobot/releases/new) with the following parameters.
+=== "Automated Release Preparation"
 
-* **Tag:** Version to be released, prefixed with `v` (e.g. `v3.0.1`)
-* **Target:** `main`
-* **Title:** Version and date (e.g. `v3.0.1 - 2025-11-24`)
-* **Release notes:** Follow the steps below:
-    1. Click on **Generate release notes** button and you should see some release notes auto-generated by GitHub.
-    2. Change the heading **What's Changed** to **Contributors**.
-    3. Create a new **What's Changed** heading before the **Contributors** heading and here, copy and paste the changelog entries for the new release from `nautobot/docs/release-notes/version-<major.minor>.md` (or from your previous pull request).
-    4. Change the entries under the **Contributors** heading to be a list of the usernames of the contributors, for example `* Updated dockerfile by @nautobot_user in https://github.com/nautobot/nautobot/pull/123` --> `* @nautobot_user`, removing duplicate usernames as you go.
-    5. Leave the **New Contributors** list (if any) at the end of the release note as is.
-    6. When done, the release note should look similar to any other recent Nautobot release, for example [v2.4.22](https://github.com/nautobot/nautobot/releases/tag/v2.4.22)
-* **Set as the latest release** should be checked if this release will be the latest for Nautobot. It should **not** be checked for prereleases or for releases from an LTM (long-term maintenance) branch such as `ltm-2.4`.
-* **Create a discussion for this release** should be checked as well.
+    If you successfully ran the "prepare-release" GitHub Action above, it will have automatically created a draft of the release for you. Find it under the [Nautobot releases page](https://github.com/nautobot/nautobot/releases). Verify that the release notes are correct (including any required changes or updates resulting from the PR review). Also confirm that the **Set as the latest release** check is correctly set (or unset, for releases from LTM or pre-releases), and that **Create a discussion for this release** is checked.
+
+=== "Manual Release Preparation"
+
+    Draft a [new release](https://github.com/nautobot/nautobot/releases/new) with the following parameters.
+
+    * **Tag:** Version to be released, prefixed with `v` (e.g. `v3.0.1`)
+    * **Target:** `main`
+    * **Title:** Version and date (e.g. `v3.0.1 - 2025-11-24`)
+    * **Release notes:** Follow the steps below:
+        1. Click on **Generate release notes** button and you should see some release notes auto-generated by GitHub.
+        2. Change the heading **What's Changed** to **Contributors**.
+        3. Create a new **What's Changed** heading before the **Contributors** heading and here, copy and paste the changelog entries for the new release from `nautobot/docs/release-notes/version-<major.minor>.md` (or from your previous pull request).
+        4. Change the entries under the **Contributors** heading to be a list of the usernames of the contributors, for example `* Updated dockerfile by @nautobot_user in https://github.com/nautobot/nautobot/pull/123` --> `* @nautobot_user`, removing duplicate usernames as you go.
+        5. Leave the **New Contributors** list (if any) at the end of the release note as is.
+        6. When done, the release note should look similar to any other recent Nautobot release, for example [v2.4.22](https://github.com/nautobot/nautobot/releases/tag/v2.4.22)
+    * **Set as the latest release** should be checked if this release will be the latest for Nautobot. It should **not** be checked for prereleases or for releases from an LTM (long-term maintenance) branch such as `ltm-2.4`.
+    * **Create a discussion for this release** should be checked as well.
 
 Once you have verified that all of the above is correct, publish the release and wait for the release CI to run in GitHub Actions.
 
-### Publish to PyPI Manually (if needed)
+### Publish Release to PyPI and Docker Registries
 
-!!! tip
-    This is normally done automatically by GitHub Actions after you create the release above. The below is only needed if the automated release fails for some reason.
+=== "Automated Release Preparation"
 
-Now that there is a tagged release, the final step is to upload the package to the Python Package Index.
+    This should occur automatically as a GitHub Action after you publish the release. If for some reason it fails, refer to "Manual Release Preparation".
 
-First, you'll need to render the documentation.
+=== "Manual Release Preparation"
 
-```no-highlight
-poetry run mkdocs build --no-directory-urls --strict
-```
+    <h4>Publish to PyPI Manually</h4>
 
-Second, you'll need to build the Python package distributions (which will include the rendered documentation):
+    Now that there is a tagged release, the final step is to upload the package to the Python Package Index.
 
-```no-highlight
-poetry build
-```
+    First, you'll need to render the documentation.
 
-Finally, publish to PyPI using the username `__token__` and the Nautobot PyPI API token as the password. The API token can be found in the Nautobot maintainers vault (if you're a maintainer, you'll have access to this vault):
+    ```no-highlight
+    poetry run mkdocs build --no-directory-urls --strict
+    ```
 
-```no-highlight
-poetry publish --username __token__ --password <api_token>
-```
+    Second, you'll need to build the Python package distributions (which will include the rendered documentation):
 
-### Publish Docker Images Manually (if needed)
+    ```no-highlight
+    poetry build
+    ```
 
-!!! tip
-    This is normally done automatically by GitHub Actions after you create the release above. The below is only needed if the automated release fails for some reason.
+    Finally, publish to PyPI using the username `__token__` and the Nautobot PyPI API token as the password. The API token can be found in the Nautobot maintainers vault (if you're a maintainer, you'll have access to this vault):
 
-Build the images locally:
+    ```no-highlight
+    poetry publish --username __token__ --password <api_token>
+    ```
 
-```no-highlight
-for ver in 3.10 3.11 3.12 3.13 3.14; do
-  export INVOKE_NAUTOBOT_PYTHON_VER=$ver
-  invoke buildx --target final --tag networktocode/nautobot-py${INVOKE_NAUTOBOT_PYTHON_VER}:local
-  invoke buildx --target final-dev --tag networktocode/nautobot-dev-py${INVOKE_NAUTOBOT_PYTHON_VER}:local
-done
-```
+    <h4>Publish Docker Images Manually</h4>
 
-Test the images locally as needed - to do this you need to set the following in your `invoke.yml`:
+    Build the images locally:
 
-```yaml
----
-nautobot:
-  compose_files:
-    - "docker-compose.yml"
-    - "docker-compose.postgres.yml"
-    - "docker-compose.final.yml"  # or "docker-compose.final-dev.yml" as appropriate
-```
+    ```no-highlight
+    for ver in 3.10 3.11 3.12 3.13 3.14; do
+      export INVOKE_NAUTOBOT_PYTHON_VER=$ver
+      invoke buildx --target final --tag networktocode/nautobot-py${INVOKE_NAUTOBOT_PYTHON_VER}:local
+      invoke buildx --target final-dev --tag networktocode/nautobot-dev-py${INVOKE_NAUTOBOT_PYTHON_VER}:local
+    done
+    ```
 
-!!! warning
-    You should *not* include `docker-compose.dev.yml` in this test scenario!
+    Test the images locally as needed - to do this you need to set the following in your `invoke.yml`:
 
-Push the images to GitHub Container Registry and Docker Hub
+    ```yaml
+    ---
+    nautobot:
+      compose_files:
+        - "docker-compose.yml"
+        - "docker-compose.postgres.yml"
+        - "docker-compose.final.yml"  # or "docker-compose.final-dev.yml" as appropriate
+    ```
 
-```no-highlight
-docker login
-docker login ghcr.io
-for ver in 3.10 3.11 3.12 3.13 3.14; do
-  export INVOKE_NAUTOBOT_PYTHON_VER=$ver
-  invoke docker-push main
-done
-```
+    !!! warning
+        You should *not* include `docker-compose.dev.yml` in this test scenario!
+
+    Push the images to GitHub Container Registry and Docker Hub
+
+    ```no-highlight
+    docker login
+    docker login ghcr.io
+    for ver in 3.10 3.11 3.12 3.13 3.14; do
+      export INVOKE_NAUTOBOT_PYTHON_VER=$ver
+      invoke docker-push main
+    done
+    ```
 
 ### Bump the Development Version in `develop`
 
-Create a new branch off of `main` (typically named `main-to-develop-post-<x.y.z>`) and use `invoke version -v prepatch` to bump the version in preparation for developing the next release. Then open a pull request from this branch to the `develop` branch to update the version and sync the release notes and changelog fragment updates from `main`.
+=== "Automated Release Preparation"
 
-For example, if you just released `v3.0.1`:
+    A pull request to update the `develop` branch should be created automatically as a part of the release CI process. If for some reason this fails, see "Manual Release Preparation" for steps to follow.
 
-```no-highlight
-invoke version -v prepatch
-```
+=== "Manual Release Preparation"
 
-Example output:
+    Create a new branch off of `main` (typically named `main-to-develop-post-<x.y.z>`) and use `invoke version -v prepatch` to bump the version in preparation for developing the next release. Then open a pull request from this branch to the `develop` branch to update the version and sync the release notes and changelog fragment updates from `main`.
 
-```no-highlight
-Bumping version from 3.0.1 to 3.0.2a0
-```
+    For example, if you just released `v3.0.1`:
 
-!!! tip
-    We normally use `beta` version numbers rather than `alpha` versions for `develop`, so you may need to manually edit `pyproject.toml` after the above, for example to change `"3.0.2a0"` to `"3.0.2b1"` to follow our convention.
+    ```no-highlight
+    invoke version -v prepatch
+    ```
 
-!!! important
-    Do not squash merge this branch into `develop`. Make sure to select `Create a merge commit` when merging in GitHub.
+    Example output:
+
+    ```no-highlight
+    Bumping version from 3.0.1 to 3.0.2a0
+    ```
+
+    !!! tip
+        We normally use `beta` version numbers rather than `alpha` versions for `develop`, so you may need to manually edit `pyproject.toml` after the above, for example to change `"3.0.2a0"` to `"3.0.2b1"` to follow our convention.
+
+!!! warning
+    Do not squash merge this PR into `develop`. Make sure to select `Create a merge commit` when merging in GitHub.
 
 ### Sync Changes into `next`
+
+!!! tip
+    This step is not yet automated, but may be in the future.
 
 After the main-to-develop pull request is merged into `develop`, create a new branch off of `next` (typically named `develop-to-next-post-<x.y.z>`) and `git merge develop`. Resolve any merge conflicts as appropriate (if you're lucky, there may only be one, a version number clash in `pyproject.toml`), then open a pull request to `next`.
 
@@ -281,5 +305,5 @@ When resolving conflicts, always keep the Nautobot app version number from the *
 
 During the pull request, the CI pipeline may fail at the **changelog** step. This is expected in this case and should not be a cause for concern (the error can be safely ignored).
 
-!!! important
+!!! warning
     Do not squash merge this branch into `next`. Make sure to select `Create a merge commit` when merging in GitHub.

--- a/tasks.py
+++ b/tasks.py
@@ -814,7 +814,7 @@ def build_example_app_docs(context):
         "keep": "Keep existing change fragment files. Useful for testing. (default: False).",
     }
 )
-def generate_release_notes(context, version="", date="", keep=False):
+def generate_release_notes(context, version="", date="", keep=False):  # pylint: disable=redefined-outer-name
     """Generate Release Notes using Towncrier."""
     command = "poetry run towncrier build"
     if not version:

--- a/tasks.py
+++ b/tasks.py
@@ -807,6 +807,31 @@ def build_example_app_docs(context):
         docker_compose(context, docker_command, pty=True)
 
 
+@task(
+    help={
+        "version": "Nautobot version number to associate with the release notes.",
+        "date": "Date of the release (default: today).",
+        "keep": "Keep existing change fragment files. Useful for testing. (default: False).",
+    }
+)
+def generate_release_notes(context, version="", date="", keep=False):
+    """Generate Release Notes using Towncrier."""
+    command = "poetry run towncrier build"
+    if not version:
+        version = context.run("poetry version --short", hide=True).stdout.strip()
+    command += f" --version {version}"
+    if date:
+        command += f" --date {date}"
+    command += " --keep" if keep else " --yes"
+
+    # N/A for Nautobot core; we create `nautobot/docs/release-notes/version-X.Y.md` for new X.Y versions in advance
+    # version_major_minor = ".".join(version.split(".")[:2])
+    # context.run(f"poetry run python scripts/ensure_release_notes.py --version {version_major_minor}")
+
+    # Due to issues with git repo ownership in the containers, this must always run locally.
+    context.run(command)
+
+
 def task_navigate_to_service_port(context, service: str, internal_port: str, proto: str = "http", creds: str = ""):
     """Navigate to the default system application for a specified uri."""
     nautobot_raw_uri = docker_compose(context, f"port {service} {internal_port}").stdout.rstrip()


### PR DESCRIPTION
# Closes #6267

# What's Changed

- Import `generate-release-notes` task as implemented previously by the Apps team, adapted slightly as needed. Verified to work locally.
- Import `prepare-release` GHA as implemented previously by the Apps team, adapted slightly as needed. **Not tested locally, will need to run the action to verify it.**
- Update `release` GHA to follow patterns adopted previously by the Apps team, including: **Not tested locally, will need to actually make a prerelease to verify it.**
  - Using `gh release upload` CLI in place of third-party action (#6267)
  - Publishing to PyPI using Trusted Publisher
  - Using a newer version of `slackapi/slack-github-action` (but not the latest)
  - Adding `create-pr-to-develop` step.
- Update release documentation accordingly.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
