### PR TITLE
Remove custom verbose_name from ObjectPermission

### DIFF
--- a/changes/2998.changed
+++ b/changes/2998.changed
@@ -1,0 +1,1 @@
+Removed custom `verbose_name = "permission"` from `ObjectPermission` model, restoring the default Django-derived verbose name.

--- a/nautobot/users/migrations/0011_remove_objectpermission_verbose_name.py
+++ b/nautobot/users/migrations/0011_remove_objectpermission_verbose_name.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0010_user_default_saved_views"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="objectpermission",
+            options={"ordering": ["name"]},
+        ),
+    ]

--- a/nautobot/users/models.py
+++ b/nautobot/users/models.py
@@ -327,7 +327,6 @@ class ObjectPermission(BaseModel, ChangeLoggedModel):
 
     class Meta:
         ordering = ["name"]
-        verbose_name = "permission"
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Removes the explicit `verbose_name = "permission"` from `ObjectPermission`'s Meta class. Django will now auto-generate the verbose name as "object permission", which is consistent with how other models in the project are named.

Includes a migration to update the model options.

Fixes #2998
