### PR TITLE
slow csv export optimization

### DIFF
--- a/changes/8894.changed
+++ b/changes/8894.changed
@@ -1,0 +1,2 @@
+Changed the csv export algo to speed up the export of a large number of objects in nautobot/core/api/serializers.py
+

--- a/changes/8894.changed
+++ b/changes/8894.changed
@@ -1,2 +1,2 @@
-Changed the csv export algo to speed up the export of a large number of objects in nautobot/core/api/serializers.py
+Changed the CSV export algorithm to speed up the export of a large number of objects.
 

--- a/nautobot/core/api/serializers.py
+++ b/nautobot/core/api/serializers.py
@@ -173,9 +173,10 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializ
                 # We would only need to run one additional query, making this a more efficient method of
                 # obtaining all the natural key values for this instance;
                 queryset = self.Meta.model.objects.filter(pk=self.instance.pk)
-            self.natural_keys_values = queryset.annotate(**case_query).values(
-                *all_related_fields_natural_key_lookups, "pk"
-            )
+            self.natural_keys_values = {
+                item["pk"]: item
+                for item in queryset.annotate(**case_query).values(*all_related_fields_natural_key_lookups, "pk")
+            }
 
     def _get_lookup_field_name_and_output_field(self, lookup_field):
         """Get lookup field name and its corresponding output_field.
@@ -465,8 +466,7 @@ class BaseModelSerializer(OptInFieldsMixin, serializers.HyperlinkedModelSerializ
         altered_data = {}
 
         if self._is_csv_request() and self.natural_keys_values is not None:
-            if natural_key_field_instance := [item for item in self.natural_keys_values if item["pk"] == instance.pk]:
-                cleaned_natural_key_field_instance = natural_key_field_instance[0]
+            if cleaned_natural_key_field_instance := self.natural_keys_values.get(instance.pk):
                 for key, value in data.items():
                     # FK field with natural_field_lookups
                     if natural_key_field_lookups_for_field := self._get_natural_key_lookups_value_for_field(

--- a/nautobot/core/tests/test_csv.py
+++ b/nautobot/core/tests/test_csv.py
@@ -108,9 +108,9 @@ class CSVParsingRelatedTestCase(TestCase):
                 sorted(expected_related_natural_key_fields),
             )
 
-        with self.subTest("Assert Lookup Querysets is valid"):
-            lookup_querysets = serializer.natural_keys_values
-            self.assertEqual(lookup_querysets.count(), 1)
+        with self.subTest("Assert natural_keys_values dict is valid"):
+            natural_keys_values = serializer.natural_keys_values
+            self.assertEqual(len(natural_keys_values), 1)
 
             # Assert FK Field lookups without an object is swapped for None
             field_without_values = [
@@ -131,23 +131,28 @@ class CSVParsingRelatedTestCase(TestCase):
                 field_lookups = Device._meta.get_field(field_name).related_model.natural_key_field_lookups
                 for lookup in field_lookups:
                     self.assertIn(
-                        lookup_querysets[0][f"{field_name}__{lookup}"],
+                        natural_keys_values[self.device.pk][f"{field_name}__{lookup}"],
                         [CSV_NO_OBJECT, VARBINARY_IP_FIELD_REPR_OF_CSV_NO_OBJECT],
                     )
 
             # Assert FK Field lookups with an object
-            self.assertEqual(device.device_type.model, lookup_querysets[0]["device_type__model"])
+            self.assertEqual(device.device_type.model, natural_keys_values[self.device.pk]["device_type__model"])
             self.assertEqual(
-                device.device_type.manufacturer.name, lookup_querysets[0]["device_type__manufacturer__name"]
+                device.device_type.manufacturer.name,
+                natural_keys_values[self.device.pk]["device_type__manufacturer__name"],
             )
-            self.assertEqual(device.status.name, lookup_querysets[0]["status__name"])
-            self.assertEqual(device.role.name, lookup_querysets[0]["role__name"])
+            self.assertEqual(device.status.name, natural_keys_values[self.device.pk]["status__name"])
+            self.assertEqual(device.role.name, natural_keys_values[self.device.pk]["role__name"])
 
-            self.assertEqual(device.location.name, lookup_querysets[0]["location__name"])
-            self.assertEqual(device.location.parent.name, lookup_querysets[0]["location__parent__name"])
-            self.assertEqual(lookup_querysets[0]["location__parent__parent__name"], CSV_NO_OBJECT)
-            self.assertEqual(lookup_querysets[0]["location__parent__parent__parent__name"], CSV_NO_OBJECT)
-            self.assertEqual(lookup_querysets[0]["location__parent__parent__parent__parent__name"], CSV_NO_OBJECT)
+            self.assertEqual(device.location.name, natural_keys_values[self.device.pk]["location__name"])
+            self.assertEqual(device.location.parent.name, natural_keys_values[self.device.pk]["location__parent__name"])
+            self.assertEqual(natural_keys_values[self.device.pk]["location__parent__parent__name"], CSV_NO_OBJECT)
+            self.assertEqual(
+                natural_keys_values[self.device.pk]["location__parent__parent__parent__name"], CSV_NO_OBJECT
+            )
+            self.assertEqual(
+                natural_keys_values[self.device.pk]["location__parent__parent__parent__parent__name"], CSV_NO_OBJECT
+            )
 
         expected_location_nested_lookup_values = {
             f"location__{'parent__' * depth}name": CSV_NO_OBJECT
@@ -155,7 +160,9 @@ class CSVParsingRelatedTestCase(TestCase):
         }  # Location max_tree_depth is based on factory data so this has to be generated dynamically
         with self.subTest("Get the natural lookup field and its value"):
             # For Location
-            location_lookup_value = serializer._get_natural_key_lookups_value_for_field("location", lookup_querysets[0])
+            location_lookup_value = serializer._get_natural_key_lookups_value_for_field(
+                "location", natural_keys_values[self.device.pk]
+            )
             self.assertEqual(
                 location_lookup_value,
                 {
@@ -166,11 +173,15 @@ class CSVParsingRelatedTestCase(TestCase):
             )
 
             # For Status
-            status_lookup_value = serializer._get_natural_key_lookups_value_for_field("status", lookup_querysets[0])
+            status_lookup_value = serializer._get_natural_key_lookups_value_for_field(
+                "status", natural_keys_values[self.device.pk]
+            )
             self.assertEqual(status_lookup_value, {"status__name": device.status.name})
 
             # For Rack, since `device.rack` does not exists, all rack natural_key_lookups should be `NoObject`
-            rack_lookup_value = serializer._get_natural_key_lookups_value_for_field("rack", lookup_querysets[0])
+            rack_lookup_value = serializer._get_natural_key_lookups_value_for_field(
+                "rack", natural_keys_values[self.device.pk]
+            )
             expected_rack_group_nested_lookup_values = {
                 f"rack__rack_group__location__{'parent__' * depth}name": CSV_NO_OBJECT
                 for depth in range(1, Location.objects.max_tree_depth() + 1)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Intro

This is an internal small change/optimization that can speed up devices export to csv quite dramatically.

Other workarounds to speedup the export are known, e.g. create an [Export Template - Nautobot Documentation](https://docs.nautobot.com/projects/core/en/stable/user-guide/platform-functionality/exporttemplate/)  to export only a subset of relevant fields. By default all model fields get exported and this is often not ideal (e.g. for the device model there are more than 50 fields exported).

Instead this optimization does not try to export less fields and for this reason, once applied, it won't change the actual final exported file whatsoever. Its focus is just to speed up the default behavior. Further optimizations around the concept of exporting less fields are certainly possible on top of this one, cfr. https://github.com/nautobot/nautobot/issues/4373.

## What's Changed

`self.natural_keys_values` field of the `BaseModelSerializer` class changes from a plain queryset containing the fields of all the devices we want to export to a dict of queryset. 

The point of this change is converting the list scan at line 468 in the to_representation() method to a dict lookup. This change alone eliminates the quadratic scaling and cut e.g. the 20k export from ~10 minutes to under ~3 minutes.

Of course the speedup becomes more visible the more devices are being exported.

## Root Cause Analysis

Analysis of performances of csv export jobs done through a lot of profiling shows that the dominant bottleneck is the linear scan in the to_representation method (time complexity is O(n²)).

`if natural_key_field_instance := [item for item in self.natural_keys_values if item["pk"] == instance.pk]:`

For every one of the n objects being serialized, this scans the entire natural_keys_values list (also n items) comparing UUIDs. The scaling is quadratic:

| Objects 	| _get_pk_val calls 	| uuid.__eq__calls 	|    Time spent   	|
|:-------:	|:-----------------:	|:----------------:	|:---------------:	|
| 5,000   	| 25 million        	| 25 million       	| 55.6s           	|
| 10,000  	| 100 million       	| 100 million      	| 146.3s          	|
| 20,000  	| 400 million       	| 400 million      	| 487.1s (8+ min) 	|

Doubling the objects quadruples the calls and time. This single list comprehension accounts for ~80% of total job time at 20k objects. This fix builds a dict keyed by PK once, then we can have O(1) lookups per object in to_representation().

## Results

These are the results on my local machine.

| # csv exported devices 	|        without fix        	|        fix applied       	| % improvement 	|
|:--------------------:	|:-------------------------:	|:------------------------:	|:-------------:	|
|          20k         	| 9 minutes, 37.98 seconds  	| 4 minutes, 19.62 seconds 	| ≈ 55% faster  	|
|          30k         	| 16 minutes, 44.35 seconds 	| 6 minutes, 2.18 seconds  	| ≈ 64% faster  	|
|          40k         	| 113 minutes, 5.06 seconds 	| 8 minutes, 4.75 seconds  	| ≈ 93% faster  	|

The devices in my test did not contain any custom fields.

<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
