### PR TITLE
[2.4] CI backports to LTM

### DIFF
--- a/.github/actions/build-nautobot-image/action.yaml
+++ b/.github/actions/build-nautobot-image/action.yaml
@@ -22,68 +22,137 @@
 # ```
 ---
 name: "Build Nautobot Image"
-description: "Builds and pushes Nautobot image"
+description: "Build (and optionally push) a Docker image for Nautobot"
+
 inputs:
-  branch:
-    description: "Branch Name Used In Tag"
-    required: true
-  image:
-    description: "Produced Image Name"
-    required: true
-  tag-latest:
-    description: "Whether To Tag As Latest"
-    required: true
-  tag-latest-for-branch:
-    description: "Whether To Tag As Latest For Branch"
-    required: true
-  tag-latest-for-py:
-    description: "Whether To Tag As Latest For Python Version"
-    required: true
-  platforms:
-    description: "Platforms To Build For"
-    required: false
-    default: "linux/amd64,linux/arm64"
-  push:
-    description: "Whether To Push"
+  images:
+    description: "Full image name(s), comma-separated (e.g. networktocode/nautobot,ghcr.io/nautobot/nautobot)"
     required: true
   python-version:
-    description: "Python Version"
+    description: "Python version for the build matrix"
+    required: true
+  nautobot-version:
+    description: "Nautobot version to install (either PEP440 or branch name)"
     required: true
   target:
-    description: "Target Stage Name"
+    description: "Dockerfile target stage"
     required: true
+    default: "final"
+  push:
+    description: "Whether to push the image"
+    required: false
+    default: false
+  platforms:
+    description: "Target platforms"
+    required: false
+    default: "linux/amd64,linux/arm64"
+  cache-scope:
+    description: "GHA cache scope prefix"
+    required: false
+    default: ""
+  default-python-version:
+    description: "Default Python version to use for 'latest' tag"
+    required: true
+  set-latest:
+    description: "Whether to set the 'latest' and stable tag for releases"
+    required: false
+    default: "false"
+  poetry-parallel:
+    description: "Whether to set POETRY_INSTALLER_PARALLEL to true"
+    required: false
+    default: "false"
+
+outputs:
+  tags:
+    description: "Generated Docker tags"
+    value: "${{ steps.dockermeta.outputs.tags }}"
+  labels:
+    description: "Generated Docker labels"
+    value: "${{ steps.dockermeta.outputs.labels }}"
+  digest:
+    description: "Image digest"
+    value: "${{ steps.build.outputs.digest }}"
+
 runs:
   using: "composite"
   steps:
-    - name: "Setup Metadata"
-      id: "metadata"
-      uses: "docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175" # v4
+    - name: "Clean nautobot-version Input in Case of Leading 'v' and Valid Version Check"
+      id: "cleannautobotversion"
+      shell: "python"
+      run: |
+        import os
+        import sys
+        from packaging.version import Version, InvalidVersion
+        nautobot_version = "${{ inputs.nautobot-version }}"
+        if nautobot_version.startswith("v"):
+            candidate_version = nautobot_version[1:]
+        else:
+            candidate_version = nautobot_version
+        try:
+            v = Version(candidate_version)
+            clean_version = candidate_version
+        except InvalidVersion:
+            clean_version = nautobot_version  # keep original if not valid version
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f"clean-version={clean_version}\n")
+
+    - name: "Determine if Nautobot Version is Pre-release"
+      id: "prereleasecheck"
+      shell: "python"
+      run: |
+        import os
+        import sys
+        from packaging.version import Version, InvalidVersion
+
+        nautobot_version = "${{ steps.cleannautobotversion.outputs.clean-version }}"
+
+        try:
+            v = Version(nautobot_version)
+            is_prerelease = v.is_prerelease
+        except InvalidVersion:
+            is_prerelease = True  # assume branch names are not stable releases
+
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f"is-prerelease={str(is_prerelease).lower()}\n")
+
+    - name: "Docker Metadata"
+      id: "dockermeta"
+      uses: "docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051" # v5.10.0
       with:
-        images: "${{ inputs.image }}"
+        images: "${{ inputs.images }}"
         flavor: |
-          latest=false
+          latest=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
         tags: |
-          type=raw,value=${{ inputs.branch }}-py${{ inputs.python-version }}
-          type=raw,value=latest,enable=${{ inputs.tag-latest }}
-          type=raw,value=${{ inputs.branch }},enable=${{ inputs.tag-latest-for-branch }}
-          type=raw,value=latest-py${{ inputs.python-version }},enable=${{ inputs.tag-latest-for-py }}
+          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }}-py${{ inputs.python-version }}
+          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ inputs.python-version == inputs.default-python-version }}
+          type=pep440,pattern={{major}}.{{minor}}-py${{ inputs.python-version }},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' }}
+          type=pep440,pattern={{major}}.{{minor}},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.python-version == inputs.default-python-version }}
+          type=raw,value=latest-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
+          type=raw,value=stable,enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
+          type=raw,value=stable-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
         labels: |
           org.opencontainers.image.title=Nautobot
-    - name: "Build Dev"
-      env:
-        INVOKE_NAUTOBOT_PYTHON_VER: "${{ inputs.python-version }}"
-      uses: "docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9" # v4
+
+    - name: "Log tags"
+      shell: "bash"
+      run: |
+        echo "=== Tags for ${{ inputs.image }} (py${{ inputs.python-version }}) ==="
+        echo "${{ steps.dockermeta.outputs.tags }}"
+
+    - name: "Build and possibly Push"
+      id: "build"
+      uses: "docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83" # v6.18.0
       with:
         push: "${{ inputs.push }}"
         target: "${{ inputs.target }}"
-        file: "docker/Dockerfile"
         platforms: "${{ inputs.platforms }}"
-        tags: "${{ steps.metadata.outputs.tags }}"
-        labels: "${{ steps.metadata.outputs.labels }}"
-        cache-from: "type=gha,scope=nautobot-${{ inputs.branch }}-${{ inputs.python-version }}"
-        cache-to: "type=gha,mode=max,scope=nautobot-${{ inputs.branch }}-${{ inputs.python-version }}"
+        file: "docker/Dockerfile"
+        tags: "${{ steps.dockermeta.outputs.tags }}"
+        labels: "${{ steps.dockermeta.outputs.labels }}"
+        cache-from: "type=gha,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}"
+        cache-to: "type=gha,mode=max,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}"
         context: "."
         build-args: |
+          INVOKE_NAUTOBOT_PYTHON_VER: ${{ inputs.python-version }}
           PYTHON_VER=${{ inputs.python-version }}
-          DEPENDENCIES_BASE_BRANCH=${{ inputs.branch }}
-          POETRY_INSTALLER_PARALLEL=true
+          POETRY_INSTALLER_PARALLEL=${{ inputs.poetry-parallel }}

--- a/.github/actions/build-nautobot-image/action.yaml
+++ b/.github/actions/build-nautobot-image/action.yaml
@@ -132,16 +132,17 @@ runs:
     - name: "Export digest"
       shell: "bash"
       run: |
-        mkdir -p ${{ runner.temp }}/digests
-        digest="${{ steps.build.outputs.digest }}"
-        touch "${{ runner.temp }}/digests/${digest#sha256:}"
         cache_scope="${{ inputs.cache-scope }}"
+        DIGEST_SCOPE="${cache_scope//\//-}"
         echo "DIGEST_SCOPE=${cache_scope//\//-}" >> $GITHUB_ENV
+        mkdir -p ${{ runner.temp }}/digests/$DIGEST_SCOPE
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/$DIGEST_SCOPE/${digest#sha256:}"
 
     - name: "Upload digest"
       uses: "actions/upload-artifact@v4"
       with:
         name: "digests-${{ env.DIGEST_SCOPE }}-${{ inputs.python-version }}-${{ inputs.arch }}"
-        path: "${{ runner.temp }}/digests/*"
+        path: "${{ runner.temp }}/digests/${{ env.DIGEST_SCOPE }}/*"
         if-no-files-found: error
         retention-days: 1

--- a/.github/actions/build-nautobot-image/action.yaml
+++ b/.github/actions/build-nautobot-image/action.yaml
@@ -7,11 +7,9 @@
 # ```
 # steps:
 #   - name: "Check out repository code"
-#     uses: "actions/checkout@v3"
-#   - name: "Set up QEMU"
-#     uses: "docker/setup-qemu-action@v2"
+#     uses: "actions/checkout@v4"
 #   - name: "Set up Docker Buildx"
-#     uses: "docker/setup-buildx-action@v2"
+#     uses: "docker/setup-buildx-action@v4"
 #   # To be able to push to GitHub Container Registry, we need to log in to it first.
 #   - name: "Login to GitHub Container Registry"
 #     uses: "docker/login-action@v2"
@@ -42,30 +40,20 @@ inputs:
     description: "Whether to push the image"
     required: false
     default: false
-  platforms:
-    description: "Target platforms"
+  arch:
+    description: "Target architecture"
     required: false
-    default: "linux/amd64,linux/arm64"
+    default: "amd64"
   cache-scope:
     description: "GHA cache scope prefix"
     required: false
     default: ""
-  default-python-version:
-    description: "Default Python version to use for 'latest' tag"
-    required: true
-  set-latest:
-    description: "Whether to set the 'latest' and stable tag for releases"
-    required: false
-    default: "false"
   poetry-parallel:
     description: "Whether to set POETRY_INSTALLER_PARALLEL to true"
     required: false
     default: "false"
 
 outputs:
-  tags:
-    description: "Generated Docker tags"
-    value: "${{ steps.dockermeta.outputs.tags }}"
   labels:
     description: "Generated Docker labels"
     value: "${{ steps.dockermeta.outputs.labels }}"
@@ -120,39 +108,39 @@ runs:
       uses: "docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051" # v5.10.0
       with:
         images: "${{ inputs.images }}"
-        flavor: |
-          latest=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
-        tags: |
-          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }}-py${{ inputs.python-version }}
-          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ inputs.python-version == inputs.default-python-version }}
-          type=pep440,pattern={{major}}.{{minor}}-py${{ inputs.python-version }},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' }}
-          type=pep440,pattern={{major}}.{{minor}},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.python-version == inputs.default-python-version }}
-          type=raw,value=latest-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
-          type=raw,value=stable,enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
-          type=raw,value=stable-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
         labels: |
           org.opencontainers.image.title=Nautobot
-
-    - name: "Log tags"
-      shell: "bash"
-      run: |
-        echo "=== Tags for ${{ inputs.image }} (py${{ inputs.python-version }}) ==="
-        echo "${{ steps.dockermeta.outputs.tags }}"
 
     - name: "Build and possibly Push"
       id: "build"
       uses: "docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83" # v6.18.0
       with:
-        push: "${{ inputs.push }}"
         target: "${{ inputs.target }}"
-        platforms: "${{ inputs.platforms }}"
+        platforms: "linux/${{ inputs.arch }}"
         file: "docker/Dockerfile"
-        tags: "${{ steps.dockermeta.outputs.tags }}"
         labels: "${{ steps.dockermeta.outputs.labels }}"
-        cache-from: "type=gha,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}"
-        cache-to: "type=gha,mode=max,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}"
+        cache-from: "type=gha,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}-${{ inputs.arch }}"
+        cache-to: "type=gha,mode=max,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}-${{ inputs.arch }}"
         context: "."
+        outputs: "type=image,push-by-digest=true,name-canonical=true,push=${{ inputs.push }}"
         build-args: |
           INVOKE_NAUTOBOT_PYTHON_VER: ${{ inputs.python-version }}
           PYTHON_VER=${{ inputs.python-version }}
           POETRY_INSTALLER_PARALLEL=${{ inputs.poetry-parallel }}
+
+    - name: "Export digest"
+      shell: "bash"
+      run: |
+        mkdir -p ${{ runner.temp }}/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+        cache_scope="${{ inputs.cache-scope }}"
+        echo "DIGEST_SCOPE=${cache_scope//\//-}" >> $GITHUB_ENV
+
+    - name: "Upload digest"
+      uses: "actions/upload-artifact@v4"
+      with:
+        name: "digests-${{ env.DIGEST_SCOPE }}-${{ inputs.python-version }}-${{ inputs.arch }}"
+        path: "${{ runner.temp }}/digests/*"
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/actions/build-nautobot-image/action.yaml
+++ b/.github/actions/build-nautobot-image/action.yaml
@@ -119,6 +119,7 @@ runs:
         platforms: "linux/${{ inputs.arch }}"
         file: "docker/Dockerfile"
         labels: "${{ steps.dockermeta.outputs.labels }}"
+        tags: "${{ inputs.images }}"
         cache-from: "type=gha,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}-${{ inputs.arch }}"
         cache-to: "type=gha,mode=max,scope=${{ inputs.cache-scope }}-${{ inputs.python-version }}-${{ inputs.arch }}"
         context: "."

--- a/.github/actions/merge-image-digests/action.yaml
+++ b/.github/actions/merge-image-digests/action.yaml
@@ -1,0 +1,114 @@
+# Action to merge manifests for multi-platform Docker images built by `build-nautobot-image` action.
+---
+name: "Merge manifests and publish"
+description: "Merge Docker image manifests and publish the merge for multiple platforms"
+
+inputs:
+  image:
+    description: "Full image name (e.g. networktocode/nautobot or ghcr.io/nautobot/nautobot)"
+    required: true
+  python-version:
+    description: "Python version for the build matrix"
+    required: true
+  nautobot-version:
+    description: "Nautobot version to install (either PEP440 or branch name)"
+    required: true
+  cache-scope:
+    description: "GHA cache scope prefix"
+    required: false
+    default: ""
+  default-python-version:
+    description: "Default Python version to use for 'latest' tag"
+    required: true
+  set-latest:
+    description: "Whether to set the 'latest' and stable tag for releases"
+    required: false
+    default: "false"
+
+outputs:
+  tags:
+    description: "Generated Docker tags"
+    value: "${{ steps.dockermeta.outputs.tags }}"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Clean nautobot-version Input in Case of Leading 'v' and Valid Version Check"
+      id: "cleannautobotversion"
+      shell: "python"
+      run: |
+        import os
+        import sys
+        from packaging.version import Version, InvalidVersion
+        nautobot_version = "${{ inputs.nautobot-version }}"
+        if nautobot_version.startswith("v"):
+            candidate_version = nautobot_version[1:]
+        else:
+            candidate_version = nautobot_version
+        try:
+            v = Version(candidate_version)
+            clean_version = candidate_version
+        except InvalidVersion:
+            clean_version = nautobot_version  # keep original if not valid version
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f"clean-version={clean_version}\n")
+
+    - name: "Determine if Nautobot Version is Pre-release"
+      id: "prereleasecheck"
+      shell: "python"
+      run: |
+        import os
+        import sys
+        from packaging.version import Version, InvalidVersion
+
+        nautobot_version = "${{ steps.cleannautobotversion.outputs.clean-version }}"
+
+        try:
+            v = Version(nautobot_version)
+            is_prerelease = v.is_prerelease
+        except InvalidVersion:
+            is_prerelease = True  # assume branch names are not stable releases
+
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f"is-prerelease={str(is_prerelease).lower()}\n")
+
+    - name: "Docker Metadata"
+      id: "dockermeta"
+      uses: "docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051" # v5.10.0
+      with:
+        images: "${{ inputs.image }}"
+        flavor: |
+          latest=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
+        tags: |
+          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }}-py${{ inputs.python-version }}
+          type=raw,value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ inputs.python-version == inputs.default-python-version }}
+          type=pep440,pattern={{major}}.{{minor}}-py${{ inputs.python-version }},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' }}
+          type=pep440,pattern={{major}}.{{minor}},value=${{ steps.cleannautobotversion.outputs.clean-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.python-version == inputs.default-python-version }}
+          type=raw,value=latest-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
+          type=raw,value=stable,enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' && inputs.python-version == inputs.default-python-version }}
+          type=raw,value=stable-py${{ inputs.python-version }},enable=${{ steps.prereleasecheck.outputs.is-prerelease == 'false' && inputs.set-latest == 'true' }}
+        labels: |
+          org.opencontainers.image.title=Nautobot
+
+    - name: "Log tags"
+      shell: "bash"
+      run: |
+        echo "=== Tags for ${{ inputs.image }} (py${{ inputs.python-version }}) ==="
+        echo "${{ steps.dockermeta.outputs.tags }}"
+        cache_scope="${{ inputs.cache-scope }}"
+        echo "DIGEST_SCOPE=${cache_scope//\//-}" >> $GITHUB_ENV
+
+    - name: "Download digests"
+      uses: "actions/download-artifact@v4"
+      with:
+        path: "${{ runner.temp }}/digests"
+        pattern: "digests-${{ env.DIGEST_SCOPE }}-${{ inputs.python-version }}-*"
+        merge-multiple: true
+
+    - name: "Create and publish manifest list"
+      shell: "bash"
+      working-directory: "${{ runner.temp }}/digests"
+      run: |
+        docker buildx imagetools create \
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ inputs.image }}@sha256:%s ' *)

--- a/.github/actions/merge-image-digests/action.yaml
+++ b/.github/actions/merge-image-digests/action.yaml
@@ -101,13 +101,13 @@ runs:
     - name: "Download digests"
       uses: "actions/download-artifact@v4"
       with:
-        path: "${{ runner.temp }}/digests"
+        path: "${{ runner.temp }}/digests/${{ env.DIGEST_SCOPE }}/${{ inputs.python-version }}"
         pattern: "digests-${{ env.DIGEST_SCOPE }}-${{ inputs.python-version }}-*"
         merge-multiple: true
 
     - name: "Create and publish manifest list"
       shell: "bash"
-      working-directory: "${{ runner.temp }}/digests"
+      working-directory: "${{ runner.temp }}/digests/${{ env.DIGEST_SCOPE }}/${{ inputs.python-version }}"
       run: |
         docker buildx imagetools create \
           $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -221,8 +221,7 @@ jobs:
         # If NAUTOBOT_SELENIUM_HOST is set to 'localhost' or '127.0.0.1' the connection does not work
         run: "NAUTOBOT_SELENIUM_HOST=`hostname -f` poetry run invoke tests --tag integration --no-keepdb"
   container-build:
-    name: "Build Container Images (amd64 on GHCR Only)"
-    runs-on: "ubuntu-24.04"
+    name: "Build Container Images (GHCR Only)"
     if: |
       github.event_name == 'push' &&
       (github.ref_name == 'develop' || github.ref_name == 'next' || github.ref_name == 'ltm-2.4')
@@ -237,16 +236,19 @@ jobs:
       fail-fast: true
       matrix:
         python-version: [ "3.10", "3.11", "3.12" ]
-    env:
-      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.12"
-      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "false" # Change this to false for LTM, Pre-release versions force this to false.
+        arch: [ "amd64", "arm64" ]
+        os: [ "ubuntu-24.04", "ubuntu-24.04-arm" ]
+        exclude:
+          - os: "ubuntu-24.04"
+            arch: "arm64"
+          - os: "ubuntu-24.04-arm"
+            arch: "amd64"
+    runs-on: "${{ matrix.os }}"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7" # v2
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55" # v2
+        uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
       - name: "Login to GitHub Container Registry"
         uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
         with:
@@ -269,22 +271,11 @@ jobs:
           images: "ghcr.io/nautobot/nautobot"
           python-version: "${{ matrix.python-version }}"
           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
-          platforms: "linux/amd64"
+          arch: "${{ matrix.arch }}"
           push: false
           target: "final"
           poetry-parallel: true
-          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
-          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
-          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
-
-      - name: "Determine if we should build multi-arch dev image if python-version is default, return platforms string"
-        id: "devplatforms"
-        run: |
-          if [[ "${{ matrix.python-version }}" == "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}" ]]; then
-            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
-          else
-            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
-          fi
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
 
       - name: "Build and Push (dev - final-dev target)"
         uses: "./.github/actions/build-nautobot-image"
@@ -292,10 +283,54 @@ jobs:
           images: "ghcr.io/nautobot/nautobot-dev"
           python-version: "${{ matrix.python-version }}"
           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
-          platforms: "${{ steps.devplatforms.outputs.platforms }}"
+          arch: "${{ matrix.arch }}"
           push: true
           target: "final-dev"
           poetry-parallel: true
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}"
+
+  container-merge:
+    name: "Merge Manifests (publish GHCR, final-dev only)"
+    if: |
+      github.event_name == 'push' &&
+      (github.ref_name == 'develop' || github.ref_name == 'next' || github.ref_name == 'ltm-2.4')
+    needs:
+      - "container-build"
+    runs-on: "ubuntu-24.04"
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [ "3.10", "3.11", "3.12" ]
+    env:
+      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.12"
+      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "false" # Change this to false for LTM, Pre-release versions force this to false.
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Set up Docker Buildx"
+        uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
+      - name: "Login to GitHub Container Registry"
+        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Determine if nautobot-version is branch name or from tag name"
+        id: "versionname"
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Merge (dev - final-dev target)"
+        uses: "./.github/actions/merge-image-digests"
+        with:
+          image: "ghcr.io/nautobot/nautobot-dev"
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
           default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
           set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
-          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}"

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -236,25 +236,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [ "3.10", "3.11", "3.12"]
+        python-version: [ "3.10", "3.11", "3.12" ]
+    env:
+      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.12"
+      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "false" # Change this to false for LTM, Pre-release versions force this to false.
     steps:
-      - name: "Configuration"
-        id: "config"
-        shell: "bash"
-        run: |
-          export BRANCH="${{ github.ref_name }}"
-          export TAG_LATEST="false"
-          export TAG_LATEST_FOR_BRANCH="false"
-          export TAG_LATEST_FOR_PY="false"
-
-          if [[ "${{ matrix.python-version }}" == "3.12" ]]; then
-            export TAG_LATEST_FOR_BRANCH="true"
-          fi
-
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "tag-latest=$TAG_LATEST" >> $GITHUB_OUTPUT
-          echo "tag-latest-for-branch=$TAG_LATEST_FOR_BRANCH" >> $GITHUB_OUTPUT
-          echo "tag-latest-for-py=$TAG_LATEST_FOR_PY" >> $GITHUB_OUTPUT
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Set up QEMU"
@@ -267,29 +253,49 @@ jobs:
           registry: "ghcr.io"
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
-      - name: "Build `final`"
-        if: |
-          steps.config.outputs.tag-latest-for-branch == 'true'
+
+      - name: "Determine if nautobot-version is branch name or from tag name"
+        id: "versionname"
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Build Only Test (prod - final target)"
         uses: "./.github/actions/build-nautobot-image"
         with:
-          branch: "${{ steps.config.outputs.branch }}"
-          image: "ghcr.io/nautobot/nautobot"
-          platforms: "linux/amd64"
-          push: "false"
+          images: "ghcr.io/nautobot/nautobot"
           python-version: "${{ matrix.python-version }}"
-          tag-latest: "${{ steps.config.outputs.tag-latest }}"
-          tag-latest-for-branch: "${{ steps.config.outputs.tag-latest-for-branch }}"
-          tag-latest-for-py: "${{ steps.config.outputs.tag-latest-for-py }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          platforms: "linux/amd64"
+          push: false
           target: "final"
-      - name: "Build and Push `final-dev`"
+          poetry-parallel: true
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+
+      - name: "Determine if we should build multi-arch dev image if python-version is default, return platforms string"
+        id: "devplatforms"
+        run: |
+          if [[ "${{ matrix.python-version }}" == "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}" ]]; then
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+          else
+            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Build and Push (dev - final-dev target)"
         uses: "./.github/actions/build-nautobot-image"
         with:
-          branch: "${{ steps.config.outputs.branch }}"
-          image: "ghcr.io/nautobot/nautobot-dev"
-          platforms: "linux/amd64"
-          push: "true"
+          images: "ghcr.io/nautobot/nautobot-dev"
           python-version: "${{ matrix.python-version }}"
-          tag-latest: "${{ steps.config.outputs.tag-latest }}"
-          tag-latest-for-branch: "${{ steps.config.outputs.tag-latest-for-branch }}"
-          tag-latest-for-py: "${{ steps.config.outputs.tag-latest-for-py }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          platforms: "${{ steps.devplatforms.outputs.platforms }}"
+          push: true
           target: "final-dev"
+          poetry-parallel: true
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -507,7 +507,6 @@ jobs:
           arch: "${{ matrix.arch }}"
           push: false
           target: "final"
-          default-python-version: "3.12"
           cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
 
 #   container-merge-test:

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -491,18 +491,25 @@ jobs:
           registry: "ghcr.io"
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
-      - name: "Build `final`"
+      - name: "Determine if nautobot-version is branch name or from tag name"
+        id: "versionname"
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          fi
+      - name: "Build Only Test (prod - final target)"
         uses: "./.github/actions/build-nautobot-image"
         with:
-          branch: "${{ github.head_ref }}"
-          image: "ghcr.io/nautobot/nautobot"
-          platforms: "linux/amd64"
-          push: "false"
+          images: "ghcr.io/nautobot/nautobot"
           python-version: "3.12"
-          tag-latest: "false"
-          tag-latest-for-branch: "false"
-          tag-latest-for-py: "false"
+          platforms: "linux/amd64" # only build for amd64 in PRs to save on time/resources
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          push: false
           target: "final"
+          default-python-version: "3.12"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
   all-tests-passed:
     runs-on: "ubuntu-24.04"
     steps:

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -466,8 +466,15 @@ jobs:
           git fetch --no-tags origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
           poetry run towncrier check --compare-with origin/${{ github.base_ref }}
   container-build-test:
-    name: "Test Container Build (amd64 only on Python 3.12)"
-    runs-on: "ubuntu-24.04"
+    name: "Test Container Build (Python 3.12 only)"
+    strategy:
+      matrix:
+        include:
+          - os: "ubuntu-24.04"
+            arch: "amd64"
+          - os: "ubuntu-24.04-arm"
+            arch: "arm64"
+    runs-on: "${{ matrix.os }}"
     needs:
       - "check-migrations"
       - "check-schema"
@@ -481,16 +488,8 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7" # v2
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55" # v2
-      - name: "Login to GitHub Container Registry"
-        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
-        with:
-          registry: "ghcr.io"
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
+        uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
       - name: "Determine if nautobot-version is branch name or from tag name"
         id: "versionname"
         run: |
@@ -504,12 +503,41 @@ jobs:
         with:
           images: "ghcr.io/nautobot/nautobot"
           python-version: "3.12"
-          platforms: "linux/amd64" # only build for amd64 in PRs to save on time/resources
           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          arch: "${{ matrix.arch }}"
           push: false
           target: "final"
           default-python-version: "3.12"
-          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
+
+#   container-merge-test:
+#     name: "Test Merge Manifests (Python 3.12 only)"
+#     needs:
+#       - "container-build-test"
+#     runs-on: "ubuntu-24.04"
+#     steps:
+#       - name: "Check out repository code"
+#         uses: "actions/checkout@v4"
+#       - name: "Set up Docker Buildx"
+#         uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
+#       - name: "Determine if nautobot-version is branch name or from tag name"
+#         id: "versionname"
+#         run: |
+#           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+#             echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+#           else
+#             echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+#           fi
+#       - name: "Merge Test (prod - final target)"
+#         uses: "./.github/actions/merge-image-digests"
+#         with:
+#           image: "ghcr.io/nautobot/nautobot"
+#           python-version: "3.12"
+#           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+#           default-python-version: "3.12"
+#           set-latest: false
+#           cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
+
   all-tests-passed:
     runs-on: "ubuntu-24.04"
     steps:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,180 @@
+---
+name: "Prepare Release"
+on: # yamllint disable-line rule:truthy rule:comments
+  workflow_dispatch:
+    inputs:
+      bump_rule:
+        description: "Select the version bump type"
+        required: true
+        default: "patch"
+        type: "choice"
+        options:
+          - "prerelease"
+          - "patch"
+          - "minor"
+          - "major"
+      target_branch:
+        description: "Create the release from this branch (default: main)."
+        required: true
+        default: "main"
+      date:
+        description: "Date of the release YYYY-MM-DD (defaults to today's date in the US Eastern TZ)."
+        required: false
+        default: ""
+
+jobs:
+  prepare-release:
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Prepare Release"
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v4"
+        with:
+          # If target_branch is 'main', use 'develop' as the source branch. Otherwise, the source and target branch are the same.
+          ref: "${{ github.event.inputs['target_branch'] == 'main' && 'develop' || github.event.inputs['target_branch'] }}"
+          fetch-depth: 0  # Fetch all history for git tags
+
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-install-options: "--with dev"
+          poetry-version: "2.1.4"
+
+      - name: "Validate Branch and Tags"
+        run: |
+          # 1. Verify branch exists
+          if ! git rev-parse --verify origin/${{ github.event.inputs.target_branch }} > /dev/null 2>&1; then
+            echo "Error: Branch ${{ github.event.inputs.target_branch }} does not exist."
+            exit 1
+          fi
+
+          # 2. Try to get the previous version tag
+          # If it fails (no tags), get the hash of the first commit
+          if PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
+            echo "PREVIOUS_TAG=$PREV_TAG" >> $GITHUB_ENV
+            echo "Found previous tag: $PREV_TAG"
+          else
+            # Fallback to the first commit in the repository
+            FIRST_COMMIT=$(git rev-list --max-parents=0 HEAD)
+            echo "PREVIOUS_TAG=$FIRST_COMMIT" >> $GITHUB_ENV
+            echo "No tags found. Falling back to initial commit: $FIRST_COMMIT"
+          fi
+
+      - name: "Determine New Version"
+        id: "versioning"
+        run: |
+          if [[ "${{ github.event.inputs.bump_rule }}" != "prerelease" ]]; then
+            # Perform the bump based on the user input
+            poetry version ${{ github.event.inputs.bump_rule }}
+          fi
+
+          # Capture the New version string for use in other steps
+          NEW_VER=$(poetry version --short)
+          echo "NEW_VERSION=$NEW_VER" >> $GITHUB_ENV
+          echo "RELEASE_BRANCH=release/$NEW_VER" >> $GITHUB_ENV
+
+      - name: "Set Date Variable"
+        run: |
+          if [ -z "${{ github.event.inputs.date }}" ]; then
+            RELEASE_DATE=$(TZ=America/New_York date +%Y-%m-%d)
+          else
+            RELEASE_DATE="${{ github.event.inputs.date }}"
+          fi
+          echo "RELEASE_DATE=$RELEASE_DATE" >> $GITHUB_ENV
+
+      - name: "Create Release Branch"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          # Ensure release branch doesn't already exist
+          if git rev-parse --verify origin/${{ env.RELEASE_BRANCH }} > /dev/null 2>&1; then
+            echo "Error: Release branch ${{ env.RELEASE_BRANCH }} already exists."
+            exit 1
+          fi
+
+          # Create a new branch for the release
+          git checkout -b "${{ env.RELEASE_BRANCH }}"
+
+      - name: "Regenerate poetry.lock"
+        run: "poetry lock --regenerate"
+
+      - name: "Generate Github Release Notes"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          # 1. Get Towncrier Draft
+          TOWNCRIER_NOTES=$(poetry run towncrier build --version "${{ env.NEW_VERSION }}" --date "${{ env.RELEASE_DATE }}" --draft)
+
+          # 2. Call GitHub API to generate raw notes
+          RAW_GH_NOTES=$(gh api /repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name="v${{ env.NEW_VERSION }}" \
+            -f target_commitish="${{ github.event.inputs['target_branch'] == 'main' && 'develop' || github.event.inputs['target_branch'] }}" \
+            -f previous_tag_name="${{ env.PREVIOUS_TAG }}" --jq '.body')
+
+          # 3. Parse usernames (Regex match)
+          # We use grep to find "@user" patterns, sort, and uniq them
+          USERNAMES=$(echo "$RAW_GH_NOTES" | grep -oP 'by @\K[a-zA-Z0-9-]+' | sort -u | grep -vE 'dependabot|nautobot-bot|github-actions' || true)
+
+          # 4. Format the Contributors section
+          CONTRIBUTORS_SECTION="## Contributors"
+          for user in $USERNAMES; do
+            CONTRIBUTORS_SECTION="$CONTRIBUTORS_SECTION"$'\n'"* @$user"
+          done
+
+          # 5. Extract the "Full Changelog" or "New Contributors" part
+          # Using awk to grab everything from '## New Contributors' or '**Full Changelog**' to the end
+          GH_FOOTER=$(echo "$RAW_GH_NOTES" | awk '/## New Contributors/ || /\*\*Full Changelog\*\*/ {found=1} found {print}')
+          if [ -z "$GH_FOOTER" ]; then
+            GH_FOOTER=$(echo "$RAW_GH_NOTES" | sed -n '/**Full Changelog**/,$p')
+          fi
+
+          # 6. Combine everything
+          FINAL_NOTES="$TOWNCRIER_NOTES"$'\n\n'"$CONTRIBUTORS_SECTION"$'\n\n'"$GH_FOOTER"
+
+          # 7. Save to a temporary file to avoid shell argument length limits
+          echo "$FINAL_NOTES" > ../consolidated_notes.md
+
+      - name: "Generate App Release Notes and update mkdocs.yml"
+        run: "poetry run inv generate-release-notes --version '${{ env.NEW_VERSION }}' --date '${{ env.RELEASE_DATE }}'"
+
+      - name: "Commit Changes and Push"
+        run: |
+          # Add all changes (pyproject.toml, poetry.lock, etc.)
+          git add .
+          git commit -m "prepare release v${{ env.NEW_VERSION }}"
+          git push origin "${{ env.RELEASE_BRANCH }}"
+
+      - name: "Create Pull Request"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          gh pr create \
+            --title "Release v${{ env.NEW_VERSION }}" \
+            --body-file "../consolidated_notes.md" \
+            --base "${{ github.event.inputs.target_branch }}" \
+            --head "${{ env.RELEASE_BRANCH }}"
+
+      - name: "Create Draft Release"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          if [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" ]]; then
+            RELEASE_FLAGS="--prerelease"
+          elif [[ "${{ github.event.inputs.target_branch }}" == "main" ]]; then
+            RELEASE_FLAGS="--latest"
+          else
+            RELEASE_FLAGS="--latest=false"
+          fi
+
+          gh release create "v${{ env.NEW_VERSION }}" \
+            --draft \
+            $RELEASE_FLAGS \
+            --title "v${{ env.NEW_VERSION }} - ${{ env.RELEASE_DATE }}" \
+            --notes-file "../consolidated_notes.md" \
+            --target "${{ github.event.inputs.target_branch }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
             echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           else
             echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          fi
 
       - name: "Build and Push (prod - final target)"
         uses: "./.github/actions/build-nautobot-image"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
         python-version: [ "3.10", "3.11", "3.12" ]
     env:
       BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.12"
-      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "true" # Change this to false for LTM, Pre-release versions force this to false.
+      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "false" # Change this to false for LTM, Pre-release versions force this to false.
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,3 @@
----
 name: "Release"
 on:
   release:
@@ -7,7 +6,7 @@ on:
 jobs:
   # Publish to GitHub followed by pypi
   publish_python:
-    if: "${{ ! github.event.release.draft }}"
+    if: ${{ ! github.event.release.draft }}
     name: "Publish Python Packages"
     runs-on: "ubuntu-24.04"
     steps:
@@ -38,26 +37,27 @@ jobs:
           password: "${{ secrets.PYPI_API_TOKEN }}"
 
   publish_containers:
-    if: "${{ ! github.event.release.draft }}"
+    if: ${{ ! github.event.release.draft }}
     name: "Build & Publish Container Images"
-    runs-on: "ubuntu-24.04"
     strategy:
       fail-fast: true
       matrix:
         python-version: [ "3.10", "3.11", "3.12" ]
-    env:
-      INVOKE_NAUTOBOT_PYTHON_VER: "${{ matrix.python-version }}"
-      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.12"
-      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "false" # Change this to false for LTM, Pre-release versions force this to false.
+        arch: [ "amd64", "arm64" ]
+        os: [ "ubuntu-24.04", "ubuntu-24.04-arm" ]
+        exclude:
+          - os: "ubuntu-24.04"
+            arch: "arm64"
+          - os: "ubuntu-24.04-arm"
+            arch: "amd64"
+    runs-on: "${{ matrix.os }}"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: "gitbranch"
-      - name: "Set up QEMU"
-        uses: "docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7" # v2
       - name: "Set up Docker Buildx"
-        uses: "docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55" # v2
+        uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
       - name: "Login to GitHub Container Registry"
         uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
         with:
@@ -84,11 +84,10 @@ jobs:
           images: "networktocode/nautobot,ghcr.io/nautobot/nautobot"
           python-version: "${{ matrix.python-version }}"
           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          arch: "${{ matrix.arch }}"
           push: true
           target: "final"
-          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
-          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
-          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
 
       - name: "Build and Push (dev - final-dev target)"
         uses: "./.github/actions/build-nautobot-image"
@@ -96,17 +95,94 @@ jobs:
           images: "networktocode/nautobot-dev,ghcr.io/nautobot/nautobot-dev"
           python-version: "${{ matrix.python-version }}"
           nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          arch: "${{ matrix.arch }}"
           push: true
           target: "final-dev"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}"
+
+  merge_containers:
+    name: "Merge Manifests"
+    if: ${{ ! github.event.release.draft }}
+    needs:
+      - "publish_containers"
+    runs-on: "ubuntu-24.04"
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [ "3.10", "3.11", "3.12" ]
+    env:
+      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.12"
+      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "true" # Change this to false for LTM, Pre-release versions force this to false.
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Set up Docker Buildx"
+        uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4
+      - name: "Login to GitHub Container Registry"
+        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+      - name: "Login to Docker"
+        uses: "docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc" # v2
+        with:
+          username: "${{ secrets.DOCKERHUB_USERNAME }}"
+          password: "${{ secrets.DOCKERHUB_TOKEN }}"
+      - name: "Determine if nautobot-version is branch name or from tag name"
+        id: "versionname"
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Merge (prod - final target) to ghcr.io"
+        uses: "./.github/actions/merge-image-digests"
+        with:
+          image: "ghcr.io/nautobot/nautobot"
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
           default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
           set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
-          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
+
+      - name: "Merge (prod - final target) to dockerhub"
+        uses: "./.github/actions/merge-image-digests"
+        with:
+          image: "networktocode/nautobot"
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}"
+
+      - name: "Merge (dev - final-dev target) to ghcr.io"
+        uses: "./.github/actions/merge-image-digests"
+        with:
+          image: "ghcr.io/nautobot/nautobot-dev"
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}"
+
+      - name: "Merge (dev - final-dev target) to dockerhub"
+        uses: "./.github/actions/merge-image-digests"
+        with:
+          image: "networktocode/nautobot-dev"
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}"
 
   slack-notify:
-    if: "${{ ! github.event.release.draft }}"
+    if: ${{ ! github.event.release.draft }}
     needs:
       - "publish_python"
-      - "publish_containers"
+      - "merge_containers"
     runs-on: "ubuntu-24.04"
     env:
       SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
@@ -119,7 +195,7 @@ jobs:
       - name: "Send a notification to Slack"
         # ENVs cannot be used directly in job.if. This is a workaround to check
         # if SLACK_WEBHOOK_URL is present.
-        if: "${{ env.SLACK_WEBHOOK_URL != '' }}"
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         uses: "slackapi/slack-github-action@8157a0f4d70c5099e42dcff1258b19bdaabb030b" # v1.17.0
         with:
           payload: |
@@ -140,10 +216,10 @@ jobs:
           SLACK_WEBHOOK_TYPE: "INCOMING_WEBHOOK"
 
   deploy-sandbox:
-    if: "${{ ! github.event.release.draft && ! github.event.release.prerelease }}"
+    if: ${{ ! github.event.release.draft && ! github.event.release.prerelease }}
     needs:
       - "publish_python"
-      - "publish_containers"
+      - "merge_containers"
     runs-on: "ubuntu-24.04"
     steps:
       - name: "Call deploy sandbox workflow for demo.nautobot.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,9 @@ on:
     types: ["published"]  # covers releases, prereleases, and drafts
 
 jobs:
-  # Publish to GitHub followed by pypi
-  publish_python:
+  build:
     if: ${{ ! github.event.release.draft }}
-    name: "Publish Python Packages"
+    name: "Build Python Packages"
     runs-on: "ubuntu-24.04"
     steps:
       - name: "Check out repository code"
@@ -19,22 +18,53 @@ jobs:
           poetry-version: "2.1.4"
           python-version: "3.12"
       - name: "Build Documentation"
-        run: "poetry run mkdocs build --no-directory-urls --strict"
+        run: "poetry run invoke build-and-check-docs"
       - name: "Run Poetry Build"
         run: "poetry build"
       - name: "Upload binaries to release"
-        uses: "svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd" # v2
+        uses: "actions/upload-artifact@v4"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          file: "dist/*"
-          tag: "${{ github.ref }}"
-          overwrite: true
-          file_glob: true
+          name: "distfiles"
+          path: "dist/"
+          if-no-files-found: "error"
+
+  publish_github:
+    if: ${{ ! github.event.release.draft }}
+    name: "Publish to GitHub"
+    runs-on: "ubuntu-24.04"
+    permissions:
+      contents: "write"
+    needs: "build"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Retrieve built package from cache"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "distfiles"
+          path: "dist/"
+      - name: "Upload binaries to release"
+        run: "gh release upload ${{ github.ref_name }} dist/*.{tar.gz,whl}"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  publish_pypi:
+    if: ${{ ! github.event.release.draft }}
+    name: "Publish to PyPI"
+    runs-on: "ubuntu-24.04"
+    needs: "build"
+    environment: "pypi"
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: "write"
+    steps:
+      - name: "Retrieve built package from cache"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "distfiles"
+          path: "dist/"
       - name: "Push to PyPI"
-        uses: "pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc" # release/v1
-        with:
-          user: "__token__"
-          password: "${{ secrets.PYPI_API_TOKEN }}"
+        uses: "pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e" # v1.13.0
 
   publish_containers:
     if: ${{ ! github.event.release.draft }}
@@ -181,11 +211,13 @@ jobs:
   slack-notify:
     if: ${{ ! github.event.release.draft }}
     needs:
-      - "publish_python"
+      - "publish_github"
+      - "publish_pypi"
       - "merge_containers"
     runs-on: "ubuntu-24.04"
     env:
       SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
+      SLACK_WEBHOOK_TYPE: "INCOMING_WEBHOOK"
       SLACK_MESSAGE: >-
         *NOTIFICATION: NEW-RELEASE-PUBLISHED*\n
         Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\n
@@ -196,7 +228,7 @@ jobs:
         # ENVs cannot be used directly in job.if. This is a workaround to check
         # if SLACK_WEBHOOK_URL is present.
         if: ${{ env.SLACK_WEBHOOK_URL != '' }}
-        uses: "slackapi/slack-github-action@8157a0f4d70c5099e42dcff1258b19bdaabb030b" # v1.17.0
+        uses: "slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3" # v1.27.1
         with:
           payload: |
             {
@@ -218,7 +250,8 @@ jobs:
   deploy-sandbox:
     if: ${{ ! github.event.release.draft && ! github.event.release.prerelease }}
     needs:
-      - "publish_python"
+      - "publish_github"
+      - "publish_pypi"
       - "merge_containers"
     runs-on: "ubuntu-24.04"
     steps:
@@ -226,3 +259,63 @@ jobs:
         run: "gh workflow run deploy_sandbox.yml -R nautobot/sandboxes -f sandbox_environment=ltm.demo.nautobot.com"
         env:
           GH_TOKEN: "${{ secrets.GH_NAUTOBOT_BOT_TOKEN }}"
+
+  create-pr-to-develop:
+    if: "github.event.release.target_commitish == 'main'"
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Create a PR from main into develop"
+    needs:
+      - "publish_github"
+      - "publish_pypi"
+      - "merge_containers"
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "Checkout main"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "main"
+          fetch-depth: 0
+
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-version: "2.1.4"
+          poetry-install-options: "--no-root"
+
+      - name: "Create release branch from main"
+        id: "branch"
+        run: |
+
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME#v}"
+
+          BRANCH_NAME="release-${VERSION}-to-develop"
+
+          # Ensure release branch doesn't already exist
+          if git rev-parse --verify origin/$BRANCH_NAME > /dev/null 2>&1; then
+            echo "Error: Release branch $BRANCH_NAME already exists."
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH_NAME"
+
+          poetry version prepatch
+          git add pyproject.toml && git commit -m "Bump version"
+          git push origin "$BRANCH_NAME"
+
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: "Create Pull Request to develop"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          gh pr create \
+            --title "Post release ${{ github.event.release.tag_name }} to develop" \
+            --body "Please do a merge commit." \
+            --base "develop" \
+            --head "${{ steps.branch.outputs.branch_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
         python-version: [ "3.10", "3.11", "3.12" ]
     env:
       INVOKE_NAUTOBOT_PYTHON_VER: "${{ matrix.python-version }}"
+      BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION: "3.12"
+      BUILD_PUSH_CONTAINER_ACTION_SET_LATEST: "false" # Change this to false for LTM, Pre-release versions force this to false.
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
@@ -67,64 +69,37 @@ jobs:
         with:
           username: "${{ secrets.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_TOKEN }}"
-      - name: "Docker Metadata"
-        id: "dockermeta"
-        uses: "docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175" # v4
+      - name: "Determine if nautobot-version is branch name or from tag name"
+        id: "versionname"
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "nautobot-version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "nautobot-version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+
+      - name: "Build and Push (prod - final target)"
+        uses: "./.github/actions/build-nautobot-image"
         with:
           images: "networktocode/nautobot,ghcr.io/nautobot/nautobot"
-          flavor: |
-            latest=false
-          tags: |
-            type=semver,pattern={{version}}-py${{ matrix.python-version }}
-            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.12 }}
-            type=semver,pattern={{major}}.{{minor}}-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.12 }}
-          labels: |
-            org.opencontainers.image.title=Nautobot
-      - name: "Build"
-        uses: "docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9" # v4
-        with:
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
           push: true
           target: "final"
-          file: "docker/Dockerfile"
-          platforms: "linux/amd64,linux/arm64"
-          tags: "${{ steps.dockermeta.outputs.tags }}"
-          labels: "${{ steps.dockermeta.outputs.labels }}"
-          cache-from: "type=gha,scope=nautobot-${{ steps.gitbranch.outputs.branch }}-${{ matrix.python-version }}"
-          cache-to: "type=gha,mode=max,scope=nautobot-${{ steps.gitbranch.outputs.branch }}-${{ matrix.python-version }}"
-          context: "."
-          build-args: |
-            PYTHON_VER=${{ matrix.python-version }}
-            POETRY_INSTALLER_PARALLEL=false
-      - name: "Docker Dev Metadata"
-        id: "dockerdevmeta"
-        uses: "docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175" # v4
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
+
+      - name: "Build and Push (dev - final-dev target)"
+        uses: "./.github/actions/build-nautobot-image"
         with:
           images: "networktocode/nautobot-dev,ghcr.io/nautobot/nautobot-dev"
-          flavor: |
-            latest=false
-          tags: |
-            type=semver,pattern={{version}}-py${{ matrix.python-version }}
-            type=semver,pattern={{version}},enable=${{ matrix.python-version == 3.12 }}
-            type=semver,pattern={{major}}.{{minor}}-py${{ matrix.python-version }},enable=${{ ! github.event.release.prerelease }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ ! github.event.release.prerelease && matrix.python-version == 3.12 }}
-          labels: |
-            org.opencontainers.image.title=Nautobot
-      - name: "Build Dev Containers"
-        uses: "docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9" # v4
-        with:
+          python-version: "${{ matrix.python-version }}"
+          nautobot-version: "${{ steps.versionname.outputs.nautobot-version }}"
           push: true
           target: "final-dev"
-          file: "docker/Dockerfile"
-          platforms: "linux/amd64,linux/arm64"
-          tags: "${{ steps.dockerdevmeta.outputs.tags }}"
-          labels: "${{ steps.dockerdevmeta.outputs.labels }}"
-          cache-from: "type=gha,scope=nautobot-${{ steps.gitbranch.outputs.branch }}-${{ matrix.python-version }}"
-          cache-to: "type=gha,mode=max,scope=nautobot-${{ steps.gitbranch.outputs.branch }}-${{ matrix.python-version }}"
-          context: "."
-          build-args: |
-            PYTHON_VER=${{ matrix.python-version }}
-            POETRY_INSTALLER_PARALLEL=false
+          default-python-version: "${{ env.BUILD_PUSH_CONTAINER_ACTION_DEFAULT_PYTHON_VERSION }}"
+          set-latest: "${{ env.BUILD_PUSH_CONTAINER_ACTION_SET_LATEST }}"
+          cache-scope: "nautobot-dev-${{ steps.versionname.outputs.nautobot-version }}-${{ matrix.python-version }}"
 
   slack-notify:
     if: "${{ ! github.event.release.draft }}"

--- a/changes/6267.housekeeping
+++ b/changes/6267.housekeeping
@@ -1,0 +1,1 @@
+Replaced third-party GitHub action in release CI.

--- a/changes/8502.housekeeping
+++ b/changes/8502.housekeeping
@@ -1,0 +1,1 @@
+Improved the Docker build process and tagging in CI.

--- a/changes/8689.added
+++ b/changes/8689.added
@@ -1,0 +1,1 @@
+Added ARM64 variants for all published Docker images.

--- a/changes/8689.housekeeping
+++ b/changes/8689.housekeeping
@@ -1,0 +1,1 @@
+Refactored GitHub CI to use multi-architecture runners for Docker image build and publish.

--- a/changes/8697.housekeeping
+++ b/changes/8697.housekeeping
@@ -1,0 +1,1 @@
+Fixed Docker image publication for integration branches and releases.

--- a/changes/8699.housekeeping
+++ b/changes/8699.housekeeping
@@ -1,0 +1,1 @@
+Fixed isolation of docker image digests by cache scope when building multiple images in a single workflow.

--- a/changes/8774.documentation
+++ b/changes/8774.documentation
@@ -1,0 +1,1 @@
+Updated release process documentation to reflect available automation.

--- a/changes/8774.housekeeping
+++ b/changes/8774.housekeeping
@@ -1,0 +1,1 @@
+Updated PyPI publication to use Trusted Publisher.

--- a/changes/8799.housekeeping
+++ b/changes/8799.housekeeping
@@ -1,0 +1,1 @@
+Fixed state leakage between consecutive calls to `merge-image-digests` GitHub action.

--- a/nautobot/docs/development/core/getting-started.md
+++ b/nautobot/docs/development/core/getting-started.md
@@ -188,6 +188,7 @@ Available tasks:
   docker-push                  Tags and pushes docker images to the appropriate repos, intended for release use only.
   dump-service-ports-to-disk   Useful for downstream utilities without direct docker access to determine ports.
   dumpdata                     Dump data from database to db_output file.
+  generate-release-notes       Generate Release Notes using Towncrier.
   hadolint                     Check Dockerfile for hadolint compliance and other style issues.
   lint                         Run all linters.
   loaddata                     Load data from file.

--- a/tasks.py
+++ b/tasks.py
@@ -771,6 +771,31 @@ def build_example_app_docs(context):
         docker_compose(context, docker_command, pty=True)
 
 
+@task(
+    help={
+        "version": "Nautobot version number to associate with the release notes.",
+        "date": "Date of the release (default: today).",
+        "keep": "Keep existing change fragment files. Useful for testing. (default: False).",
+    }
+)
+def generate_release_notes(context, version="", date="", keep=False):  # pylint: disable=redefined-outer-name
+    """Generate Release Notes using Towncrier."""
+    command = "poetry run towncrier build"
+    if not version:
+        version = context.run("poetry version --short", hide=True).stdout.strip()
+    command += f" --version {version}"
+    if date:
+        command += f" --date {date}"
+    command += " --keep" if keep else " --yes"
+
+    # N/A for Nautobot core; we create `nautobot/docs/release-notes/version-X.Y.md` for new X.Y versions in advance
+    # version_major_minor = ".".join(version.split(".")[:2])
+    # context.run(f"poetry run python scripts/ensure_release_notes.py --version {version_major_minor}")
+
+    # Due to issues with git repo ownership in the containers, this must always run locally.
+    context.run(command)
+
+
 def task_navigate_to_service_port(context, service: str, internal_port: str, proto: str = "http", creds: str = ""):
     """Navigate to the default system application for a specified uri."""
     nautobot_raw_uri = docker_compose(context, f"port {service} {internal_port}").stdout.rstrip()


### PR DESCRIPTION
# What's Changed

2.4 counterpart to #8795 and #8799. 

Backport:
- #8502 
- #8538 
- #8689 
- #8697 
- #8699
- #8774 
- #8799 

There were a number of merge conflicts, mostly due to differences in supported Python versions (2.4: 3.10-3.12, 3.0: 3.10-3.13, next: 3.10-3.14). I'll post the remaining diff between `.github` in this branch and the current in `next` in a followup comment.
