### PR TITLE
Fix docker - disable Poetry keyring to fix arm64 build SIGILL

### DIFF
--- a/changes/8919.fixed
+++ b/changes/8919.fixed
@@ -1,0 +1,1 @@
+Fixed Docker build failing with "Illegal instruction" on ARM64 hosts by disabling Poetry's keyring lookup during dependency installation.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,7 +117,8 @@ ENV PATH="${POETRY_HOME}/bin:${PATH}"
 
 RUN poetry config virtualenvs.create ${POETRY_VIRTUALENVS_CREATE} && \
     poetry config installer.parallel "${POETRY_INSTALLER_PARALLEL}" && \
-    poetry config installer.no-binary lxml,pyuwsgi,xmlsec
+    poetry config installer.no-binary lxml,pyuwsgi,xmlsec && \
+    poetry config keyring.enabled false
 
 ################################ Stage: python-dependencies (intermediate build target)
 


### PR DESCRIPTION
# What's Changed
Adds poetry config keyring.enabled false to the poetry build stage in docker/Dockerfile.


# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
