### PR TITLE
Fixed scheduled jobs to run even if the user is removed

### DIFF
--- a/changes/8413.fixed
+++ b/changes/8413.fixed
@@ -1,0 +1,1 @@
+Fixed scheduled jobs to be able to run even if the user that created them is removed.

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -73,12 +73,6 @@ class NautobotScheduleEntry(ModelEntry):
 
         if model.user:
             self.options["nautobot_job_user_id"] = model.user.id
-        else:
-            logger.error(
-                "Disabling schedule %s with missing user",
-                self.name,
-            )
-            self._disable(model)
 
         if model.job_model:
             self.options["nautobot_job_job_model_id"] = model.job_model.id

--- a/nautobot/core/constants.py
+++ b/nautobot/core/constants.py
@@ -107,6 +107,9 @@ CONFIG_SETTING_SEPARATOR = ","
 
 CHARFIELD_MAX_LENGTH = 255
 
+# This mirrors the max_length from django.contrib.auth.models.User
+USERNAME_MAX_LENGTH = 150
+
 # Default values for pagination settings.
 MAX_PAGE_SIZE_DEFAULT = 1000
 PAGINATE_COUNT_DEFAULT = 50

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -19,6 +19,7 @@ from django import forms
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import UploadedFile
@@ -167,7 +168,9 @@ class BaseJob:
         else:
             change_context = ObjectChangeEventContextChoices.CONTEXT_JOB
 
-        with web_request_context(user=self.user, context_detail=self.class_path, context=change_context):
+        with web_request_context(
+            user=self.user or AnonymousUser(), context_detail=self.class_path, context=change_context
+        ):
             if self.celery_kwargs.get("nautobot_job_profile", False) is True:
                 import cProfile
 
@@ -1316,10 +1319,16 @@ def _prepare_job(job_class_path, request, kwargs) -> tuple[Job, dict]:
         )
 
     # Send notice that the job is running
+    if job_result.user:
+        user_name = job_result.user.username
+    elif job_result.scheduled_job:
+        user_name = job_result.scheduled_job.user_name
+    else:
+        user_name = "Undefined"
     event_payload = {
         "job_result_id": request.id,
         "job_name": job.name,  # TODO: should this be job.job_model.name instead? Possible breaking change
-        "user_name": job_result.user.username,
+        "user_name": user_name,
     }
     if not job.job_model.has_sensitive_variables:
         event_payload["job_kwargs"] = kwargs

--- a/nautobot/extras/migrations/0143_scheduledjob_user_name.py
+++ b/nautobot/extras/migrations/0143_scheduledjob_user_name.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("extras", "0142_remove_scheduledjob_approval_required"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="scheduledjob",
+            name="user_name",
+            field=models.CharField(db_index=True, default="", editable=False, max_length=150),
+            preserve_default=False,
+        ),
+    ]

--- a/nautobot/extras/migrations/0144_scheduledjob_user_name_data_migration.py
+++ b/nautobot/extras/migrations/0144_scheduledjob_user_name_data_migration.py
@@ -1,0 +1,40 @@
+from django.conf import settings
+from django.db import migrations
+
+
+def populate_user_name(apps, schema_editor):
+    """
+    Populate the new ScheduledJob.user_name field for existing rows.
+
+    Sets user_name to the associated user's username, or "Undefined" when the
+    user has been deleted (user FK is null).
+    """
+    ScheduledJob = apps.get_model("extras", "ScheduledJob")
+    user_app_label, user_model_name = settings.AUTH_USER_MODEL.split(".")
+    User = apps.get_model(user_app_label, user_model_name)
+
+    user_ids = (
+        ScheduledJob.objects.filter(user__isnull=False, user_name="").values_list("user_id", flat=True).distinct()
+    )
+    usernames_by_id = dict(User.objects.filter(pk__in=list(user_ids)).values_list("pk", "username"))
+
+    to_update = []
+    for scheduled_job in ScheduledJob.objects.filter(user_name="").only("pk", "user_id", "user_name"):
+        if scheduled_job.user_id and scheduled_job.user_id in usernames_by_id:
+            scheduled_job.user_name = usernames_by_id[scheduled_job.user_id]
+        else:
+            scheduled_job.user_name = "Undefined"
+        to_update.append(scheduled_job)
+
+    if to_update:
+        ScheduledJob.objects.bulk_update(to_update, ["user_name"], 1000)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("extras", "0143_scheduledjob_user_name"),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_user_name, migrations.RunPython.noop),
+    ]

--- a/nautobot/extras/models/approvals.py
+++ b/nautobot/extras/models/approvals.py
@@ -8,7 +8,7 @@ from django.core.exceptions import FieldError, ValidationError
 from django.db import models
 from django.utils import timezone
 
-from nautobot.core.constants import CHARFIELD_MAX_LENGTH
+from nautobot.core.constants import CHARFIELD_MAX_LENGTH, USERNAME_MAX_LENGTH
 from nautobot.core.models import BaseManager, BaseModel
 from nautobot.core.models.generics import OrganizationalModel, PrimaryModel
 from nautobot.core.models.querysets import RestrictedQuerySet
@@ -208,7 +208,7 @@ class ApprovalWorkflow(OrganizationalModel):
         blank=True,
         null=True,
     )
-    user_name = models.CharField(max_length=150, editable=False, db_index=True)
+    user_name = models.CharField(max_length=USERNAME_MAX_LENGTH, editable=False, db_index=True)
     documentation_static_path = "docs/user-guide/platform-functionality/approval-workflow.html"
 
     is_data_compliance_model = False

--- a/nautobot/extras/models/change_logging.py
+++ b/nautobot/extras/models/change_logging.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.urls import NoReverseMatch, reverse
 
 from nautobot.core.celery import NautobotKombuJSONEncoder
+from nautobot.core.constants import USERNAME_MAX_LENGTH
 from nautobot.core.models import BaseModel
 from nautobot.core.models.utils import serialize_object, serialize_object_v2
 from nautobot.core.utils.data import shallow_compare_dict
@@ -80,7 +81,7 @@ class ObjectChange(BaseModel):
         blank=True,
         null=True,
     )
-    user_name = models.CharField(max_length=150, editable=False, db_index=True)
+    user_name = models.CharField(max_length=USERNAME_MAX_LENGTH, editable=False, db_index=True)
     request_id = models.UUIDField(editable=False, db_index=True)
     action = models.CharField(max_length=50, choices=ObjectChangeActionChoices)
     changed_object_type = models.ForeignKey(to=ContentType, on_delete=models.SET_NULL, null=True, related_name="+")

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -29,7 +29,7 @@ from nautobot.core.celery import (
     NautobotKombuJSONEncoder,
     setup_nautobot_job_logging,
 )
-from nautobot.core.constants import CHARFIELD_MAX_LENGTH
+from nautobot.core.constants import CHARFIELD_MAX_LENGTH, USERNAME_MAX_LENGTH
 from nautobot.core.events import publish_event
 from nautobot.core.models import BaseManager, BaseModel
 from nautobot.core.models.generics import OrganizationalModel, PrimaryModel
@@ -1561,7 +1561,7 @@ class ScheduledJob(ApprovableModelMixin, BaseModel):
         null=True,
         help_text="User that requested the schedule",
     )
-    user_name = models.CharField(max_length=150, editable=False, db_index=True)
+    user_name = models.CharField(max_length=USERNAME_MAX_LENGTH, editable=False, db_index=True)
 
     # todoindex:
     decision_date = models.DateTimeField(

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -1561,6 +1561,7 @@ class ScheduledJob(ApprovableModelMixin, BaseModel):
         null=True,
         help_text="User that requested the schedule",
     )
+    user_name = models.CharField(max_length=150, editable=False, db_index=True)
 
     # todoindex:
     decision_date = models.DateTimeField(
@@ -1598,6 +1599,11 @@ class ScheduledJob(ApprovableModelMixin, BaseModel):
         # so they won't be affected by this check.
         if not self.enabled and self.state == ScheduledJobStateChoices.ACTIVE:
             self.state = ScheduledJobStateChoices.COMPLETED
+        if not self.user_name:
+            if self.user:
+                self.user_name = self.user.username
+            else:
+                self.user_name = "Undefined"
         is_new = not self.present_in_database
         super().save(*args, **kwargs)
         if is_new:

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -20,7 +20,7 @@ from jsonschema.exceptions import SchemaError, ValidationError as JSONSchemaVali
 from jsonschema.validators import Draft7Validator
 from rest_framework.utils.encoders import JSONEncoder
 
-from nautobot.core.constants import CHARFIELD_MAX_LENGTH
+from nautobot.core.constants import CHARFIELD_MAX_LENGTH, USERNAME_MAX_LENGTH
 from nautobot.core.models import BaseManager, BaseModel
 from nautobot.core.models.fields import ForeignKeyWithAutoRelatedName, LaxURLField
 from nautobot.core.models.generics import OrganizationalModel, PrimaryModel
@@ -851,7 +851,7 @@ class Note(ChangeLoggedModel, DataComplianceModelMixin, BaseModel):
         blank=True,
         null=True,
     )
-    user_name = models.CharField(max_length=150, editable=False)
+    user_name = models.CharField(max_length=USERNAME_MAX_LENGTH, editable=False)
 
     note = models.TextField()
     objects = BaseManager.from_queryset(NotesQuerySet)()

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -1577,7 +1577,11 @@ class ScheduledJobApprovalQueueTable(BaseTable):
     job_model = tables.Column(verbose_name="Job", linkify=True)
     interval = tables.Column(verbose_name="Execution Type")
     start_time = tables.Column(verbose_name="Requested")
-    user = tables.Column(verbose_name="Requestor")
+    user = tables.TemplateColumn(
+        template_code="{% if record.user %}{{ record.user }}{% else %}{{ record.user_name }}{% endif %}",
+        verbose_name="Requestor",
+        order_by=("user__username", "user_name"),
+    )
     actions = tables.TemplateColumn(
         SCHEDULED_JOB_APPROVAL_QUEUE_BUTTONS,
         attrs={

--- a/nautobot/extras/templates/extras/scheduledjob_retrieve.html
+++ b/nautobot/extras/templates/extras/scheduledjob_retrieve.html
@@ -58,7 +58,7 @@
             <tr>
                 <td>Requester</td>
                 <td>
-                    {{ object.user|placeholder }}
+                    {% if object.user %}{{ object.user }}{% else %}{{ object.user_name|placeholder }}{% endif %}
                 </td>
             </tr>
             <tr>

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -11,6 +11,7 @@ import uuid
 
 from constance.test import override_config
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
@@ -41,7 +42,7 @@ from nautobot.extras.choices import (
     ObjectChangeEventContextChoices,
 )
 from nautobot.extras.context_managers import change_logging, JobHookChangeContext, web_request_context
-from nautobot.extras.jobs import BaseJob, get_job, get_jobs, run_console_log_job_and_return_job_result
+from nautobot.extras.jobs import _prepare_job, BaseJob, get_job, get_jobs, run_console_log_job_and_return_job_result
 from nautobot.extras.models import Job, JobQueue, JobResult
 from nautobot.extras.models.jobs import JOB_LOGS, JobLogEntry
 
@@ -1717,6 +1718,71 @@ class ScheduledJobIntervalTestCase(TestCase):
         schedule_day_of_week = next(iter(scheduled_job.schedule.day_of_week))
         scheduled_job_weekday = self.cron_days[schedule_day_of_week]
         self.assertEqual(scheduled_job_weekday, requested_weekday)
+
+
+class PrepareJobUserNameTestCase(TransactionTestCase):
+    """Tests for the user_name fallback in `_prepare_job`'s event payload (regression for #8413)."""
+
+    def setUp(self):
+        super().setUp()
+        self.job_model = Job.objects.get_for_class_path("pass_job.TestPassJob")
+        self.job_model.enabled = True
+        self.job_model.save()
+
+    def _build_request(self, job_result):
+        request = mock.Mock()
+        request.id = str(job_result.pk)
+        return request
+
+    @mock.patch("nautobot.extras.jobs.publish_event")
+    def test_prepare_job_uses_scheduled_job_user_name_when_user_deleted(self, mock_publish_event):
+        """When JobResult.user is None but scheduled_job has a preserved user_name, the event payload uses it."""
+        deleted_username = "deleteduser"
+        deleted_user = get_user_model().objects.create(username=deleted_username, is_active=True)
+        scheduled_job = models.ScheduledJob.objects.create(
+            name="Scheduled Job For Deleted User",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=deleted_user,
+            interval=JobExecutionType.TYPE_FUTURE,
+            start_time=timezone.now() + datetime.timedelta(days=1),
+        )
+        deleted_user.delete()
+        scheduled_job.refresh_from_db()
+        self.assertIsNone(scheduled_job.user)
+        self.assertEqual(scheduled_job.user_name, deleted_username)
+
+        job_result = JobResult.objects.create(
+            name=self.job_model.name,
+            job_model=self.job_model,
+            scheduled_job=scheduled_job,
+            user=None,
+            status=JobResultStatusChoices.STATUS_PENDING,
+        )
+
+        _prepare_job("pass_job.TestPassJob", self._build_request(job_result), {})
+
+        mock_publish_event.assert_called_once()
+        topic = mock_publish_event.call_args.kwargs["topic"]
+        payload = mock_publish_event.call_args.kwargs["payload"]
+        self.assertEqual(topic, "nautobot.jobs.job.started")
+        self.assertEqual(payload["user_name"], deleted_username)
+
+    @mock.patch("nautobot.extras.jobs.publish_event")
+    def test_prepare_job_uses_undefined_when_no_user_and_no_scheduled_job(self, mock_publish_event):
+        """When JobResult has no user and no scheduled_job, the event payload uses 'Undefined'."""
+        job_result = JobResult.objects.create(
+            name=self.job_model.name,
+            job_model=self.job_model,
+            user=None,
+            status=JobResultStatusChoices.STATUS_PENDING,
+        )
+
+        _prepare_job("pass_job.TestPassJob", self._build_request(job_result), {})
+
+        mock_publish_event.assert_called_once()
+        payload = mock_publish_event.call_args.kwargs["payload"]
+        self.assertEqual(payload["user_name"], "Undefined")
 
 
 class JobResultEnqueueJobCase(TransactionTestCase):

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -3403,6 +3403,70 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
                 self.daily_utc_job.refresh_from_db()
                 self.assertEqual(self.daily_utc_job.state, state)
 
+    def test_save_populates_user_name_from_user(self):
+        """Test that save() populates user_name from the associated user's username."""
+        scheduled_job = ScheduledJob.objects.create(
+            name="User Name Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=self.user,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        self.assertEqual(scheduled_job.user_name, self.user.username)
+
+    def test_save_populates_user_name_undefined_when_no_user(self):
+        """Test that save() populates user_name with 'Undefined' when no user is associated."""
+        scheduled_job = ScheduledJob.objects.create(
+            name="No User Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        self.assertEqual(scheduled_job.user_name, "Undefined")
+
+    def test_user_deletion_preserves_user_name(self):
+        """Test that deleting the associated user preserves user_name for historical record."""
+        original_username = self.user.username
+        scheduled_job = ScheduledJob.objects.create(
+            name="Preserve User Name Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=self.user,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        self.assertEqual(scheduled_job.user_name, original_username)
+
+        self.user.delete()
+        scheduled_job.refresh_from_db()
+        self.assertIsNone(scheduled_job.user)
+        self.assertEqual(scheduled_job.user_name, original_username)
+
+    def test_schedule_entry_does_not_disable_when_user_is_none(self):
+        """Regression test for #8413: NautobotScheduleEntry should not disable schedules when user is None."""
+        from nautobot.core.celery.schedulers import NautobotScheduleEntry
+
+        scheduled_job = ScheduledJob.objects.create(
+            name="No User Schedule Entry Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        entry = NautobotScheduleEntry(model=scheduled_job)
+        scheduled_job.refresh_from_db()
+        self.assertTrue(scheduled_job.enabled)
+        self.assertNotEqual(scheduled_job.state, ScheduledJobStateChoices.ERRORED)
+        self.assertNotIn("nautobot_job_user_id", entry.options)
+
     # TODO uncomment when we have a way to setup the NautobotDatabaseScheduler correctly
     # @mock.patch("nautobot.extras.utils.run_kubernetes_job_and_return_job_result")
     # def test_nautobot_database_scheduler_apply_async_method(self, mock_run_kubernetes_job_and_return_job_result):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8413
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
When a user creates a scheduled job and then that user is then removed, the scheduled job will fail silently as it tries to read the username. This PR accomplishes the following changes:
- Changed scheduled jobs to run even if the user no longer exists
  - This change should be able to be backported if needed
- Added a `user_name` field with the intent of preserving the name of the original user in the same way we do with ObjectChange and ApprovalWorkflow
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
You can see here the username still shows on the ScheduledJob detail view despite the user have been deleted:
<img width="514" height="357" alt="Screenshot 2026-04-28 at 4 45 20 PM" src="https://github.com/user-attachments/assets/1c6dc616-6a1d-42d9-ac3d-c92a32a41968" />

This has a side effect of the User field on the JobResult table now showing the placeholder since the User no longer exists there either:
<img width="1022" height="248" alt="Screenshot 2026-04-28 at 4 45 27 PM" src="https://github.com/user-attachments/assets/9b786b9f-5677-4c94-85e1-85016021f7f7" />

If we want the `user_name` field on JobResult to remedy that table, we can pivot to do that as well.
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests

NTC-4974