### PR TITLE
[2.4] Backport #8756: Add reload=True to ScheduledJobView get_job() call

### DIFF
--- a/changes/8629.fixed
+++ b/changes/8629.fixed
@@ -1,0 +1,1 @@
+Fixed a scenario where rendering a GitRepository-related Jobs "Scheduled Job View" would sometimes show the Job as not installed.

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2137,7 +2137,7 @@ class ScheduledJobView(generic.ObjectView):
     queryset = ScheduledJob.objects.all()
 
     def get_extra_context(self, request, instance):
-        job_class = get_job(instance.task)
+        job_class = get_job(instance.task, reload=True)
         labels = {}
         if job_class is not None:
             for name, var in job_class._get_vars().items():


### PR DESCRIPTION
## Summary
- Backport of #8756 to the 2.4.x branch
- Adds `reload=True` to the `get_job()` call in `ScheduledJobView.get_extra_context()` so that GitRepository-related jobs are properly discovered when rendering the Scheduled Job detail view
- Without this fix, scheduled jobs sourced from a Git repository may incorrectly show "This job source for this scheduled job is no longer installed"

Closes #8629

## What's Changed
Single-line change in `nautobot/extras/views.py`: `get_job(instance.task)` -> `get_job(instance.task, reload=True)`

## TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s)