### PR TITLE
Changed scheduled jobs to fail loudly if the user is deleted, and added button to transfer ownership

### DIFF
--- a/changes/8413.added
+++ b/changes/8413.added
@@ -1,0 +1,1 @@
+Added an "Assume Ownership" action button on the Scheduled Job detail view that allows users with the required permissions to take over ownership of a scheduled job.

--- a/changes/8413.fixed
+++ b/changes/8413.fixed
@@ -1,0 +1,1 @@
+Fixed silent failure of scheduled jobs whose originating user has been removed. The scheduler now records a failed JobResult as well as disables the schedule with state ERRORED.

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -71,14 +71,11 @@ def _record_missing_user_failure(model):
             date_started=timestamp,
             date_done=timestamp,
             traceback=err_message,
+            # We are intentionally omitting JobResult fields that are not necessary
+            # as we only need it to create a JobLogEntry to log the failure.
         )
         log_object = str(model)[:JOB_LOG_MAX_LOG_OBJECT_LENGTH]
-        absolute_url = ""
-        if hasattr(model, "get_absolute_url"):
-            try:
-                absolute_url = model.get_absolute_url()[:JOB_LOG_MAX_ABSOLUTE_URL_LENGTH]
-            except (AttributeError, NotImplementedError):
-                logger.debug("Scheduled job %s does not provide a usable absolute URL", model.name)
+        absolute_url = model.get_absolute_url()[:JOB_LOG_MAX_ABSOLUTE_URL_LENGTH]
         JobLogEntry.objects.create(
             job_result=job_result,
             log_level=LogLevelChoices.LOG_ERROR,

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -8,14 +8,90 @@ from celery import current_app
 from celery.beat import _evaluate_entry_args, _evaluate_entry_kwargs, reraise, SchedulingError
 from celery.result import AsyncResult
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.utils import timezone
 from django_celery_beat.schedulers import DatabaseScheduler, ModelEntry
 from kombu.utils.json import loads
 
-from nautobot.extras.choices import JobQueueTypeChoices, ScheduledJobStateChoices
-from nautobot.extras.models import JobResult, ScheduledJob, ScheduledJobs
+from nautobot.extras.choices import (
+    JobQueueTypeChoices,
+    JobResultStatusChoices,
+    LogLevelChoices,
+    ScheduledJobStateChoices,
+)
+from nautobot.extras.constants import JOB_LOG_MAX_ABSOLUTE_URL_LENGTH, JOB_LOG_MAX_LOG_OBJECT_LENGTH
+from nautobot.extras.models import JobLogEntry, JobResult, ScheduledJob, ScheduledJobs
 from nautobot.extras.utils import run_kubernetes_job_and_return_job_result
 
 logger = logging.getLogger(__name__)
+
+
+def _user_exists(user_id):
+    """Return True if `user_id` is non-null and references an existing user row."""
+    if user_id is None:
+        return False
+    return get_user_model().objects.filter(pk=user_id).exists()
+
+
+def _record_missing_user_failure(model):
+    """
+    Record a failed JobResult for a ScheduledJob whose originating user is missing.
+
+    Used when celery beat fires a schedule whose `user` FK is null or refers to a
+    deleted user. We create a JobResult marked FAILURE so administrators have a
+    durable record of the missed run instead of a silent failure.
+
+    Also clears the in-memory `user_id` so that subsequent `model.save()` calls
+    (e.g. from `_disable`) cannot raise an FK violation when the FK is orphaned.
+    """
+    # If user_id points to a row that no longer exists (FK orphan, e.g. user was deleted via
+    # raw SQL bypassing on_delete=SET_NULL), any save() of this model will raise an
+    # IntegrityError. Patch the DB directly via queryset update, then null in-memory.
+    if model.user_id is not None:
+        ScheduledJob.objects.filter(pk=model.pk).update(user=None)
+        model.user_id = None
+
+    if model.job_model is None:
+        # Can't create a JobResult without a job_model FK; the scheduler will disable
+        # the entry below, which is the best we can do.
+        return
+    err_message = (
+        f"Scheduled job '{model.name}' cannot run: the originating user has been removed. "
+        "Use 'Assume Ownership' on the scheduled job detail view to reassign it."
+    )
+    try:
+        timestamp = timezone.now()
+        job_result = JobResult.objects.create(
+            name=model.job_model.name,
+            job_model=model.job_model,
+            scheduled_job=model,
+            user=None,
+            task_name=model.job_model.class_path,
+            status=JobResultStatusChoices.STATUS_FAILURE,
+            date_started=timestamp,
+            date_done=timestamp,
+            traceback=err_message,
+        )
+        log_object = str(model)[:JOB_LOG_MAX_LOG_OBJECT_LENGTH]
+        absolute_url = ""
+        if hasattr(model, "get_absolute_url"):
+            try:
+                absolute_url = model.get_absolute_url()[:JOB_LOG_MAX_ABSOLUTE_URL_LENGTH]
+            except (AttributeError, NotImplementedError):
+                pass
+        JobLogEntry.objects.create(
+            job_result=job_result,
+            log_level=LogLevelChoices.LOG_ERROR,
+            grouping="main",
+            message=err_message,
+            log_object=log_object,
+            absolute_url=absolute_url,
+        )
+        job_result.count_logs_by_level()
+        job_result.save()
+    except Exception:  # pylint: disable=broad-except
+        # Never let a bookkeeping failure crash celery beat itself.
+        logger.exception("Failed to record missing-user JobResult for schedule %s", model.name)
 
 
 class NautobotScheduleEntry(ModelEntry):
@@ -71,13 +147,14 @@ class NautobotScheduleEntry(ModelEntry):
         # Nautobot-specific logic
         self.options = {"nautobot_job_scheduled_job_id": model.id, "headers": {}}
 
-        if model.user:
-            self.options["nautobot_job_user_id"] = model.user.id
+        if _user_exists(model.user_id):
+            self.options["nautobot_job_user_id"] = model.user_id
         else:
             logger.error(
                 "Disabling schedule %s with missing user",
                 self.name,
             )
+            _record_missing_user_failure(model)
             self._disable(model)
 
         if model.job_model:
@@ -141,6 +218,13 @@ class NautobotDatabaseScheduler(DatabaseScheduler):
         resp = None
         entry = self.reserve(entry) if advance else entry
         task = self.app.tasks.get(entry.task)
+
+        # If the entry's options lack `nautobot_job_user_id`, the originating user is
+        # missing and `__init__` already recorded a failed JobResult and disabled the
+        # schedule. Skip dispatch so we don't fire a doomed task into celery for this
+        # tick — the next tick will not pick the entry up (enabled=False).
+        if isinstance(entry, NautobotScheduleEntry) and "nautobot_job_user_id" not in entry.options:
+            return None
 
         try:
             entry_args = _evaluate_entry_args(entry.args)

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -78,7 +78,7 @@ def _record_missing_user_failure(model):
             try:
                 absolute_url = model.get_absolute_url()[:JOB_LOG_MAX_ABSOLUTE_URL_LENGTH]
             except (AttributeError, NotImplementedError):
-                pass
+                logger.debug("Scheduled job %s does not provide a usable absolute URL", model.name)
         JobLogEntry.objects.create(
             job_result=job_result,
             log_level=LogLevelChoices.LOG_ERROR,

--- a/nautobot/core/templates/components/button/post_extradetailviewactionbutton.html
+++ b/nautobot/core/templates/components/button/post_extradetailviewactionbutton.html
@@ -1,7 +1,9 @@
 <li id="component-{{ component.component_id }}">
     <form method="post" action="{{ link }}" style="margin: 0;">
         {% csrf_token %}
-        <button type="submit" class="dropdown-item">
+        <button type="submit" class="dropdown-item"
+                {% for key, value in attributes.items %}{{ key }}="{{ value }}" {% endfor %}
+        >
             {% if icon %}<span class="mdi {{ icon }}" aria-hidden="true"></span>{% endif %}
             {{ label }}
         </button>

--- a/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
@@ -23,6 +23,19 @@ If the job requires no approval, it will then be added to the queue of scheduled
 
 Once a job has been scheduled, the schedule can be deleted by navigating to `Jobs > Scheduled Jobs`, selecting the schedule name and clicking the `Delete` button. You can also select multiple schedules and click the `Delete Selected` button to delete them all at once.
 
+### Assuming Ownership of a Scheduled Job
+
+Each scheduled job is owned by the user that created it. If that user is removed, the schedule can no longer run and is automatically disabled with a state of `Errored` the next time it would have fired; a failed `JobResult` is also recorded.
+
+Ownership of a scheduled job can be transferred at any time from the `Assume Ownership` action in the Actions dropdown on the Scheduled Job detail view. Clicking it reassigns the schedule to the current user. If the scheduled job was previously disabled due to a failure, the button also re-enables it, and resets its state to `Active`.
+
+The button is only visible to users with **both** of the following permissions:
+
+- `extras.change_scheduledjob` — required to modify the scheduled job record.
+- `extras.run_job` — required to be eligible to run the job.
+
+The most common reason to use this action is to recover a scheduled job whose original owner was removed, but it can also be used to hand off a recurring schedule to another administrator.
+
 ### Scheduling via the API
 
 Jobs can also be scheduled via the REST API. The endpoint used for this is the regular job endpoint; specifying the optional `schedule` parameter will act just as scheduling in the UI.

--- a/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
@@ -29,10 +29,11 @@ Each scheduled job is owned by, and runs as, the user that created it. If that u
 
 Ownership of a scheduled job can be transferred at any time from the `Assume Ownership` action in the Actions dropdown on the Scheduled Job detail view. Clicking it reassigns the schedule to the current user. If the scheduled job was previously disabled due to a failure, the button also re-enables it, and resets its state to `Active`.
 
-The button is only visible to users with **both** of the following permissions:
+The button is hidden when the requester is already the current owner, and is only visible to users that meet **all** of the following criteria:
 
-- `extras.change_scheduledjob` — required to modify the scheduled job record.
-- `extras.run_job` — required to be eligible to run the job.
+- They are not the current owner of the scheduled job.
+- They have the `extras.change_scheduledjob` permission for this scheduled job.
+- They have the `extras.run_job` permission for the specific Job that the schedule runs (object-level permissions on the Job are honored).
 
 The most common reason to use this action is to recover a scheduled job whose original owner was removed, but it can also be used to hand off a recurring schedule to another administrator.
 

--- a/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
@@ -25,7 +25,7 @@ Once a job has been scheduled, the schedule can be deleted by navigating to `Job
 
 ### Assuming Ownership of a Scheduled Job
 
-Each scheduled job is owned by the user that created it. If that user is removed, the schedule can no longer run and is automatically disabled with a state of `Errored` the next time it would have fired; a failed `JobResult` is also recorded.
+Each scheduled job is owned by, and runs as, the user that created it. If that user is removed, the schedule can no longer run and is automatically disabled with a state of `Errored` the next time it would have fired; a failed `JobResult` is also recorded.
 
 Ownership of a scheduled job can be transferred at any time from the `Assume Ownership` action in the Actions dropdown on the Scheduled Job detail view. Clicking it reassigns the schedule to the current user. If the scheduled job was previously disabled due to a failure, the button also re-enables it, and resets its state to `Active`.
 

--- a/nautobot/extras/templates/extras/inc/scheduledjob_assume_ownership_dropdown_item.html
+++ b/nautobot/extras/templates/extras/inc/scheduledjob_assume_ownership_dropdown_item.html
@@ -1,0 +1,9 @@
+<li id="component-{{ component.component_id }}">
+    <form method="post" action="{{ link }}" style="margin: 0;">
+        {% csrf_token %}
+        <button type="submit" class="dropdown-item">
+            {% if icon %}<span class="mdi {{ icon }}" aria-hidden="true"></span>{% endif %}
+            {{ label }}
+        </button>
+    </form>
+</li>

--- a/nautobot/extras/templates/extras/scheduledjob_retrieve.html
+++ b/nautobot/extras/templates/extras/scheduledjob_retrieve.html
@@ -14,6 +14,13 @@
             This scheduled job will fail to run unless reinstalled at the original location.
         </div>
     {% endif %}
+    {% if not object.user %}
+        <div class="alert alert-danger">
+            <span class="mdi mdi-alert"></span>
+            The user that scheduled this job has been removed.
+            The job will not run until ownership is reassigned.
+        </div>
+    {% endif %}
     {{ block.super }}
 {% endblock content %}
 

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -3474,6 +3474,93 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
         self.assertEqual(entry.options["nautobot_job_user_id"], self.user.id)
         self.assertEqual(JobResult.objects.filter(scheduled_job=scheduled_job).count(), 0)
 
+    def test_schedule_entry_missing_user_skips_jobresult_when_job_model_is_none(self):
+        """If both user and job_model are missing, no JobResult is created (can't construct one without job_model)."""
+        scheduled_job = ScheduledJob.objects.create(
+            name="No Job Model Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        # job_model is required at the DB layer, but the in-memory mutation exercises the
+        # `_record_missing_user_failure` early-return path.
+        scheduled_job.job_model = None
+
+        NautobotScheduleEntry(model=scheduled_job)
+
+        scheduled_job.refresh_from_db()
+        self.assertFalse(scheduled_job.enabled)
+        self.assertEqual(JobResult.objects.filter(scheduled_job=scheduled_job).count(), 0)
+
+    def test_schedule_entry_missing_user_handles_get_absolute_url_error(self):
+        """If get_absolute_url() raises, the JobLogEntry is still created with an empty absolute_url."""
+        scheduled_job = ScheduledJob.objects.create(
+            name="No Absolute URL Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        with mock.patch.object(ScheduledJob, "get_absolute_url", side_effect=NotImplementedError):
+            NautobotScheduleEntry(model=scheduled_job)
+
+        scheduled_job.refresh_from_db()
+        self.assertFalse(scheduled_job.enabled)
+        log_entry = JobLogEntry.objects.get(job_result__scheduled_job=scheduled_job)
+        self.assertEqual(log_entry.absolute_url, "")
+        self.assertTrue(log_entry.log_object)
+
+    def test_schedule_entry_missing_user_swallows_jobresult_creation_failure(self):
+        """A failure during JobResult/JobLogEntry creation must not crash celery beat — the schedule is still disabled."""
+        scheduled_job = ScheduledJob.objects.create(
+            name="JobResult Create Fails Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        with mock.patch(
+            "nautobot.core.celery.schedulers.JobResult.objects.create",
+            side_effect=RuntimeError("simulated bookkeeping failure"),
+        ):
+            # Must not propagate the exception.
+            NautobotScheduleEntry(model=scheduled_job)
+
+        scheduled_job.refresh_from_db()
+        self.assertFalse(scheduled_job.enabled)
+        self.assertEqual(scheduled_job.state, ScheduledJobStateChoices.ERRORED)
+        self.assertEqual(JobResult.objects.filter(scheduled_job=scheduled_job).count(), 0)
+
+    def test_apply_async_skips_dispatch_when_user_is_missing(self):
+        """When the entry lacks `nautobot_job_user_id`, apply_async returns None without dispatching."""
+        from nautobot.core.celery.schedulers import NautobotDatabaseScheduler
+
+        scheduled_job = ScheduledJob.objects.create(
+            name="Apply Async Skip Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        entry = NautobotScheduleEntry(model=scheduled_job)
+        self.assertNotIn("nautobot_job_user_id", entry.options)
+
+        scheduler = mock.MagicMock(spec=NautobotDatabaseScheduler)
+        scheduler.app = entry.app
+        result = NautobotDatabaseScheduler.apply_async(scheduler, entry, advance=False)
+        self.assertIsNone(result)
+        # Verify the task was never dispatched.
+        scheduler.send_task.assert_not_called()
+
     # TODO uncomment when we have a way to setup the NautobotDatabaseScheduler correctly
     # @mock.patch("nautobot.extras.utils.run_kubernetes_job_and_return_job_result")
     # def test_nautobot_database_scheduler_apply_async_method(self, mock_run_kubernetes_job_and_return_job_result):

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -3495,26 +3495,6 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
         self.assertFalse(scheduled_job.enabled)
         self.assertEqual(JobResult.objects.filter(scheduled_job=scheduled_job).count(), 0)
 
-    def test_schedule_entry_missing_user_handles_get_absolute_url_error(self):
-        """If get_absolute_url() raises, the JobLogEntry is still created with an empty absolute_url."""
-        scheduled_job = ScheduledJob.objects.create(
-            name="No Absolute URL Job",
-            task="pass_job.TestPassJob",
-            job_model=self.job_model,
-            user=None,
-            interval=JobExecutionType.TYPE_DAILY,
-            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
-            time_zone=get_default_timezone(),
-        )
-        with mock.patch.object(ScheduledJob, "get_absolute_url", side_effect=NotImplementedError):
-            NautobotScheduleEntry(model=scheduled_job)
-
-        scheduled_job.refresh_from_db()
-        self.assertFalse(scheduled_job.enabled)
-        log_entry = JobLogEntry.objects.get(job_result__scheduled_job=scheduled_job)
-        self.assertEqual(log_entry.absolute_url, "")
-        self.assertTrue(log_entry.log_object)
-
     def test_schedule_entry_missing_user_swallows_jobresult_creation_failure(self):
         """A failure during JobResult/JobLogEntry creation must not crash celery beat — the schedule is still disabled."""
         scheduled_job = ScheduledJob.objects.create(

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -3443,10 +3443,10 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
             time_zone=get_default_timezone(),
         )
         # Simulate a FK orphan: a user_id that doesn't correspond to any auth_user row.
-        # We do this by pointing user_id at a random UUID via queryset.update() to bypass
-        # Django's on_delete logic — mirroring how raw-SQL deletes can leave dangling FKs.
-        ScheduledJob.objects.filter(pk=scheduled_job.pk).update(user_id=uuid.uuid4())
-        scheduled_job.refresh_from_db()
+        # We can't write the orphan to the DB on MySQL (FK enforced on UPDATE), so we
+        # mutate the in-memory model instead; the schedulers code reads from the in-memory
+        # model and that's the code path we want to verify.
+        scheduled_job.user_id = uuid.uuid4()
 
         entry = NautobotScheduleEntry(model=scheduled_job)
         scheduled_job.refresh_from_db()

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -22,6 +22,7 @@ from jinja2.exceptions import TemplateAssertionError, TemplateSyntaxError
 import time_machine
 
 from nautobot.circuits.models import CircuitType
+from nautobot.core.celery.schedulers import NautobotScheduleEntry
 from nautobot.core.choices import ColorChoices
 from nautobot.core.testing import get_job_class_and_model, TestCase
 from nautobot.core.testing.models import ModelTestCases
@@ -3267,7 +3268,6 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
 
     def test_schedule_entry_sets_last_run_at(self):
         """Test that NautobotScheduleEntry sets last_run_at to start_time - 1 minute when model has no last_run_at."""
-        from nautobot.core.celery.schedulers import NautobotScheduleEntry
 
         for job, interval_type in [
             (self.daily_utc_job, JobExecutionType.TYPE_DAILY),
@@ -3287,7 +3287,6 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
         on each tick) correctly waits for the next crontab match instead of running ASAP.
         Regression test for https://github.com/nautobot/nautobot/issues/8316
         """
-        from nautobot.core.celery.schedulers import NautobotScheduleEntry
 
         with self.subTest("TYPE_CUSTOM crontab job should not be immediately due"):
             with time_machine.travel("2050-01-22 12:00 +0000"):
@@ -3402,6 +3401,78 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
                 self.daily_utc_job.save()
                 self.daily_utc_job.refresh_from_db()
                 self.assertEqual(self.daily_utc_job.state, state)
+
+    def test_schedule_entry_records_failure_when_user_is_null(self):
+        """ScheduledJob with user=None should: create failed JobResult, disable, set state=ERRORED."""
+
+        scheduled_job = ScheduledJob.objects.create(
+            name="Null User Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        entry = NautobotScheduleEntry(model=scheduled_job)
+        scheduled_job.refresh_from_db()
+        self.assertFalse(scheduled_job.enabled)
+        self.assertEqual(scheduled_job.state, ScheduledJobStateChoices.ERRORED)
+        self.assertNotIn("nautobot_job_user_id", entry.options)
+
+        job_results = JobResult.objects.filter(scheduled_job=scheduled_job)
+        self.assertEqual(job_results.count(), 1)
+        job_result = job_results.first()
+        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertIsNone(job_result.user)
+        self.assertIn("originating user has been removed", job_result.traceback)
+        log_entries = JobLogEntry.objects.filter(job_result=job_result)
+        self.assertEqual(log_entries.count(), 1)
+        self.assertEqual(log_entries.first().log_level, "error")
+
+    def test_schedule_entry_records_failure_when_user_is_orphan_fk(self):
+        """When user_id refers to a deleted user (FK orphan), behave like user=None."""
+
+        scheduled_job = ScheduledJob.objects.create(
+            name="Orphan FK Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=self.user,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        # Simulate a FK orphan: a user_id that doesn't correspond to any auth_user row.
+        # We do this by pointing user_id at a random UUID via queryset.update() to bypass
+        # Django's on_delete logic — mirroring how raw-SQL deletes can leave dangling FKs.
+        ScheduledJob.objects.filter(pk=scheduled_job.pk).update(user_id=uuid.uuid4())
+        scheduled_job.refresh_from_db()
+
+        entry = NautobotScheduleEntry(model=scheduled_job)
+        scheduled_job.refresh_from_db()
+        self.assertIsNone(scheduled_job.user_id)
+        self.assertFalse(scheduled_job.enabled)
+        self.assertEqual(scheduled_job.state, ScheduledJobStateChoices.ERRORED)
+        self.assertNotIn("nautobot_job_user_id", entry.options)
+        self.assertEqual(JobResult.objects.filter(scheduled_job=scheduled_job).count(), 1)
+
+    def test_schedule_entry_with_valid_user_does_not_record_failure(self):
+        """Sanity check: a valid user should not trigger the failure path."""
+
+        scheduled_job = ScheduledJob.objects.create(
+            name="Valid User Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=self.user,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        entry = NautobotScheduleEntry(model=scheduled_job)
+        scheduled_job.refresh_from_db()
+        self.assertTrue(scheduled_job.enabled)
+        self.assertEqual(entry.options["nautobot_job_user_id"], self.user.id)
+        self.assertEqual(JobResult.objects.filter(scheduled_job=scheduled_job).count(), 0)
 
     # TODO uncomment when we have a way to setup the NautobotDatabaseScheduler correctly
     # @mock.patch("nautobot.extras.utils.run_kubernetes_job_and_return_job_result")

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -4292,8 +4292,6 @@ class ScheduledJobTestCase(
 
     def test_assume_ownership_rejected_without_run_perm_on_specific_job(self):
         """A user with extras.run_job at the model level but no per-Job run constraint match is rejected."""
-        from nautobot.users.models import ObjectPermission
-
         self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob")
         # Grant `run` on a constraint that does NOT match the schedule's job_model.
         obj_perm = ObjectPermission.objects.create(

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -4157,6 +4157,7 @@ class ScheduledJobTestCase(
             "interval": JobExecutionType.TYPE_DAILY,
             "user": self.user,
             "start_time": timezone.now(),
+            "job_model": Job.objects.get(name="TestPassJob"),
         }
         defaults.update(kwargs)
         return ScheduledJob.objects.create(name=name, **defaults)
@@ -4181,16 +4182,27 @@ class ScheduledJobTestCase(
 
     def test_detail_view_shows_assume_ownership_button_with_perms(self):
         self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
-        sj = self._make_scheduled_job("assume_button_with_perm")
+        other_user = User.objects.create(username="other_owner_button_visible", is_active=True)
+        sj = self._make_scheduled_job("assume_button_with_perm", user=other_user)
 
         response = self.client.get(sj.get_absolute_url())
         self.assertHttpStatus(response, 200)
         body = extract_page_body(response.content.decode(response.charset))
         self.assertIn("Assume Ownership", body)
 
+    def test_detail_view_hides_assume_ownership_button_when_already_owner(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        sj = self._make_scheduled_job("assume_button_already_owner")  # owned by self.user
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertNotIn("Assume Ownership", body)
+
     def test_detail_view_hides_assume_ownership_button_without_run_job_perm(self):
         self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob")
-        sj = self._make_scheduled_job("assume_button_no_run")
+        other_user = User.objects.create(username="other_owner_no_run", is_active=True)
+        sj = self._make_scheduled_job("assume_button_no_run", user=other_user)
 
         response = self.client.get(sj.get_absolute_url())
         self.assertHttpStatus(response, 200)
@@ -4199,7 +4211,8 @@ class ScheduledJobTestCase(
 
     def test_detail_view_hides_assume_ownership_button_without_change_perm(self):
         self.add_permissions("extras.view_scheduledjob", "extras.run_job")
-        sj = self._make_scheduled_job("assume_button_no_change")
+        other_user = User.objects.create(username="other_owner_no_change", is_active=True)
+        sj = self._make_scheduled_job("assume_button_no_change", user=other_user)
 
         response = self.client.get(sj.get_absolute_url())
         self.assertHttpStatus(response, 200)
@@ -4239,37 +4252,69 @@ class ScheduledJobTestCase(
 
     def test_assume_ownership_forbidden_without_run_job_perm(self):
         self.add_permissions("extras.change_scheduledjob")
-        sj = self._make_scheduled_job("assume_forbidden_no_run")
+        other_user = User.objects.create(username="prior_owner_no_run", is_active=True)
+        sj = self._make_scheduled_job("assume_forbidden_no_run", user=other_user)
 
         url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
 
         sj.refresh_from_db()
-        self.assertEqual(sj.user_id, self.user.id)  # unchanged from setup default
+        self.assertEqual(sj.user_id, other_user.id)  # unchanged
 
     def test_assume_ownership_forbidden_without_change_perm(self):
         self.add_permissions("extras.view_scheduledjob", "extras.run_job")
-        sj = self._make_scheduled_job("assume_forbidden_no_change")
+        other_user = User.objects.create(username="prior_owner_no_change", is_active=True)
+        sj = self._make_scheduled_job("assume_forbidden_no_change", user=other_user)
 
         url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
 
         sj.refresh_from_db()
-        self.assertEqual(sj.user_id, self.user.id)
+        self.assertEqual(sj.user_id, other_user.id)
 
-    def test_assume_ownership_idempotent_when_already_owner(self):
+    def test_assume_ownership_no_op_when_already_owner(self):
+        """A direct POST while already owning the schedule short-circuits without modification."""
         self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
-        sj = self._make_scheduled_job("assume_idempotent")  # already owned by self.user
+        sj = self._make_scheduled_job("assume_already_owner_post", enabled=False)
+        sj.state = ScheduledJobStateChoices.ERRORED
+        sj.save()
 
         url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
         response = self.client.post(url, follow=True)
         self.assertHttpStatus(response, 200)
 
+        # State must NOT have been mutated since the requester already owns it.
         sj.refresh_from_db()
-        self.assertEqual(sj.user_id, self.user.id)
-        self.assertTrue(sj.enabled)
+        self.assertFalse(sj.enabled)
+        self.assertEqual(sj.state, ScheduledJobStateChoices.ERRORED)
+
+    def test_assume_ownership_rejected_without_run_perm_on_specific_job(self):
+        """A user with extras.run_job at the model level but no per-Job run constraint match is rejected."""
+        from nautobot.users.models import ObjectPermission
+
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob")
+        # Grant `run` on a constraint that does NOT match the schedule's job_model.
+        obj_perm = ObjectPermission.objects.create(
+            name="run only fail jobs",
+            actions=["run"],
+            constraints={"name": "TestFailJob"},
+        )
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ContentType.objects.get_for_model(Job))
+
+        other_user = User.objects.create(username="other_owner_no_run_for_job", is_active=True)
+        sj = self._make_scheduled_job("assume_no_run_specific_job", user=other_user)
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertIn("do not have permission to run the job", body)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, other_user.id)  # unchanged
 
 
 class JobQueueTestCase(ViewTestCases.PrimaryObjectViewTestCase):

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -52,6 +52,7 @@ from nautobot.extras.choices import (
     LogLevelChoices,
     MetadataTypeDataTypeChoices,
     ObjectChangeActionChoices,
+    ScheduledJobStateChoices,
     SecretsGroupAccessTypeChoices,
     SecretsGroupSecretTypeChoices,
     WebhookHttpMethodChoices,
@@ -4149,6 +4150,126 @@ class ScheduledJobTestCase(
         response = self.client.get(self._get_url("list"), headers={"HX-Request": "true"})
         self.assertHttpStatus(response, 200)
         self.assertIn("test11", extract_page_body(response.content.decode(response.charset)))
+
+    def _make_scheduled_job(self, name, **kwargs):
+        defaults = {
+            "task": "pass_job.TestPassJob",
+            "interval": JobExecutionType.TYPE_DAILY,
+            "user": self.user,
+            "start_time": timezone.now(),
+        }
+        defaults.update(kwargs)
+        return ScheduledJob.objects.create(name=name, **defaults)
+
+    def test_detail_view_shows_banner_when_user_is_null(self):
+        self.add_permissions("extras.view_scheduledjob")
+        sj = self._make_scheduled_job("banner_null_user", user=None)
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertIn("user that scheduled this job has been removed", body)
+
+    def test_detail_view_no_banner_when_user_is_present(self):
+        self.add_permissions("extras.view_scheduledjob")
+        sj = self._make_scheduled_job("banner_with_user")
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertNotIn("user that scheduled this job has been removed", body)
+
+    def test_detail_view_shows_assume_ownership_button_with_perms(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        sj = self._make_scheduled_job("assume_button_with_perm")
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertIn("Assume Ownership", body)
+
+    def test_detail_view_hides_assume_ownership_button_without_run_job_perm(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob")
+        sj = self._make_scheduled_job("assume_button_no_run")
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertNotIn("Assume Ownership", body)
+
+    def test_detail_view_hides_assume_ownership_button_without_change_perm(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.run_job")
+        sj = self._make_scheduled_job("assume_button_no_change")
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertNotIn("Assume Ownership", body)
+
+    def test_assume_ownership_succeeds_with_required_perms(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        other_user = User.objects.create(username="prior_owner", is_active=True)
+        sj = self._make_scheduled_job("assume_other_owner", user=other_user, enabled=False)
+        sj.state = ScheduledJobStateChoices.ERRORED
+        sj.save()
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+        self.assertTrue(sj.enabled)
+        self.assertEqual(sj.state, ScheduledJobStateChoices.ACTIVE)
+
+    def test_assume_ownership_recovers_schedule_when_user_is_null(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        sj = self._make_scheduled_job("assume_null_owner", user=None, enabled=False)
+        sj.state = ScheduledJobStateChoices.ERRORED
+        sj.save()
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+        self.assertTrue(sj.enabled)
+        self.assertEqual(sj.state, ScheduledJobStateChoices.ACTIVE)
+
+    def test_assume_ownership_forbidden_without_run_job_perm(self):
+        self.add_permissions("extras.change_scheduledjob")
+        sj = self._make_scheduled_job("assume_forbidden_no_run")
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 403)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)  # unchanged from setup default
+
+    def test_assume_ownership_forbidden_without_change_perm(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.run_job")
+        sj = self._make_scheduled_job("assume_forbidden_no_change")
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 403)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+
+    def test_assume_ownership_idempotent_when_already_owner(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        sj = self._make_scheduled_job("assume_idempotent")  # already owned by self.user
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+        self.assertTrue(sj.enabled)
 
 
 class JobQueueTestCase(ViewTestCases.PrimaryObjectViewTestCase):

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -39,7 +39,7 @@ from nautobot.core.models.querysets import count_related
 from nautobot.core.models.utils import pretty_print_query
 from nautobot.core.templatetags import helpers
 from nautobot.core.templatetags.helpers import bettertitle
-from nautobot.core.templatetags.perms import can_cancel
+from nautobot.core.templatetags.perms import can_cancel, can_change
 from nautobot.core.ui import object_detail
 from nautobot.core.ui.breadcrumbs import (
     BaseBreadcrumbItem,
@@ -119,6 +119,7 @@ from .choices import (
     JobExecutionType,
     JobQueueTypeChoices,
     JobResultStatusChoices,
+    ScheduledJobStateChoices,
 )
 from .datasources import (
     enqueue_git_repository_diff_origin_and_local,
@@ -3162,6 +3163,17 @@ class ScheduledJobUIViewSet(
     serializer_class = serializers.ScheduledJobSerializer
     table_class = tables.ScheduledJobTable
     action_buttons = ()
+    extra_detail_view_action_buttons = [
+        object_detail.ExtraDetailViewActionButton(
+            action="assume_ownership",
+            label="Assume Ownership",
+            icon="mdi-account-arrow-right",
+            link_name="extras:scheduledjob_assume_ownership",
+            template_path="extras/inc/scheduledjob_assume_ownership_dropdown_item.html",
+            permission_check=lambda user, obj: can_change(user, obj) and user.has_perm("extras.run_job"),
+            weight=100,
+        )
+    ]
 
     def get_extra_context(self, request, instance):
         context = super().get_extra_context(request, instance)
@@ -3205,6 +3217,27 @@ class ScheduledJobUIViewSet(
         )
 
         return context
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="assume-ownership",
+        url_name="assume_ownership",
+        custom_view_base_action="change",
+        custom_view_additional_permissions=["extras.run_job"],
+    )
+    def assume_ownership(self, request, pk=None):
+        """Reassign this scheduled job's owner to the requesting user and re-enable it."""
+        obj = self.get_object()
+        if obj.user_id == request.user.id and obj.enabled and obj.state == ScheduledJobStateChoices.ACTIVE:
+            messages.info(request, f"You already own scheduled job '{obj.name}'.")
+        else:
+            obj.user = request.user
+            obj.enabled = True
+            obj.state = ScheduledJobStateChoices.ACTIVE
+            obj.validated_save()
+            messages.success(request, f"You are now the owner of scheduled job '{obj.name}'.")
+        return redirect(obj.get_absolute_url())
 
 
 #

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -3170,7 +3170,14 @@ class ScheduledJobUIViewSet(
             icon="mdi-account-arrow-right",
             link_name="extras:scheduledjob_assume_ownership",
             template_path="extras/inc/scheduledjob_assume_ownership_dropdown_item.html",
-            permission_check=lambda user, obj: can_change(user, obj) and user.has_perm("extras.run_job"),
+            # Hide the button when the requester is already the owner, lacks change perms,
+            # or doesn't have run permission on the specific Job that this schedule runs.
+            permission_check=lambda user, obj: (
+                obj.user_id != user.id
+                and can_change(user, obj)
+                and obj.job_model is not None
+                and JobModel.objects.restrict(user, "run").filter(pk=obj.job_model_id).exists()
+            ),
             weight=100,
         )
     ]
@@ -3229,14 +3236,22 @@ class ScheduledJobUIViewSet(
     def assume_ownership(self, request, pk=None):
         """Reassign this scheduled job's owner to the requesting user and re-enable it."""
         obj = self.get_object()
-        if obj.user_id == request.user.id and obj.enabled and obj.state == ScheduledJobStateChoices.ACTIVE:
+        if obj.user_id == request.user.id:
             messages.info(request, f"You already own scheduled job '{obj.name}'.")
-        else:
-            obj.user = request.user
-            obj.enabled = True
-            obj.state = ScheduledJobStateChoices.ACTIVE
-            obj.validated_save()
-            messages.success(request, f"You are now the owner of scheduled job '{obj.name}'.")
+            return redirect(obj.get_absolute_url())
+        # Defensively confirm the requester can run this specific Job — the UI hides the
+        # button in this case but a direct POST could still reach here.
+        if (
+            obj.job_model is None
+            or not JobModel.objects.restrict(request.user, "run").filter(pk=obj.job_model_id).exists()
+        ):
+            messages.error(request, f"You do not have permission to run the job '{obj.job_model}'.")
+            return redirect(obj.get_absolute_url())
+        obj.user = request.user
+        obj.enabled = True
+        obj.state = ScheduledJobStateChoices.ACTIVE
+        obj.validated_save()
+        messages.success(request, f"You are now the owner of scheduled job '{obj.name}'.")
         return redirect(obj.get_absolute_url())
 
 

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -3169,7 +3169,7 @@ class ScheduledJobUIViewSet(
             label="Assume Ownership",
             icon="mdi-account-arrow-right",
             link_name="extras:scheduledjob_assume_ownership",
-            template_path="extras/inc/scheduledjob_assume_ownership_dropdown_item.html",
+            template_path="components/button/post_extradetailviewactionbutton.html",
             # Hide the button when the requester is already the owner, lacks change perms,
             # or doesn't have run permission on the specific Job that this schedule runs.
             permission_check=lambda user, obj: (


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8413
# What's Changed
This is an alternative solution to fixing the issue of Scheduled Jobs failing silently when the user is deleted. This PR replaces both #8920 and #8414.

In this solution, to combat the silent failure we now create a failed JobResult object with a single log message to notify the user that the scheduled job was disabled:

<img width="911" height="480" alt="Screenshot 2026-05-05 at 2 11 26 PM" src="https://github.com/user-attachments/assets/15a97d82-6ac0-4460-b508-74e3959170da" />

I have also added a banner to the detailed view of the scheduled job when the `obj.user` is not found:

<img width="989" height="973" alt="Screenshot 2026-05-05 at 2 11 46 PM" src="https://github.com/user-attachments/assets/96e39ba2-113e-4025-a249-fed5276c6b69" />

In addition to this, I have added an **Assume Ownership** action button that changes the user to the current user and re-enables the scheduled job:

<img width="256" height="129" alt="Screenshot 2026-05-05 at 2 11 54 PM" src="https://github.com/user-attachments/assets/e33ece25-4d36-4002-b82c-afcd1e66b1cf" />

<img width="326" height="64" alt="Screenshot 2026-05-05 at 2 12 06 PM" src="https://github.com/user-attachments/assets/fe140853-9f80-4d0a-a239-8e311cd55c19" />

Once the job is re-enabled, it picks back up. Only a single failed job is recorded for each failed scheduled job.

<img width="736" height="197" alt="Screenshot 2026-05-05 at 2 12 49 PM" src="https://github.com/user-attachments/assets/98e1aa15-9ab6-4005-b69d-f085d3159061" />


Note: I coded the Assume Ownership button to always be present - not just when the scheduled job is in an errored state. This helps facilitate the transfer of ownership of a scheduled job at any time in the future.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)

NTC-4974