### PR TITLE
Fixed Kubernetes job kwarg serialization

### DIFF
--- a/changes/8885.fixed
+++ b/changes/8885.fixed
@@ -1,0 +1,1 @@
+Fixed Kubernetes job kwarg serialization.

--- a/nautobot/extras/jobs_console_log.py
+++ b/nautobot/extras/jobs_console_log.py
@@ -147,7 +147,7 @@ class JobConsoleLogExecutor:
             f"{self.job_result_pk}",
             f"--config={settings.SETTINGS_PATH}",
             "--data",
-            NautobotKombuJSONEncoder().encode(self.job_kwargs),
+            NautobotKombuJSONEncoder(ensure_ascii=False).encode(self.job_kwargs),
         ]
 
     def _print_output(self):

--- a/nautobot/extras/jobs_console_log.py
+++ b/nautobot/extras/jobs_console_log.py
@@ -1,5 +1,4 @@
 import functools
-import json
 import logging
 from queue import Empty, Queue
 import subprocess
@@ -9,6 +8,7 @@ from typing import Any, Dict
 from django.conf import settings
 from django.utils import timezone
 
+from nautobot.core.celery.encoders import NautobotKombuJSONEncoder
 from nautobot.core.utils.logging import sanitize
 from nautobot.extras.choices import JobConsoleEntryOutputTypeChoices
 from nautobot.extras.models import JobConsoleEntry, JobResult
@@ -147,7 +147,7 @@ class JobConsoleLogExecutor:
             f"{self.job_result_pk}",
             f"--config={settings.SETTINGS_PATH}",
             "--data",
-            json.dumps(self.job_kwargs),
+            NautobotKombuJSONEncoder().encode(self.job_kwargs),
         ]
 
     def _print_output(self):

--- a/nautobot/extras/tests/test_jobs_console_log.py
+++ b/nautobot/extras/tests/test_jobs_console_log.py
@@ -197,7 +197,7 @@ class JobConsoleLogExecutorTestCase(CelerySubprocessTestCase):
                 f"{self.job_result.pk}",
                 f"--config={settings.SETTINGS_PATH}",
                 "--data",
-                NautobotKombuJSONEncoder().encode(job_kwargs),
+                NautobotKombuJSONEncoder(ensure_ascii=False).encode(job_kwargs),
             ],
             stdout=mock.ANY,
             stderr=mock.ANY,

--- a/nautobot/extras/tests/test_jobs_console_log.py
+++ b/nautobot/extras/tests/test_jobs_console_log.py
@@ -1,13 +1,14 @@
 from io import StringIO
-import json
 import re
 import subprocess
 from unittest import mock
+import uuid
 
 from django.conf import settings
 from django.test import override_settings
 from django.utils import timezone
 
+from nautobot.core.celery.encoders import NautobotKombuJSONEncoder
 from nautobot.core.testing import CelerySubprocessTestCase, TestCase
 from nautobot.extras.choices import JobConsoleEntryOutputTypeChoices, JobResultStatusChoices
 from nautobot.extras.jobs_console_log import (
@@ -196,7 +197,7 @@ class JobConsoleLogExecutorTestCase(CelerySubprocessTestCase):
                 f"{self.job_result.pk}",
                 f"--config={settings.SETTINGS_PATH}",
                 "--data",
-                json.dumps(job_kwargs),
+                NautobotKombuJSONEncoder().encode(job_kwargs),
             ],
             stdout=mock.ANY,
             stderr=mock.ANY,
@@ -302,3 +303,13 @@ class JobConsoleLogExecutorTestCase(CelerySubprocessTestCase):
             executor.execute()
 
         self.assertEqual(exc.exception.args[0], "Job console log subprocess failed")
+
+    def test_build_command_serializes_uuid_kwargs(self):
+        # Regression: _build_command must serialize UUID values in job_kwargs without raising.
+        test_uuid = uuid.uuid4()
+        executor = JobConsoleLogExecutor(
+            job_result_pk=self.job_result.pk,
+            job_kwargs={"object_id": test_uuid},
+        )
+        command = executor._build_command()
+        self.assertIn(str(test_uuid), command[-1])

--- a/nautobot/extras/tests/test_utils.py
+++ b/nautobot/extras/tests/test_utils.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.test import override_settings
 
+from nautobot.core.celery.encoders import NautobotKombuJSONEncoder
 from nautobot.core.testing import TestCase
 from nautobot.dcim.models import Cable, Device, PowerPort
 from nautobot.extras.choices import JobQueueTypeChoices
@@ -360,7 +361,7 @@ class UtilsTestCase(TestCase):
                 str(job_result.pk),
                 f"--config={settings.SETTINGS_PATH}",
                 "--data",
-                json.dumps(job_kwargs),
+                NautobotKombuJSONEncoder().encode(job_kwargs),
             ],
         )
         self.assertEqual(create_call[1]["namespace"], "test-namespace")
@@ -393,3 +394,9 @@ class UtilsTestCase(TestCase):
                     run_kubernetes_job_and_return_job_result(job_result, job_kwargs)
                 self.assertIn("Unable to retrieve a kubernetes job manifest.", str(cm.exception))
                 self.assertTrue(issubclass(KubernetesJobManifestError, ValidationError))
+
+    def test_kubernetes_job_kwargs_encoder_handles_uuid(self):
+        """Test that NautobotKombuJSONEncoder encodes UUID values correctly."""
+        test_uuid = uuid.uuid4()
+        encoded = NautobotKombuJSONEncoder().encode({"object_id": test_uuid})
+        self.assertIn(str(test_uuid), encoded)

--- a/nautobot/extras/tests/test_utils.py
+++ b/nautobot/extras/tests/test_utils.py
@@ -361,7 +361,7 @@ class UtilsTestCase(TestCase):
                 str(job_result.pk),
                 f"--config={settings.SETTINGS_PATH}",
                 "--data",
-                NautobotKombuJSONEncoder().encode(job_kwargs),
+                NautobotKombuJSONEncoder(ensure_ascii=False).encode(job_kwargs),
             ],
         )
         self.assertEqual(create_call[1]["namespace"], "test-namespace")

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -746,7 +746,7 @@ def run_kubernetes_job_and_return_job_result(job_result, job_kwargs):
         f"{job_result.pk}",
         f"--config={settings.SETTINGS_PATH}",
         "--data",
-        NautobotKombuJSONEncoder().encode(job_kwargs),
+        NautobotKombuJSONEncoder(ensure_ascii=False).encode(job_kwargs),
     ]
 
     def create_kubernetes_job():

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -22,6 +22,7 @@ from django.utils.deconstruct import deconstructible
 import kubernetes.client
 import redis.exceptions
 
+from nautobot.core.celery.encoders import NautobotKombuJSONEncoder
 from nautobot.core.choices import ColorChoices
 from nautobot.core.constants import CHARFIELD_MAX_LENGTH
 from nautobot.core.exceptions import FilterSetFieldNotFound
@@ -745,7 +746,7 @@ def run_kubernetes_job_and_return_job_result(job_result, job_kwargs):
         f"{job_result.pk}",
         f"--config={settings.SETTINGS_PATH}",
         "--data",
-        json.dumps(job_kwargs),
+        NautobotKombuJSONEncoder().encode(job_kwargs),
     ]
 
     def create_kubernetes_job():


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8885
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
This PR replaces the base `json.dumps` to use `NautobotKombuJSONEncoder` instead when encoding Job kwargs to run inside a Kubernetes Job.
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests
