### PR TITLE
Fix state leakage between consecutive calls to merge-image-digests GHA

### DIFF
--- a/.github/actions/merge-image-digests/action.yaml
+++ b/.github/actions/merge-image-digests/action.yaml
@@ -101,13 +101,13 @@ runs:
     - name: "Download digests"
       uses: "actions/download-artifact@v4"
       with:
-        path: "${{ runner.temp }}/digests"
+        path: "${{ runner.temp }}/digests/${{ env.DIGEST_SCOPE }}/${{ inputs.python-version }}"
         pattern: "digests-${{ env.DIGEST_SCOPE }}-${{ inputs.python-version }}-*"
         merge-multiple: true
 
     - name: "Create and publish manifest list"
       shell: "bash"
-      working-directory: "${{ runner.temp }}/digests"
+      working-directory: "${{ runner.temp }}/digests/${{ env.DIGEST_SCOPE }}/${{ inputs.python-version }}"
       run: |
         docker buildx imagetools create \
           $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \

--- a/changes/8799.housekeeping
+++ b/changes/8799.housekeeping
@@ -1,0 +1,1 @@
+Fixed state leakage between consecutive calls to `merge-image-digests` GitHub action.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nautobot"
 # Primary package version gets set here. This is used for publishing, and once
 # installed, `nautobot.__version__` will have this version number.
-version = "3.1.0a4"
+version = "3.1.0a5"
 description = "Source of truth and network automation platform."
 authors = [
     {name = "Network to Code", email = "<opensource@networktocode.com>"}


### PR DESCRIPTION
Ensure that the directory we download Docker image digests into is scoped by cache-scope and by Python version, avoiding state leakage between consecutive calls to the same action with different scopes.

This should fix the failure in release 3.1.0a4 (https://github.com/nautobot/nautobot/actions/runs/23921674536/job/69770598615) which was due to the Docker image digests from the `nautobot/nautobot` image carrying over into the subsequent attempt to generate a combined manifest for the `nautobot/nautobot-dev` image in the same overall workflow.