### PR TITLE
Added guard for missing auto-field source attribute in forms.js

### DIFF
--- a/changes/8972.fixed
+++ b/changes/8972.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where form auto-population logic in `forms.js` would crash when a form contained an `id_slug` or `id_key` field without a `slug-source` attribute, silently breaking downstream form initialization (including Flatpickr date/time pickers) on affected pages such as the API Token create form.

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -54,6 +54,10 @@ function watchSourceFields(context, targetField, sourceFields, repopulate){
     sourceFields.forEach(function(sourceFieldName){
         const sourceFieldId = `id_${sourceFieldName}`;
         const sourceField = context.getElementById(sourceFieldId);
+        if (!sourceField) {
+            // Skip missing source fields so partial/conditional form layouts don't break global form initialization.
+            return;
+        }
         const onFieldUpdate = function(){ repopulateIfChanged(targetField, repopulate)}
         sourceField.addEventListener('keyup', onFieldUpdate)
         sourceField.addEventListener('change', onFieldUpdate)
@@ -63,6 +67,10 @@ function watchSourceFields(context, targetField, sourceFields, repopulate){
 function watchRegenerateButton(context, targetField, repopulate){
     // If user clicks the "regenerate" button, set target field to be auto-populate again
     const regenerateButton = context.querySelector(`[data-regenerate=${targetField.getAttribute('id')}]`)
+    if (!regenerateButton) {
+        // Regenerate button is optional; skip binding when the control isn't rendered for this field.
+        return;
+    }
     regenerateButton.addEventListener('click', repopulate)
 }
 
@@ -78,7 +86,12 @@ function getSlugField(){
 
 function initializeAutoField(context, field, sourceFieldsAttrName, defaultMaxLength = 255, transformValue = null){
     // Get source fields and length values set as html attributes on given field
-    const sourceFields = field.getAttribute(sourceFieldsAttrName).split(" ");
+    const sourceFieldsAttr = field.getAttribute(sourceFieldsAttrName);
+    if (!sourceFieldsAttr) {
+        // Guard `id_key`/similar non-slug fields (e.g. API Token key) with no source attribute to avoid `.split(null)` crashes.
+        return;
+    }
+    const sourceFields = sourceFieldsAttr.split(" ");
     const length = field.getAttribute('maxlength') || defaultMaxLength
 
     // Prepare repopulate function with custom source fields and length set on this field


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes 
[[NBOTQA-58]](https://networktocode.atlassian.net/browse/NBOTQA-58)
# What's Changed
**Title**
Fix forms.js crash when slug/key field has no source attribute
**Why**
forms.js runs on every Nautobot edit form. If any step throws, all later steps (including Flatpickr date pickers) silently stop running.
**Three spots assumed DOM state that isn't always there:**

initializeAutoField→null.split(" ")when a field has noslug-sourceattribute.
watchSourceFields→addEventListeneron a missing source field.
watchRegenerateButton→addEventListeneron a missing regenerate button.
**How it surfaced**
Token add page: expires field rendered as plain text instead of a calendar. The Token form has an id_key field with no slug-source, which made getSlugField() fall back to it and crash on .split(null). Flatpickr never initialized. Edit page worked only because key is popped on edit.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design


[NBOTQA-58]: https://networktocode.atlassian.net/browse/NBOTQA-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ