### PR TITLE
Invoke task enhancements

### DIFF
--- a/changes/8925.housekeeping
+++ b/changes/8925.housekeeping
@@ -1,0 +1,2 @@
+Added support for `--no-input` option to `invoke tests` task.
+Added support for `--command` option to `invoke nbshell` task.

--- a/changes/xxxx.housekeeping
+++ b/changes/xxxx.housekeeping
@@ -1,1 +1,0 @@
-Added support for `--no-input` option to `invoke tests` task.

--- a/changes/xxxx.housekeeping
+++ b/changes/xxxx.housekeeping
@@ -1,0 +1,1 @@
+Added support for `--no-input` option to `invoke tests` task.

--- a/tasks.py
+++ b/tasks.py
@@ -17,6 +17,7 @@ import json
 import os
 import platform
 import re
+import shlex
 import time
 
 from invoke import Collection, task as invoke_task
@@ -639,18 +640,21 @@ def logs(context, service=None, follow=False, tail=0):
     help={
         "quiet": "Suppress verbose output on launch",
         "print_sql": "Enable printing of all executed SQL statements",
+        "command": "Python code to execute non-interactively, instead of launching an interactive shell",
     }
 )
-def nbshell(context, quiet=False, print_sql=False):
-    """Launch an interactive Nautobot shell."""
-    command = "nautobot-server nbshell"
+def nbshell(context, quiet=False, print_sql=False, command=None):
+    """Launch an interactive Nautobot shell, or run a single Python command non-interactively."""
+    cmd = "nautobot-server nbshell"
 
     if quiet:
-        command += " --quiet"
+        cmd += " --quiet"
     if print_sql:
-        command += " --print-sql"
+        cmd += " --print-sql"
+    if command:
+        cmd += f" --command {shlex.quote(command)}"
 
-    run_command(context, command)
+    run_command(context, cmd)
 
 
 @task(

--- a/tasks.py
+++ b/tasks.py
@@ -1101,6 +1101,7 @@ def check_schema(context, api_version=None):
         "failfast": "Fail as soon as a single test fails don't run the entire test suite.",
         "keepdb": "Save test database after test run for faster re-testing in combination with `--reusedb`.",
         "label": "Specify a directory or module to test instead of running all Nautobot tests.",
+        "no_input": "Suppress interactive prompts (e.g. confirmation when `--no-reusedb` would destroy an existing test database).",
         "parallel": "Run tests in parallel; auto-detects the number of workers if not specified with `--parallel-workers`.",
         "parallel_workers": "Specify the number of workers to use when running tests in parallel.",
         "pattern": "Only run tests which match the given substring. Can be used multiple times.",
@@ -1123,6 +1124,7 @@ def tests(
     failfast=False,
     keepdb=True,
     label="nautobot",
+    no_input=False,
     parallel=True,
     parallel_workers=None,
     pattern=None,
@@ -1164,6 +1166,8 @@ def tests(
         command += " --keepdb"
     if not reusedb:
         command += " --no-reusedb"
+    if no_input:
+        command += " --no-input"
     if failfast:
         command += " --failfast"
     if buffer:


### PR DESCRIPTION
A couple of enhancements to our `invoke` tasks to address a couple of use cases I've tripped over recently:

- `invoke tests --no-input`, for example so that `invoke tests --no-reusedb --no-input` will avoid hanging indefinitely while waiting for you to confirm that yes, you really are OK with not reusing the test database
- `invoke nbshell --command '....'`, exposing the built-in capability of `nbshell` itself to run a string of Python code.