### PR TITLE
Fixed Job History home page panel sorting

### DIFF
--- a/changes/8937.fixed
+++ b/changes/8937.fixed
@@ -1,0 +1,1 @@
+Fixed Job History home page panel sorting.

--- a/nautobot/extras/homepage.py
+++ b/nautobot/extras/homepage.py
@@ -1,3 +1,5 @@
+from django.db.models.functions import Coalesce
+
 from nautobot.core.apps import HomePageItem, HomePagePanel
 from nautobot.extras.choices import ApprovalWorkflowStateChoices, JobResultStatusChoices
 from nautobot.extras.models import ApprovalWorkflowStage, DynamicGroup, GitRepository, JobResult, ObjectChange
@@ -21,7 +23,8 @@ def get_job_results(request):
         JobResult.objects.filter(status__in=JobResultStatusChoices.READY_STATES)
         .restrict(request.user, "view")
         .only("id", "name", "status", "date_done", "user")
-        .order_by("-date_done")[:10]
+        .alias(effective_done=Coalesce("date_done", "date_created"))
+        .order_by("-effective_done")[:10]
     )
 
 

--- a/nautobot/extras/tests/test_homepage.py
+++ b/nautobot/extras/tests/test_homepage.py
@@ -1,0 +1,51 @@
+from datetime import timedelta
+
+from django.test import RequestFactory
+from django.utils.timezone import now
+
+from nautobot.core.testing import TestCase
+from nautobot.extras.choices import JobResultStatusChoices
+from nautobot.extras.homepage import get_job_results
+from nautobot.extras.models import JobResult
+
+
+class GetJobResultsTestCase(TestCase):
+    """Tests for the home page Job History panel callback."""
+
+    def setUp(self):
+        super().setUp()
+        # Parent setUp creates self.user as a non-superuser; elevate it so .restrict() returns all rows.
+        self.user.is_superuser = True
+        self.user.save()
+        self.factory = RequestFactory()
+
+    def _build_request(self):
+        request = self.factory.get("/")
+        request.user = self.user
+        return request
+
+    def test_orders_null_date_done_by_date_created(self):
+        """A FAILURE result with NULL date_done must not float above a more recently completed SUCCESS."""
+        timestamp = now()
+
+        old_failure = JobResult.objects.create(
+            name="old failure",
+            status=JobResultStatusChoices.STATUS_FAILURE,
+        )
+        # auto_now_add ignores manual assignment; override via queryset.update.
+        JobResult.objects.filter(pk=old_failure.pk).update(
+            date_done=None,
+            date_created=timestamp - timedelta(days=30),
+        )
+
+        new_success = JobResult.objects.create(
+            name="new success",
+            status=JobResultStatusChoices.STATUS_SUCCESS,
+            date_done=timestamp,
+        )
+
+        result_pks = [jr.pk for jr in get_job_results(self._build_request())]
+
+        self.assertIn(new_success.pk, result_pks)
+        self.assertIn(old_failure.pk, result_pks)
+        self.assertLess(result_pks.index(new_success.pk), result_pks.index(old_failure.pk))


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8937
# What's Changed
Job Results with a null `date_done` were getting sorted to the top of the Job History homepage panel. This PR uses Django's Coalesce to create an alias field for sorting by `date_done` and by `date_created`.
# Screenshots

## Actual Job Results
<img width="728" height="282" alt="Screenshot 2026-05-06 at 1 50 36 PM" src="https://github.com/user-attachments/assets/c5ff8f73-642e-425a-8dbc-545b5fbbf86d" />

## Before
<img width="566" height="457" alt="Screenshot 2026-05-06 at 1 44 45 PM" src="https://github.com/user-attachments/assets/987dded2-fea5-497a-8650-ad5372bc8e82" />

## After
<img width="572" height="460" alt="Screenshot 2026-05-06 at 1 50 12 PM" src="https://github.com/user-attachments/assets/b42620ea-c87a-4e91-a8fb-12090c5f0097" />


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
