### PR TITLE
Fix #8847 - exception in apps using test_filters_generic

### DIFF
--- a/changes/8847.fixed
+++ b/changes/8847.fixed
@@ -1,0 +1,1 @@
+Fixed an exception in `test_filters_generic` when an App didn't explicitly provide default Role and Status records for ContactAssociations.

--- a/nautobot/core/testing/filters.py
+++ b/nautobot/core/testing/filters.py
@@ -191,6 +191,14 @@ class FilterTestCases:
                     Team.objects.create(name="Generic Filter Test Team 3")
 
                 # Make sure we have some valid contact-associations:
+                if not Role.objects.get_for_model(ContactAssociation).exists():
+                    contact_role, _ = Role.objects.get_or_create(name="Administration")
+                    contact_role.content_types.add(ContentType.objects.get_for_model(ContactAssociation))
+
+                if not Status.objects.get_for_model(ContactAssociation).exists():
+                    contact_status, _ = Status.objects.get_or_create(name="Active")
+                    contact_status.content_types.add(ContentType.objects.get_for_model(ContactAssociation))
+
                 for contact, team, instance in zip(Contact.objects.all()[:3], Team.objects.all()[:3], self.queryset):
                     ContactAssociation.objects.create(
                         contact=contact,


### PR DESCRIPTION
# Closes #8847
# What's Changed

Add logic in `test_filters_generic` to create appropriate Status and Role objects for ContactAssociations if needed, rather than assuming they must already exist. Fixes an exception encountered in some Apps using this generic test.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
