### PR TITLE
Fixed crontab scheduled jobs to not run immediately

### DIFF
--- a/changes/8316.fixed
+++ b/changes/8316.fixed
@@ -1,0 +1,1 @@
+Fixed scheduled jobs with custom crontab schedules running once immediately (ASAP) before following their crontab schedule.

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -84,12 +84,18 @@ class NautobotScheduleEntry(ModelEntry):
 
         if not model.last_run_at:
             model.last_run_at = self._default_now()
-            # if last_run_at is not set and
-            # model.start_time last_run_at should be in way past.
-            # This will trigger the job to run at start_time
-            # and avoid the heap block.
             if model.start_time:
-                model.last_run_at = model.last_run_at - timedelta(days=365 * 30)
+                # Set last_run_at to one minute before start_time so that celery's crontab
+                # remaining_delta (which uses strict less-than: last_run_at.minute < max(self.minute))
+                # correctly identifies the first crontab match at/after start_time as due.
+                model.last_run_at = model.start_time - timedelta(minutes=1)
+                # This replaces the upstream 30-year-ago hack from django-celery-beat PR #636,
+                # which was intended to avoid a "heap block" issue with interval-based schedules.
+                # That fix doesn't apply to Nautobot since we use DatabaseScheduler (max_interval=5s)
+                # and convert all schedules to crontab (ScheduledJob.to_cron()).
+                # The 30-year trick caused crontab-scheduled jobs to run once immediately (ASAP)
+                # before following their crontab schedule.
+                # See: https://github.com/nautobot/nautobot/issues/8316
 
         self.last_run_at = model.last_run_at
 

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -1501,8 +1501,9 @@ class ScheduledJob(ApprovableModelMixin, BaseModel):
                 # accurately reflects when it will first run, rather than using creation time.
                 # Note: start_time is validated against ScheduledJob.earliest_possible_time()
                 # (now + 15s) in the API serializer; the next crontab match always exceeds this.
-                crontab_schedule = cls.get_crontab(crontab)
-                now = timezone.now()
+                tz = timezone.get_current_timezone()
+                crontab_schedule = cls.get_crontab(crontab, tz=tz)
+                now = timezone.localtime()
                 next_run_delta = crontab_schedule.remaining_estimate(now)
                 # Round up to the nearest minute to compensate for floating-point
                 # precision loss in celery's remaining_estimate (e.g., 4:59:59.999991 -> 5:00:00)

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -1497,7 +1497,10 @@ class ScheduledJob(ApprovableModelMixin, BaseModel):
             name = name or f"{job_model.name} - {start_time}"
         elif interval == JobExecutionType.TYPE_CUSTOM:
             if start_time is None:
-                # Calculate the next crontab match as the start_time.
+                # Calculate the next crontab match as the start_time so that the scheduled job
+                # accurately reflects when it will first run, rather than using creation time.
+                # Note: start_time is validated against ScheduledJob.earliest_possible_time()
+                # (now + 15s) in the API serializer; the next crontab match always exceeds this.
                 crontab_schedule = cls.get_crontab(crontab)
                 now = timezone.now()
                 next_run_delta = crontab_schedule.remaining_estimate(now)

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -1338,20 +1338,6 @@ class ScheduledJob(ApprovableModelMixin, BaseModel):
                 raise ValidationError({"crontab": e})
         if not self.enabled:
             self.last_run_at = None
-        elif not self.last_run_at:
-            # I'm not sure if this is a bug, or "works as designed", but if self.last_run_at is not set,
-            # the celery beat scheduler will never pick up a recurring job. One-off jobs work just fine though.
-            if self.interval in [
-                JobExecutionType.TYPE_HOURLY,
-                JobExecutionType.TYPE_DAILY,
-                JobExecutionType.TYPE_WEEKLY,
-            ]:
-                # A week is 7 days, otherwise the iteration is set to 1
-                multiplier = 7 if self.interval == JobExecutionType.TYPE_WEEKLY else 1
-                # Set the "last run at" time to one interval before the scheduled start time
-                self.last_run_at = self.start_time - timedelta(
-                    **{JobExecutionType.CELERY_INTERVAL_MAP[self.interval]: multiplier},
-                )
         is_new = not self.present_in_database
         super().save(*args, **kwargs)
         if is_new:
@@ -1511,9 +1497,14 @@ class ScheduledJob(ApprovableModelMixin, BaseModel):
             name = name or f"{job_model.name} - {start_time}"
         elif interval == JobExecutionType.TYPE_CUSTOM:
             if start_time is None:
-                # "start_time" is checked against models.ScheduledJob.earliest_possible_time()
-                # which returns timezone.now() + timedelta(seconds=15)
-                start_time = timezone.localtime() + timedelta(seconds=20)
+                # Calculate the next crontab match as the start_time.
+                crontab_schedule = cls.get_crontab(crontab)
+                now = timezone.now()
+                next_run_delta = crontab_schedule.remaining_estimate(now)
+                # Round up to the nearest minute to compensate for floating-point
+                # precision loss in celery's remaining_estimate (e.g., 4:59:59.999991 -> 5:00:00)
+                total_minutes = -(-int(next_run_delta.total_seconds()) // 60)  # ceiling division
+                start_time = now + timedelta(minutes=total_minutes)
 
         celery_kwargs = {
             "nautobot_job_profile": profile,

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -3196,6 +3196,141 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
                 is_due, _ = crontab.is_due(last_run_at=datetime(2024, 3, 9, 17, 0, tzinfo=ZoneInfo("America/New_York")))
                 self.assertTrue(is_due)
 
+    def test_last_run_at_not_set_on_save(self):
+        """Test that save() does not set a fake last_run_at for any interval type."""
+        for job, interval_type in [
+            (self.daily_utc_job, JobExecutionType.TYPE_DAILY),
+            (self.crontab_utc_job, JobExecutionType.TYPE_CUSTOM),
+            (self.one_off_utc_job, JobExecutionType.TYPE_FUTURE),
+        ]:
+            with self.subTest(interval_type=interval_type):
+                job.refresh_from_db()
+                self.assertIsNone(job.last_run_at)
+
+        for interval_type in [JobExecutionType.TYPE_WEEKLY, JobExecutionType.TYPE_HOURLY]:
+            with self.subTest(interval_type=interval_type):
+                job = ScheduledJob.objects.create(
+                    name=f"{interval_type} Job",
+                    task="pass_job.TestPassJob",
+                    job_model=self.job_model,
+                    interval=interval_type,
+                    start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+                    time_zone=get_default_timezone(),
+                )
+                job.refresh_from_db()
+                self.assertIsNone(job.last_run_at)
+
+    def test_disabled_job_last_run_at_cleared(self):
+        """Test that disabling a job clears last_run_at."""
+        self.daily_utc_job.last_run_at = now()
+        self.daily_utc_job.save()
+        self.assertIsNotNone(self.daily_utc_job.last_run_at)
+        self.daily_utc_job.enabled = False
+        self.daily_utc_job.save()
+        self.assertIsNone(self.daily_utc_job.last_run_at)
+
+    def test_schedule_entry_sets_last_run_at(self):
+        """Test that NautobotScheduleEntry sets last_run_at to start_time - 1 minute when model has no last_run_at."""
+        from nautobot.core.celery.schedulers import NautobotScheduleEntry
+
+        for job, interval_type in [
+            (self.daily_utc_job, JobExecutionType.TYPE_DAILY),
+            (self.crontab_est_job, JobExecutionType.TYPE_CUSTOM),
+        ]:
+            with self.subTest(interval_type=interval_type):
+                job.refresh_from_db()
+                self.assertIsNone(job.last_run_at)
+                entry = NautobotScheduleEntry(model=job)
+                expected = job.start_time - timedelta(minutes=1)
+                self.assertEqual(entry.last_run_at, expected)
+
+    def test_schedule_entry_is_due_not_immediate(self):
+        """Test that new scheduled jobs with last_run_at=None do not run immediately.
+
+        Integration test verifying that NautobotScheduleEntry.is_due() (called by celery-beat
+        on each tick) correctly waits for the next crontab match instead of running ASAP.
+        Regression test for https://github.com/nautobot/nautobot/issues/8316
+        """
+        from nautobot.core.celery.schedulers import NautobotScheduleEntry
+
+        with self.subTest("TYPE_CUSTOM crontab job should not be immediately due"):
+            with time_machine.travel("2050-01-22 12:00 +0000"):
+                crontab_job = ScheduledJob.objects.create(
+                    name="Crontab Not Due Job",
+                    task="pass_job.TestPassJob",
+                    job_model=self.job_model,
+                    user=self.user,
+                    interval=JobExecutionType.TYPE_CUSTOM,
+                    start_time=datetime(year=2050, month=1, day=22, hour=11, minute=0, tzinfo=ZoneInfo("UTC")),
+                    time_zone=ZoneInfo("UTC"),
+                    crontab="0 17 * * *",  # 5 PM UTC — 5 hours away from "now"
+                )
+                self.assertIsNone(crontab_job.last_run_at)
+                entry = NautobotScheduleEntry(model=crontab_job)
+                is_due, next_run_delay = entry.is_due()
+                self.assertFalse(is_due, "TYPE_CUSTOM job should not be immediately due")
+                self.assertGreater(next_run_delay, 3600, "Next run delay should be hours away, not seconds")
+
+        with self.subTest("TYPE_CUSTOM crontab job should be due at crontab match time"):
+            with time_machine.travel("2050-01-22 17:00 +0000"):
+                entry = NautobotScheduleEntry(model=crontab_job)
+                is_due, _ = entry.is_due()
+                self.assertTrue(is_due, "TYPE_CUSTOM job should be due when crontab matches")
+
+        with self.subTest("TYPE_DAILY job should not be immediately due"):
+            with time_machine.travel("2050-01-22 12:00 +0000"):
+                daily_job = ScheduledJob.objects.create(
+                    name="Daily Not Due Job",
+                    task="pass_job.TestPassJob",
+                    job_model=self.job_model,
+                    user=self.user,
+                    interval=JobExecutionType.TYPE_DAILY,
+                    start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=ZoneInfo("UTC")),
+                    time_zone=ZoneInfo("UTC"),
+                )
+                self.assertIsNone(daily_job.last_run_at)
+                entry = NautobotScheduleEntry(model=daily_job)
+                is_due, next_run_delay = entry.is_due()
+                self.assertFalse(is_due, "TYPE_DAILY job should not be immediately due")
+
+        with self.subTest("TYPE_DAILY job should be due at scheduled time"):
+            with time_machine.travel("2050-01-23 17:00 +0000"):
+                entry = NautobotScheduleEntry(model=daily_job)
+                is_due, _ = entry.is_due()
+                self.assertTrue(is_due, "TYPE_DAILY job should be due at its scheduled time")
+
+    def test_custom_schedule_start_time_is_next_crontab_match(self):
+        """Test that create_schedule sets start_time to the next crontab match when no start_time is provided."""
+        with time_machine.travel("2050-01-22 12:00 +0000"):
+            job = ScheduledJob.create_schedule(
+                job_model=self.job_model,
+                user=self.user,
+                name="Custom No Start Time",
+                interval=JobExecutionType.TYPE_CUSTOM,
+                crontab="0 17 * * *",  # 5 PM daily
+            )
+            # start_time should be the next crontab match (2050-01-22 17:00 UTC), not ~now
+            self.assertEqual(job.start_time.hour, 17)
+            self.assertEqual(job.start_time.minute, 0)
+            self.assertEqual(job.start_time.date(), datetime(2050, 1, 22).date())
+
+    def test_custom_schedule_start_time_all_crontab_fields(self):
+        """Test that create_schedule correctly computes the next match for a fully specified crontab."""
+        # "5 4 3 2 1" = minute=5, hour=4, day_of_month=3, month=February, day_of_week=Monday
+        # Next Feb 3 from 2050-01-22 is 2050-02-03 at 04:05 UTC
+        with time_machine.travel("2050-01-22 12:00 +0000"):
+            job = ScheduledJob.create_schedule(
+                job_model=self.job_model,
+                user=self.user,
+                name="Custom All Fields",
+                interval=JobExecutionType.TYPE_CUSTOM,
+                crontab="5 4 3 2 1",
+            )
+            self.assertEqual(job.start_time.minute, 5)
+            self.assertEqual(job.start_time.hour, 4)
+            self.assertEqual(job.start_time.month, 2)
+            self.assertEqual(job.start_time.day, 3)
+
     def test_on_workflow_canceled(self):
         """Should change decision_date and schedule_job should be disabled."""
         decision_date = datetime(2025, 1, 1)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8316
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
This PR fixes a bug with custom scheduled jobs that caused them to run once immediately and then follow their configured crontab schedule.

<details>
    <summary>Detailed Analysis and Breakdown</summary>

## History

Scheduled jobs were created in #805. The original implementation did not include custom crontab scheduled jobs, that came later in #2084. In the original implementation, there was this interesting [comment added](https://github.com/nautobot/nautobot/pull/805/changes#diff-843f33404e733176805c25c9171af4af6152b4d06d09c5d214c3e75aaed81d9bR1094-R1107):

```python
# I'm not sure if this is a bug, or "works as designed", but if self.last_run_at is not set,
# the celery beat scheduler will never pick up a recurring job. One-off jobs work just fine though.
```

When crontab jobs were added they did not set the `last_run_at` like they did for the other types. We also didn't require a `start_time` when scheduling via API since we could just derive the next start time from the crontab. Instead, we just set the start time to [20 seconds into the future](https://github.com/nautobot/nautobot/pull/2084/changes#diff-9a2bdd132c5e3a0e6947134b0ae99c641837ad953eb9f5585633bf33e4a60dc9R345-R349) and let it figure out the next run time automatically. This was probably fine until a recent change introduced an [upstream django-celery-beat unrelated bug fix](https://github.com/nautobot/nautobot/pull/6122/changes#r1725760565):

```python
            # if last_run_at is not set and
            # model.start_time last_run_at should be in way past.
            # This will trigger the job to run at start_time
            # and avoid the heap block.
            if model.start_time:
                model.last_run_at = model.last_run_at - datetime.timedelta(days=365 * 30)
```

Since we didn't have a `last_run_at` and we had a `start_time`, this effectively told celery "this job is severely overdue, you should run it ASAP", which it did handily.

So, a simple patch to just add the `last_run_at` would fix the problem...but I just couldn't accept that this hack was needed. Setting the `last_run_at` felt disingenuous because the job _hasn't actually_ run yet. Instead, I decided to fix it so that the hack is no longer required.

## What the hack?

In order to dig into why the hack was originally added I ripped it out. Maybe it's no longer applicable, or maybe it was a bug that has since been fixed. I also ripped out the 30-year-ago hack from upstream so no jobs would think they were overdue and run immediately. I then created a scheduled job of each type to start in 5 minutes. The crontab scheduled job started on time! Problem fixed. But, none of the other scheduled jobs started...until 1 hour and 5 minutes after I created them, then the hourly scheduled job fired for the first time. I ran the test again, but this time the daily scheduled job ran but none of the others did. So, something was causing these scheduled jobs to miss their first run.

As it turns out, the reason why they didn't run the first run comes down to a race condition combined with a small flaw in [how celery determines](https://github.com/celery/celery/blob/main/celery/schedules.py#L585-L592) if it should run or not:

```python
        execute_this_hour = (
            execute_this_date and
            last_run_at.day == now.day and
            last_run_at.month == now.month and
            last_run_at.year == now.year and
            last_run_at.hour in self.hour and
            last_run_at.minute < max(self.minute)
        )
```

Since we no longer set the `last_run_at` in the DB when we create them, they default to `None` instead. Then, when the schedule gets built via `NautobotScheduleEntry.__init__` we were setting `model.last_run_at = self._default_now()`. This means, in memory, it thinks the last time it ran was when it was created.

Now that we have 4 jobs set to execute at the same time it's off to the race condition to see who wins. After the first job is started, we update the DB to notate the _now real_ `last_run_at` on the job that just ran and then we rebuild the schedule again....oh no. We just set the remaining 3 jobs `last_run_at` (in memory) to right now again. So, it goes through the logic in celery's `execute_this_hour` and gets to `last_run_at.minute < max(self.minute)` which checks if right now's minute is less than the start time (right now) minute. This will always equate to `False` since it's strictly `<` rather than `<=`. The same thing would have happened over and over for all jobs that are supposed to run at the same minute possibly causing an endless loop where some jobs would never fire.

In order to overcome this flaw I simply refactored the 30-year-ago timedelta hack to a 1-minute-ago hack and we are back in business. We now set the last run time (when it's not set in the DB) to "start time minus 1 minute" so that all jobs can start at the same time.

```bash
[2026-03-31 19:24:01,776: INFO/MainProcess] beat: Starting...
[2026-03-31 19:27:02,228: INFO/MainProcess] DatabaseScheduler: Schedule changed.
[2026-03-31 19:30:00,651: INFO/MainProcess] Scheduler: Sending due task Custom Logs Cleanup_c8ac8e16-27f1-4810-9381-14420a2d122c (nautobot.extras.jobs.run_job)
[2026-03-31 19:30:00,682: INFO/MainProcess] DatabaseScheduler: Schedule changed.
[2026-03-31 19:30:00,698: INFO/MainProcess] Scheduler: Sending due task Daily Logs Cleanup_9fb1f53b-03d1-476b-8c31-c1514e3764f2 (nautobot.extras.jobs.run_job)
[2026-03-31 19:30:00,713: INFO/MainProcess] DatabaseScheduler: Schedule changed.
[2026-03-31 19:30:00,729: INFO/MainProcess] Scheduler: Sending due task Hourly Logs Cleanup_13552a2a-24ec-4d5e-81f8-ccf86b88c429 (nautobot.extras.jobs.run_job)
[2026-03-31 19:30:00,736: INFO/MainProcess] DatabaseScheduler: Schedule changed.
[2026-03-31 19:30:00,749: INFO/MainProcess] Scheduler: Sending due task Weekly Logs Cleanup_f34792c7-03f1-44cd-9199-db951f0cbf95 (nautobot.extras.jobs.run_job)
[2026-03-31 19:30:00,757: INFO/MainProcess] DatabaseScheduler: Schedule changed.
```

Now that we had that fixed, we just needed to properly set the `start_time` for any scheduled jobs that don't have one (I believe currently only crontab set via API when the field is omitted).

</details>

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests

NTC-4713