### PR TITLE
Closes #8802: Config Context Schema Value failing to update on repo sync

### DIFF
--- a/changes/8802.fixed
+++ b/changes/8802.fixed
@@ -1,0 +1,1 @@
+Fixed config_context_schema value failing to update when syncing a config context repository.

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -468,6 +468,7 @@ def import_config_context(context_data, repository_record, job_result):
                     schema = ConfigContextSchema.objects.get(name=context_metadata["config_context_schema"])
                     context_record.config_context_schema = schema
                     modified = True
+                    save_needed = True
                 except ConfigContextSchema.DoesNotExist:
                     msg = f"ConfigContextSchema {context_metadata['config_context_schema']} does not exist."
                     logger.error(msg)
@@ -478,6 +479,7 @@ def import_config_context(context_data, repository_record, job_result):
             if context_record.config_context_schema is not None:
                 context_record.config_context_schema = None
                 modified = True
+                save_needed = True
 
         if context_record.data != data:
             context_record.data = data


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8802
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
The `modified` variable was updated however `save_needed` was not, so the logs erroneously said the Config Context was refreshed (updated), but the Context was never actually saved so the changes were lost. Simply adding this value in both places resolved both issues.
