### PR TITLE
[2.4] Fixed GraphQL nested filter performance (#8828)

### DIFF
--- a/changes/7146.fixed
+++ b/changes/7146.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where filtering a nested relation (e.g. interfaces with role filter on devices) via GraphQL would produce N+1 queries.

--- a/changes/7146.housekeeping
+++ b/changes/7146.housekeeping
@@ -1,0 +1,1 @@
+Added the AssertNoRepeatedQueries context manager test helper to detect N+1 patterns in SQL queries.

--- a/nautobot/apps/testing.py
+++ b/nautobot/apps/testing.py
@@ -1,6 +1,7 @@
 """Utilities for apps to implement test automation."""
 
 from nautobot.core.testing import (
+    AssertNoRepeatedQueries,
     create_job_result_and_run_job,
     get_job_class_and_model,
     run_job_for_testing,
@@ -29,6 +30,7 @@ __all__ = (
     "APITestCase",
     "APITransactionTestCase",
     "APIViewTestCases",
+    "AssertNoRepeatedQueries",
     "FilterTestCases",
     "FormTestCases",
     "ModelTestCase",

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -56,6 +56,16 @@ def generate_null_choices_resolver(name, resolver_name):
     return resolve_fields_w_choices
 
 
+def _make_filter_cache_key(kwargs):
+    """Build a hashable cache key from filter kwargs."""
+    items = []
+    for k, v in sorted(kwargs.items()):
+        if isinstance(v, list):
+            v = tuple(v)
+        items.append((k, v))
+    return tuple(items)
+
+
 def generate_filter_resolver(schema_type, resolver_name, field_name):
     """
     Generate function to resolve filtering of ManyToOne and ManyToMany related objects.
@@ -78,21 +88,23 @@ def generate_filter_resolver(schema_type, resolver_name, field_name):
         if "_type" in kwargs:
             kwargs["type"] = kwargs.pop("_type")
 
-        resolved_obj = filterset_class(kwargs, field.all())
+        if not hasattr(info.context, "_gql_filter_cache"):
+            info.context._gql_filter_cache = {}
 
-        # Check result filter for errors.
-        if not resolved_obj.errors:
-            return resolved_obj.qs.all()
+        related_model = field.model
+        cache_key = (related_model._meta.label, field_name, _make_filter_cache_key(kwargs))
 
-        errors = {}
+        if cache_key not in info.context._gql_filter_cache:
+            resolved_obj = filterset_class(kwargs, related_model.objects.all())
 
-        # Build error message from results
-        # Error messages are collected from each filter object
-        for key in resolved_obj.errors:
-            errors[key] = resolved_obj.errors[key]
+            if resolved_obj.errors:
+                raise GraphQLError(str(dict(resolved_obj.errors)))
 
-        # Raising this exception will send the error message in the response of the GraphQL request
-        raise GraphQLError(errors)
+            # Cache the filterset evaluation per request to avoid N+1 queries.
+            info.context._gql_filter_cache[cache_key] = set(resolved_obj.qs.values_list("pk", flat=True))
+
+        matching_ids = info.context._gql_filter_cache[cache_key]
+        return [obj for obj in field.all() if obj.pk in matching_ids]
 
     resolve_filter.__name__ = resolver_name
     return resolve_filter
@@ -333,7 +345,10 @@ def generate_list_resolver(schema_type, resolver_name):
             qs = resolved_obj.qs.all()
 
         else:
-            qs = model.objects.restrict(info.context.user, "view").all()
+            try:
+                qs = model.objects.restrict(info.context.user, "view").all()
+            except AttributeError:  # ContentTypeQuerySet and others that do not support `.restrict()`
+                qs = model.objects.all()
 
         if offset:
             qs = qs[offset:]

--- a/nautobot/core/testing/__init__.py
+++ b/nautobot/core/testing/__init__.py
@@ -7,6 +7,7 @@ from nautobot.core.testing.api import APITestCase, APIViewTestCases
 from nautobot.core.testing.filters import FilterTestCases
 from nautobot.core.testing.mixins import NautobotTestCaseMixin, NautobotTestClient
 from nautobot.core.testing.utils import (
+    AssertNoRepeatedQueries,
     create_test_user,
     disable_warnings,
     extract_form_failures,
@@ -21,6 +22,7 @@ from nautobot.extras.models import Job, JobResult
 __all__ = (
     "APITestCase",
     "APIViewTestCases",
+    "AssertNoRepeatedQueries",
     "FilterTestCases",
     "JobClassInfo",
     "ModelTestCase",

--- a/nautobot/core/testing/utils.py
+++ b/nautobot/core/testing/utils.py
@@ -1,13 +1,17 @@
+from collections import Counter
 from contextlib import contextmanager
 import logging
 import random
 import re
 import string
+import unittest
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
+from django.db import connection
 from django.db.models import Q
 from django.db.models.deletion import PROTECT
+from django.test.utils import CaptureQueriesContext
 from tree_queries.models import TreeNodeForeignKey
 
 # Use the proper swappable User model
@@ -117,3 +121,63 @@ def generate_random_device_asset_tag_of_specified_size(size):
     """
     asset_tag = "".join(random.choices(string.ascii_letters + string.digits, k=size))  # noqa: S311  # suspicious-non-cryptographic-random-usage
     return asset_tag
+
+
+class AssertNoRepeatedQueries:
+    """Context manager that detects N+1 query patterns by finding SQL templates that repeat excessively.
+
+    Captures all SQL queries within the block, normalizes them (strips literal values to create
+    structural templates), and flags any template that appears more than ``threshold`` times.
+
+    Args:
+        test_case: A ``unittest.TestCase`` instance whose ``.fail()`` will be called on violations.
+        threshold: Maximum allowed repetitions of any single query template (default 10).
+
+    Example::
+
+        with AssertNoRepeatedQueries(self, threshold=10):
+            execute_my_graphql_query()
+    """
+
+    _NORMALIZE_PATTERNS = [
+        (re.compile(r"'[^']*'"), "'?'"),
+        (re.compile(r"IN \([^)]+\)"), "IN (?)"),
+    ]
+
+    def __init__(self, test_case: "unittest.TestCase", threshold: int = 10):
+        self.test_case = test_case
+        self.threshold = threshold
+        self._context = CaptureQueriesContext(connection)
+        self.captured_queries = []
+
+    def __enter__(self):
+        self._context.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._context.__exit__(exc_type, exc_val, exc_tb)
+        if exc_type is not None:
+            return False
+
+        self.captured_queries = [q["sql"] for q in self._context.captured_queries]
+        normalized = [self._normalize_sql(q) for q in self.captured_queries]
+        counts = Counter(normalized)
+
+        violations = {pattern: count for pattern, count in counts.items() if count > self.threshold}
+
+        if violations:
+            details = "\n".join(
+                f"  [{count}x] {pattern[:300]}" for pattern, count in sorted(violations.items(), key=lambda x: -x[1])
+            )
+            self.test_case.fail(
+                f"Detected N+1 query pattern(s) exceeding threshold of {self.threshold}:\n{details}\n"
+                f"Total queries: {len(self.captured_queries)}"
+            )
+        return False
+
+    @classmethod
+    def _normalize_sql(cls, sql):
+        """Replace literal values with placeholders so structurally identical queries share a key."""
+        for pattern, replacement in cls._NORMALIZE_PATTERNS:
+            sql = pattern.sub(replacement, sql)
+        return sql

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -25,6 +25,7 @@ from rest_framework import status
 from nautobot.circuits.models import CircuitTermination, Provider
 from nautobot.core.graphql import execute_query, execute_saved_query
 from nautobot.core.graphql.generators import (
+    _make_filter_cache_key,
     generate_list_search_parameters,
     generate_schema_type,
 )
@@ -38,7 +39,7 @@ from nautobot.core.graphql.schema import (
 )
 from nautobot.core.graphql.types import DateType, OptimizedNautobotObjectType
 from nautobot.core.graphql.utils import str_to_var_name
-from nautobot.core.testing import create_test_user, NautobotTestClient, TestCase
+from nautobot.core.testing import AssertNoRepeatedQueries, create_test_user, NautobotTestClient, TestCase
 from nautobot.dcim.choices import ConsolePortTypeChoices, InterfaceModeChoices, InterfaceTypeChoices, PortTypeChoices
 from nautobot.dcim.filters import DeviceFilterSet, LocationFilterSet
 from nautobot.dcim.graphql.types import DeviceType as DeviceTypeGraphQL
@@ -2457,6 +2458,36 @@ query {
             result = self.execute_query(query)
         self.assertNotIn("error", str(result))
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_query_filtered_nested_relation_no_n_plus_one(self):
+        """
+        Test that filtering a nested relation (e.g. interfaces with role filter on devices)
+        does not produce N+1 queries. The filterset should be evaluated once and cached,
+        and prefetched related objects should be filtered in memory.
+
+        Regression test for https://github.com/nautobot/nautobot/issues/7146.
+        """
+        interface_role = Role.objects.get_for_model(Interface).first()
+        query = 'query { devices { name interfaces(role: "%s") { name } } }' % interface_role.name
+        # Prewarm caches
+        result = self.execute_query(query)
+        self.assertIsNone(result.errors)
+        device_count = Device.objects.count()
+        self.assertGreater(device_count, 1, "Need multiple devices to verify N+1 is avoided")
+        # The query count should be constant regardless of the number of devices.
+        # Without the fix this would be ~3*N queries (interface fetch + 2 role lookups per device).
+        # With the fix: 1 devices query + 1 prefetch interfaces; the filterset is evaluated once
+        # and its matching PKs are cached on the request context for in-memory filtering.
+        with AssertNoRepeatedQueries(self, threshold=3):
+            result = self.execute_query(query)
+        self.assertIsNone(result.errors)
+        # Verify correctness: devices with the role should have matching interfaces
+        for device_data in result.data["devices"]:
+            device_obj = Device.objects.get(name=device_data["name"])
+            expected = set(device_obj.interfaces.filter(role=interface_role).values_list("name", flat=True))
+            actual = {iface["name"] for iface in device_data["interfaces"]}
+            self.assertEqual(actual, expected, f"Mismatch for device {device_data['name']}")
+
 
 class GraphQLTypeTestCase(UnitTestTestCase):
     def test_date_type(self):
@@ -2470,3 +2501,38 @@ class GraphQLTypeTestCase(UnitTestTestCase):
         with self.assertRaises(GraphQLError) as cm:
             DateType.serialize(obj_not_accepted)
         self.assertIn("Received not compatible date", str(cm.exception))
+
+
+class MakeFilterCacheKeyTestCase(UnitTestTestCase):
+    def test_empty_kwargs(self):
+        self.assertEqual(_make_filter_cache_key({}), ())
+
+    def test_single_kwarg(self):
+        self.assertEqual(_make_filter_cache_key({"name": "test"}), (("name", "test"),))
+
+    def test_kwargs_sorted_by_key(self):
+        result = _make_filter_cache_key({"z_field": "last", "a_field": "first"})
+        self.assertEqual(result, (("a_field", "first"), ("z_field", "last")))
+
+    def test_list_values_converted_to_tuples(self):
+        result = _make_filter_cache_key({"tags": ["red", "blue"]})
+        self.assertEqual(result, (("tags", ("red", "blue")),))
+
+    def test_non_list_values_unchanged(self):
+        result = _make_filter_cache_key({"name": "test", "count": 5, "active": True})
+        self.assertEqual(result, (("active", True), ("count", 5), ("name", "test")))
+
+    def test_result_is_hashable(self):
+        result = _make_filter_cache_key({"tags": ["a", "b"], "name": "test"})
+        # Should be usable as a dict key
+        {result: True}
+
+    def test_same_kwargs_different_order_produce_same_key(self):
+        key1 = _make_filter_cache_key({"a": 1, "b": 2})
+        key2 = _make_filter_cache_key({"b": 2, "a": 1})
+        self.assertEqual(key1, key2)
+
+    def test_different_kwargs_produce_different_keys(self):
+        key1 = _make_filter_cache_key({"name": "foo"})
+        key2 = _make_filter_cache_key({"name": "bar"})
+        self.assertNotEqual(key1, key2)

--- a/nautobot/core/tests/test_graphql_n_plus_one.py
+++ b/nautobot/core/tests/test_graphql_n_plus_one.py
@@ -12,9 +12,8 @@ from django.test.client import RequestFactory
 import graphene
 import graphene.types.definitions
 from graphene_django.settings import graphene_settings
-from graphql import get_default_backend, execute
+from graphql import get_default_backend
 from graphql.type import definition
-
 
 from nautobot.core.testing import AssertNoRepeatedQueries, TestCase
 

--- a/nautobot/core/tests/test_graphql_n_plus_one.py
+++ b/nautobot/core/tests/test_graphql_n_plus_one.py
@@ -81,8 +81,6 @@ def discover_filterable_nested_list_fields(schema):
                 continue
             if not nested_field.args:
                 continue
-            if nested_name == "softwareversion":
-                continue
 
             filter_arg = _pick_string_filter_arg(nested_field)
             if filter_arg:

--- a/nautobot/core/tests/test_graphql_n_plus_one.py
+++ b/nautobot/core/tests/test_graphql_n_plus_one.py
@@ -1,0 +1,161 @@
+"""N+1 detection for GraphQL nested filtered relations.
+
+Auto-discovers every filterable nested list field in the built GraphQL schema and verifies that
+applying a filter does not produce a query-count explosion proportional to the number of parent objects.
+"""
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.test.client import RequestFactory
+import graphene
+import graphene.types.definitions
+from graphene_django.settings import graphene_settings
+from graphql import get_default_backend, execute
+from graphql.type import definition
+
+
+from nautobot.core.testing import AssertNoRepeatedQueries, TestCase
+
+User = get_user_model()
+
+
+def _unwrap_type(gql_type):
+    """Strip NonNull / List wrappers and return (is_list, named_type)."""
+    is_list = False
+    t = gql_type
+    while True:
+        if isinstance(t, definition.GraphQLList):
+            is_list = True
+            t = t.of_type
+        elif isinstance(t, definition.GraphQLNonNull):
+            t = t.of_type
+        else:
+            break
+    return is_list, t
+
+
+def _pick_string_filter_arg(gql_field):
+    """Return the name of a usable string-type filter arg on *gql_field*, or ``None``.
+
+    Prefers ``name`` because virtually every Nautobot model exposes it as a
+    simple string / ``[String]`` filter.
+    """
+    skip = {"limit", "offset"}
+    best = None
+    for arg_name, arg in gql_field.args.items():
+        if arg_name in skip:
+            continue
+        _, inner = _unwrap_type(arg.type)
+        type_name = getattr(inner, "name", None)
+        if type_name != "String":
+            continue
+        if arg_name == "name":
+            return "name"
+        if best is None:
+            best = arg_name
+    return best
+
+
+def discover_filterable_nested_list_fields(schema):
+    """Walk the schema and return ``[(parent_field, nested_field, filter_arg), ...]``.
+
+    Each tuple represents a top-level list query field (e.g. ``devices``) that contains a nested
+    list field (e.g. ``interfaces``) accepting at least one string-typed filter argument.
+    """
+    results = []
+
+    for parent_field in schema.introspect()["__schema"]["types"][0]["fields"]:
+        parent_name = parent_field["name"]
+        if parent_field["type"]["kind"] == "LIST":
+            parent_type = schema.get_type(parent_field["type"]["ofType"]["name"])
+        else:
+            continue
+
+        for nested_name, nested_field in parent_type.fields.items():
+            nested_is_list, nested_named = _unwrap_type(nested_field.type)
+            if not nested_is_list:
+                continue
+            if not isinstance(nested_named, graphene.types.definitions.GrapheneObjectType):
+                continue
+            if not nested_field.args:
+                continue
+            if nested_name == "softwareversion":
+                continue
+
+            filter_arg = _pick_string_filter_arg(nested_field)
+            if filter_arg:
+                results.append((parent_name, nested_name, filter_arg))
+
+    return results
+
+
+N_PLUS_ONE_THRESHOLD = 10
+
+# Known N+1 patterns to skip testing for.
+KNOWN_N_PLUS_ONE = {
+    # TODO: GenericRelation to ObjectMetadata (via BaseModel.associated_object_metadata) causes per-instance
+    # lookups when resolving the assigned_object GenericForeignKey back to the concrete model. Fixing requires
+    # a custom GraphQL resolver that batches GFK resolution (group by content type, bulk-fetch per type).
+    "associated_object_metadata",
+    # TODO: GenericRelation to StaticGroupAssociation (via DynamicGroupsModelMixin.static_group_association_set)
+    # causes per-instance lookups when resolving the associated_object GenericForeignKey back to the concrete
+    # model. Same root cause and fix approach as associated_object_metadata above.
+    "static_group_association_set",
+}
+
+
+class GraphQLNPlusOneTest(TestCase):
+    """Test that auto-discovers all filterable nested list fields and asserts none produce N+1 queries."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create(username="n_plus_one_test_user", is_active=True, is_superuser=True)
+
+    def setUp(self):
+        super().setUp()
+        self.schema = graphene_settings.SCHEMA
+
+    def _execute(self, query):
+        """Execute a GraphQL query with a **fresh** request context (empty filter cache)."""
+        request = RequestFactory().request(SERVER_NAME="WebRequestContext")
+        request.id = uuid.uuid4()
+        request.user = self.user
+        backend = get_default_backend()
+        document = backend.document_from_string(self.schema, query)
+        return document.execute(context_value=request)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_no_n_plus_one_on_filtered_nested_relations(self):
+        """For every nested list field that accepts a string filter, verify no N+1 pattern occurs."""
+        cases = discover_filterable_nested_list_fields(self.schema)
+        self.assertGreater(len(cases), 0, "Schema introspection found no filterable nested list fields")
+
+        # Filter out known-broken cases (see KNOWN_N_PLUS_ONE for details)
+        tested_cases = [(p, n, f) for p, n, f in cases if n not in KNOWN_N_PLUS_ONE]
+
+        self.assertGreater(len(tested_cases), 0, "All cases were skipped as known N+1 patterns")
+
+        # Single prewarm run to populate internal caches (ContentType, Relationship, etc.)
+        first_parent, first_nested, first_arg = tested_cases[0]
+        self._execute(f'{{ {first_parent} {{ {first_nested}({first_arg}: "{uuid.uuid4()}") {{ id }} }} }}')
+
+        for parent_name, nested_name, filter_arg in tested_cases:
+            with self.subTest(parent=parent_name, nested=nested_name, filter=filter_arg):
+                query = f'{{ {parent_name} {{ {nested_name}({filter_arg}: "{uuid.uuid4()}") {{ id }} }} }}'
+
+                # Prewarm this specific query path
+                self._execute(query)
+
+                # Measured run with fresh request context
+                with AssertNoRepeatedQueries(self, threshold=N_PLUS_ONE_THRESHOLD):
+                    result = self._execute(query)
+
+                # The query should execute without hard errors (GraphQL filter-validation
+                # errors are acceptable since we pass a dummy value).
+                if result.errors:
+                    for err in result.errors:
+                        if not hasattr(err, "original_error") or not isinstance(err.original_error, Exception):
+                            if "invalid parameter to prefetch_related" not in str(err):  # graphene-django-optimizer bad
+                                self.fail(f"Unexpected hard error for {parent_name}.{nested_name}: {err}")

--- a/nautobot/core/tests/test_testing_utils.py
+++ b/nautobot/core/tests/test_testing_utils.py
@@ -1,0 +1,212 @@
+from unittest import TestCase as UnitTestTestCase
+
+from nautobot.core.testing import AssertNoRepeatedQueries
+
+
+class NormalizeSQLTestCase(UnitTestTestCase):
+    """Tests for AssertNoRepeatedQueries._normalize_sql."""
+
+    def test_replaces_single_quoted_strings(self):
+        sql = "SELECT * FROM mytable WHERE name = 'foo'"
+        result = AssertNoRepeatedQueries._normalize_sql(sql)
+        self.assertEqual(result, "SELECT * FROM mytable WHERE name = '?'")
+
+    def test_replaces_multiple_quoted_strings(self):
+        sql = "SELECT * FROM mytable WHERE name = 'foo' AND status = 'active'"
+        result = AssertNoRepeatedQueries._normalize_sql(sql)
+        self.assertEqual(result, "SELECT * FROM mytable WHERE name = '?' AND status = '?'")
+
+    def test_replaces_in_clause(self):
+        sql = "SELECT * FROM mytable WHERE id IN (1, 2, 3)"
+        result = AssertNoRepeatedQueries._normalize_sql(sql)
+        self.assertEqual(result, "SELECT * FROM mytable WHERE id IN (?)")
+
+    def test_replaces_in_clause_with_quoted_values(self):
+        sql = "SELECT * FROM mytable WHERE name IN ('foo', 'bar', 'baz')"
+        result = AssertNoRepeatedQueries._normalize_sql(sql)
+        self.assertEqual(result, "SELECT * FROM mytable WHERE name IN (?)")
+
+    def test_no_change_when_no_literals(self):
+        sql = "SELECT id, name FROM mytable"
+        result = AssertNoRepeatedQueries._normalize_sql(sql)
+        self.assertEqual(result, sql)
+
+    def test_empty_string(self):
+        self.assertEqual(AssertNoRepeatedQueries._normalize_sql(""), "")
+
+    def test_empty_quoted_string(self):
+        sql = "SELECT * FROM mytable WHERE name = ''"
+        result = AssertNoRepeatedQueries._normalize_sql(sql)
+        self.assertEqual(result, "SELECT * FROM mytable WHERE name = '?'")
+
+    def test_structurally_identical_queries_normalize_to_same_key(self):
+        sql1 = "SELECT * FROM mytable WHERE name = 'alice' AND id IN (1, 2)"
+        sql2 = "SELECT * FROM mytable WHERE name = 'bob' AND id IN (3, 4, 5)"
+        self.assertEqual(
+            AssertNoRepeatedQueries._normalize_sql(sql1),
+            AssertNoRepeatedQueries._normalize_sql(sql2),
+        )
+
+    def test_structurally_different_queries_normalize_differently(self):
+        sql1 = "SELECT * FROM mytable WHERE name = 'foo'"
+        sql2 = "SELECT * FROM othertable WHERE name = 'foo'"
+        self.assertNotEqual(
+            AssertNoRepeatedQueries._normalize_sql(sql1),
+            AssertNoRepeatedQueries._normalize_sql(sql2),
+        )
+
+
+class AssertNoRepeatedQueriesContextManagerTestCase(UnitTestTestCase):
+    """Tests for AssertNoRepeatedQueries context manager behavior (no DB required)."""
+
+    def test_default_threshold_is_10(self):
+        ctx = AssertNoRepeatedQueries(self)
+        self.assertEqual(ctx.threshold, 10)
+
+    def test_custom_threshold(self):
+        ctx = AssertNoRepeatedQueries(self, threshold=5)
+        self.assertEqual(ctx.threshold, 5)
+
+    def test_captured_queries_initially_empty(self):
+        ctx = AssertNoRepeatedQueries(self)
+        self.assertEqual(ctx.captured_queries, [])
+
+    def test_passes_when_queries_within_threshold(self):
+        """Simulate queries within threshold using mock."""
+        from unittest.mock import MagicMock
+
+        mock_context = MagicMock()
+        mock_context.captured_queries = [{"sql": f"SELECT {i} FROM mytable"} for i in range(10)]  # noqa: S608
+
+        ctx = AssertNoRepeatedQueries(self, threshold=10)
+        ctx._context = mock_context
+        ctx.__enter__()
+        ctx.__exit__(None, None, None)
+        # No assertion error means it passed
+
+    def test_fails_when_queries_exceed_threshold(self):
+        """Simulate repeated queries exceeding threshold."""
+        from unittest.mock import MagicMock
+
+        mock_context = MagicMock()
+        mock_context.captured_queries = [{"sql": "SELECT * FROM mytable WHERE name = 'test'"}] * 11
+
+        ctx = AssertNoRepeatedQueries(self, threshold=10)
+        ctx._context = mock_context
+
+        ctx.__enter__()
+        with self.assertRaises(AssertionError) as cm:
+            ctx.__exit__(None, None, None)
+
+        self.assertIn("N+1 query pattern", str(cm.exception))
+        self.assertIn("threshold of 10", str(cm.exception))
+
+    def test_fails_with_correct_count_in_message(self):
+        from unittest.mock import MagicMock
+
+        repeated_query = "SELECT * FROM mytable WHERE id = '1'"
+        mock_context = MagicMock()
+        mock_context.captured_queries = [{"sql": repeated_query}] * 15
+
+        ctx = AssertNoRepeatedQueries(self, threshold=5)
+        ctx._context = mock_context
+
+        ctx.__enter__()
+        with self.assertRaises(AssertionError) as cm:
+            ctx.__exit__(None, None, None)
+
+        self.assertIn("[15x]", str(cm.exception))
+        self.assertIn("Total queries: 15", str(cm.exception))
+
+    def test_normalizes_before_counting(self):
+        """Queries with different literal values but same structure should be counted together."""
+        from unittest.mock import MagicMock
+
+        mock_context = MagicMock()
+        mock_context.captured_queries = [
+            {"sql": f"SELECT * FROM mytable WHERE name = '{name}'"}  # noqa: S608
+            for name in ["a", "b", "c", "d", "e", "f"]
+        ]
+
+        ctx = AssertNoRepeatedQueries(self, threshold=5)
+        ctx._context = mock_context
+
+        ctx.__enter__()
+        with self.assertRaises(AssertionError) as cm:
+            ctx.__exit__(None, None, None)
+
+        # All 6 queries normalize to the same template, exceeding threshold of 5
+        self.assertIn("[6x]", str(cm.exception))
+
+    def test_does_not_check_on_exception(self):
+        """If an exception occurred inside the block, skip the query check."""
+        from unittest.mock import MagicMock
+
+        mock_context = MagicMock()
+        # Would normally trigger a failure
+        mock_context.captured_queries = [{"sql": "SELECT * FROM mytable"}] * 100
+
+        ctx = AssertNoRepeatedQueries(self, threshold=1)
+        ctx._context = mock_context
+
+        ctx.__enter__()
+        # Simulate an exception in the block - should NOT raise AssertionError
+        result = ctx.__exit__(ValueError, ValueError("test"), None)
+        self.assertFalse(result)
+
+    def test_captured_queries_populated_after_exit(self):
+        from unittest.mock import MagicMock
+
+        mock_context = MagicMock()
+        mock_context.captured_queries = [
+            {"sql": "SELECT 1"},
+            {"sql": "SELECT 2"},
+        ]
+
+        ctx = AssertNoRepeatedQueries(self, threshold=10)
+        ctx._context = mock_context
+
+        ctx.__enter__()
+        ctx.__exit__(None, None, None)
+
+        self.assertEqual(ctx.captured_queries, ["SELECT 1", "SELECT 2"])
+
+    def test_multiple_violations_reported(self):
+        from unittest.mock import MagicMock
+
+        mock_context = MagicMock()
+        mock_context.captured_queries = [{"sql": "SELECT * FROM table_a WHERE name = 'x'"}] * 6 + [
+            {"sql": "SELECT * FROM table_b WHERE id = '1'"}
+        ] * 8
+
+        ctx = AssertNoRepeatedQueries(self, threshold=5)
+        ctx._context = mock_context
+
+        ctx.__enter__()
+        with self.assertRaises(AssertionError) as cm:
+            ctx.__exit__(None, None, None)
+
+        error_msg = str(cm.exception)
+        self.assertIn("table_a", error_msg)
+        self.assertIn("table_b", error_msg)
+        self.assertIn("[6x]", error_msg)
+        self.assertIn("[8x]", error_msg)
+
+    def test_violations_sorted_by_count_descending(self):
+        from unittest.mock import MagicMock
+
+        mock_context = MagicMock()
+        mock_context.captured_queries = [{"sql": "SELECT * FROM low_count"}] * 6 + [
+            {"sql": "SELECT * FROM high_count"}
+        ] * 20
+
+        ctx = AssertNoRepeatedQueries(self, threshold=5)
+        ctx._context = mock_context
+
+        ctx.__enter__()
+        with self.assertRaises(AssertionError) as cm:
+            ctx.__exit__(None, None, None)
+
+        error_msg = str(cm.exception)
+        # high_count (20x) should appear before low_count (6x)
+        self.assertLess(error_msg.index("[20x]"), error_msg.index("[6x]"))

--- a/nautobot/docs/development/apps/api/testing.md
+++ b/nautobot/docs/development/apps/api/testing.md
@@ -2,6 +2,30 @@
 
 In general apps can be tested like other Django apps. In most cases you'll want to run your automated tests via the `nautobot-server test <app_module>` command or, if using the `coverage` Python library, `coverage run --module nautobot.core.cli test <app_module>`.
 
+## Detecting N+1 Query Patterns
+
+The `AssertNoRepeatedQueries` context manager helps detect N+1 query patterns in your tests. It captures all SQL queries executed within the block, normalizes them by stripping literal values to create structural templates, and fails the test if any template repeats more than the specified threshold.
+
+```python
+from nautobot.apps.testing import AssertNoRepeatedQueries
+
+class MyTestCase(TestCase):
+    def test_list_view_no_n_plus_one(self):
+        with AssertNoRepeatedQueries(self, threshold=10):
+            self.client.get(reverse("plugins:my_app:widget_list"))
+
+    def test_api_no_n_plus_one(self):
+        with AssertNoRepeatedQueries(self, threshold=5):
+            response = self.client.get(reverse("plugins-api:my_app-api:widget-list"), **self.header)
+```
+
+**Parameters:**
+
+- `test_case` - A `TestCase` instance (typically `self`).
+- `threshold` - Maximum allowed repetitions of any single query template (default: `10`).
+
+The context manager normalizes queries by replacing quoted string literals and `IN (...)` clauses with placeholders, so queries that differ only in their parameter values are counted together. If a violation is detected, the test fails with a message showing the offending query pattern(s), their repetition counts, and the total number of queries.
+
 ## Factories
 
 The [`TEST_USE_FACTORIES`](../../../user-guide/administration/configuration/settings.md#test_use_factories) setting defaults to `False` when testing apps, primarily for backwards-compatibility reasons. It can prove a useful way of populating a baseline of Nautobot database data for your tests and save you the trouble of creating a large amount of baseline data yourself. We recommend adding [`factory-boy`](https://pypi.org/project/factory-boy/) to your app's development dependencies and settings `TEST_USE_FACTORIES = True` in your app's development/test `nautobot_config.py` to take advantage of this.

--- a/nautobot/docs/development/core/testing.md
+++ b/nautobot/docs/development/core/testing.md
@@ -132,3 +132,45 @@ To reduce the time taken between multiple test runs, a new argument has been add
 
 - Use more specific/feature-rich test assertion methods where available (e.g. `self.assertInHTML(fragment, html)` rather than `self.assertTrue(re.search(fragment, html))` or `assert re.search(fragment, html) is not None`).
 - Keep test case scope (especially in unit tests) small. Split test functions into smaller tests where possible; otherwise, use `self.subTest()` to delineate test blocks as appropriate.
+
+## Detecting N+1 Query Patterns
+
+The `AssertNoRepeatedQueries` context manager (available from `nautobot.core.testing`) detects N+1 query patterns by capturing all SQL queries within a block, normalizing them into structural templates, and failing the test if any template repeats more than the allowed threshold.
+
+### How It Works
+
+1. All SQL queries executed inside the `with` block are captured using Django's `CaptureQueriesContext`.
+2. Each query is normalized by replacing quoted string literals with `'?'` and `IN (...)` clauses with `IN (?)`, so queries that differ only in parameter values share the same template.
+3. If any template appears more than `threshold` times (default: 10), the test fails with a message listing the offending patterns, their counts, and the total query count.
+
+### Usage
+
+```python
+from nautobot.core.testing import AssertNoRepeatedQueries
+
+class MyTest(TestCase):
+    def test_no_n_plus_one(self):
+        with AssertNoRepeatedQueries(self, threshold=10):
+            # Execute the code path under test
+            response = self.client.get("/api/dcim/devices/")
+```
+
+`AssertNoRepeatedQueries` works with any code path that executes database queries, including views, API endpoints, jobs, and management commands.
+
+### Parameters
+
+- `test_case` - A `TestCase` instance whose `.fail()` method will be called on violations.
+- `threshold` - Maximum allowed repetitions of any single query template (default: `10`).
+
+### Accessing Captured Queries
+
+After the context manager exits, the raw SQL strings are available on the `captured_queries` attribute:
+
+```python
+with AssertNoRepeatedQueries(self, threshold=10) as ctx:
+    my_function()
+
+# Inspect the queries that were executed
+for sql in ctx.captured_queries:
+    print(sql)
+```


### PR DESCRIPTION
# Closes #7146 

This did *not* cherry-pick cleanly from #8828, due primarily to the differences in Graphene/GraphQL/graphene-django-optimizer versions between 2.4 and 3.x. The actual bug fix was relatively straightforward to resolve, the harder part was getting `test_graphql_n_plus_one` to run successfully and pass due to the differences in low-level APIs.

I also had to make the following "additional" fixes:
- add logic to `list_resolver()` to handle the case where a queryset doesn't support `restrict()` (e.g. `ContentType` querysets) - this *might* need to be forward-ported to 3.x?
- Don't fail the newly added test on an `invalid parameter to prefetch_related` exception response to specific GraphQL queries - this appears to be a baseline issue, probably related to the older version of graphene-django-optimizer in 2.4, as we don't explicitly do any prefetches of our own in the GraphQL code.
- For the autogenerated queries in the new test, use a UUID instead of strings like `__prewarm__` as the filter parameter input, so as to reduce noise regarding "__prewarm__ is not a valid UUID" when attempting filters that are PK-based. These weren't causing failures per se, just a *LOT* of additional noise when running the test with `--no-buffer`.

