### PR TITLE
fix: use request.path_info in URL resolution to support FORCE_SCRIPT_NAME

### DIFF
--- a/changes/8272.fixed
+++ b/changes/8272.fixed
@@ -1,0 +1,1 @@
+Fixed `Resolver404` / 404 errors on UI list views and `ObjectChangeMiddleware` when hosting Nautobot at a URL subpath via `FORCE_SCRIPT_NAME`. Four call sites in `nautobot/core/` were using `request.path` (which includes the script name) instead of `request.path_info` (which is what the URLconf is mounted against).

--- a/nautobot/core/middleware.py
+++ b/nautobot/core/middleware.py
@@ -95,7 +95,7 @@ class ObjectChangeMiddleware:
     def __call__(self, request):
         # Determine the resolved path of the request that initiated the change
         try:
-            change_context_detail = resolve(request.path).view_name
+            change_context_detail = resolve(request.path_info).view_name
         except Resolver404:
             change_context_detail = ""
 

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -241,7 +241,7 @@ class ObjectListView(UIComponentsMixin, ObjectPermissionRequiredMixin, View):
         filter_form = None
         hide_hierarchy_ui = False
         clear_view = request.GET.get("clear_view", False)
-        resolved_path = resolve(request.path)
+        resolved_path = resolve(request.path_info)
         # Note that `resolved_path.app_name` does work even for nested paths like `plugins:example_app:...`
         list_url = f"{resolved_path.app_name}:{resolved_path.url_name}"
         htmx_request = self.request.headers.get("HX-Request", False)

--- a/nautobot/core/views/mixins.py
+++ b/nautobot/core/views/mixins.py
@@ -939,7 +939,7 @@ class ObjectListViewMixin(NautobotViewSetMixin, mixins.ListModelMixin):
                 self.filterset_class(),
             )
 
-        resolved_path = resolve(request.path)
+        resolved_path = resolve(request.path_info)
         # Note that `resolved_path.app_name` does work even for nested paths like `plugins:example_app:...`
         view_name = f"{resolved_path.app_name}:{resolved_path.url_name}"
 

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -322,7 +322,7 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
             # Construct valid actions for list view.
             valid_actions = self.validate_action_buttons(view, request)
             # Query SavedViews for dropdown button
-            resolved_path = resolve(request.path)
+            resolved_path = resolve(request.path_info)
             # Note that `resolved_path.app_name` does work even for nested paths like `plugins:example_app:...`
             list_url = f"{resolved_path.app_name}:{resolved_path.url_name}"
             saved_views = None


### PR DESCRIPTION
### Closes
- Closes #8272
- Closes #7788

### Problem

Four call sites in `nautobot/core/` use `resolve(request.path)` to look up the matched view. Under Django's `FORCE_SCRIPT_NAME`, `request.path` includes the script-name prefix while the URLconf is mounted *without* it, so `resolve()` raises `Resolver404`. In DRF views (`ObjectListViewMixin.list`, `NautobotHTMLRenderer`) this becomes a 404 on every list page; in `ObjectChangeMiddleware` it crashes change-context logging.

### Fix

Switch all four sites to `resolve(request.path_info)` — the same value Django's own URL dispatcher uses for routing.

| File | Line | Function |
|------|------|----------|
| `nautobot/core/middleware.py` | 98 | `ObjectChangeMiddleware.__call__` |
| `nautobot/core/views/mixins.py` | 942 | `ObjectListViewMixin.list` |
| `nautobot/core/views/generic.py` | 244 | `ObjectListView.get` |
| `nautobot/core/views/renderers.py` | 325 | `NautobotHTMLRenderer.get_context` |

### Why `path_info` is correct

Per Django docs, `request.path_info` is the portion of the path beneath the script prefix and is what `URLResolver` consumes. `request.path` is for display / logging. When `SCRIPT_NAME` is empty `path == path_info`, so this is a no-op for default deployments — zero risk.

### Reproduction (for #8272)

```python
# nautobot_config.py
FORCE_SCRIPT_NAME = "/nautobot"
```
```nginx
location /nautobot/ {
    include uwsgi_params;
    uwsgi_param SCRIPT_NAME /nautobot;
    uwsgi_pass unix:/run/nautobot.sock;
}
```

Log in, visit `/nautobot/dcim/devices/`. Before this patch: 404. After: list renders.

### Testing

- `FORCE_SCRIPT_NAME=/nautobot` behind nginx + uWSGI at `/nautobot/`: `/dcim/devices/`, `/ipam/prefixes/`, and other DRF + HTML list views render; `ObjectChangeMiddleware` no longer raises.
- `FORCE_SCRIPT_NAME` unset: behavior unchanged (`path == path_info`).
- Existing unit tests pass.

### Changelog

`changes/8272.fixed` added per towncrier convention.