### PR TITLE
Fixed slow page loads on detail views at large scale

### DIFF
--- a/changes/8965.fixed
+++ b/changes/8965.fixed
@@ -1,0 +1,1 @@
+Fixed slow page loads on detail views at large scale.

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -283,7 +283,8 @@ class BaseTable(django_tables2.Table):
 
             if count_fields:
                 for column_name, column_model, lookup_name, distinct in count_fields:
-                    if hasattr(queryset.first(), column_name):
+                    # Keep the check lazy so the queryset is not evaluated here.
+                    if column_name in queryset.query.annotations or hasattr(model, column_name):
                         continue
                     try:
                         logger.debug(

--- a/nautobot/core/tests/test_tables.py
+++ b/nautobot/core/tests/test_tables.py
@@ -1,4 +1,7 @@
+from django.db import connection
+from django.db.models import IntegerField, Value
 from django.test import tag, TestCase
+from django.test.utils import CaptureQueriesContext
 
 from nautobot.circuits.models import Circuit
 from nautobot.circuits.tables import CircuitTable
@@ -7,6 +10,8 @@ from nautobot.dcim.models import Device, InventoryItem, Location, LocationType, 
 from nautobot.dcim.tables import InventoryItemTable, LocationTable, LocationTypeTable, RackGroupTable
 from nautobot.extras.models import JobLogEntry
 from nautobot.extras.tables import JobLogEntryTable
+from nautobot.ipam.models import RIR
+from nautobot.ipam.tables import RIRTable
 from nautobot.tenancy.tables import TenantGroupTable
 from nautobot.wireless.models import WirelessNetwork
 from nautobot.wireless.tables import WirelessNetworkTable
@@ -203,3 +208,46 @@ class TableTestCase(TestCase):
         ]
         self.assertEqual(job_log_entry_table.visible_columns, expected_visible_columns)
         self.assertEqual(job_log_entry_table.configurable_columns, expected_configurable_columns)
+
+
+class BaseTableLinkedCountColumnTestCase(TestCase):
+    """Covers the `count_fields` annotation pathway in `BaseTable.__init__`."""
+
+    def test_basetable_construction_is_lazy(self):
+        """Constructing a BaseTable around a lazy queryset must not query the DB.
+
+        Querysets are lazy; column setup, annotation chaining, and prefetch
+        wiring are pure-Python operations. Any DB query issued here is a sign
+        that something forced evaluation of the queryset.
+        """
+        with CaptureQueriesContext(connection) as ctx:
+            RIRTable(RIR.objects.all())
+        self.assertEqual(
+            len(ctx.captured_queries),
+            0,
+            f"BaseTable.__init__ issued {len(ctx.captured_queries)} DB queries; "
+            "expected 0 because the input queryset is lazy.\n" + "\n".join(q["sql"] for q in ctx.captured_queries),
+        )
+
+    def test_annotation_applied_when_missing(self):
+        """A LinkedCountColumn's annotation is applied when neither the queryset nor the model has it."""
+        table = RIRTable(RIR.objects.all())
+        self.assertIn("assigned_prefix_count", table.data.data.query.annotations)
+
+    def test_annotation_preserved_when_already_on_queryset(self):
+        """A caller-supplied annotation with the same name as a LinkedCountColumn is preserved, not overwritten."""
+        qs = RIR.objects.annotate(assigned_prefix_count=Value(42, output_field=IntegerField()))
+        table = RIRTable(qs)
+        self.assertIn("assigned_prefix_count", table.data.data.query.annotations)
+        row = table.data.data.first()
+        if row is not None:
+            self.assertEqual(row.assigned_prefix_count, 42)
+
+    def test_annotation_skipped_when_model_defines_attribute(self):
+        """The annotation is not applied if the model class already exposes the attribute."""
+        RIR.assigned_prefix_count = property(lambda self: 999)
+        try:
+            table = RIRTable(RIR.objects.all())
+            self.assertNotIn("assigned_prefix_count", table.data.data.query.annotations)
+        finally:
+            del RIR.assigned_prefix_count


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8965
# What's Changed
While investigating a performance issue for a client, a minor issue was uncovered when rendering tables at a large scale.

While rendering `LinkedCountColumn`, we were checking `if hasattr(queryset.first(), column_name)`. This was causing additional unneeded SQL queries. This was compounded for each `LinkedCountColumn` in the table. Although this is minor in smaller environments, in large environments with large querysets the additional queries can increase the render time noticeably.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

<details>
    <summary>SQL Query details</summary>

Using the VRF to Prefix Assignment table as an example, we have the `vrf_count` and `location_count` as part of the [default columns](https://github.com/nautobot/nautobot/blob/494f6e61aec124d82c7bcaf7c68070d38434a85d/nautobot/ipam/tables.py#L458-L471).

The table below represents the SQL queries that are made when viewing this page. The leftmost column (Eliminated) are the queries that are no longer present after the fix. These were the extra queries (6 queries x 2 columns) that were eliminated.

|Eliminated|At | Action | Tables | Num. Joins | Execution Time (ms)|
|-|-|-|-|-|-|
| |+0:00:02.696773 |SELECT|  "extras_objectchange", "auth_user", "django_content_type"   |2   |1.923000|
| |+0:00:02.682314 |SELECT|  "a", "extras_objectmetadata"    |0   |1.663000|
| |+0:00:02.675761 |SELECT|  "a", "extras_dynamicgroup", "django_content_type", "extras_staticgroupassociation"  |2   |1.906000|
| |+0:00:02.659579 |SELECT|  "__count", "extras_contactassociation"  |0   |1.589000|
| |+0:00:02.653972 |SELECT|  "__count", "extras_contactassociation"  |0   |1.600000|
| |+0:00:02.631305 |SELECT|  "__count", "extras_contactassociation"  |0   |1.755000|
| |+0:00:02.623022 |SELECT|  "extras_relationship", "django_content_type", "django_content_type" |2   |2.163000|
| |+0:00:02.615246 |SELECT|  "extras_relationship", "django_content_type", "django_content_type" |2   |2.345000|
| |+0:00:02.601969 |SELECT|  "extras_computedfield"  |0   |1.617000|
| |+0:00:02.591974 |SELECT|  "extras_customfield", "extras_customfield_content_types"    |1   |2.023000|
| |+0:00:02.569671 |SELECT|  "extras_tag", "extras_taggeditem", "django_content_type"    |2   |1.913000|
| |+0:00:02.558153 |SELECT|  "extras_customfield", "extras_customfield_content_types"    |1   |1.966000|
| |+0:00:02.543413 |SELECT|  "ipam_routetarget", "ipam_vrf_export_targets"   |1   |1.729000|
| |+0:00:02.536499 |SELECT|  "ipam_routetarget", "ipam_vrf_import_targets"   |1   |2.166000|
| |+0:00:01.369678 |SELECT|  "ipam_prefix", "ipam_vrfprefixassignment", "ipam_namespace" |2   |269.411000|
| |+0:00:01.362922 |SELECT|  "dcim_virtualdevicecontext", "ipam_vrfdeviceassignment" |1   |1.964000|
| |+0:00:01.356080 |SELECT|  "virtualization_virtualmachine", "ipam_vrfdeviceassignment" |1   |2.280000|
| |+0:00:01.348190 |SELECT|  "dcim_device", "ipam_vrfdeviceassignment"   |1   |2.908000|
| |+0:00:01.341051 |SELECT|  "extras_taggeditem", "extras_tag"   |1   |1.771000|
| |+0:00:01.334374 |SELECT|  "extras_jobbutton", "extras_jobbutton_content_types"    |1   |1.840000|
| |+0:00:01.328434 |SELECT|  "extras_customlink" |0   |1.865000|
| |+0:00:01.312074 |SELECT|  "__count", "ipam_vrfdeviceassignment"   |0   |1.203000|
| |+0:00:01.306687 |SELECT|  "__count", "ipam_vrfdeviceassignment"   |0   |1.637000|
| |+0:00:00.981440 |SELECT|  "_prefetch_related_val_prefix_id", "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10", "col11", "col12", "col13", "col14", "col15", "col16", "col17", "col18", "col19", "col20", "col21", "col22", "qual0", "dcim_location", "ipam_prefixlocationassignment"   |1   |3.361000|
| |+0:00:00.969005 |SELECT|  "_prefetch_related_val_prefix_id", "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10", "qual0", "ipam_vrf", "ipam_vrfprefixassignment" |1   |3.638000|
| |+0:00:00.895249 |SELECT|  "c", "ipam_vrf", "ipam_vrfprefixassignment", "vrf_count", "c", "dcim_location", "ipam_prefixlocationassignment", "location_count", "ipam_prefix", "ipam_vrfprefixassignment", "extras_status", "extras_role", "ipam_namespace", "tenancy_tenant", "ipam_vlan"   |8   |57.430000|
| |+0:00:00.878872 |SELECT|  "__count", "ipam_prefix", "ipam_vrfprefixassignment"    |1   |4.860000|
| |+0:00:00.869513 |SELECT|  "__count", "ipam_prefix", "ipam_vrfprefixassignment"    |1   |5.273000|
|X|+0:00:00.856134 |SELECT|  "_prefetch_related_val_prefix_id", "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10", "col11", "col12", "col13", "col14", "col15", "col16", "col17", "col18", "col19", "col20", "col21", "col22", "qual0", "dcim_location", "ipam_prefixlocationassignment"   |1   |2.506000|
|X|+0:00:00.848221 |SELECT|  "_prefetch_related_val_prefix_id", "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10", "qual0", "ipam_vrf", "ipam_vrfprefixassignment" |1   |2.280000|
|X|+0:00:00.802979 |SELECT|  "c", "ipam_vrf", "ipam_vrfprefixassignment", "vrf_count", "ipam_prefix", "ipam_vrfprefixassignment", "extras_status", "extras_role", "ipam_namespace", "tenancy_tenant", "ipam_vlan"    |7   |33.409000|
|X|+0:00:00.793008 |SELECT|  "_prefetch_related_val_prefix_id", "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10", "col11", "col12", "col13", "col14", "col15", "col16", "col17", "col18", "col19", "col20", "col21", "col22", "qual0", "dcim_location", "ipam_prefixlocationassignment"   |1   |2.513000|
|X|+0:00:00.785170 |SELECT|  "_prefetch_related_val_prefix_id", "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10", "qual0", "ipam_vrf", "ipam_vrfprefixassignment" |1   |2.250000|
|X|+0:00:00.735087 |SELECT|  "ipam_prefix", "ipam_vrfprefixassignment", "extras_status", "extras_role", "ipam_namespace", "tenancy_tenant", "ipam_vlan"  |6   |38.254000|
| |+0:00:00.707537 |SELECT|  "__count", "ipam_routetarget", "ipam_vrf_export_targets"    |1   |1.243000|
| |+0:00:00.702329 |SELECT|  "__count", "ipam_routetarget", "ipam_vrf_export_targets"    |1   |1.465000|
| |+0:00:00.672386 |SELECT|  "__count", "ipam_routetarget", "ipam_vrf_import_targets"    |1   |1.280000|
| |+0:00:00.667131 |SELECT|  "__count", "ipam_routetarget", "ipam_vrf_import_targets"    |1   |1.483000|
| |+0:00:00.641647 |SELECT|  "extras_tag", "extras_taggeditem", "django_content_type"    |2   |1.992000|
| |+0:00:00.633950 |SELECT|  "extras_relationship", "django_content_type", "django_content_type" |2   |1.970000|
| |+0:00:00.627474 |SELECT|  "extras_relationship", "django_content_type", "django_content_type" |2   |2.185000|
| |+0:00:00.615698 |SELECT|  "extras_computedfield"  |0   |1.663000|
| |+0:00:00.607003 |SELECT|  "extras_customfield", "extras_customfield_content_types"    |1   |1.925000|
| |+0:00:00.593947 |SELECT|  "__count", "extras_note"    |0   |1.582000|
| |+0:00:00.586896 |SELECT|  "a", "extras_objectmetadata"    |0   |1.480000|
| |+0:00:00.581275 |SELECT|  "a", "extras_dynamicgroup", "django_content_type", "extras_staticgroupassociation"  |2   |1.656000|
| |+0:00:00.574323 |SELECT|  "__count", "extras_contactassociation"  |0   |1.541000|
| |+0:00:00.561415 |SELECT|  "ipam_namespace"    |0   |1.370000|
| |+0:00:00.547654 |SELECT|  "a", "extras_objectmetadata"    |0   |1.415000|
| |+0:00:00.542120 |SELECT|  "a", "extras_dynamicgroup", "django_content_type", "extras_staticgroupassociation"  |2   |1.709000|
| |+0:00:00.536155 |SELECT|  "__count", "extras_contactassociation"  |0   |1.391000|
| |+0:00:00.530934 |SELECT|  "__count", "extras_contactassociation"  |0   |1.569000|
| |+0:00:00.512055 |SELECT|  "__count", "ipam_vrfdeviceassignment"   |0   |1.338000|
| |+0:00:00.506572 |SELECT|  "__count", "ipam_vrfdeviceassignment"   |0   |1.769000|
| |+0:00:00.481778 |SELECT|  "__count", "ipam_prefix", "ipam_vrfprefixassignment"    |1   |5.102000|
| |+0:00:00.471952 |SELECT|  "__count", "ipam_prefix", "ipam_vrfprefixassignment"    |1   |5.730000|
|X|+0:00:00.457967 |SELECT|  "_prefetch_related_val_prefix_id", "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10", "col11", "col12", "col13", "col14", "col15", "col16", "col17", "col18", "col19", "col20", "col21", "col22", "qual0", "dcim_location", "ipam_prefixlocationassignment"   |1   |3.111000|
|X|+0:00:00.447407 |SELECT|  "_prefetch_related_val_prefix_id", "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10", "qual0", "ipam_vrf", "ipam_vrfprefixassignment" |1   |2.919000|
|X|+0:00:00.399809 |SELECT|  "c", "ipam_vrf", "ipam_vrfprefixassignment", "vrf_count", "ipam_prefix", "ipam_vrfprefixassignment", "extras_status", "extras_role", "ipam_namespace", "tenancy_tenant", "ipam_vlan"    |7   |34.782000|
|X|+0:00:00.388972 |SELECT|  "_prefetch_related_val_prefix_id", "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10", "col11", "col12", "col13", "col14", "col15", "col16", "col17", "col18", "col19", "col20", "col21", "col22", "qual0", "dcim_location", "ipam_prefixlocationassignment"   |1   |3.333000|
|X|+0:00:00.379874 |SELECT|  "_prefetch_related_val_prefix_id", "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10", "qual0", "ipam_vrf", "ipam_vrfprefixassignment" |1   |2.808000|
|X|+0:00:00.330905 |SELECT|  "ipam_prefix", "ipam_vrfprefixassignment", "extras_status", "extras_role", "ipam_namespace", "tenancy_tenant", "ipam_vlan"  |6   |35.995000|
| |+0:00:00.310600 |SELECT|  "__count", "ipam_routetarget", "ipam_vrf_export_targets"    |1   |1.507000|
| |+0:00:00.303627 |SELECT|  "__count", "ipam_routetarget", "ipam_vrf_export_targets"    |1   |2.122000|
| |+0:00:00.278845 |SELECT|  "__count", "ipam_routetarget", "ipam_vrf_import_targets"    |1   |2.272000|
| |+0:00:00.272472 |SELECT|  "__count", "ipam_routetarget", "ipam_vrf_import_targets"    |1   |2.012000|
| |+0:00:00.202932 |SELECT|  "__count", "extras_objectmetadata"  |0   |1.230000|
| |+0:00:00.189206 |SELECT|  "__count", "extras_dynamicgroup", "django_content_type", "extras_staticgroupassociation"    |2   |1.912000|
| |+0:00:00.174843 |SELECT|  "__count", "extras_contactassociation"  |0   |1.736000|
| |+0:00:00.029230 |SELECT|  "extras_objectchange"   |0   |0.996000|
| |+0:00:00.024870 |SELECT|  "extras_objectchange"   |0   |1.570000|
| |+0:00:00.010351 |SELECT|  "ipam_vrf"  |0   |1.341000|
| |+0:00:00.004602 |SELECT|  "auth_user" |0   |1.438000|

</details>


# Screenshots
|Before|After|
|-|-|
|<img width="447" height="150" alt="Screenshot 2026-05-12 at 2 44 58 PM" src="https://github.com/user-attachments/assets/71f4aa1d-484f-41d2-b20c-9695c14044d8" />|<img width="457" height="147" alt="Screenshot 2026-05-12 at 2 45 06 PM" src="https://github.com/user-attachments/assets/0820be0e-221b-4879-b0a6-583139334c29" />|

<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests

NTC-4982