### PR TITLE
Fix Job Result Summary timestamps using user timezone

### DIFF
--- a/changes/8954.fixed
+++ b/changes/8954.fixed
@@ -1,0 +1,1 @@
+Job Result Summary timestamps now display in user timezone instead of UTC.

--- a/nautobot/core/tests/test_ui.py
+++ b/nautobot/core/tests/test_ui.py
@@ -1,11 +1,17 @@
 """Test cases for nautobot.core.ui module."""
 
 import json
+from datetime import date, datetime, timezone as datetime_timezone
 from unittest.mock import patch
+from unittest.mock import Mock
+from zoneinfo import ZoneInfo
 
-from django.db.models import Sum
+from django.core.exceptions import FieldDoesNotExist
+from django.db.models import DateField, DateTimeField, Sum
 from django.template import Context
 from django.test import RequestFactory
+from django.test import override_settings
+from django.utils import timezone
 from django.urls import reverse
 
 from nautobot.cloud.models import CloudNetwork, CloudResourceType, CloudService
@@ -196,6 +202,29 @@ class ObjectFieldsPanelTest(TestCase):
         panel = ObjectFieldsPanel(weight=100, fields=["name", "foo", "bar"], ignore_nonexistent_fields=False)
         with self.assertRaises(AttributeError):
             panel.get_data(context)
+
+    def test_render_value_formats_dates_and_preserves_none_behavior(self):
+        panel = ObjectFieldsPanel(weight=100, fields=["decision_date"])
+
+        def build_context(field_instance):
+            obj = Mock()
+            if field_instance is None:
+                obj._meta.get_field.side_effect = FieldDoesNotExist
+            else:
+                obj._meta.get_field.return_value = field_instance
+            return Context({"object": obj})
+
+        utc_datetime = datetime(2024, 1, 1, 0, 30, tzinfo=datetime_timezone.utc)
+
+        with override_settings(DATETIME_FORMAT="Y-m-d H:i:s", DATE_FORMAT="Y-m-d"), timezone.override(ZoneInfo("Asia/Tokyo")):
+            self.assertEqual(panel.render_value("decision_date", utc_datetime, build_context(DateTimeField())), "2024-01-01 09:30:00")
+            self.assertEqual(panel.render_value("install_date", date(2024, 1, 1), build_context(DateField())), "2024-01-01")
+            self.assertEqual(
+                panel.render_value("related__decision_date", utc_datetime, build_context(None)),
+                "2024-01-01 09:30:00",
+            )
+            hidden_panel = ObjectFieldsPanel(weight=100, fields=["decision_date"], hide_if_unset=["decision_date"])
+            self.assertEqual(hidden_panel.render_value("decision_date", None, build_context(DateField())), "")
 
 
 class BaseTextPanelTest(TestCase):

--- a/nautobot/core/tests/test_ui.py
+++ b/nautobot/core/tests/test_ui.py
@@ -1,18 +1,16 @@
 """Test cases for nautobot.core.ui module."""
 
-import json
 from datetime import date, datetime, timezone as datetime_timezone
-from unittest.mock import patch
-from unittest.mock import Mock
+import json
+from unittest.mock import Mock, patch
 from zoneinfo import ZoneInfo
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import DateField, DateTimeField, Sum
 from django.template import Context
-from django.test import RequestFactory
-from django.test import override_settings
-from django.utils import timezone
+from django.test import override_settings, RequestFactory
 from django.urls import reverse
+from django.utils import timezone
 
 from nautobot.cloud.models import CloudNetwork, CloudResourceType, CloudService
 from nautobot.cloud.tables import CloudServiceTable
@@ -216,9 +214,16 @@ class ObjectFieldsPanelTest(TestCase):
 
         utc_datetime = datetime(2024, 1, 1, 0, 30, tzinfo=datetime_timezone.utc)
 
-        with override_settings(DATETIME_FORMAT="Y-m-d H:i:s", DATE_FORMAT="Y-m-d"), timezone.override(ZoneInfo("Asia/Tokyo")):
-            self.assertEqual(panel.render_value("decision_date", utc_datetime, build_context(DateTimeField())), "2024-01-01 09:30:00")
-            self.assertEqual(panel.render_value("install_date", date(2024, 1, 1), build_context(DateField())), "2024-01-01")
+        with (
+            override_settings(DATETIME_FORMAT="Y-m-d H:i:s", DATE_FORMAT="Y-m-d"),
+            timezone.override(ZoneInfo("Asia/Tokyo")),
+        ):
+            self.assertEqual(
+                panel.render_value("decision_date", utc_datetime, build_context(DateTimeField())), "2024-01-01 09:30:00"
+            )
+            self.assertEqual(
+                panel.render_value("install_date", date(2024, 1, 1), build_context(DateField())), "2024-01-01"
+            )
             self.assertEqual(
                 panel.render_value("related__decision_date", utc_datetime, build_context(None)),
                 "2024-01-01 09:30:00",

--- a/nautobot/core/tests/test_ui.py
+++ b/nautobot/core/tests/test_ui.py
@@ -222,6 +222,10 @@ class ObjectFieldsPanelTest(TestCase):
                 panel.render_value("decision_date", utc_datetime, build_context(DateTimeField())), "2024-01-01 09:30:00"
             )
             self.assertEqual(
+                panel.render_value("decision_date", datetime(2024, 1, 1, 0, 30), build_context(DateTimeField())),
+                "2024-01-01 09:30:00",
+            )
+            self.assertEqual(
                 panel.render_value("install_date", date(2024, 1, 1), build_context(DateField())), "2024-01-01"
             )
             self.assertEqual(

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -3,6 +3,7 @@
 import contextlib
 from dataclasses import dataclass
 from enum import Enum
+from datetime import date, datetime
 import hashlib
 import json
 import logging
@@ -1747,11 +1748,14 @@ class ObjectFieldsPanel(KeyValueTablePanel):
             # Note that we *don't* want to do this for models with a StatusField and its `get_status_display()`
             return super().render_value(key, getattr(obj, f"get_{key}_display")(), context)
 
-        if isinstance(field_instance, (DateTimeField, DateField)):
-            if value is None:
-                return placeholder(value)
-            format_string = "DATETIME_FORMAT" if isinstance(field_instance, DateTimeField) else "DATE_FORMAT"
-            return format_date(value, format_string)
+        if value is None:
+            return super().render_value(key, value, context)
+
+        if isinstance(field_instance, DateTimeField) or isinstance(value, datetime):
+            return format_date(value, "DATETIME_FORMAT")
+
+        if isinstance(field_instance, DateField) or isinstance(value, date):
+            return format_date(value, "DATE_FORMAT")
 
         return super().render_value(key, value, context)
 

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -23,6 +23,7 @@ from django.template.defaultfilters import date as format_date, truncatechars
 from django.template.loader import render_to_string
 from django.templatetags.l10n import localize
 from django.urls import NoReverseMatch, reverse
+from django.utils import timezone
 from django.utils.html import format_html, format_html_join
 from django_tables2 import RequestConfig
 
@@ -1749,7 +1750,9 @@ class ObjectFieldsPanel(KeyValueTablePanel):
             return super().render_value(key, getattr(obj, f"get_{key}_display")(), context)
 
         if isinstance(value, datetime):
-            return format_date(value, "DATETIME_FORMAT")
+            if timezone.is_naive(value):
+                value = timezone.make_aware(value, timezone.get_default_timezone())
+            return format_date(timezone.localtime(value), "DATETIME_FORMAT")
 
         if isinstance(value, date):
             return format_date(value, "DATE_FORMAT")

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -2,8 +2,8 @@
 
 import contextlib
 from dataclasses import dataclass
-from enum import Enum
 from datetime import date, datetime
+from enum import Enum
 import hashlib
 import json
 import logging
@@ -15,7 +15,7 @@ import uuid
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.db import models
-from django.db.models import CharField, DateField, DateTimeField, JSONField, Q, URLField
+from django.db.models import CharField, JSONField, Q, URLField
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields.related import ManyToManyField
 from django.template import Context

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -1748,13 +1748,10 @@ class ObjectFieldsPanel(KeyValueTablePanel):
             # Note that we *don't* want to do this for models with a StatusField and its `get_status_display()`
             return super().render_value(key, getattr(obj, f"get_{key}_display")(), context)
 
-        if value is None:
-            return super().render_value(key, value, context)
-
-        if isinstance(field_instance, DateTimeField) or isinstance(value, datetime):
+        if isinstance(value, datetime):
             return format_date(value, "DATETIME_FORMAT")
 
-        if isinstance(field_instance, DateField) or isinstance(value, date):
+        if isinstance(value, date):
             return format_date(value, "DATE_FORMAT")
 
         return super().render_value(key, value, context)

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -14,11 +14,11 @@ import uuid
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.db import models
-from django.db.models import CharField, JSONField, Q, URLField
+from django.db.models import CharField, DateField, DateTimeField, JSONField, Q, URLField
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields.related import ManyToManyField
 from django.template import Context
-from django.template.defaultfilters import truncatechars
+from django.template.defaultfilters import date as format_date, truncatechars
 from django.template.loader import render_to_string
 from django.templatetags.l10n import localize
 from django.urls import NoReverseMatch, reverse
@@ -1746,6 +1746,12 @@ class ObjectFieldsPanel(KeyValueTablePanel):
             # For example, Secret.provider -> Secret.get_provider_display()
             # Note that we *don't* want to do this for models with a StatusField and its `get_status_display()`
             return super().render_value(key, getattr(obj, f"get_{key}_display")(), context)
+
+        if isinstance(field_instance, (DateTimeField, DateField)):
+            if value is None:
+                return placeholder(value)
+            format_string = "DATETIME_FORMAT" if isinstance(field_instance, DateTimeField) else "DATE_FORMAT"
+            return format_date(value, format_string)
 
         return super().render_value(key, value, context)
 


### PR DESCRIPTION
## Issue
Fixes #8954

## Problem
Job Result Summary displays timestamps in UTC instead of user timezone. Logs and Footer already work correctly with user timezone, but Summary section was showing inconsistent time.

## Root Cause
ObjectFieldsPanel.render_value() lacks handler for DateTimeField/DateField types, causing datetime values to bypass timezone conversion and display as UTC.

## Solution
Added timezone-aware datetime rendering handler to ObjectFieldsPanel.render_value() using Django's date template filter which respects USE_TZ setting.

## Changes
- Added DateField and DateTimeField imports to ObjectFieldsPanel
- Implemented timezone-aware datetime rendering in render_value() method
- Handler uses Django's date filter for consistent timezone conversion
