### PR TITLE
[LTM Backport] Changed scheduled jobs to fail loudly if the user is deleted, and added button to transfer ownership

### DIFF
--- a/changes/8413.added
+++ b/changes/8413.added
@@ -1,0 +1,1 @@
+Added an "Assume Ownership" action button on the Scheduled Job detail view that allows users with the required permissions to take over ownership of a scheduled job.

--- a/changes/8413.fixed
+++ b/changes/8413.fixed
@@ -1,0 +1,1 @@
+Fixed silent failure of scheduled jobs whose originating user has been removed. The scheduler now records a failed JobResult as well as disables the schedule.

--- a/nautobot/core/celery/schedulers.py
+++ b/nautobot/core/celery/schedulers.py
@@ -8,14 +8,80 @@ from celery import current_app
 from celery.beat import _evaluate_entry_args, _evaluate_entry_kwargs, reraise, SchedulingError
 from celery.result import AsyncResult
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.utils import timezone
 from django_celery_beat.schedulers import DatabaseScheduler, ModelEntry
 from kombu.utils.json import loads
 
-from nautobot.extras.choices import JobQueueTypeChoices
-from nautobot.extras.models import JobResult, ScheduledJob, ScheduledJobs
+from nautobot.extras.choices import JobQueueTypeChoices, JobResultStatusChoices, LogLevelChoices
+from nautobot.extras.constants import JOB_LOG_MAX_ABSOLUTE_URL_LENGTH, JOB_LOG_MAX_LOG_OBJECT_LENGTH
+from nautobot.extras.models import JobLogEntry, JobResult, ScheduledJob, ScheduledJobs
 from nautobot.extras.utils import run_kubernetes_job_and_return_job_result
 
 logger = logging.getLogger(__name__)
+
+
+def _user_exists(user_id):
+    """Return True if `user_id` is non-null and references an existing user row."""
+    if user_id is None:
+        return False
+    return get_user_model().objects.filter(pk=user_id).exists()
+
+
+def _record_missing_user_failure(model):
+    """
+    Record a failed JobResult for a ScheduledJob whose originating user is missing.
+
+    Used when celery beat fires a schedule whose `user` FK is null or refers to a
+    deleted user. We create a JobResult marked FAILURE so administrators have a
+    durable record of the missed run instead of a silent failure.
+
+    Also clears the in-memory `user_id` so that subsequent `model.save()` calls
+    (e.g. from `_disable`) cannot raise an FK violation when the FK is orphaned.
+    """
+    # If user_id points to a row that no longer exists (FK orphan, e.g. user was deleted via
+    # raw SQL bypassing on_delete=SET_NULL), any save() of this model will raise an
+    # IntegrityError. Patch the DB directly via queryset update, then null in-memory.
+    if model.user_id is not None:
+        ScheduledJob.objects.filter(pk=model.pk).update(user=None)
+        model.user_id = None
+
+    if model.job_model is None:
+        # Can't create a JobResult without a job_model FK; the scheduler will disable
+        # the entry below, which is the best we can do.
+        return
+    err_message = (
+        f"Scheduled job '{model.name}' cannot run: the originating user has been removed. "
+        "Use 'Assume Ownership' on the scheduled job detail view to reassign it."
+    )
+    try:
+        timestamp = timezone.now()
+        job_result = JobResult.objects.create(
+            name=model.job_model.name,
+            job_model=model.job_model,
+            scheduled_job=model,
+            user=None,
+            task_name=model.job_model.class_path,
+            status=JobResultStatusChoices.STATUS_FAILURE,
+            date_started=timestamp,
+            date_done=timestamp,
+            traceback=err_message,
+            # We are intentionally omitting JobResult fields that are not necessary
+            # as we only need it to create a JobLogEntry to log the failure.
+        )
+        log_object = str(model)[:JOB_LOG_MAX_LOG_OBJECT_LENGTH]
+        absolute_url = model.get_absolute_url()[:JOB_LOG_MAX_ABSOLUTE_URL_LENGTH]
+        JobLogEntry.objects.create(
+            job_result=job_result,
+            log_level=LogLevelChoices.LOG_ERROR,
+            grouping="main",
+            message=err_message,
+            log_object=log_object,
+            absolute_url=absolute_url,
+        )
+    except Exception:  # pylint: disable=broad-except
+        # Never let a bookkeeping failure crash celery beat itself.
+        logger.exception("Failed to record missing-user JobResult for schedule %s", model.name)
 
 
 class NautobotScheduleEntry(ModelEntry):
@@ -56,13 +122,14 @@ class NautobotScheduleEntry(ModelEntry):
         # Nautobot-specific logic
         self.options = {"nautobot_job_scheduled_job_id": model.id, "headers": {}}
 
-        if model.user:
-            self.options["nautobot_job_user_id"] = model.user.id
+        if _user_exists(model.user_id):
+            self.options["nautobot_job_user_id"] = model.user_id
         else:
             logger.error(
                 "Disabling schedule %s with missing user",
                 self.name,
             )
+            _record_missing_user_failure(model)
             self._disable(model)
 
         if model.job_model:
@@ -126,6 +193,13 @@ class NautobotDatabaseScheduler(DatabaseScheduler):
         resp = None
         entry = self.reserve(entry) if advance else entry
         task = self.app.tasks.get(entry.task)
+
+        # If the entry's options lack `nautobot_job_user_id`, the originating user is
+        # missing and `__init__` already recorded a failed JobResult and disabled the
+        # schedule. Skip dispatch so we don't fire a doomed task into celery for this
+        # tick — the next tick will not pick the entry up (enabled=False).
+        if isinstance(entry, NautobotScheduleEntry) and "nautobot_job_user_id" not in entry.options:
+            return None
 
         try:
             entry_args = _evaluate_entry_args(entry.args)

--- a/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
@@ -23,6 +23,20 @@ If the job requires no approval, it will then be added to the queue of scheduled
 
 Once a job has been scheduled, the schedule can be deleted by navigating to `Jobs > Scheduled Jobs`, selecting the schedule name and clicking the `Delete` button. You can also select multiple schedules and click the `Delete Selected` button to delete them all at once.
 
+### Assuming Ownership of a Scheduled Job
+
+Each scheduled job is owned by, and runs as, the user that created it. If that user is removed, the schedule can no longer run and is automatically disabled the next time it would have fired; a failed `JobResult` is also recorded.
+
+Ownership of a scheduled job can be transferred at any time via the `Assume Ownership` button on the Scheduled Job detail view. Clicking it reassigns the schedule to the current user. If the scheduled job was previously disabled due to a failure, the button also re-enables it.
+
+The button is hidden when the requester is already the current owner, and is only visible to users that meet **all** of the following criteria:
+
+- They are not the current owner of the scheduled job.
+- They have the `extras.change_scheduledjob` permission.
+- They have the `extras.run_job` permission for the specific Job that the schedule runs (object-level permissions on the Job are honored).
+
+The most common reason to use this action is to recover a scheduled job whose original owner was removed, but it can also be used to hand off a recurring schedule to another administrator.
+
 ### Scheduling via the API
 
 Jobs can also be scheduled via the REST API. The endpoint used for this is the regular job endpoint; specifying the optional `schedule` parameter will act just as scheduling in the UI.

--- a/nautobot/extras/templates/extras/scheduledjob.html
+++ b/nautobot/extras/templates/extras/scheduledjob.html
@@ -8,6 +8,14 @@
 
 {% block buttons %}
     {% plugin_buttons object %}
+    {% if can_assume_ownership %}
+        <form method="post" action="{% url 'extras:scheduledjob_assume_ownership' pk=object.pk %}" style="display: inline;">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-primary">
+                <span class="mdi mdi-account-arrow-right" aria-hidden="true"></span> Assume Ownership
+            </button>
+        </form>
+    {% endif %}
     {% if user|can_delete:object %}
         {% delete_button object %}
     {% endif %}
@@ -19,6 +27,13 @@
             <i class="mdi mdi-alert"></i>
             This job source for this scheduled job is no longer installed.
             This scheduled job will fail to run unless reinstalled at the original location.
+        </div>
+    {% endif %}
+    {% if not object.user %}
+        <div class="alert alert-danger">
+            <span class="mdi mdi-alert"></span>
+            The user that scheduled this job has been removed.
+            The job will not run until ownership is reassigned.
         </div>
     {% endif %}
     {{ block.super }}

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -23,6 +23,7 @@ from jinja2.exceptions import TemplateAssertionError, TemplateSyntaxError
 import time_machine
 
 from nautobot.circuits.models import CircuitType
+from nautobot.core.celery.schedulers import NautobotScheduleEntry
 from nautobot.core.choices import ColorChoices
 from nautobot.core.testing import TestCase
 from nautobot.core.testing.models import ModelTestCases
@@ -2765,8 +2766,6 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
 
     def test_schedule_entry_sets_last_run_at(self):
         """Test that NautobotScheduleEntry sets last_run_at to start_time - 1 minute when model has no last_run_at."""
-        from nautobot.core.celery.schedulers import NautobotScheduleEntry
-
         for job, interval_type in [
             (self.daily_utc_job, JobExecutionType.TYPE_DAILY),
             (self.crontab_est_job, JobExecutionType.TYPE_CUSTOM),
@@ -2785,8 +2784,6 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
         on each tick) correctly waits for the next crontab match instead of running ASAP.
         Regression test for https://github.com/nautobot/nautobot/issues/8316
         """
-        from nautobot.core.celery.schedulers import NautobotScheduleEntry
-
         with self.subTest("TYPE_CUSTOM crontab job should not be immediately due"):
             with time_machine.travel("2050-01-22 12:00 +0000"):
                 crontab_job = ScheduledJob.objects.create(
@@ -2864,6 +2861,142 @@ class ScheduledJobTest(ModelTestCases.BaseModelTestCase):
             self.assertEqual(job.start_time.hour, 4)
             self.assertEqual(job.start_time.month, 2)
             self.assertEqual(job.start_time.day, 3)
+
+    def test_schedule_entry_records_failure_when_user_is_null(self):
+        """ScheduledJob with user=None should: create failed JobResult, disable."""
+
+        scheduled_job = ScheduledJob.objects.create(
+            name="Null User Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        entry = NautobotScheduleEntry(model=scheduled_job)
+        scheduled_job.refresh_from_db()
+        self.assertFalse(scheduled_job.enabled)
+        self.assertNotIn("nautobot_job_user_id", entry.options)
+
+        job_results = JobResult.objects.filter(scheduled_job=scheduled_job)
+        self.assertEqual(job_results.count(), 1)
+        job_result = job_results.first()
+        self.assertEqual(job_result.status, JobResultStatusChoices.STATUS_FAILURE)
+        self.assertIsNone(job_result.user)
+        self.assertIn("originating user has been removed", job_result.traceback)
+        log_entries = JobLogEntry.objects.filter(job_result=job_result)
+        self.assertEqual(log_entries.count(), 1)
+        self.assertEqual(log_entries.first().log_level, "error")
+
+    def test_schedule_entry_records_failure_when_user_is_orphan_fk(self):
+        """When user_id refers to a deleted user (FK orphan), behave like user=None."""
+
+        scheduled_job = ScheduledJob.objects.create(
+            name="Orphan FK Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=self.user,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        # Simulate a FK orphan: a user_id that doesn't correspond to any auth_user row.
+        # We can't write the orphan to the DB on MySQL (FK enforced on UPDATE), so we
+        # mutate the in-memory model instead; the schedulers code reads from the in-memory
+        # model and that's the code path we want to verify.
+        scheduled_job.user_id = uuid.uuid4()
+
+        entry = NautobotScheduleEntry(model=scheduled_job)
+        scheduled_job.refresh_from_db()
+        self.assertIsNone(scheduled_job.user_id)
+        self.assertFalse(scheduled_job.enabled)
+        self.assertNotIn("nautobot_job_user_id", entry.options)
+        self.assertEqual(JobResult.objects.filter(scheduled_job=scheduled_job).count(), 1)
+
+    def test_schedule_entry_with_valid_user_does_not_record_failure(self):
+        """Sanity check: a valid user should not trigger the failure path."""
+
+        scheduled_job = ScheduledJob.objects.create(
+            name="Valid User Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=self.user,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        entry = NautobotScheduleEntry(model=scheduled_job)
+        scheduled_job.refresh_from_db()
+        self.assertTrue(scheduled_job.enabled)
+        self.assertEqual(entry.options["nautobot_job_user_id"], self.user.id)
+        self.assertEqual(JobResult.objects.filter(scheduled_job=scheduled_job).count(), 0)
+
+    def test_schedule_entry_missing_user_skips_jobresult_when_job_model_is_none(self):
+        """If both user and job_model are missing, no JobResult is created (can't construct one without job_model)."""
+        scheduled_job = ScheduledJob.objects.create(
+            name="No Job Model Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        # job_model is required at the DB layer, but the in-memory mutation exercises the
+        # `_record_missing_user_failure` early-return path.
+        scheduled_job.job_model = None
+
+        NautobotScheduleEntry(model=scheduled_job)
+
+        scheduled_job.refresh_from_db()
+        self.assertFalse(scheduled_job.enabled)
+        self.assertEqual(JobResult.objects.filter(scheduled_job=scheduled_job).count(), 0)
+
+    def test_schedule_entry_missing_user_swallows_jobresult_creation_failure(self):
+        """A failure during JobResult/JobLogEntry creation must not crash celery beat — the schedule is still disabled."""
+        scheduled_job = ScheduledJob.objects.create(
+            name="JobResult Create Fails Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        with mock.patch(
+            "nautobot.core.celery.schedulers.JobResult.objects.create",
+            side_effect=RuntimeError("simulated bookkeeping failure"),
+        ):
+            # Must not propagate the exception.
+            NautobotScheduleEntry(model=scheduled_job)
+
+        scheduled_job.refresh_from_db()
+        self.assertFalse(scheduled_job.enabled)
+        self.assertEqual(JobResult.objects.filter(scheduled_job=scheduled_job).count(), 0)
+
+    def test_apply_async_skips_dispatch_when_user_is_missing(self):
+        """When the entry lacks `nautobot_job_user_id`, apply_async returns None without dispatching."""
+        from nautobot.core.celery.schedulers import NautobotDatabaseScheduler
+
+        scheduled_job = ScheduledJob.objects.create(
+            name="Apply Async Skip Job",
+            task="pass_job.TestPassJob",
+            job_model=self.job_model,
+            user=None,
+            interval=JobExecutionType.TYPE_DAILY,
+            start_time=datetime(year=2050, month=1, day=22, hour=17, minute=0, tzinfo=get_default_timezone()),
+            time_zone=get_default_timezone(),
+        )
+        entry = NautobotScheduleEntry(model=scheduled_job)
+        self.assertNotIn("nautobot_job_user_id", entry.options)
+
+        scheduler = mock.MagicMock(spec=NautobotDatabaseScheduler)
+        scheduler.app = entry.app
+        result = NautobotDatabaseScheduler.apply_async(scheduler, entry, advance=False)
+        self.assertIsNone(result)
+        # Verify the task was never dispatched.
+        scheduler.send_task.assert_not_called()
 
     # TODO uncomment when we have a way to setup the NautobotDatabaseScheduler correctly
     # @mock.patch("nautobot.extras.utils.run_kubernetes_job_and_return_job_result")

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2345,6 +2345,24 @@ class ScheduledJobTestCase(
         self.assertHttpStatus(response, 200)
         self.assertNotIn("test4", extract_page_body(response.content.decode(response.charset)))
 
+    def test_disabled_with_missing_user_is_listed(self):
+        """Auto-disabled schedules whose user has been removed must remain visible in the list
+        so admins can reassign ownership."""
+        self.add_permissions("extras.view_scheduledjob")
+
+        ScheduledJob.objects.create(
+            enabled=False,
+            name="test_orphaned",
+            task="pass_job.TestPassJob",
+            interval=JobExecutionType.TYPE_IMMEDIATELY,
+            user=None,
+            start_time=timezone.now(),
+        )
+
+        response = self.client.get(self._get_url("list"))
+        self.assertHttpStatus(response, 200)
+        self.assertIn("test_orphaned", extract_page_body(response.content.decode(response.charset)))
+
     def test_non_valid_crontab_syntax(self):
         self.add_permissions("extras.view_scheduledjob")
 
@@ -2393,6 +2411,160 @@ class ScheduledJobTestCase(
         response = self.client.get(self._get_url("list"))
         self.assertHttpStatus(response, 200)
         self.assertIn("test11", extract_page_body(response.content.decode(response.charset)))
+
+    def _make_scheduled_job(self, name, **kwargs):
+        defaults = {
+            "task": "pass_job.TestPassJob",
+            "interval": JobExecutionType.TYPE_DAILY,
+            "user": self.user,
+            "start_time": timezone.now(),
+            "job_model": Job.objects.get(name="TestPassJob"),
+        }
+        defaults.update(kwargs)
+        return ScheduledJob.objects.create(name=name, **defaults)
+
+    def test_detail_view_shows_banner_when_user_is_null(self):
+        self.add_permissions("extras.view_scheduledjob")
+        sj = self._make_scheduled_job("banner_null_user", user=None)
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertIn("user that scheduled this job has been removed", body)
+
+    def test_detail_view_no_banner_when_user_is_present(self):
+        self.add_permissions("extras.view_scheduledjob")
+        sj = self._make_scheduled_job("banner_with_user")
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertNotIn("user that scheduled this job has been removed", body)
+
+    def test_detail_view_shows_assume_ownership_button_with_perms(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        other_user = User.objects.create(username="other_owner_button_visible", is_active=True)
+        sj = self._make_scheduled_job("assume_button_with_perm", user=other_user)
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertIn("Assume Ownership", body)
+
+    def test_detail_view_hides_assume_ownership_button_when_already_owner(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        sj = self._make_scheduled_job("assume_button_already_owner")  # owned by self.user
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertNotIn("Assume Ownership", body)
+
+    def test_detail_view_hides_assume_ownership_button_without_run_job_perm(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob")
+        other_user = User.objects.create(username="other_owner_no_run", is_active=True)
+        sj = self._make_scheduled_job("assume_button_no_run", user=other_user)
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertNotIn("Assume Ownership", body)
+
+    def test_detail_view_hides_assume_ownership_button_without_change_perm(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.run_job")
+        other_user = User.objects.create(username="other_owner_no_change", is_active=True)
+        sj = self._make_scheduled_job("assume_button_no_change", user=other_user)
+
+        response = self.client.get(sj.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertNotIn("Assume Ownership", body)
+
+    def test_assume_ownership_succeeds_with_required_perms(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        other_user = User.objects.create(username="prior_owner", is_active=True)
+        sj = self._make_scheduled_job("assume_other_owner", user=other_user, enabled=False)
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+        self.assertTrue(sj.enabled)
+
+    def test_assume_ownership_recovers_schedule_when_user_is_null(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        sj = self._make_scheduled_job("assume_null_owner", user=None, enabled=False)
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+        self.assertTrue(sj.enabled)
+
+    def test_assume_ownership_forbidden_without_run_job_perm(self):
+        self.add_permissions("extras.change_scheduledjob")
+        other_user = User.objects.create(username="prior_owner_no_run", is_active=True)
+        sj = self._make_scheduled_job("assume_forbidden_no_run", user=other_user)
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 403)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, other_user.id)  # unchanged
+
+    def test_assume_ownership_forbidden_without_change_perm(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.run_job")
+        other_user = User.objects.create(username="prior_owner_no_change", is_active=True)
+        sj = self._make_scheduled_job("assume_forbidden_no_change", user=other_user)
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 403)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, other_user.id)
+
+    def test_assume_ownership_no_op_when_already_owner(self):
+        """A direct POST while already owning the schedule short-circuits without modification."""
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        sj = self._make_scheduled_job("assume_already_owner_post", enabled=False)
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        # State must NOT have been mutated since the requester already owns it.
+        sj.refresh_from_db()
+        self.assertFalse(sj.enabled)
+
+    def test_assume_ownership_rejected_without_run_perm_on_specific_job(self):
+        """A user with extras.run_job at the model level but no per-Job run constraint match is rejected."""
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob")
+        # Grant `run` on a constraint that does NOT match the schedule's job_model.
+        obj_perm = ObjectPermission.objects.create(
+            name="run only fail jobs",
+            actions=["run"],
+            constraints={"name": "TestFailJob"},
+        )
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ContentType.objects.get_for_model(Job))
+
+        other_user = User.objects.create(username="other_owner_no_run_for_job", is_active=True)
+        sj = self._make_scheduled_job("assume_no_run_specific_job", user=other_user)
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+        self.assertIn("do not have permission to run the job", body)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, other_user.id)  # unchanged
 
 
 class ApprovalQueueTestCase(

--- a/nautobot/extras/urls.py
+++ b/nautobot/extras/urls.py
@@ -71,6 +71,11 @@ urlpatterns = [
     path("jobs/", views.JobListView.as_view(), name="job_list"),
     path("jobs/scheduled-jobs/", views.ScheduledJobListView.as_view(), name="scheduledjob_list"),
     path("jobs/scheduled-jobs/<uuid:pk>/", views.ScheduledJobView.as_view(), name="scheduledjob"),
+    path(
+        "jobs/scheduled-jobs/<uuid:pk>/assume-ownership/",
+        views.ScheduledJobAssumeOwnershipView.as_view(),
+        name="scheduledjob_assume_ownership",
+    ),
     path("jobs/scheduled-jobs/<uuid:pk>/delete/", views.ScheduledJobDeleteView.as_view(), name="scheduledjob_delete"),
     path(
         "jobs/scheduled-jobs/delete/",

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2113,9 +2113,7 @@ class SavedViewUIViewSet(
 class ScheduledJobListView(generic.ObjectListView):
     # Show enabled schedules plus schedules whose owning user has been removed (auto-disabled
     # by the scheduler) so admins can still see them and reassign ownership.
-    queryset = ScheduledJob.objects.filter(
-        Q(pk__in=ScheduledJob.objects.enabled().values("pk")) | Q(user__isnull=True)
-    )
+    queryset = ScheduledJob.objects.filter(Q(pk__in=ScheduledJob.objects.enabled().values("pk")) | Q(user__isnull=True))
     table = tables.ScheduledJobTable
     filterset = filters.ScheduledJobFilterSet
     filterset_form = forms.ScheduledJobFilterForm

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import IntegrityError, transaction
@@ -2166,7 +2167,7 @@ class ScheduledJobView(generic.ObjectView):
         }
 
 
-class ScheduledJobAssumeOwnershipView(View):
+class ScheduledJobAssumeOwnershipView(LoginRequiredMixin, View):
     """Reassign this scheduled job's owner to the requesting user and re-enable it."""
 
     queryset = ScheduledJob.objects.all()

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2111,7 +2111,11 @@ class SavedViewUIViewSet(
 
 
 class ScheduledJobListView(generic.ObjectListView):
-    queryset = ScheduledJob.objects.enabled()
+    # Show enabled schedules plus schedules whose owning user has been removed (auto-disabled
+    # by the scheduler) so admins can still see them and reassign ownership.
+    queryset = ScheduledJob.objects.filter(
+        Q(pk__in=ScheduledJob.objects.enabled().values("pk")) | Q(user__isnull=True)
+    )
     table = tables.ScheduledJobTable
     filterset = filters.ScheduledJobFilterSet
     filterset_form = forms.ScheduledJobFilterForm
@@ -2146,12 +2150,54 @@ class ScheduledJobView(generic.ObjectView):
                     labels[name] = field.label
                 else:
                     labels[name] = pretty_name(name)
+        # Hide the "Assume Ownership" button when the requester is already the owner,
+        # lacks change perms, or doesn't have run permission on the specific Job that
+        # this schedule runs.
+        can_assume_ownership = (
+            instance.user_id != request.user.id
+            and request.user.has_perm("extras.change_scheduledjob")
+            and instance.job_model is not None
+            and JobModel.objects.restrict(request.user, "run").filter(pk=instance.job_model_id).exists()
+        )
         return {
             "labels": labels,
             "job_class_found": (job_class is not None),
             "default_time_zone": get_current_timezone(),
+            "can_assume_ownership": can_assume_ownership,
             **super().get_extra_context(request, instance),
         }
+
+
+class ScheduledJobAssumeOwnershipView(View):
+    """Reassign this scheduled job's owner to the requesting user and re-enable it."""
+
+    queryset = ScheduledJob.objects.all()
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponseForbidden()
+
+    def post(self, request, *args, **kwargs):
+        if not request.user.has_perm("extras.run_job"):
+            return HttpResponseForbidden()
+        if not request.user.has_perm("extras.change_scheduledjob"):
+            return HttpResponseForbidden()
+        obj = get_object_or_404(self.queryset, pk=kwargs["pk"])
+        if obj.user_id == request.user.id:
+            messages.info(request, f"You already own scheduled job '{obj.name}'.")
+            return redirect(obj.get_absolute_url())
+        # Defensively confirm the requester can run this specific Job — the UI hides the
+        # button in this case but a direct POST could still reach here.
+        if (
+            obj.job_model is None
+            or not JobModel.objects.restrict(request.user, "run").filter(pk=obj.job_model_id).exists()
+        ):
+            messages.error(request, f"You do not have permission to run the job '{obj.job_model}'.")
+            return redirect(obj.get_absolute_url())
+        obj.user = request.user
+        obj.enabled = True
+        obj.validated_save()
+        messages.success(request, f"You are now the owner of scheduled job '{obj.name}'.")
+        return redirect(obj.get_absolute_url())
 
 
 class ScheduledJobDeleteView(generic.ObjectDeleteView):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8413
# What's Changed
This PR replicates the changes from #8934, but I had to make some changes due to the difference between develop and ltm-2.4.

Primary changes
- Added directly to the existing templates and bespoke View and URL as LTM lacks UI Component
- Changed the Scheduled Job list view queryset to include disabled schedules that don't have a user (current view hides disabled scheduled jobs)

# Screenshots
<img width="1686" height="671" alt="Screenshot 2026-05-08 at 10 03 13 AM" src="https://github.com/user-attachments/assets/99a74bc6-0870-446b-b154-bc325f3de598" />
<img width="725" height="207" alt="Screenshot 2026-05-08 at 10 03 27 AM" src="https://github.com/user-attachments/assets/7c08acf1-638c-41a7-b85f-2c0b71a8b370" />
<img width="319" height="80" alt="Screenshot 2026-05-08 at 9 58 31 AM" src="https://github.com/user-attachments/assets/b2510dc9-f07f-4c2a-a364-dd27e4cb93dc" />

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)

NTC-4974