### PR TITLE
Fix 'Mark planned'/'Mark installed' actions

### DIFF
--- a/changes/8969.changed
+++ b/changes/8969.changed
@@ -1,0 +1,2 @@
+Added "View change log" item to "actions" dropdown in Device component (Interface, etc.) tables.
+Added model verbose name to "Edit" and "Delete" items in table action dropdowns.

--- a/changes/8969.changed
+++ b/changes/8969.changed
@@ -1,2 +1,3 @@
 Added "View change log" item to "actions" dropdown in Device component (Interface, etc.) tables.
 Added model verbose name to "Edit" and "Delete" items in table action dropdowns.
+Changed `nautobot-migrate-bootstrap-v3-to-v5` script to apply to `*.js` files as well.

--- a/changes/8969.fixed
+++ b/changes/8969.fixed
@@ -1,0 +1,1 @@
+Fixed "Mark planned"/"Mark installed" actions not working in Device Interfaces table and others.

--- a/changes/8969.housekeeping
+++ b/changes/8969.housekeeping
@@ -1,0 +1,1 @@
+Removed `initializeSortableList` logic in forms.js, unused since 3.1.0.

--- a/nautobot/core/cli/bootstrap_v3_to_v5.py
+++ b/nautobot/core/cli/bootstrap_v3_to_v5.py
@@ -769,7 +769,7 @@ def convert_bootstrap_classes(html_input: str, file_path: str) -> tuple[str, dic
 
 def fix_html_files_in_directory(directory: str, dry_run=False, skip_templates=False) -> None:
     """
-    Recursively finds all .html files in the given directory, applies convert_bootstrap_classes,
+    Recursively finds all .html and .js files in the given directory, applies convert_bootstrap_classes,
     and overwrites each file with the fixed content.
     """
 
@@ -799,7 +799,7 @@ def fix_html_files_in_directory(directory: str, dry_run=False, skip_templates=Fa
         for filename in files:
             if only_filename and only_filename != filename:
                 continue
-            if filename.lower().endswith(".html"):
+            if filename.lower().endswith(".html") or filename.lower().endswith(".js"):
                 file_path = os.path.join(root, filename)
                 logger.info("Processing: %s", file_path)
                 with open(file_path, "r", encoding="utf-8") as f:
@@ -921,7 +921,7 @@ def main():
         action="store_true",
         help="Show which files would be modified without making any changes.",
     )
-    parser.add_argument("path", type=str, help="Path to directory in which to recursively fix all .html files.")
+    parser.add_argument("path", type=str, help="Path to directory in which to recursively fix all .html and .js files.")
     parser.add_argument(
         "-st", "--skip-template-replacement", action="store_true", help="Skip replacing deprecated templates."
     )

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -459,7 +459,7 @@ class ButtonsColumn(django_tables2.TemplateColumn):
                 <li>
                     <a href="{{% url '{changelog_route}' {pk_field}=record.{pk_field} %}}" class="dropdown-item">
                         <span class="mdi mdi-history" aria-hidden="true"></span>
-                        Change Log
+                        View change log
                     </a>
                 </li>
             {{% endif %}}
@@ -468,7 +468,7 @@ class ButtonsColumn(django_tables2.TemplateColumn):
                     <li>
                         <a href="{{% url '{edit_route}' {pk_field}=record.{pk_field} %}}?return_url={{{{ return_url|default:request_path }}}}{{{{ return_url_extra }}}}" class="dropdown-item text-warning">
                             <span class="mdi mdi-pencil" aria-hidden="true"></span>
-                            Edit
+                            Edit {verbose_name}
                         </a>
                     </li>
                 {{% endif %}}
@@ -476,7 +476,7 @@ class ButtonsColumn(django_tables2.TemplateColumn):
                     <li>
                         <a href="{{% url '{delete_route}' {pk_field}=record.{pk_field} %}}?return_url={{{{ return_url|default:request_path }}}}{{{{ return_url_extra }}}}" class="dropdown-item text-danger">
                             <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span>
-                            Delete
+                            Delete {verbose_name}
                         </a>
                     </li>
                 {{% endif %}}
@@ -504,6 +504,7 @@ class ButtonsColumn(django_tables2.TemplateColumn):
         template_code = self.template_code.format(
             app_label=app_label,
             model_name=model._meta.model_name,
+            verbose_name=model._meta.verbose_name,
             changelog_route=changelog_route,
             edit_route=edit_route,
             delete_route=delete_route,

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -458,7 +458,6 @@ class DeviceModuleConsolePortTable(ConsolePortTable):
     )
     actions = ButtonsColumn(
         model=ConsolePort,
-        buttons=("edit", "delete"),
         prepend_template=CONSOLEPORT_BUTTONS,
     )
 
@@ -522,7 +521,6 @@ class DeviceModuleConsoleServerPortTable(ConsoleServerPortTable):
     )
     actions = ButtonsColumn(
         model=ConsoleServerPort,
-        buttons=("edit", "delete"),
         prepend_template=CONSOLESERVERPORT_BUTTONS,
     )
 
@@ -597,7 +595,7 @@ class DeviceModulePowerPortTable(PowerPortTable):
         "{{ value }}</a>",
         attrs={"td": {"class": "text-nowrap"}},
     )
-    actions = ButtonsColumn(model=PowerPort, buttons=("edit", "delete"), prepend_template=POWERPORT_BUTTONS)
+    actions = ButtonsColumn(model=PowerPort, prepend_template=POWERPORT_BUTTONS)
 
     class Meta(ModularDeviceComponentTable.Meta):
         model = PowerPort
@@ -674,7 +672,6 @@ class DeviceModulePowerOutletTable(PowerOutletTable):
     )
     actions = ButtonsColumn(
         model=PowerOutlet,
-        buttons=("edit", "delete"),
         prepend_template=POWEROUTLET_BUTTONS,
     )
 
@@ -797,7 +794,7 @@ class DeviceModuleInterfaceTable(InterfaceTable):
     parent_interface = tables.Column(linkify=True, verbose_name="Parent")
     bridge = tables.Column(linkify=True)
     lag = tables.Column(linkify=True, verbose_name="LAG")
-    actions = ButtonsColumn(model=Interface, buttons=("edit", "delete"), prepend_template=INTERFACE_BUTTONS)
+    actions = ButtonsColumn(model=Interface, prepend_template=INTERFACE_BUTTONS)
 
     class Meta(ModularDeviceComponentTable.Meta):
         model = Interface
@@ -905,7 +902,7 @@ class DeviceModuleFrontPortTable(FrontPortTable):
         '<a href="{{ record.get_absolute_url }}">{{ value }}</a>',
         attrs={"td": {"class": "text-nowrap"}},
     )
-    actions = ButtonsColumn(model=FrontPort, buttons=("edit", "delete"), prepend_template=FRONTPORT_BUTTONS)
+    actions = ButtonsColumn(model=FrontPort, prepend_template=FRONTPORT_BUTTONS)
 
     class Meta(ModularDeviceComponentTable.Meta):
         model = FrontPort
@@ -966,7 +963,7 @@ class DeviceModuleRearPortTable(RearPortTable):
         '<a href="{{ record.get_absolute_url }}">{{ value }}</a>',
         attrs={"td": {"class": "text-nowrap"}},
     )
-    actions = ButtonsColumn(model=RearPort, buttons=("edit", "delete"), prepend_template=REARPORT_BUTTONS)
+    actions = ButtonsColumn(model=RearPort, prepend_template=REARPORT_BUTTONS)
 
     class Meta(ModularDeviceComponentTable.Meta):
         model = RearPort
@@ -1081,7 +1078,7 @@ class DeviceDeviceBayTable(DeviceBayTable):
         '"></i> <a href="{{ record.get_absolute_url }}">{{ value }}</a>',
         attrs={"td": {"class": "text-nowrap"}},
     )
-    actions = ButtonsColumn(model=DeviceBay, buttons=("edit", "delete"), prepend_template=DEVICEBAY_BUTTONS)
+    actions = ButtonsColumn(model=DeviceBay, prepend_template=DEVICEBAY_BUTTONS)
 
     class Meta(DeviceComponentTable.Meta):
         model = DeviceBay
@@ -1116,7 +1113,7 @@ class DeviceModuleBayTable(ModuleBayTable):
     installed_module = tables.Column(linkify=True, verbose_name="Installed Module")
     installed_module__status = ColoredLabelColumn(verbose_name="Installed Module Status")
     requires_first_party_modules = BooleanColumn(verbose_name="First-Party Only")
-    actions = ButtonsColumn(model=ModuleBay, buttons=("edit", "delete"), prepend_template=MODULEBAY_BUTTONS)
+    actions = ButtonsColumn(model=ModuleBay, prepend_template=MODULEBAY_BUTTONS)
 
     class Meta(ModularDeviceComponentTable.Meta):
         model = ModuleBay
@@ -1146,7 +1143,7 @@ class DeviceModuleBayTable(ModuleBayTable):
 
 
 class ModuleModuleBayTable(DeviceModuleBayTable):
-    actions = ButtonsColumn(model=ModuleBay, buttons=("edit", "delete"), prepend_template=MODULEBAY_BUTTONS)
+    actions = ButtonsColumn(model=ModuleBay, prepend_template=MODULEBAY_BUTTONS)
 
     class Meta(DeviceModuleBayTable.Meta):
         pass
@@ -1193,7 +1190,7 @@ class DeviceInventoryItemTable(InventoryItemTable):
         "{{ value }}</a>",
         attrs={"td": {"class": "text-nowrap"}},
     )
-    actions = ButtonsColumn(model=InventoryItem, buttons=("edit", "delete"))
+    actions = ButtonsColumn(model=InventoryItem)
 
     class Meta(DeviceComponentTable.Meta):
         model = InventoryItem
@@ -1341,10 +1338,7 @@ class InterfaceRedundancyGroupAssociationTable(BaseTable):
         orderable=False,
         verbose_name="IP Addresses",
     )
-    actions = ButtonsColumn(
-        model=InterfaceRedundancyGroupAssociation,
-        buttons=("edit", "delete"),
-    )
+    actions = ButtonsColumn(model=InterfaceRedundancyGroupAssociation)
 
     class Meta(BaseTable.Meta):
         """Meta attributes."""

--- a/nautobot/dcim/tables/template_code.py
+++ b/nautobot/dcim/tables/template_code.py
@@ -185,8 +185,6 @@ CONSOLEPORT_BUTTONS = """
     <li><a href="{% url 'dcim:consoleport_trace' pk=record.pk %}" class="dropdown-item text-primary"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
     {% include 'dcim/inc/cable_toggle_buttons.html' with cable=record.cable %}
 {% elif perms.dcim.add_cable %}
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-lan-connect" aria-hidden="true"></span>Mark installed</a></li>
     <li>
         <a href="{% url 'dcim:consoleport_connect' termination_a_id=record.pk termination_b_type='console-server-port' %}?return_url={{ request.path }}" class="dropdown-item text-success">
             <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span>
@@ -213,8 +211,6 @@ CONSOLESERVERPORT_BUTTONS = """
     <li><a href="{% url 'dcim:consoleserverport_trace' pk=record.pk %}" class="dropdown-item text-primary"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
     {% include 'dcim/inc/cable_toggle_buttons.html' with cable=record.cable %}
 {% elif perms.dcim.add_cable %}
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-lan-connect" aria-hidden="true"></span>Mark installed</a></li>
     <li>
         <a href="{% url 'dcim:consoleserverport_connect' termination_a_id=record.pk termination_b_type='console-port' %}?return_url={{ request.path }}" class="dropdown-item text-success">
             <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span>
@@ -241,8 +237,6 @@ POWERPORT_BUTTONS = """
     <li><a href="{% url 'dcim:powerport_trace' pk=record.pk %}" class="dropdown-item text-primary"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
     {% include 'dcim/inc/cable_toggle_buttons.html' with cable=record.cable %}
 {% elif perms.dcim.add_cable %}
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-lan-connect" aria-hidden="true"></span>Mark installed</a></li>
     <li>
         <a href="{% url 'dcim:powerport_connect' termination_a_id=record.pk termination_b_type='power-outlet' %}?return_url={{ request.path }}" class="dropdown-item text-success">
             <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span>
@@ -263,8 +257,6 @@ POWEROUTLET_BUTTONS = """
     <li><a href="{% url 'dcim:poweroutlet_trace' pk=record.pk %}" class="dropdown-item text-primary"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
     {% include 'dcim/inc/cable_toggle_buttons.html' with cable=record.cable %}
 {% elif perms.dcim.add_cable %}
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-lan-connect" aria-hidden="true"></span>Mark installed</a></li>
     <li>
         <a href="{% url 'dcim:poweroutlet_connect' termination_a_id=record.pk termination_b_type='power-port' %}?return_url={{ request.path }}" class="dropdown-item text-success">
             <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span>
@@ -287,8 +279,6 @@ INTERFACE_BUTTONS = """
     <li><a href="{% url 'dcim:interface_trace' pk=record.pk %}" class="dropdown-item text-primary"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
     {% include 'dcim/inc/cable_toggle_buttons.html' with cable=record.cable %}
 {% elif record.is_connectable and perms.dcim.add_cable %}
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-lan-connect" aria-hidden="true"></span>Mark installed</a></li>
     <li>
         <a href="{% url 'dcim:interface_connect' termination_a_id=record.pk termination_b_type='interface' %}?return_url={{ request.path }}" class="dropdown-item text-success">
             <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span>
@@ -321,8 +311,6 @@ FRONTPORT_BUTTONS = """
     <li><a href="{% url 'dcim:frontport_trace' pk=record.pk %}" class="dropdown-item text-primary"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
     {% include 'dcim/inc/cable_toggle_buttons.html' with cable=record.cable %}
 {% elif perms.dcim.add_cable %}
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-lan-connect" aria-hidden="true"></span>Mark installed</a></li>
     <li>
         <a href="{% url 'dcim:frontport_connect' termination_a_id=record.pk termination_b_type='interface' %}?return_url={{ request.path }}" class="dropdown-item text-success">
             <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span>
@@ -367,8 +355,6 @@ REARPORT_BUTTONS = """
     <li><a href="{% url 'dcim:rearport_trace' pk=record.pk %}" class="dropdown-item text-primary"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
     {% include 'dcim/inc/cable_toggle_buttons.html' with cable=record.cable %}
 {% elif perms.dcim.add_cable %}
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>Trace</a></li>
-    <li><a class="dropdown-item disabled" aria-disabled="true"><span class="mdi mdi-lan-connect" aria-hidden="true"></span>Mark installed</a></li>
     <li>
         <a href="{% url 'dcim:rearport_connect' termination_a_id=record.pk termination_b_type='interface' %}?return_url={{ request.path }}" class="dropdown-item text-success">
             <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span>

--- a/nautobot/dcim/templates/dcim/inc/cable_toggle_buttons.html
+++ b/nautobot/dcim/templates/dcim/inc/cable_toggle_buttons.html
@@ -2,15 +2,15 @@
     {% if cable.status.name == 'Connected' %}
         <li>
             <a href="#" class="dropdown-item text-warning cable-toggle connected" data="{{ cable.pk }}">
-                <span class="mdi mdi-lan-disconnect" aria-hidden="true"></span>
-                Mark planned
+                <span class="mdi mdi-lan-pending" aria-hidden="true"></span>
+                Mark cable as Planned
             </a>
         </li>
     {% else %}
         <li>
             <a href="#" class="dropdown-item text-success cable-toggle" data="{{ cable.pk }}">
                 <span class="mdi mdi-lan-connect" aria-hidden="true"></span>
-                Mark installed
+                Mark cable as Connected
             </a>
         </li>
     {% endif %}

--- a/nautobot/project-static/js/connection_toggles.js
+++ b/nautobot/project-static/js/connection_toggles.js
@@ -1,47 +1,64 @@
-function toggleConnection(elem) {
-    var url = nautobot_api_path + "dcim/cables/" + elem.attr('data') + "/";
-    elem.tooltip("destroy");
-    if (elem.hasClass('connected')) {
-        $.ajax({
-            url: url,
-            method: 'PATCH',
-            contentType: "application/json",
-            dataType: 'json',
-            beforeSend: function(xhr, settings) {
-                xhr.setRequestHeader("X-CSRFToken", nautobot_csrf_token);
-            },
-            data: JSON.stringify({'status': 'Planned'}),
-            context: this,
-            success: function() {
-                elem.parents('tr').removeClass('success').addClass('info');
-                elem.removeClass('connected btn-warning').addClass('btn-success');
-                elem.attr('title', 'Mark installed');
-                elem.children('i').removeClass('mdi mdi-lan-disconnect').addClass('mdi mdi-lan-connect')
-                elem.tooltip("show");
-            }
-        });
-    } else {
-        $.ajax({
-            url: url,
-            method: 'PATCH',
-            contentType: "application/json",
-            dataType: 'json',
-            beforeSend: function(xhr, settings) {
-                xhr.setRequestHeader("X-CSRFToken", nautobot_csrf_token);
-            },
-            data: JSON.stringify({'status': 'Connected'}),
-            context: this,
-            success: function() {
-                elem.parents('tr').removeClass('info').addClass('success');
-                elem.removeClass('btn-success').addClass('connected btn-warning');
-                elem.attr('title', 'Mark planned');
-                elem.children('i').removeClass('mdi mdi-lan-connect').addClass('mdi mdi-lan-disconnect')
-                elem.tooltip("show");
-            }
-        });
+function setLabel(elem, icon, text) {
+    elem.textContent = '';
+    if (icon) {
+        elem.appendChild(icon);
     }
+    elem.appendChild(document.createTextNode(' ' + text));
+}
+
+function toggleConnection(elem) {
+    const url = nautobot_api_path + "dcim/cables/" + elem.getAttribute('data') + "/";
+    const isConnected = elem.classList.contains('connected');
+    const newStatus = isConnected ? 'Planned' : 'Connected';
+
+    fetch(url, {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-CSRFToken': nautobot_csrf_token,
+        },
+        body: JSON.stringify({status: newStatus}),
+    }).then(function(response) {
+        if (!response.ok) {
+            return;
+        }
+        const row = elem.closest('tr');
+        const icon = elem.querySelector(':scope > span');
+        if (isConnected) {
+            if (row) {
+                row.classList.remove('table-success');
+                row.classList.add('table-info');
+            }
+            elem.classList.remove('connected', 'text-warning');
+            elem.classList.add('text-success');
+            if (icon) {
+                icon.classList.remove('mdi-lan-pending');
+                icon.classList.add('mdi-lan-connect');
+            }
+            setLabel(elem, icon, 'Mark cable as Connected');
+        } else {
+            if (row) {
+                row.classList.remove('table-info');
+                row.classList.add('table-success');
+            }
+            elem.classList.remove('text-success');
+            elem.classList.add('connected', 'text-warning');
+            if (icon) {
+                icon.classList.remove('mdi-lan-connect');
+                icon.classList.add('mdi-lan-pending');
+            }
+            setLabel(elem, icon, 'Mark cable as Planned');
+        }
+    });
     return false;
 }
-$(".cable-toggle").click(function() {
-    return toggleConnection($(this));
+
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.cable-toggle').forEach(function(elem) {
+        elem.addEventListener('click', function(event) {
+            event.preventDefault();
+            toggleConnection(elem);
+        });
+    });
 });

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -258,37 +258,6 @@ function initializeVLANModeSelection(context) {
     });
 }
 
-function initializeSortableList(context){
-    this_context = $(context);
-    // Rearrange options within a <select> list
-    this_context.find('#move-option-up').bind('click', function() {
-        var select_id = '#' + $(this).attr('data-target');
-        $(select_id + ' option:selected').each(function () {
-            var newPos = $(select_id + ' option').index(this) - 1;
-            if (newPos > -1) {
-                $(select_id + ' option').eq(newPos).before("<option value='" + $(this).val() + "' selected='selected'>" + $(this).text() + "</option>");
-                $(this).remove();
-            }
-        });
-    });
-    this_context.find('#move-option-down').bind('click', function() {
-        var select_id = '#' + $(this).attr('data-target');
-        var countOptions = $(select_id + ' option').length;
-        var countSelectedOptions = $(select_id + ' option:selected').length;
-        $(select_id + ' option:selected').each(function () {
-            var newPos = $(select_id + ' option').index(this) + countSelectedOptions;
-            if (newPos < countOptions) {
-                $(select_id + ' option').eq(newPos).after("<option value='" + $(this).val() + "' selected='selected'>" + $(this).text() + "</option>");
-                $(this).remove();
-            }
-        });
-    });
-    this_context.find('#select-all-options').bind('click', function() {
-        var select_id = '#' + $(this).attr('data-target');
-        $(select_id + ' option').prop('selected',true);
-    });
-}
-
 function initializeImagePreview(context){
     this_context = $(context);
     // Offset between the preview window and the window edges
@@ -345,7 +314,6 @@ function initializeInputs(context) {
     initializeBulkEditNullification(this_context)
     initializeDateTimePicker(this_context)
     initializeVLANModeSelection(this_context)
-    initializeSortableList(this_context)
     initializeImagePreview(this_context)
 
     window.nb.checkbox.initializeCheckboxes()


### PR DESCRIPTION
# Closes #8969 
# What's Changed

- Update icon and text to clarify the meaning of the "Mark planned" and "Mark installed" actions
- Rewrite `connection_toggles.js` to remove jQuery usage and fix the logic to address breakage that we missed when moving to Bootstrap 5.x. (fix for #8969)
- Remove unnecessary always-disabled menu entries for non-cabled interfaces, front-ports, etc.
- Add "View change log" menu entry to all device-component tables
- Add `verbose_name` to "Edit" and "Delete" menu entries globally for clarity.
- Update `nautobot-migrate-bootstrap-v3-to-v5` to inspect JS files as well.
- Remove some dead code.

# Screenshots

## Before

<img width="257" height="205" alt="image" src="https://github.com/user-attachments/assets/5d2dee48-dd33-46f9-a8c5-70fb756c27cf" />

<img width="270" height="306" alt="image" src="https://github.com/user-attachments/assets/ee78e704-c83b-4154-b16b-f5a929877931" />

## After

<img width="254" height="236" alt="image" src="https://github.com/user-attachments/assets/de5aaee5-3f51-43d1-a854-cfb95661aeff" />

<img width="263" height="263" alt="image" src="https://github.com/user-attachments/assets/f7de4229-eaf0-437e-82ef-a5446f9bb1dd" />



<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
