### PR TITLE
Use iterator for JobLogEntry count migration to reduce resource usage

### DIFF
--- a/changes/8861.fixed
+++ b/changes/8861.fixed
@@ -1,0 +1,1 @@
+Add an iterator to the queryset in migration 0130_jobresult_generate_log_entry_counts to prevent resource exhaustion.

--- a/nautobot/extras/migrations/0130_jobresult_generate_log_entry_counts.py
+++ b/nautobot/extras/migrations/0130_jobresult_generate_log_entry_counts.py
@@ -13,7 +13,7 @@ def _populate_log_counts(apps, *_):
         | Q(warning_log_count=None)
         | Q(error_log_count=None)
     )
-    for job_result in job_results_missing_counts:
+    for job_result in job_results_missing_counts.iterator(chunk_size=1000):
         db_log_counts = job_result.job_log_entries.aggregate(
             debug_log_count=Count("pk", filter=Q(log_level="debug")),
             success_log_count=Count("pk", filter=Q(log_level="success")),


### PR DESCRIPTION
# Closes #8861
# What's Changed
Update the migration for JobLogEntry counts to use an iterator to prevent loading all JobLogEntry objects into memory and crashing the migrations when counts are in the >5mil range

- [X ] Added change log fragment(s)