### PR TITLE
fix job class template override only working as a class attribute

### DIFF
--- a/changes/6199.fixed
+++ b/changes/6199.fixed
@@ -1,0 +1,1 @@
+Fixed job class template override not working when template_name is set as a Meta attribute.

--- a/examples/example_app/example_app/jobs.py
+++ b/examples/example_app/example_app/jobs.py
@@ -303,9 +303,6 @@ class ExampleDryRunJob(Job):
 class ExampleJob(Job):
     some_json_data = JSONVar(label="JSON", description="Example JSONVar for a job.", default={})
 
-    # specify template_name to override the default job scheduling template
-    template_name = "example_app/example_with_custom_template.html"
-
     class Meta:
         name = "Example job, does nothing"
         description = """
@@ -314,6 +311,9 @@ class ExampleJob(Job):
             *This is italicized*
         """
         has_sensitive_variables = False
+
+        # specify template_name to override the default job scheduling template
+        template_name = "example_app/example_with_custom_template.html"
 
     def run(self, some_json_data):  # pylint:disable=arguments-differ
         # some_json_data is passed to the run method as a Python object (e.g. dictionary)
@@ -341,12 +341,12 @@ class ExampleCustomFormJob(Job):
     # display a text area instead in the template.
     custom_job_data = StringVar(label="Input Data", description="Some input data", default="Lorem Ipsum")
 
-    # specify template_name to override the default job scheduling template
-    template_name = "example_app/custom_job_form.html"
-
     class Meta:
         name = "Custom form."
         has_sensitive_variables = False
+
+        # specify template_name to override the default job scheduling template
+        template_name = "example_app/custom_job_form.html"
 
     def run(self, custom_job_data):  # pylint:disable=arguments-differ
         """Run the job."""

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -417,6 +417,11 @@ class BaseJob:
 
     @final
     @classproperty
+    def template_name(cls) -> bool:  # pylint: disable=no-self-argument
+        return cls._get_meta_attr_and_assert_type("template_name", "", expected_type=str)
+
+    @final
+    @classproperty
     def properties_dict(cls) -> dict:  # pylint: disable=no-self-argument
         """
         Return all relevant classproperties as a dict.
@@ -434,6 +439,7 @@ class BaseJob:
             "has_sensitive_variables": cls.has_sensitive_variables,
             "task_queues": cls.task_queues,
             "is_singleton": cls.is_singleton,
+            "template_name": cls.template_name,
         }
 
     @final

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -417,7 +417,7 @@ class BaseJob:
 
     @final
     @classproperty
-    def template_name(cls) -> bool:  # pylint: disable=no-self-argument
+    def template_name(cls) -> str:  # pylint: disable=no-self-argument
         return cls._get_meta_attr_and_assert_type("template_name", "", expected_type=str)
 
     @final

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2563,6 +2563,8 @@ class JobUIViewSet(NautobotUIViewSet):
     def _get_template_name(self, job_class, htmx_modal):
         """Determine the appropriate template to use for the job form."""
         template_name = "extras/job.html"
+        if job_class is None:
+            return template_name
         if htmx_modal:
             template_name = "extras/htmx/job_form_modal.html"
             if hasattr(job_class, "htmx_template_name"):

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2563,8 +2563,6 @@ class JobUIViewSet(NautobotUIViewSet):
     def _get_template_name(self, job_class, htmx_modal):
         """Determine the appropriate template to use for the job form."""
         template_name = "extras/job.html"
-        if job_class is None:
-            return template_name
         if htmx_modal:
             template_name = "extras/htmx/job_form_modal.html"
             if hasattr(job_class, "htmx_template_name"):
@@ -2576,7 +2574,7 @@ class JobUIViewSet(NautobotUIViewSet):
                         self.request,
                         f'Unable to render requested custom HTMX job template "{job_class.htmx_template_name}": {err}',
                     )
-        elif job_class.template_name:
+        elif job_class is not None and job_class.template_name:
             try:
                 get_template(job_class.template_name)
                 template_name = job_class.template_name

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2574,7 +2574,7 @@ class JobUIViewSet(NautobotUIViewSet):
                         self.request,
                         f'Unable to render requested custom HTMX job template "{job_class.htmx_template_name}": {err}',
                     )
-        elif hasattr(job_class, "template_name"):
+        elif job_class.template_name:
             try:
                 get_template(job_class.template_name)
                 template_name = job_class.template_name


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6199
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

The documentation states that the `template_name` should be placed on the Job.Meta class but the implementation previously only worked when it was placed directly on the class. This fixes that and updates the example_app to use the correct pattern.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
