### PR TITLE
Backport release and CI updates to develop

### DIFF
--- a/.github/actions/build-nautobot-image/action.yaml
+++ b/.github/actions/build-nautobot-image/action.yaml
@@ -22,68 +22,137 @@
 # ```
 ---
 name: "Build Nautobot Image"
-description: "Builds and pushes Nautobot image"
+description: "Build (and optionally push) a Docker image for Nautobot"
+
 inputs:
-  branch:
-    description: "Branch Name Used In Tag"
-    required: true
-  image:
-    description: "Produced Image Name"
-    required: true
-  tag-latest:
-    description: "Whether To Tag As Latest"
-    required: true
-  tag-latest-for-branch:
-    description: "Whether To Tag As Latest For Branch"
-    required: true
-  tag-latest-for-py:
-    description: "Whether To Tag As Latest For Python Version"
-    required: true
-  platforms:
-    description: "Platforms To Build For"
-    required: false
-    default: "linux/amd64,linux/arm64"
-  push:
-    description: "Whether To Push"
+  images:
+    description: "Full image name(s), comma-separated (e.g. networktocode/nautobot,ghcr.io/nautobot/nautobot)"
     required: true
   python-version:
-    description: "Python Version"
+    description: "Python version for the build matrix"
+    required: true
+  nautobot-version:
+    description: "Nautobot version to install (either PEP440 or branch name)"
     required: true
   target:
-    description: "Target Stage Name"
+    description: "Dockerfile target stage"
     required: true
+    default: "final"
+  push:
+    description: "Whether to push the image"
+    required: false
+    default: false
+  platforms:
+    description: "Target platforms"
+    required: false
+    default: "linux/amd64,linux/arm64"
+  cache-scope:
+    description: "GHA cache scope prefix"
+    required: false
+    default: ""
+  default-python-version:
+    description: "Default Python version to use for 'latest' tag"
+    required: true
+  set-latest:
+    description: "Whether to set the 'latest' and stable tag for releases"
+    required: false
+    default: "false"
+  poetry-parallel:
+    description: "Whether to set POETRY_INSTALLER_PARALLEL to true"
+    required: false
+    default: "false"
+
+outputs:
+  tags:
+    description: "Generated Docker tags"
+    value: "${{ steps.dockermeta.outputs.tags }}"
+  labels:
+    description: "Generated Docker labels"
+    value: "${{ steps.dockermeta.outputs.labels }}"
+  digest:
+    description: "Image digest"
+    value: "${{ steps.build.outputs.digest }}"
+
 runs:
   using: "composite"
   steps:
-    - name: "Setup Metadata"
-      id: "metadata"
-      uses: "docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175" # v4
+    - name: "Clean nautobot-version Input in Case of Leading 'v' and Valid Version Check"
+      id: "cleannautobotversion"
+      shell: "python"
+      run: |
+        import os
+        import sys
+        from packaging.version import Version, InvalidVersion
+        nautobot_version = "${{ inputs.nautobot-version }}"
+        if nautobot_version.startswith("v"):
+            candidate_version = nautobot_version[1:]
+        else:
+            candidate_version = nautobot_version
+        try:
+            v = Version(candidate_version)
+            clean_version = candidate_version
+        except InvalidVersion:
+            clean_version = nautobot_version  # keep original if not valid version
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f"clean-version={clean_version}\n")
+
+    - name: "Determine if Nautobot Version is Pre-release"
+      id: "prereleasecheck"
+      shell: "python"
+      run: |
+        import os
+        import sys
+        from packaging.version import Version, InvalidVersion
+
+        nautobot_version = "${{ steps.cleannautobotversion.outputs.clean-version }}"
+
+        try:
+            v = Version(nautobot_version)
+            is_prerelease = v.is_prerelease
+        except InvalidVersion:
+            is_prerelease = True  # assume branch names are not stable releases
+
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f"is-prerelease={str(is_prerelease).lower()}\n")
+
+    - name: "Docker Metadata"
+      id: "dockermeta"
+      uses: "docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051" # v5.10.0
       with:
-        images: "${{ inputs.image }}"
+        images: "${{ inputs.images }}"
         flavor: |
-          latest=false
+          latest=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
         tags: |
-          type=raw,value=${{ inputs.branch }}-py${{ inputs.python-version }}
-          type=raw,value=latest,enable=${{ inputs.tag-latest }}
-          type=raw,value=${{ inputs.branch }},enable=${{ inputs.tag-latest-for-branch }}
-          type=raw,value=latest-py${{ inputs.python-version }},enable=${{ inputs.tag-latest-for-py }}
+          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }}-py${{ inputs.python-version }}
+          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ inputs.python-version == inputs.default-python-version }}
+          type=pep440,pattern={{major}}.{{minor}}-py${{ inputs.python-version }},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' }}
+          type=pep440,pattern={{major}}.{{minor}},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.python-version == inputs.default-python-version }}
+          type=raw,value=latest-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
+          type=raw,value=stable,enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
+          type=raw,value=stable-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
         labels: |
           org.opencontainers.image.title=Nautobot
-    - name: "Build Dev"
-      env:
-        INVOKE_NAUTOBOT_PYTHON_VER: "${{ inputs.python-version }}"
-      uses: "docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9" # v4
+
+    - name: "Log tags"
+      shell: "bash"
+      run: |
+        echo "=== Tags for ${{ inputs.image }} (py${{ inputs.python-version }}) ==="
+        echo "${{ steps.dockermeta.outputs.tags }}"
+
+    - name: "Build and possibly Push"
+      id: "build"
+      uses: "docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83" # v6.18.0
       with:
         push: "${{ inputs.push }}"
         target: "${{ inputs.target }}"
-        file: "docker/Dockerfile"
         platforms: "${{ inputs.platforms }}"
-        tags: "${{ steps.metadata.outputs.tags }}"
-        labels: "${{ steps.metadata.outputs.labels }}"
-        cache-from: "type=gha,scope=nautobot-${{ inputs.branch }}-${{ inputs.python-version }}"
-        cache-to: "type=gha,mode=max,scope=nautobot-${{ inputs.branch }}-${{ inputs.python-version }}"
+        file: "docker/Dockerfile"
+        tags: "${{ steps.dockermeta.outputs.tags }}"
+        labels: "${{ steps.dockermeta.outputs.labels }}"
+        cache-from: "type=gha,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}"
+        cache-to: "type=gha,mode=max,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}"
         context: "."
         build-args: |
+          INVOKE_NAUTOBOT_PYTHON_VER: ${{ inputs.python-version }}
           PYTHON_VER=${{ inputs.python-version }}
-          DEPENDENCIES_BASE_BRANCH=${{ inputs.branch }}
-          POETRY_INSTALLER_PARALLEL=true
+          POETRY_INSTALLER_PARALLEL=${{ inputs.poetry-parallel }}

--- a/.github/actions/build-nautobot-image/action.yaml
+++ b/.github/actions/build-nautobot-image/action.yaml
@@ -132,16 +132,17 @@ runs:
     - name: "Export digest"
       shell: "bash"
       run: |
-        mkdir -p ${{ runner.temp }}/digests
-        digest="${{ steps.build.outputs.digest }}"
-        touch "${{ runner.temp }}/digests/${digest#sha256:}"
         cache_scope="${{ inputs.cache-scope }}"
+        DIGEST_SCOPE="${cache_scope//\//-}"
         echo "DIGEST_SCOPE=${cache_scope//\//-}" >> $GITHUB_ENV
+        mkdir -p ${{ runner.temp }}/digests/$DIGEST_SCOPE
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/$DIGEST_SCOPE/${digest#sha256:}"
 
     - name: "Upload digest"
       uses: "actions/upload-artifact@v4"
       with:
         name: "digests-${{ env.DIGEST_SCOPE }}-${{ inputs.python-version }}-${{ inputs.arch }}"
-        path: "${{ runner.temp }}/digests/*"
+        path: "${{ runner.temp }}/digests/${{ env.DIGEST_SCOPE }}/*"
         if-no-files-found: error
         retention-days: 1

--- a/.github/actions/build-nautobot-image/action.yaml
+++ b/.github/actions/build-nautobot-image/action.yaml
@@ -7,11 +7,9 @@
 # ```
 # steps:
 #   - name: "Check out repository code"
-#     uses: "actions/checkout@v3"
-#   - name: "Set up QEMU"
-#     uses: "docker/setup-qemu-action@v2"
+#     uses: "actions/checkout@v4"
 #   - name: "Set up Docker Buildx"
-#     uses: "docker/setup-buildx-action@v2"
+#     uses: "docker/setup-buildx-action@v4"
 #   # To be able to push to GitHub Container Registry, we need to log in to it first.
 #   - name: "Login to GitHub Container Registry"
 #     uses: "docker/login-action@v2"
@@ -42,30 +40,20 @@ inputs:
     description: "Whether to push the image"
     required: false
     default: false
-  platforms:
-    description: "Target platforms"
+  arch:
+    description: "Target architecture"
     required: false
-    default: "linux/amd64,linux/arm64"
+    default: "amd64"
   cache-scope:
     description: "GHA cache scope prefix"
     required: false
     default: ""
-  default-python-version:
-    description: "Default Python version to use for 'latest' tag"
-    required: true
-  set-latest:
-    description: "Whether to set the 'latest' and stable tag for releases"
-    required: false
-    default: "false"
   poetry-parallel:
     description: "Whether to set POETRY_INSTALLER_PARALLEL to true"
     required: false
     default: "false"
 
 outputs:
-  tags:
-    description: "Generated Docker tags"
-    value: "${{ steps.dockermeta.outputs.tags }}"
   labels:
     description: "Generated Docker labels"
     value: "${{ steps.dockermeta.outputs.labels }}"
@@ -120,39 +108,39 @@ runs:
       uses: "docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051" # v5.10.0
       with:
         images: "${{ inputs.images }}"
-        flavor: |
-          latest=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
-        tags: |
-          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }}-py${{ inputs.python-version }}
-          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ inputs.python-version == inputs.default-python-version }}
-          type=pep440,pattern={{major}}.{{minor}}-py${{ inputs.python-version }},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' }}
-          type=pep440,pattern={{major}}.{{minor}},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.python-version == inputs.default-python-version }}
-          type=raw,value=latest-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
-          type=raw,value=stable,enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
-          type=raw,value=stable-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
         labels: |
           org.opencontainers.image.title=Nautobot
-
-    - name: "Log tags"
-      shell: "bash"
-      run: |
-        echo "=== Tags for ${{ inputs.image }} (py${{ inputs.python-version }}) ==="
-        echo "${{ steps.dockermeta.outputs.tags }}"
 
     - name: "Build and possibly Push"
       id: "build"
       uses: "docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83" # v6.18.0
       with:
-        push: "${{ inputs.push }}"
         target: "${{ inputs.target }}"
-        platforms: "${{ inputs.platforms }}"
+        platforms: "linux/${{ inputs.arch }}"
         file: "docker/Dockerfile"
-        tags: "${{ steps.dockermeta.outputs.tags }}"
         labels: "${{ steps.dockermeta.outputs.labels }}"
-        cache-from: "type=gha,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}"
-        cache-to: "type=gha,mode=max,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}"
+        cache-from: "type=gha,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}-${{ inputs.arch }}"
+        cache-to: "type=gha,mode=max,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}-${{ inputs.arch }}"
         context: "."
+        outputs: "type=image,push-by-digest=true,name-canonical=true,push=${{ inputs.push }}"
         build-args: |
           INVOKE_NAUTOBOT_PYTHON_VER: ${{ inputs.python-version }}
           PYTHON_VER=${{ inputs.python-version }}
           POETRY_INSTALLER_PARALLEL=${{ inputs.poetry-parallel }}
+
+    - name: "Export digest"
+      shell: "bash"
+      run: |
+        mkdir -p ${{ runner.temp }}/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+        cache_scope="${{ inputs.cache-scope }}"
+        echo "DIGEST_SCOPE=${cache_scope//\//-}" >> $GITHUB_ENV
+
+    - name: "Upload digest"
+      uses: "actions/upload-artifact@v4"
+      with:
+        name: "digests-${{ env.DIGEST_SCOPE }}-${{ inputs.python-version }}-${{ inputs.arch }}"
+        path: "${{ runner.temp }}/digests/*"
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/actions/build-nautobot-image/action.yaml
+++ b/.github/actions/build-nautobot-image/action.yaml
@@ -119,6 +119,7 @@ runs:
         platforms: "linux/${{ inputs.arch }}"
         file: "docker/Dockerfile"
         labels: "${{ steps.dockermeta.outputs.labels }}"
+        tags: "${{ inputs.images }}"
         cache-from: "type=gha,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}-${{ inputs.arch }}"
         cache-to: "type=gha,mode=max,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}-${{ inputs.arch }}"
         context: "."

--- a/.github/actions/merge-image-digests/action.yaml
+++ b/.github/actions/merge-image-digests/action.yaml
@@ -1,0 +1,114 @@
+# Action to merge manifests for multi-platform Docker images built by `build-nautobot-image` action.
+---
+name: "Merge manifests and publish"
+description: "Merge Docker image manifests and publish the merge for multiple platforms"
+
+inputs:
+  image:
+    description: "Full image name (e.g. networktocode/nautobot or ghcr.io/nautobot/nautobot)"
+    required: true
+  python-version:
+    description: "Python version for the build matrix"
+    required: true
+  nautobot-version:
+    description: "Nautobot version to install (either PEP440 or branch name)"
+    required: true
+  cache-scope:
+    description: "GHA cache scope prefix"
+    required: false
+    default: ""
+  default-python-version:
+    description: "Default Python version to use for 'latest' tag"
+    required: true
+  set-latest:
+    description: "Whether to set the 'latest' and stable tag for releases"
+    required: false
+    default: "false"
+
+outputs:
+  tags:
+    description: "Generated Docker tags"
+    value: "${{ steps.dockermeta.outputs.tags }}"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Clean nautobot-version Input in Case of Leading 'v' and Valid Version Check"
+      id: "cleannautobotversion"
+      shell: "python"
+      run: |
+        import os
+        import sys
+        from packaging.version import Version, InvalidVersion
+        nautobot_version = "${{ inputs.nautobot-version }}"
+        if nautobot_version.startswith("v"):
+            candidate_version = nautobot_version[1:]
+        else:
+            candidate_version = nautobot_version
+        try:
+            v = Version(candidate_version)
+            clean_version = candidate_version
+        except InvalidVersion:
+            clean_version = nautobot_version  # keep original if not valid version
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f"clean-version={clean_version}\n")
+
+    - name: "Determine if Nautobot Version is Pre-release"
+      id: "prereleasecheck"
+      shell: "python"
+      run: |
+        import os
+        import sys
+        from packaging.version import Version, InvalidVersion
+
+        nautobot_version = "${{ steps.cleannautobotversion.outputs.clean-version }}"
+
+        try:
+            v = Version(nautobot_version)
+            is_prerelease = v.is_prerelease
+        except InvalidVersion:
+            is_prerelease = True  # assume branch names are not stable releases
+
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f"is-prerelease={str(is_prerelease).lower()}\n")
+
+    - name: "Docker Metadata"
+      id: "dockermeta"
+      uses: "docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051" # v5.10.0
+      with:
+        images: "${{ inputs.image }}"
+        flavor: |
+          latest=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
+        tags: |
+          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }}-py${{ inputs.python-version }}
+          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ inputs.python-version == inputs.default-python-version }}
+          type=pep440,pattern={{major}}.{{minor}}-py${{ inputs.python-version }},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' }}
+          type=pep440,pattern={{major}}.{{minor}},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.python-version == inputs.default-python-version }}
+          type=raw,value=latest-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
+          type=raw,value=stable,enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
+          type=raw,value=stable-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
+        labels: |
+          org.opencontainers.image.title=Nautobot
+
+    - name: "Log tags"
+      shell: "bash"
+      run: |
+        echo "=== Tags for ${{ inputs.image }} (py${{ inputs.python-version }}) ==="
+        echo "${{ steps.dockermeta.outputs.tags }}"
+        cache_scope="${{ inputs.cache-scope }}"
+        echo "DIGEST_SCOPE=${cache_scope//\//-}" >> $GITHUB_ENV
+
+    - name: "Download digests"
+      uses: "actions/download-artifact@v4"
+      with:
+        path: "${{ runner.temp }}/digests"
+        pattern: "digests-${{ env.DIGEST_SCOPE }}-${{ inputs.python-version }}-*"
+        merge-multiple: true
+
+    - name: "Create and publish manifest list"
+      shell: "bash"
+      working-directory: "${{ runner.temp }}/digests"
+      run: |
+        docker buildx imagetools create \
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ inputs.image }}@sha256:%s ' *)

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -61,7 +61,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--only dev --only linting"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.13"
       - name: "Setup Node.js"
         uses: "actions/setup-node@v4"

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -278,24 +278,10 @@ jobs:
       fail-fast: true
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+    env:
+      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.13"
+      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "false" # Change this to false for LTM, Pre-release versions force this to false.
     steps:
-      - name: "Configuration"
-        id: "config"
-        shell: "bash"
-        run: |
-          export BRANCH="${{ github.ref_name }}"
-          export TAG_LATEST="false"
-          export TAG_LATEST_FOR_BRANCH="false"
-          export TAG_LATEST_FOR_PY="false"
-
-          if [[ "${{ matrix.python-version }}" == "3.13" ]]; then
-            export TAG_LATEST_FOR_BRANCH="true"
-          fi
-
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "tag-latest=$TAG_LATEST" >> $GITHUB_OUTPUT
-          echo "tag-latest-for-branch=$TAG_LATEST_FOR_BRANCH" >> $GITHUB_OUTPUT
-          echo "tag-latest-for-py=$TAG_LATEST_FOR_PY" >> $GITHUB_OUTPUT
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Set up QEMU"
@@ -308,47 +294,49 @@ jobs:
           registry: "ghcr.io"
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
-      - name: "Build `final` (amd64 only)"
-        if: |
-          steps.config.outputs.tag-latest-for-branch == 'true'
+
+      - name: "Determine if nautobot-version is branch name or from tag name"
+        id: "versionname"
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Build Only Test (prod - final target)"
         uses: "./.github/actions/build-nautobot-image"
         with:
-          branch: "${{ steps.config.outputs.branch }}"
-          image: "ghcr.io/nautobot/nautobot"
-          platforms: "linux/amd64"
-          push: "false"
+          images: "ghcr.io/nautobot/nautobot"
           python-version: "${{ matrix.python-version }}"
-          tag-latest: "${{ steps.config.outputs.tag-latest }}"
-          tag-latest-for-branch: "${{ steps.config.outputs.tag-latest-for-branch }}"
-          tag-latest-for-py: "${{ steps.config.outputs.tag-latest-for-py }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          platforms: "linux/amd64"
+          push: false
           target: "final"
-      - name: "Build and Push `final-dev` (amd64 only)"
-        if:
-          steps.config.outputs.tag-latest-for-branch != 'true' ||
-          steps.config.outputs.branch != 'next'
+          poetry-parallel: true
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+
+      - name: "Determine if we should build multi-arch dev image if python-version is default, return platforms string"
+        id: "devplatforms"
+        run: |
+          if [[ "${{ matrix.python-version }}" == "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}" ]]; then
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+          else
+            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Build and Push (dev - final-dev target)"
         uses: "./.github/actions/build-nautobot-image"
         with:
-          branch: "${{ steps.config.outputs.branch }}"
-          image: "ghcr.io/nautobot/nautobot-dev"
-          platforms: "linux/amd64"
-          push: "true"
+          images: "ghcr.io/nautobot/nautobot-dev"
           python-version: "${{ matrix.python-version }}"
-          tag-latest: "${{ steps.config.outputs.tag-latest }}"
-          tag-latest-for-branch: "${{ steps.config.outputs.tag-latest-for-branch }}"
-          tag-latest-for-py: "${{ steps.config.outputs.tag-latest-for-py }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          platforms: "${{ steps.devplatforms.outputs.platforms }}"
+          push: true
           target: "final-dev"
-      - name: "Build and Push `final-dev` (amd64 + arm64) for 3.13 + next"
-        if:
-          steps.config.outputs.tag-latest-for-branch == 'true' &&
-          steps.config.outputs.branch == 'next'
-        uses: "./.github/actions/build-nautobot-image"
-        with:
-          branch: "${{ steps.config.outputs.branch }}"
-          image: "ghcr.io/nautobot/nautobot-dev"
-          platforms: "linux/amd64,linux/arm64"
-          push: "true"
-          python-version: "${{ matrix.python-version }}"
-          tag-latest: "${{ steps.config.outputs.tag-latest }}"
-          tag-latest-for-branch: "${{ steps.config.outputs.tag-latest-for-branch }}"
-          tag-latest-for-py: "${{ steps.config.outputs.tag-latest-for-py }}"
-          target: "final-dev"
+          poetry-parallel: true
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -262,7 +262,6 @@ jobs:
         run: "NAUTOBOT_SELENIUM_HOST=`hostname -f` poetry run invoke tests --tag integration --no-keepdb"
   container-build:
     name: "Build Container Images (GHCR Only)"
-    runs-on: "ubuntu-24.04"
     if: |
       github.event_name == 'push' &&
       (github.ref_name == 'develop' || github.ref_name == 'next' || github.ref_name == 'ltm-1.6')
@@ -278,16 +277,19 @@ jobs:
       fail-fast: true
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13" ]
-    env:
-      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.13"
-      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "false" # Change this to false for LTM, Pre-release versions force this to false.
+        arch: [ "amd64", "arm64" ]
+        os: [ "ubuntu-24.04", "ubuntu-24.04-arm" ]
+        exclude:
+          - os: "ubuntu-24.04"
+            arch: "arm64"
+          - os: "ubuntu-24.04-arm"
+            arch: "amd64"
+    runs-on: "${{ matrix.os }}"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7" # v2
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55" # v2
+        uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
       - name: "Login to GitHub Container Registry"
         uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
         with:
@@ -310,22 +312,11 @@ jobs:
           images: "ghcr.io/nautobot/nautobot"
           python-version: "${{ matrix.python-version }}"
           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
-          platforms: "linux/amd64"
+          arch: "${{ matrix.arch }}"
           push: false
           target: "final"
           poetry-parallel: true
-          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
-          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
-          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
-
-      - name: "Determine if we should build multi-arch dev image if python-version is default, return platforms string"
-        id: "devplatforms"
-        run: |
-          if [[ "${{ matrix.python-version }}" == "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}" ]]; then
-            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
-          else
-            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
-          fi
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
 
       - name: "Build and Push (dev - final-dev target)"
         uses: "./.github/actions/build-nautobot-image"
@@ -333,10 +324,54 @@ jobs:
           images: "ghcr.io/nautobot/nautobot-dev"
           python-version: "${{ matrix.python-version }}"
           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
-          platforms: "${{ steps.devplatforms.outputs.platforms }}"
+          arch: "${{ matrix.arch }}"
           push: true
           target: "final-dev"
           poetry-parallel: true
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}"
+
+  container-merge:
+    name: "Merge Manifests (publish GHCR, final-dev only)"
+    if: |
+      github.event_name == 'push' &&
+      (github.ref_name == 'develop' || github.ref_name == 'next' || github.ref_name == 'ltm-1.6')
+    needs:
+      - "container-build"
+    runs-on: "ubuntu-24.04"
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+    env:
+      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.13"
+      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "false" # Change this to false for LTM, Pre-release versions force this to false.
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Set up Docker Buildx"
+        uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
+      - name: "Login to GitHub Container Registry"
+        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Determine if nautobot-version is branch name or from tag name"
+        id: "versionname"
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Merge (dev - final-dev target)"
+        uses: "./.github/actions/merge-image-digests"
+        with:
+          image: "ghcr.io/nautobot/nautobot-dev"
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
           default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
           set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
-          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}"

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -231,7 +231,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--only dev --only linting"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.13"
       - name: "Setup Node.js"
         uses: "actions/setup-node@v4"
@@ -253,7 +253,7 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-install-options: "--only dev --only linting"
-          poetry-version: "1.8.5"
+          poetry-version: "2.1.4"
           python-version: "3.13"
       - name: "Setup Node.js"
         uses: "actions/setup-node@v4"
@@ -429,7 +429,7 @@ jobs:
   #       uses: "networktocode/gh-action-setup-poetry-environment@v6"
   #       with:
   #         poetry-install-options: "--extras mysql"
-  #         poetry-version: "1.8.5"
+  #         poetry-version: "2.1.4"
   #         python-version: "3.13"
   #     - name: "Run unittest"
   #       run: "poetry run invoke tests --no-keepdb --no-cache-test-fixtures --no-parallel"

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -600,8 +600,15 @@ jobs:
           git fetch --no-tags origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
           poetry run towncrier check --compare-with origin/${{ github.base_ref }}
   container-build-test:
-    name: "Test Container Build (amd64 only on Python 3.13)"
-    runs-on: "ubuntu-24.04"
+    name: "Test Container Build (Python 3.13 only)"
+    strategy:
+      matrix:
+        include:
+          - os: "ubuntu-24.04"
+            arch: "amd64"
+          - os: "ubuntu-24.04-arm"
+            arch: "arm64"
+    runs-on: "${{ matrix.os }}"
     needs:
       - "check-migrations"
       - "check-schema"
@@ -617,16 +624,8 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7" # v2
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55" # v2
-      - name: "Login to GitHub Container Registry"
-        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
-        with:
-          registry: "ghcr.io"
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
+        uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
       - name: "Determine if nautobot-version is branch name or from tag name"
         id: "versionname"
         run: |
@@ -640,12 +639,41 @@ jobs:
         with:
           images: "ghcr.io/nautobot/nautobot"
           python-version: "3.13"
-          platforms: "linux/amd64" # only build for amd64 in PRs to save on time/resources
           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          arch: "${{ matrix.arch }}"
           push: false
           target: "final"
           default-python-version: "3.13"
-          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
+
+#   container-merge-test:
+#     name: "Test Merge Manifests (Python 3.13 only)"
+#     needs:
+#       - "container-build-test"
+#     runs-on: "ubuntu-24.04"
+#     steps:
+#       - name: "Check out repository code"
+#         uses: "actions/checkout@v4"
+#       - name: "Set up Docker Buildx"
+#         uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
+#       - name: "Determine if nautobot-version is branch name or from tag name"
+#         id: "versionname"
+#         run: |
+#           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+#             echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+#           else
+#             echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+#           fi
+#       - name: "Merge Test (prod - final target)"
+#         uses: "./.github/actions/merge-image-digests"
+#         with:
+#           image: "ghcr.io/nautobot/nautobot"
+#           python-version: "3.13"
+#           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+#           default-python-version: "3.13"
+#           set-latest: false
+#           cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
+
   all-tests-passed:
     runs-on: "ubuntu-24.04"
     steps:

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -643,7 +643,6 @@ jobs:
           arch: "${{ matrix.arch }}"
           push: false
           target: "final"
-          default-python-version: "3.13"
           cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
 
 #   container-merge-test:

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -627,18 +627,25 @@ jobs:
           registry: "ghcr.io"
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
-      - name: "Build `final`"
+      - name: "Determine if nautobot-version is branch name or from tag name"
+        id: "versionname"
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          fi
+      - name: "Build Only Test (prod - final target)"
         uses: "./.github/actions/build-nautobot-image"
         with:
-          branch: "${{ github.head_ref }}"
-          image: "ghcr.io/nautobot/nautobot"
-          platforms: "linux/amd64"
-          push: "false"
+          images: "ghcr.io/nautobot/nautobot"
           python-version: "3.13"
-          tag-latest: "false"
-          tag-latest-for-branch: "false"
-          tag-latest-for-py: "false"
+          platforms: "linux/amd64" # only build for amd64 in PRs to save on time/resources
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          push: false
           target: "final"
+          default-python-version: "3.13"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
   all-tests-passed:
     runs-on: "ubuntu-24.04"
     steps:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,180 @@
+---
+name: "Prepare Release"
+on: # yamllint disable-line rule:truthy rule:comments
+  workflow_dispatch:
+    inputs:
+      bump_rule:
+        description: "Select the version bump type"
+        required: true
+        default: "patch"
+        type: "choice"
+        options:
+          - "prerelease"
+          - "patch"
+          - "minor"
+          - "major"
+      target_branch:
+        description: "Create the release from this branch (default: main)."
+        required: true
+        default: "main"
+      date:
+        description: "Date of the release YYYY-MM-DD (defaults to today's date in the US Eastern TZ)."
+        required: false
+        default: ""
+
+jobs:
+  prepare-release:
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Prepare Release"
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v4"
+        with:
+          # If target_branch is 'main', use 'develop' as the source branch. Otherwise, the source and target branch are the same.
+          ref: "${{ github.event.inputs['target_branch'] == 'main' && 'develop' || github.event.inputs['target_branch'] }}"
+          fetch-depth: 0  # Fetch all history for git tags
+
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-install-options: "--with dev"
+          poetry-version: "2.1.4"
+
+      - name: "Validate Branch and Tags"
+        run: |
+          # 1. Verify branch exists
+          if ! git rev-parse --verify origin/${{ github.event.inputs.target_branch }} > /dev/null 2>&1; then
+            echo "Error: Branch ${{ github.event.inputs.target_branch }} does not exist."
+            exit 1
+          fi
+
+          # 2. Try to get the previous version tag
+          # If it fails (no tags), get the hash of the first commit
+          if PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
+            echo "PREVIOUS_TAG=$PREV_TAG" >> $GITHUB_ENV
+            echo "Found previous tag: $PREV_TAG"
+          else
+            # Fallback to the first commit in the repository
+            FIRST_COMMIT=$(git rev-list --max-parents=0 HEAD)
+            echo "PREVIOUS_TAG=$FIRST_COMMIT" >> $GITHUB_ENV
+            echo "No tags found. Falling back to initial commit: $FIRST_COMMIT"
+          fi
+
+      - name: "Determine New Version"
+        id: "versioning"
+        run: |
+          if [[ "${{ github.event.inputs.bump_rule }}" != "prerelease" ]]; then
+            # Perform the bump based on the user input
+            poetry version ${{ github.event.inputs.bump_rule }}
+          fi
+
+          # Capture the New version string for use in other steps
+          NEW_VER=$(poetry version --short)
+          echo "NEW_VERSION=$NEW_VER" >> $GITHUB_ENV
+          echo "RELEASE_BRANCH=release/$NEW_VER" >> $GITHUB_ENV
+
+      - name: "Set Date Variable"
+        run: |
+          if [ -z "${{ github.event.inputs.date }}" ]; then
+            RELEASE_DATE=$(TZ=America/New_York date +%Y-%m-%d)
+          else
+            RELEASE_DATE="${{ github.event.inputs.date }}"
+          fi
+          echo "RELEASE_DATE=$RELEASE_DATE" >> $GITHUB_ENV
+
+      - name: "Create Release Branch"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          # Ensure release branch doesn't already exist
+          if git rev-parse --verify origin/${{ env.RELEASE_BRANCH }} > /dev/null 2>&1; then
+            echo "Error: Release branch ${{ env.RELEASE_BRANCH }} already exists."
+            exit 1
+          fi
+
+          # Create a new branch for the release
+          git checkout -b "${{ env.RELEASE_BRANCH }}"
+
+      - name: "Regenerate poetry.lock"
+        run: "poetry lock --regenerate"
+
+      - name: "Generate Github Release Notes"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          # 1. Get Towncrier Draft
+          TOWNCRIER_NOTES=$(poetry run towncrier build --version "${{ env.NEW_VERSION }}" --date "${{ env.RELEASE_DATE }}" --draft)
+
+          # 2. Call GitHub API to generate raw notes
+          RAW_GH_NOTES=$(gh api /repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name="v${{ env.NEW_VERSION }}" \
+            -f target_commitish="${{ github.event.inputs['target_branch'] == 'main' && 'develop' || github.event.inputs['target_branch'] }}" \
+            -f previous_tag_name="${{ env.PREVIOUS_TAG }}" --jq '.body')
+
+          # 3. Parse usernames (Regex match)
+          # We use grep to find "@user" patterns, sort, and uniq them
+          USERNAMES=$(echo "$RAW_GH_NOTES" | grep -oP 'by @\K[a-zA-Z0-9-]+' | sort -u | grep -vE 'dependabot|nautobot-bot|github-actions' || true)
+
+          # 4. Format the Contributors section
+          CONTRIBUTORS_SECTION="## Contributors"
+          for user in $USERNAMES; do
+            CONTRIBUTORS_SECTION="$CONTRIBUTORS_SECTION"$'\n'"* @$user"
+          done
+
+          # 5. Extract the "Full Changelog" or "New Contributors" part
+          # Using awk to grab everything from '## New Contributors' or '**Full Changelog**' to the end
+          GH_FOOTER=$(echo "$RAW_GH_NOTES" | awk '/## New Contributors/ || /\*\*Full Changelog\*\*/ {found=1} found {print}')
+          if [ -z "$GH_FOOTER" ]; then
+            GH_FOOTER=$(echo "$RAW_GH_NOTES" | sed -n '/**Full Changelog**/,$p')
+          fi
+
+          # 6. Combine everything
+          FINAL_NOTES="$TOWNCRIER_NOTES"$'\n\n'"$CONTRIBUTORS_SECTION"$'\n\n'"$GH_FOOTER"
+
+          # 7. Save to a temporary file to avoid shell argument length limits
+          echo "$FINAL_NOTES" > ../consolidated_notes.md
+
+      - name: "Generate App Release Notes and update mkdocs.yml"
+        run: "poetry run inv generate-release-notes --version '${{ env.NEW_VERSION }}' --date '${{ env.RELEASE_DATE }}'"
+
+      - name: "Commit Changes and Push"
+        run: |
+          # Add all changes (pyproject.toml, poetry.lock, etc.)
+          git add .
+          git commit -m "prepare release v${{ env.NEW_VERSION }}"
+          git push origin "${{ env.RELEASE_BRANCH }}"
+
+      - name: "Create Pull Request"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          gh pr create \
+            --title "Release v${{ env.NEW_VERSION }}" \
+            --body-file "../consolidated_notes.md" \
+            --base "${{ github.event.inputs.target_branch }}" \
+            --head "${{ env.RELEASE_BRANCH }}"
+
+      - name: "Create Draft Release"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          if [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" ]]; then
+            RELEASE_FLAGS="--prerelease"
+          elif [[ "${{ github.event.inputs.target_branch }}" == "main" ]]; then
+            RELEASE_FLAGS="--latest"
+          else
+            RELEASE_FLAGS="--latest=false"
+          fi
+
+          gh release create "v${{ env.NEW_VERSION }}" \
+            --draft \
+            $RELEASE_FLAGS \
+            --title "v${{ env.NEW_VERSION }} - ${{ env.RELEASE_DATE }}" \
+            --notes-file "../consolidated_notes.md" \
+            --target "${{ github.event.inputs.target_branch }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
             echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           else
             echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          fi
 
       - name: "Build and Push (prod - final target)"
         uses: "./.github/actions/build-nautobot-image"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,3 @@
----
 name: "Release"
 on:
   release:
@@ -7,7 +6,7 @@ on:
 jobs:
   # Publish to GitHub followed by pypi
   publish_python:
-    if: "${{ ! github.event.release.draft }}"
+    if: ${{ ! github.event.release.draft }}
     name: "Publish Python Packages"
     runs-on: "ubuntu-24.04"
     steps:
@@ -38,26 +37,27 @@ jobs:
           password: "${{ secrets.PYPI_API_TOKEN }}"
 
   publish_containers:
-    if: "${{ ! github.event.release.draft }}"
+    if: ${{ ! github.event.release.draft }}
     name: "Build & Publish Container Images"
-    runs-on: "ubuntu-24.04"
     strategy:
       fail-fast: true
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13" ]
-    env:
-      INVOKE_NAUTOBOT_PYTHON_VER: "${{ matrix.python-version }}"
-      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.13"
-      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "true" # Change this to false for LTM, Pre-release versions force this to false.
+        arch: [ "amd64", "arm64" ]
+        os: [ "ubuntu-24.04", "ubuntu-24.04-arm" ]
+        exclude:
+          - os: "ubuntu-24.04"
+            arch: "arm64"
+          - os: "ubuntu-24.04-arm"
+            arch: "amd64"
+    runs-on: "${{ matrix.os }}"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: "gitbranch"
-      - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7" # v2
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55" # v2
+        uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
       - name: "Login to GitHub Container Registry"
         uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
         with:
@@ -84,11 +84,10 @@ jobs:
           images: "networktocode/nautobot,ghcr.io/nautobot/nautobot"
           python-version: "${{ matrix.python-version }}"
           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          arch: "${{ matrix.arch }}"
           push: true
           target: "final"
-          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
-          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
-          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
 
       - name: "Build and Push (dev - final-dev target)"
         uses: "./.github/actions/build-nautobot-image"
@@ -96,17 +95,94 @@ jobs:
           images: "networktocode/nautobot-dev,ghcr.io/nautobot/nautobot-dev"
           python-version: "${{ matrix.python-version }}"
           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          arch: "${{ matrix.arch }}"
           push: true
           target: "final-dev"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}"
+
+  merge_containers:
+    name: "Merge Manifests"
+    if: ${{ ! github.event.release.draft }}
+    needs:
+      - "publish_containers"
+    runs-on: "ubuntu-24.04"
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+    env:
+      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.13"
+      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "true" # Change this to false for LTM, Pre-release versions force this to false.
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Set up Docker Buildx"
+        uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
+      - name: "Login to GitHub Container Registry"
+        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+      - name: "Login to Docker"
+        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
+        with:
+          username: "${{ secrets.DOCKERHUB_USERNAME }}"
+          password: "${{ secrets.DOCKERHUB_TOKEN }}"
+      - name: "Determine if nautobot-version is branch name or from tag name"
+        id: "versionname"
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Merge (prod - final target) to ghcr.io"
+        uses: "./.github/actions/merge-image-digests"
+        with:
+          image: "ghcr.io/nautobot/nautobot"
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
           default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
           set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
-          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
+
+      - name: "Merge (prod - final target) to dockerhub"
+        uses: "./.github/actions/merge-image-digests"
+        with:
+          image: "networktocode/nautobot"
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
+
+      - name: "Merge (dev - final-dev target) to ghcr.io"
+        uses: "./.github/actions/merge-image-digests"
+        with:
+          image: "ghcr.io/nautobot/nautobot-dev"
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}"
+
+      - name: "Merge (dev - final-dev target) to dockerhub"
+        uses: "./.github/actions/merge-image-digests"
+        with:
+          image: "networktocode/nautobot-dev"
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}"
 
   slack-notify:
-    if: "${{ ! github.event.release.draft }}"
+    if: ${{ ! github.event.release.draft }}
     needs:
       - "publish_python"
-      - "publish_containers"
+      - "merge_containers"
     runs-on: "ubuntu-24.04"
     env:
       SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
@@ -119,7 +195,7 @@ jobs:
       - name: "Send a notification to Slack"
         # ENVs cannot be used directly in job.if. This is a workaround to check
         # if SLACK_WEBHOOK_URL is present.
-        if: "${{ env.SLACK_WEBHOOK_URL != '' }}"
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         uses: "slackapi/slack-github-action@8157a0f4d70c5099e42dcff1258b19bdaabb030b" # v1.17.0
         with:
           payload: |
@@ -140,10 +216,10 @@ jobs:
           SLACK_WEBHOOK_TYPE: "INCOMING_WEBHOOK"
 
   deploy-sandbox:
-    if: "${{ ! github.event.release.draft && ! github.event.release.prerelease }}"
+    if: ${{ ! github.event.release.draft && ! github.event.release.prerelease }}
     needs:
       - "publish_python"
-      - "publish_containers"
+      - "merge_containers"
     runs-on: "ubuntu-24.04"
     steps:
       - name: "Call deploy sandbox workflow for demo.nautobot.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,9 @@ on:
     types: ["published"]  # covers releases, prereleases, and drafts
 
 jobs:
-  # Publish to GitHub followed by pypi
-  publish_python:
+  build:
     if: ${{ ! github.event.release.draft }}
-    name: "Publish Python Packages"
+    name: "Build Python Packages"
     runs-on: "ubuntu-24.04"
     steps:
       - name: "Check out repository code"
@@ -19,22 +18,53 @@ jobs:
           poetry-version: "2.1.4"
           python-version: "3.13"
       - name: "Build Documentation"
-        run: "poetry run mkdocs build --no-directory-urls --strict"
+        run: "poetry run invoke build-and-check-docs"
       - name: "Run Poetry Build"
         run: "poetry build"
       - name: "Upload binaries to release"
-        uses: "svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd" # v2
+        uses: "actions/upload-artifact@v4"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          file: "dist/*"
-          tag: "${{ github.ref }}"
-          overwrite: true
-          file_glob: true
+          name: "distfiles"
+          path: "dist/"
+          if-no-files-found: "error"
+
+  publish_github:
+    if: ${{ ! github.event.release.draft }}
+    name: "Publish to GitHub"
+    runs-on: "ubuntu-24.04"
+    permissions:
+      contents: "write"
+    needs: "build"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Retrieve built package from cache"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "distfiles"
+          path: "dist/"
+      - name: "Upload binaries to release"
+        run: "gh release upload ${{ github.ref_name }} dist/*.{tar.gz,whl}"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  publish_pypi:
+    if: ${{ ! github.event.release.draft }}
+    name: "Publish to PyPI"
+    runs-on: "ubuntu-24.04"
+    needs: "build"
+    environment: "pypi"
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: "write"
+    steps:
+      - name: "Retrieve built package from cache"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "distfiles"
+          path: "dist/"
       - name: "Push to PyPI"
-        uses: "pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc" # release/v1
-        with:
-          user: "__token__"
-          password: "${{ secrets.PYPI_API_TOKEN }}"
+        uses: "pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e" # v1.13.0
 
   publish_containers:
     if: ${{ ! github.event.release.draft }}
@@ -181,11 +211,13 @@ jobs:
   slack-notify:
     if: ${{ ! github.event.release.draft }}
     needs:
-      - "publish_python"
+      - "publish_github"
+      - "publish_pypi"
       - "merge_containers"
     runs-on: "ubuntu-24.04"
     env:
       SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
+      SLACK_WEBHOOK_TYPE: "INCOMING_WEBHOOK"
       SLACK_MESSAGE: >-
         *NOTIFICATION: NEW-RELEASE-PUBLISHED*\n
         Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\n
@@ -196,7 +228,7 @@ jobs:
         # ENVs cannot be used directly in job.if. This is a workaround to check
         # if SLACK_WEBHOOK_URL is present.
         if: ${{ env.SLACK_WEBHOOK_URL != '' }}
-        uses: "slackapi/slack-github-action@8157a0f4d70c5099e42dcff1258b19bdaabb030b" # v1.17.0
+        uses: "slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3" # v1.27.1
         with:
           payload: |
             {
@@ -218,7 +250,8 @@ jobs:
   deploy-sandbox:
     if: ${{ ! github.event.release.draft && ! github.event.release.prerelease }}
     needs:
-      - "publish_python"
+      - "publish_github"
+      - "publish_pypi"
       - "merge_containers"
     runs-on: "ubuntu-24.04"
     steps:
@@ -226,3 +259,63 @@ jobs:
         run: "gh workflow run deploy_sandbox.yml -R nautobot/sandboxes -f sandbox_environment=demo.nautobot.com"
         env:
           GH_TOKEN: "${{ secrets.GH_NAUTOBOT_BOT_TOKEN }}"
+
+  create-pr-to-develop:
+    if: "github.event.release.target_commitish == 'main'"
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Create a PR from main into develop"
+    needs:
+      - "publish_github"
+      - "publish_pypi"
+      - "merge_containers"
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "Checkout main"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "main"
+          fetch-depth: 0
+
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-version: "2.1.4"
+          poetry-install-options: "--no-root"
+
+      - name: "Create release branch from main"
+        id: "branch"
+        run: |
+
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME#v}"
+
+          BRANCH_NAME="release-${VERSION}-to-develop"
+
+          # Ensure release branch doesn't already exist
+          if git rev-parse --verify origin/$BRANCH_NAME > /dev/null 2>&1; then
+            echo "Error: Release branch $BRANCH_NAME already exists."
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH_NAME"
+
+          poetry version prepatch
+          git add pyproject.toml && git commit -m "Bump version"
+          git push origin "$BRANCH_NAME"
+
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: "Create Pull Request to develop"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          gh pr create \
+            --title "Post release ${{ github.event.release.tag_name }} to develop" \
+            --body "Please do a merge commit." \
+            --base "develop" \
+            --head "${{ steps.branch.outputs.branch_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
         python-version: [ "3.10", "3.11", "3.12", "3.13" ]
     env:
       INVOKE_NAUTOBOT_PYTHON_VER: "${{ matrix.python-version }}"
+      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.13"
+      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "true" # Change this to false for LTM, Pre-release versions force this to false.
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
@@ -67,70 +69,37 @@ jobs:
         with:
           username: "${{ secrets.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_TOKEN }}"
-      - name: "Docker Metadata"
-        id: "dockermeta"
-        uses: "docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175" # v4
+      - name: "Determine if nautobot-version is branch name or from tag name"
+        id: "versionname"
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+
+      - name: "Build and Push (prod - final target)"
+        uses: "./.github/actions/build-nautobot-image"
         with:
           images: "networktocode/nautobot,ghcr.io/nautobot/nautobot"
-          flavor: |
-            latest=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
-          tags: |
-            type=semver,pattern={{version}}-py${{ matrix.python-version }}
-            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.13 }}
-            type=semver,pattern={{major}}.{{minor}}-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
-            type=raw,value=latest-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-            type=raw,value=stable,enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
-            type=raw,value=stable-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-          labels: |
-            org.opencontainers.image.title=Nautobot
-      - name: "Build"
-        uses: "docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9" # v4
-        with:
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
           push: true
           target: "final"
-          file: "docker/Dockerfile"
-          platforms: "linux/amd64,linux/arm64"
-          tags: "${{ steps.dockermeta.outputs.tags }}"
-          labels: "${{ steps.dockermeta.outputs.labels }}"
-          cache-from: "type=gha,scope=nautobot-${{ steps.gitbranch.outputs.branch }}-${{ matrix.python-version }}"
-          cache-to: "type=gha,mode=max,scope=nautobot-${{ steps.gitbranch.outputs.branch }}-${{ matrix.python-version }}"
-          context: "."
-          build-args: |
-            PYTHON_VER=${{ matrix.python-version }}
-            POETRY_INSTALLER_PARALLEL=false
-      - name: "Docker Dev Metadata"
-        id: "dockerdevmeta"
-        uses: "docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175" # v4
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+
+      - name: "Build and Push (dev - final-dev target)"
+        uses: "./.github/actions/build-nautobot-image"
         with:
           images: "networktocode/nautobot-dev,ghcr.io/nautobot/nautobot-dev"
-          flavor: |
-            latest=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
-          tags: |
-            type=semver,pattern={{version}}-py${{ matrix.python-version }}
-            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.13 }}
-            type=semver,pattern={{major}}.{{minor}}-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
-            type=raw,value=latest-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-            type=raw,value=stable,enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.13 }}
-            type=raw,value=stable-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-          labels: |
-            org.opencontainers.image.title=Nautobot
-      - name: "Build Dev Containers"
-        uses: "docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9" # v4
-        with:
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
           push: true
           target: "final-dev"
-          file: "docker/Dockerfile"
-          platforms: "linux/amd64,linux/arm64"
-          tags: "${{ steps.dockerdevmeta.outputs.tags }}"
-          labels: "${{ steps.dockerdevmeta.outputs.labels }}"
-          cache-from: "type=gha,scope=nautobot-${{ steps.gitbranch.outputs.branch }}-${{ matrix.python-version }}"
-          cache-to: "type=gha,mode=max,scope=nautobot-${{ steps.gitbranch.outputs.branch }}-${{ matrix.python-version }}"
-          context: "."
-          build-args: |
-            PYTHON_VER=${{ matrix.python-version }}
-            POETRY_INSTALLER_PARALLEL=false
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
 
   slack-notify:
     if: "${{ ! github.event.release.draft }}"

--- a/changes/6267.housekeeping
+++ b/changes/6267.housekeeping
@@ -1,0 +1,1 @@
+Replaced third-party GitHub action in release CI.

--- a/changes/8502.housekeeping
+++ b/changes/8502.housekeeping
@@ -1,0 +1,1 @@
+Improved the Docker build process and tagging in CI.

--- a/changes/8689.added
+++ b/changes/8689.added
@@ -1,0 +1,1 @@
+Added ARM64 variants for all published Docker images.

--- a/changes/8689.housekeeping
+++ b/changes/8689.housekeeping
@@ -1,0 +1,1 @@
+Refactored GitHub CI to use multi-architecture runners for Docker image build and publish.

--- a/changes/8697.housekeeping
+++ b/changes/8697.housekeeping
@@ -1,0 +1,1 @@
+Fixed Docker image publication for integration branches and releases.

--- a/changes/8699.housekeeping
+++ b/changes/8699.housekeeping
@@ -1,0 +1,1 @@
+Fixed isolation of docker image digests by cache scope when building multiple images in a single workflow.

--- a/changes/8774.documentation
+++ b/changes/8774.documentation
@@ -1,0 +1,1 @@
+Updated release process documentation to reflect available automation.

--- a/changes/8774.housekeeping
+++ b/changes/8774.housekeeping
@@ -1,0 +1,1 @@
+Updated PyPI publication to use Trusted Publisher.

--- a/nautobot/docs/development/core/docker-compose-advanced-use-cases.md
+++ b/nautobot/docs/development/core/docker-compose-advanced-use-cases.md
@@ -11,7 +11,7 @@ The Invoke tasks have some default [configuration](http://docs.pyinvoke.org/en/s
 - `local`: run the commands in the local environment vs the Docker container (default: `False`)
 - `compose_dir`: the full path to the directory containing the Docker Compose YAML files (default: `"<nautobot source directory>/development"`)
 - `compose_files`: the Docker Compose YAML file(s) to use (default: `["docker-compose.yml", "docker-compose.postgres.yml", "docker-compose.dev.yml"]`)
-- `docker_image_names_main` and `docker_image_names_develop`: Used when [building Docker images for publication](release-checklist.md#publish-docker-images-manually-if-needed); you shouldn't generally need to change these.
+- `docker_image_names_main` and `docker_image_names_develop`: Used when [building Docker images for publication](release-checklist.md#publish-release-to-pypi-and-docker-registries); you shouldn't generally need to change these.
 - `ephemeral_ports`: Setting this value to `True` and not using any custom compose files will make all Nautobot containers with published ports expose themselves with dynamic ports. This is useful when running multiple Nautobot versions at the same time on the same machine so you won't experience system port conflicts. If setting `compose_files`, this will have no effect so please ensure to manually add the `docker-compose.ephemeral-ports.yml` to your list.
 
 These setting may be overridden several different ways (from highest to lowest precedence):

--- a/nautobot/docs/development/core/getting-started.md
+++ b/nautobot/docs/development/core/getting-started.md
@@ -190,6 +190,7 @@ Available tasks:
   dump-service-ports-to-disk   Useful for downstream utilities without direct docker access to determine ports.
   dumpdata                     Dump data from database to db_output file.
   eslint                       Run ESLint to perform JavaScript code linting. Optionally, make an attempt to fix found issues with `--fix` flag.
+  generate-release-notes       Generate Release Notes using Towncrier.
   hadolint                     Check Dockerfile for hadolint compliance and other style issues.
   lint                         Run all linters.
   loaddata                     Load data from file.

--- a/nautobot/docs/development/core/release-checklist.md
+++ b/nautobot/docs/development/core/release-checklist.md
@@ -10,17 +10,12 @@ This document is intended for Nautobot maintainers and covers the steps to perfo
     3. [Link to the New Release Notes Page](#link-to-the-new-release-notes-page)
     4. [Verify and Revise the Install Documentation](#verify-and-revise-the-install-documentation)
 2. [Verify CI Build Status](#verify-ci-build-status)
-3. [Create a Release Branch](#create-a-release-branch)
-4. [Bump the Version](#bump-the-version)
-5. [Update the Changelog](#update-the-changelog)
-6. [Submit Release Pull Request](#submit-release-pull-request)
-7. [Merge Release Pull Request](#merge-release-pull-request)
-8. [Create a New Release](#create-a-new-release)
-9. If needed due to CI failures:
-    1. [Publish to PyPI Manually (if needed)](#publish-to-pypi-manually-if-needed)
-    2. [Publish Docker Images Manually (if needed)](#publish-docker-images-manually-if-needed)
-10. [Bump the Development Version in `develop`](#bump-the-development-version-in-develop)
-11. [Sync Changes into `next`](#sync-changes-into-next)
+3. [Prepare Release Pull Request](#prepare-release-pull-request)
+4. [Merge Release Pull Request](#merge-release-pull-request)
+5. [Publish Release on GitHub](#publish-release-on-github)
+6. [Publish Release to PyPI and Docker Registries](#publish-release-to-pypi-and-docker-registries)
+7. [Bump the Development Version in `develop`](#bump-the-development-version-in-develop)
+8. [Sync Changes into `next`](#sync-changes-into-next)
 
 ## Prerequisites for New Minor or Major Versions
 
@@ -44,6 +39,10 @@ Use the [`poetry update`](https://python-poetry.org/docs/cli/#update) command as
 After making any changes to `pyproject.toml` or `poetry.lock` with the above commands, you should of course commit the changes and re-run Nautobot tests and CI to verify that the dependency updates have not broken anything before proceeding with the release preparation.
 
 ### Update UI Libraries
+
+As with Python dependencies, the UI-compilation dependencies managed by `npm` are generally kept up-to-date by Renovate,and before releasing a new minor or major version of Nautobot, you should review any open Renovate PRs for suitability and merge them if appropriate.
+
+#### Manually Updating UI Libraries
 
 Update UI libraries to their latest version (specified by the tag config) respecting the semver constraints of both package and its dependencies:
 
@@ -77,203 +76,228 @@ Commit any necessary changes to the documentation before proceeding with the rel
 
 Ensure that continuous integration testing on the `develop` branch is completing successfully.
 
-### Create a Release Branch
+### Prepare Release Pull Request
 
-Create a release branch off of `develop` (`git checkout -b release/3.0.1 develop`).
+=== "Automated Release Preparation"
 
-### Bump the Version
+    As of Nautobot 3.1 and later, preparation of a release pull request is automated and can be carried out by running the "prepare-release" GitHub Action. For release preparation from an older branch such as `ltm-2.4`, refer to "Manual Release Preparation" instead.
 
-Update the package version using `invoke version`. This command shows the current version of the project or bumps the version of the project and writes the new version back to `pyproject.toml` (for the Nautobot Python package) if a valid bump rule is provided.
+=== "Manual Release Preparation"
 
-The new version should ideally be a valid semver string or a valid bump rule: `patch`, `minor`, `major`, `prepatch`, `preminor`, `premajor`, `prerelease`. Always try to use a bump rule when you can.
+    <h4>Create a Release Branch</h4>
 
-Display the current version with no arguments:
+    Create a release branch off of `develop` (`git checkout -b release/3.0.1 develop`).
 
-```no-highlight
-invoke version
-```
+    <h4>Bump the Version</h4>
 
-Example output:
+    Update the package version using `invoke version`. This command shows the current version of the project or bumps the version of the project and writes the new version back to `pyproject.toml` (for the Nautobot Python package) if a valid bump rule is provided.
 
-```no-highlight
-3.0.1.b1
-```
+    The new version should ideally be a valid semver string or a valid bump rule: `patch`, `minor`, `major`, `prepatch`, `preminor`, `premajor`, `prerelease`. Always try to use a bump rule when you can.
 
-To prepare for a patch release, use `patch`:
+    Display the current version with no arguments:
 
-```no-highlight
-invoke version -v patch
-```
+    ```no-highlight
+    invoke version
+    ```
 
-Example output:
+    Example output:
 
-```no-highlight
-3.0.2
-```
+    ```no-highlight
+    3.0.1.b1
+    ```
 
-For minor versions, use `minor`:
+    To prepare for a patch release, use `patch`:
 
-```no-highlight
-invoke version -v minor
-```
+    ```no-highlight
+    invoke version -v patch
+    ```
 
-Example output:
+    Example output:
 
-```no-highlight
-3.1.0
-```
+    ```no-highlight
+    3.0.2
+    ```
 
-And for major versions, use `major`:
+    For minor versions, use `minor`:
 
-```no-highlight
-invoke version -v major
-```
+    ```no-highlight
+    invoke version -v minor
+    ```
 
-Example output:
+    Example output:
 
-```no-highlight
-4.0.0
-```
+    ```no-highlight
+    3.1.0
+    ```
 
-The `invoke version [-v <version>]` command internally runs the [`poetry version`](https://python-poetry.org/docs/cli/#version) command to handle the versioning process. However, there might be cases where you need to manually configure the version. Refer to the Poetry documentation linked above for detailed instructions. It provides information on how to set the version directly in the `pyproject.toml` file or update it using the `poetry version` command.
+    And for major versions, use `major`:
 
-After updating the version correctly, be sure to `git add pyproject.toml`. You'll commit it after the next step.
+    ```no-highlight
+    invoke version -v major
+    ```
 
-### Update the Changelog
+    Example output:
 
-Generate release notes with `towncrier build --version <new-version-number>` and answer `yes` to the prompt `Is it okay if I remove those files? [Y/n]:`. This will update the release notes in `nautobot/docs/release-notes/version-<major.minor>.md`, stage that file in Git, and `git rm` all of the fragments that have now been incorporated into the release notes.
+    ```no-highlight
+    4.0.0
+    ```
 
-Run `invoke markdownlint` to make sure the generated release notes pass the linter checks, and manually review them for completeness/correctness as well.
+    The `invoke version [-v <version>]` command internally runs the [`poetry version`](https://python-poetry.org/docs/cli/#version) command to handle the versioning process. However, there might be cases where you need to manually configure the version. Refer to the Poetry documentation linked above for detailed instructions. It provides information on how to set the version directly in the `pyproject.toml` file or update it using the `poetry version` command.
 
-!!! important
-    The changelog must adhere to the [Keep a Changelog](https://keepachangelog.com/) style guide.
+    After updating the version correctly, be sure to `git add pyproject.toml`. You'll commit it after the next step.
 
-Check the git diff to verify the changes are correct (`git diff --cached`). You should see:
+    <h4>Update the Changelog</h4>
 
-* a one-line change to `pyproject.toml` updating the version number (from the previous step)
-* release-notes added to `nautobot/docs/release-notes/version-<major.minor>.md`
-* all change fragments removed from the `changes/` folder
+    Generate release notes with `invoke generate-release-notes --version <new-version-number>`. This will update the release notes in `nautobot/docs/release-notes/version-<major.minor>.md`, stage that file in Git, and `git rm` all of the fragments that have now been incorporated into the release notes.
 
-Commit (the traditional commit message is "Towncrier and version bump" but that's not required) and push the staged changes upstream to GitHub.
+    Run `invoke markdownlint` to make sure the generated release notes pass the linter checks, and manually review them for completeness/correctness as well.
 
-### Submit Release Pull Request
+    !!! warning
+        The changelog must adhere to the [Keep a Changelog](https://keepachangelog.com/) style guide.
 
-Submit a pull request titled **"Release vX.Y.Z"** to merge your release branch into `main`. Copy the documented release notes into the pull request's body.
+    Check the git diff to verify the changes are correct (`git diff --cached`). You should see:
+
+    * a one-line change to `pyproject.toml` updating the version number (from the previous step)
+    * release-notes added to `nautobot/docs/release-notes/version-<major.minor>.md`
+    * all change fragments removed from the `changes/` folder
+
+    Commit (the traditional commit message is "Towncrier and version bump" but that's not required) and push the staged changes upstream to GitHub.
+
+    <h4>Submit Release Pull Request</h4>
+
+    Submit a pull request titled **"Release vX.Y.Z"** to merge your release branch into `main`. Copy the documented release notes into the pull request's body.
 
 ### Merge Release Pull Request
 
 Once CI has completed on the PR, and you have obtained the required approval(s), merge it.
 
-!!! important
+!!! warning
     Do not squash merge this branch into `main`. Make sure to select `Create a merge commit` when merging in GitHub.
 
-### Create a New Release
+### Publish Release on GitHub
 
-Draft a [new release](https://github.com/nautobot/nautobot/releases/new) with the following parameters.
+=== "Automated Release Preparation"
 
-* **Tag:** Version to be released, prefixed with `v` (e.g. `v3.0.1`)
-* **Target:** `main`
-* **Title:** Version and date (e.g. `v3.0.1 - 2025-11-24`)
-* **Release notes:** Follow the steps below:
-    1. Click on **Generate release notes** button and you should see some release notes auto-generated by GitHub.
-    2. Change the heading **What's Changed** to **Contributors**.
-    3. Create a new **What's Changed** heading before the **Contributors** heading and here, copy and paste the changelog entries for the new release from `nautobot/docs/release-notes/version-<major.minor>.md` (or from your previous pull request).
-    4. Change the entries under the **Contributors** heading to be a list of the usernames of the contributors, for example `* Updated dockerfile by @nautobot_user in https://github.com/nautobot/nautobot/pull/123` --> `* @nautobot_user`, removing duplicate usernames as you go.
-    5. Leave the **New Contributors** list (if any) at the end of the release note as is.
-    6. When done, the release note should look similar to any other recent Nautobot release, for example [v2.4.22](https://github.com/nautobot/nautobot/releases/tag/v2.4.22)
-* **Set as the latest release** should be checked if this release will be the latest for Nautobot. It should **not** be checked for prereleases or for releases from an LTM (long-term maintenance) branch such as `ltm-2.4`.
-* **Create a discussion for this release** should be checked as well.
+    If you successfully ran the "prepare-release" GitHub Action above, it will have automatically created a draft of the release for you. Find it under the [Nautobot releases page](https://github.com/nautobot/nautobot/releases). Verify that the release notes are correct (including any required changes or updates resulting from the PR review). Also confirm that the **Set as the latest release** check is correctly set (or unset, for releases from LTM or pre-releases), and that **Create a discussion for this release** is checked.
+
+=== "Manual Release Preparation"
+
+    Draft a [new release](https://github.com/nautobot/nautobot/releases/new) with the following parameters.
+
+    * **Tag:** Version to be released, prefixed with `v` (e.g. `v3.0.1`)
+    * **Target:** `main`
+    * **Title:** Version and date (e.g. `v3.0.1 - 2025-11-24`)
+    * **Release notes:** Follow the steps below:
+        1. Click on **Generate release notes** button and you should see some release notes auto-generated by GitHub.
+        2. Change the heading **What's Changed** to **Contributors**.
+        3. Create a new **What's Changed** heading before the **Contributors** heading and here, copy and paste the changelog entries for the new release from `nautobot/docs/release-notes/version-<major.minor>.md` (or from your previous pull request).
+        4. Change the entries under the **Contributors** heading to be a list of the usernames of the contributors, for example `* Updated dockerfile by @nautobot_user in https://github.com/nautobot/nautobot/pull/123` --> `* @nautobot_user`, removing duplicate usernames as you go.
+        5. Leave the **New Contributors** list (if any) at the end of the release note as is.
+        6. When done, the release note should look similar to any other recent Nautobot release, for example [v2.4.22](https://github.com/nautobot/nautobot/releases/tag/v2.4.22)
+    * **Set as the latest release** should be checked if this release will be the latest for Nautobot. It should **not** be checked for prereleases or for releases from an LTM (long-term maintenance) branch such as `ltm-2.4`.
+    * **Create a discussion for this release** should be checked as well.
 
 Once you have verified that all of the above is correct, publish the release and wait for the release CI to run in GitHub Actions.
 
-### Publish to PyPI Manually (if needed)
+### Publish Release to PyPI and Docker Registries
 
-!!! tip
-    This is normally done automatically by GitHub Actions after you create the release above. The below is only needed if the automated release fails for some reason.
+=== "Automated Release Preparation"
 
-Now that there is a tagged release, the final step is to upload the package to the Python Package Index.
+    This should occur automatically as a GitHub Action after you publish the release. If for some reason it fails, refer to "Manual Release Preparation".
 
-First, you'll need to render the documentation.
+=== "Manual Release Preparation"
 
-```no-highlight
-poetry run mkdocs build --no-directory-urls --strict
-```
+    <h4>Publish to PyPI Manually</h4>
 
-Second, you'll need to build the Python package distributions (which will include the rendered documentation):
+    Now that there is a tagged release, the final step is to upload the package to the Python Package Index.
 
-```no-highlight
-poetry build
-```
+    First, you'll need to render the documentation.
 
-Finally, publish to PyPI using the username `__token__` and the Nautobot PyPI API token as the password. The API token can be found in the Nautobot maintainers vault (if you're a maintainer, you'll have access to this vault):
+    ```no-highlight
+    poetry run mkdocs build --no-directory-urls --strict
+    ```
 
-```no-highlight
-poetry publish --username __token__ --password <api_token>
-```
+    Second, you'll need to build the Python package distributions (which will include the rendered documentation):
 
-### Publish Docker Images Manually (if needed)
+    ```no-highlight
+    poetry build
+    ```
 
-!!! tip
-    This is normally done automatically by GitHub Actions after you create the release above. The below is only needed if the automated release fails for some reason.
+    Finally, publish to PyPI using the username `__token__` and the Nautobot PyPI API token as the password. The API token can be found in the Nautobot maintainers vault (if you're a maintainer, you'll have access to this vault):
 
-Build the images locally:
+    ```no-highlight
+    poetry publish --username __token__ --password <api_token>
+    ```
 
-```no-highlight
-for ver in 3.10 3.11 3.12 3.13; do
-  export INVOKE_NAUTOBOT_PYTHON_VER=$ver
-  invoke buildx --target final --tag networktocode/nautobot-py${INVOKE_NAUTOBOT_PYTHON_VER}:local
-  invoke buildx --target final-dev --tag networktocode/nautobot-dev-py${INVOKE_NAUTOBOT_PYTHON_VER}:local
-done
-```
+    <h4>Publish Docker Images Manually</h4>
 
-Test the images locally as needed - to do this you need to set the following in your `invoke.yml`:
+    Build the images locally:
 
-```yaml
----
-nautobot:
-  compose_files:
-    - "docker-compose.yml"
-    - "docker-compose.postgres.yml"
-    - "docker-compose.final.yml"  # or "docker-compose.final-dev.yml" as appropriate
-```
+    ```no-highlight
+    for ver in 3.10 3.11 3.12 3.13; do
+      export INVOKE_NAUTOBOT_PYTHON_VER=$ver
+      invoke buildx --target final --tag networktocode/nautobot-py${INVOKE_NAUTOBOT_PYTHON_VER}:local
+      invoke buildx --target final-dev --tag networktocode/nautobot-dev-py${INVOKE_NAUTOBOT_PYTHON_VER}:local
+    done
+    ```
 
-!!! warning
-    You should *not* include `docker-compose.dev.yml` in this test scenario!
+    Test the images locally as needed - to do this you need to set the following in your `invoke.yml`:
 
-Push the images to GitHub Container Registry and Docker Hub
+    ```yaml
+    ---
+    nautobot:
+      compose_files:
+        - "docker-compose.yml"
+        - "docker-compose.postgres.yml"
+        - "docker-compose.final.yml"  # or "docker-compose.final-dev.yml" as appropriate
+    ```
 
-```no-highlight
-docker login
-docker login ghcr.io
-for ver in 3.10 3.11 3.12 3.13; do
-  export INVOKE_NAUTOBOT_PYTHON_VER=$ver
-  invoke docker-push main
-done
-```
+    !!! warning
+        You should *not* include `docker-compose.dev.yml` in this test scenario!
+
+    Push the images to GitHub Container Registry and Docker Hub
+
+    ```no-highlight
+    docker login
+    docker login ghcr.io
+    for ver in 3.10 3.11 3.12 3.13; do
+      export INVOKE_NAUTOBOT_PYTHON_VER=$ver
+      invoke docker-push main
+    done
+    ```
 
 ### Bump the Development Version in `develop`
 
-Create a new branch off of `main` (typically named `main-to-develop-post-<x.y.z>`) and use `invoke version -v prepatch` to bump the version in preparation for developing the next release. Then open a pull request from this branch to the `develop` branch to update the version and sync the release notes and changelog fragment updates from `main`.
+=== "Automated Release Preparation"
 
-For example, if you just released `v3.0.1`:
+    A pull request to update the `develop` branch should be created automatically as a part of the release CI process. If for some reason this fails, see "Manual Release Preparation" for steps to follow.
 
-```no-highlight
-invoke version -v prepatch
-```
+=== "Manual Release Preparation"
 
-Example output:
+    Create a new branch off of `main` (typically named `main-to-develop-post-<x.y.z>`) and use `invoke version -v prepatch` to bump the version in preparation for developing the next release. Then open a pull request from this branch to the `develop` branch to update the version and sync the release notes and changelog fragment updates from `main`.
 
-```no-highlight
-Bumping version from 3.0.1 to 3.0.2a0
-```
+    For example, if you just released `v3.0.1`:
 
-!!! tip
-    We normally use `beta` version numbers rather than `alpha` versions for `develop`, so you may need to manually edit `pyproject.toml` after the above, for example to change `"3.0.2a0"` to `"3.0.2b1"` to follow our convention.
+    ```no-highlight
+    invoke version -v prepatch
+    ```
 
-!!! important
-    Do not squash merge this branch into `develop`. Make sure to select `Create a merge commit` when merging in GitHub.
+    Example output:
+
+    ```no-highlight
+    Bumping version from 3.0.1 to 3.0.2a0
+    ```
+
+    !!! tip
+        We normally use `beta` version numbers rather than `alpha` versions for `develop`, so you may need to manually edit `pyproject.toml` after the above, for example to change `"3.0.2a0"` to `"3.0.2b1"` to follow our convention.
+
+!!! warning
+    Do not squash merge this PR into `develop`. Make sure to select `Create a merge commit` when merging in GitHub.
 
 ### Sync Changes into `next`
+
+!!! tip
+    This step is not yet automated, but may be in the future.
 
 After the main-to-develop pull request is merged into `develop`, create a new branch off of `next` (typically named `develop-to-next-post-<x.y.z>`) and `git merge develop`. Resolve any merge conflicts as appropriate (if you're lucky, there may only be one, a version number clash in `pyproject.toml`), then open a pull request to `next`.
 
@@ -281,5 +305,5 @@ When resolving conflicts, always keep the Nautobot app version number from the *
 
 During the pull request, the CI pipeline may fail at the **changelog** step. This is expected in this case and should not be a cause for concern (the error can be safely ignored).
 
-!!! important
+!!! warning
     Do not squash merge this branch into `next`. Make sure to select `Create a merge commit` when merging in GitHub.

--- a/tasks.py
+++ b/tasks.py
@@ -807,6 +807,31 @@ def build_example_app_docs(context):
         docker_compose(context, docker_command, pty=True)
 
 
+@task(
+    help={
+        "version": "Nautobot version number to associate with the release notes.",
+        "date": "Date of the release (default: today).",
+        "keep": "Keep existing change fragment files. Useful for testing. (default: False).",
+    }
+)
+def generate_release_notes(context, version="", date="", keep=False):  # pylint: disable=redefined-outer-name
+    """Generate Release Notes using Towncrier."""
+    command = "poetry run towncrier build"
+    if not version:
+        version = context.run("poetry version --short", hide=True).stdout.strip()
+    command += f" --version {version}"
+    if date:
+        command += f" --date {date}"
+    command += " --keep" if keep else " --yes"
+
+    # N/A for Nautobot core; we create `nautobot/docs/release-notes/version-X.Y.md` for new X.Y versions in advance
+    # version_major_minor = ".".join(version.split(".")[:2])
+    # context.run(f"poetry run python scripts/ensure_release_notes.py --version {version_major_minor}")
+
+    # Due to issues with git repo ownership in the containers, this must always run locally.
+    context.run(command)
+
+
 def task_navigate_to_service_port(context, service: str, internal_port: str, proto: str = "http", creds: str = ""):
     """Navigate to the default system application for a specified uri."""
     nautobot_raw_uri = docker_compose(context, f"port {service} {internal_port}").stdout.rstrip()


### PR DESCRIPTION
# What's Changed

We can't actually run the `prepare_release` workflow added in #8774 to `next` until it's present in the default branch (i.e., `develop`). Therefore this PR backports it and related GitHub Action/Workflow updates from `next` to `develop`:

- Use poetry 2.1.4 throughout the GitHub workflows (partial manual backport of #8327)
- ~~#8459~~ _not applicable yet to develop_
- #8502
    - and subsequent fix in #8538
- ~~#8563~~ _not applicable yet to develop_
- #8689 
    - and subsequent fixes in #8697 and #8699
- #8774 

The main merge conflicts along the way involved the omission of Python 3.14 (for the moment).
