### PR TITLE
fixed list view exception when filterset_class is not defined

### DIFF
--- a/changes/8976.fixed
+++ b/changes/8976.fixed
@@ -1,0 +1,1 @@
+Fixed an exception when rendering an object list view whose viewset has no `filterset_class` configured.

--- a/nautobot/core/tests/test_renderers.py
+++ b/nautobot/core/tests/test_renderers.py
@@ -4,6 +4,7 @@ from django.test import override_settings, RequestFactory
 from django.urls import reverse
 from rest_framework.response import Response
 
+from nautobot.circuits.views import ProviderUIViewSet
 from nautobot.cloud.views import CloudResourceTypeUIViewSet
 from nautobot.core.testing import TestCase
 from nautobot.core.ui.titles import Titles
@@ -57,3 +58,17 @@ class ObjectListViewTitlesTest(TestCase):
             # Finally, render the view and verify the title appears in the response
             response = self.client.get(path)
             self.assertContains(response, "Burritos")
+
+
+class NautobotHTMLRendererFilterSetNoneTest(TestCase):
+    user_permissions = ["circuits.view_provider", "circuits.view_circuit"]
+
+    def test_filterset_class_none(self):
+        """Assert that the list view loads when filterset and filterset form are None."""
+        url = reverse("circuits:provider_list")
+        with (
+            patch.object(ProviderUIViewSet, "filterset_class", None),
+            patch.object(ProviderUIViewSet, "filterset_form_class", None),
+        ):
+            response = self.client.get(url)
+            self.assertHttpStatus(response, 200)

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -50,14 +50,14 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
         Helper function to obtain the filter_form_class,
         and then initialize and return the filter_form used in the ObjectListView UI.
         """
+        if not filterset_class:
+            return None
         factory_formset_params = {}
-        filterset = None
-        if filterset_class:
-            filterset = filterset_class()
-            factory_formset_params = convert_querydict_to_factory_formset_acceptable_querydict(
-                view.filter_params if view.filter_params is not None else request.GET, filterset
-            )
-            return DynamicFilterFormSet(filterset=filterset, data=factory_formset_params)
+        filterset = filterset_class()
+        factory_formset_params = convert_querydict_to_factory_formset_acceptable_querydict(
+            view.filter_params if view.filter_params is not None else request.GET, filterset
+        )
+        return DynamicFilterFormSet(filterset=filterset, data=factory_formset_params)
 
     def construct_user_permissions(self, request, model):
         """

--- a/nautobot/core/views/renderers.py
+++ b/nautobot/core/views/renderers.py
@@ -57,7 +57,7 @@ class NautobotHTMLRenderer(renderers.BrowsableAPIRenderer):
             factory_formset_params = convert_querydict_to_factory_formset_acceptable_querydict(
                 view.filter_params if view.filter_params is not None else request.GET, filterset
             )
-        return DynamicFilterFormSet(filterset=filterset, data=factory_formset_params)
+            return DynamicFilterFormSet(filterset=filterset, data=factory_formset_params)
 
     def construct_user_permissions(self, request, model):
         """


### PR DESCRIPTION
# What's Changed

We check for `if dynamic_filter_form` in the template here:
https://github.com/nautobot/nautobot/blob/a555d4a6a8720369f43472c6ae22eb3ce88746d2/nautobot/core/templates/generic/object_list.html#L117

And here:
https://github.com/nautobot/nautobot/blob/a555d4a6a8720369f43472c6ae22eb3ce88746d2/nautobot/core/templates/utilities/templatetags/filter_form_drawer.html#L19

But the html renderer never returns a falsey object for `dynamic_filter_form` so `filterset_class` is required to use the ObjectListViewMixin or NautobotUIViewSet. This fixes that bug.

I confirmed that this behaves as expected when removing `filterset_class` or `filterset_form_class` (or both) from the viewset. If `filterset_form_class` is None, the basic filter form tab is not rendered in the drawer and it defaults to the advanced form. If `filterset_class` is None, the filter button is not rendered and if the drawer is opened manually through the console, it's empty.


# TODO
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s)
- [x] Unit, Integration Tests
