### PR TITLE
Fixed Git Repository Job loading

### DIFF
--- a/changes/8988.fixed
+++ b/changes/8988.fixed
@@ -1,0 +1,1 @@
+Fixed Git Repository Job loading producing multiple class objects for the same source file, which caused `isinstance` checks against shared classes to return false negatives.

--- a/nautobot/core/tests/test_utils.py
+++ b/nautobot/core/tests/test_utils.py
@@ -1,4 +1,6 @@
+import os
 import sys
+import tempfile
 from unittest import mock
 import uuid
 
@@ -20,7 +22,11 @@ from nautobot.core.testing import TestCase
 from nautobot.core.utils import data as data_utils, filtering, lookup, querysets, requests
 from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.migrations import update_object_change_ct_for_replaced_models
-from nautobot.core.utils.module_loading import check_name_safe_to_import_privately, import_string_optional
+from nautobot.core.utils.module_loading import (
+    check_name_safe_to_import_privately,
+    import_modules_privately,
+    import_string_optional,
+)
 from nautobot.data_validation import models as data_validation_models
 from nautobot.dcim import (
     filters as dcim_filters,
@@ -1212,6 +1218,78 @@ class TestModuleLoadingUtils(TestCase):
             self.assertEqual(
                 import_string_optional("nautobot.core.tests.test_utils.TestModuleLoadingUtils"), self.__class__
             )
+
+    def _write_consumer_shared_fixture(self, package_dir):
+        """
+        Write the minimal 3-file fixture that exposes class-identity divergence.
+
+        `consumer.py` sorts before `shared.py` alphabetically, so the walker re-execs
+        `shared.py` after `consumer.py` has already captured `Widget`.
+        """
+        os.makedirs(package_dir, exist_ok=True)
+        with open(os.path.join(package_dir, "__init__.py"), "w"):
+            pass
+        with open(os.path.join(package_dir, "consumer.py"), "w") as fd:
+            fd.write("from .shared import Widget\nCAPTURED = Widget\n")
+        with open(os.path.join(package_dir, "shared.py"), "w") as fd:
+            fd.write("class Widget:\n    pass\n")
+
+    def _clear_test_modules(self, *prefixes):
+        for cached in list(sys.modules):
+            if any(cached == prefix or cached.startswith(f"{prefix}.") for prefix in prefixes):
+                del sys.modules[cached]
+
+    def test_import_modules_privately_preserves_class_identity(self):
+        """
+        Regression test for NTC-5779: a class imported by one sibling module and re-defined by the
+        walker on a subsequent iteration must remain a single object identity in sys.modules after
+        the loader returns.
+        """
+        package_name = f"pkg_{uuid.uuid4().hex[:8]}"
+        try:
+            with tempfile.TemporaryDirectory() as tempdir:
+                self._write_consumer_shared_fixture(os.path.join(tempdir, package_name))
+                import_modules_privately(tempdir)
+
+                consumer_module = sys.modules[f"{package_name}.consumer"]
+                shared_module = sys.modules[f"{package_name}.shared"]
+
+                self.assertIs(consumer_module.CAPTURED, shared_module.Widget)
+                self.assertIsInstance(consumer_module.CAPTURED(), shared_module.Widget)
+        finally:
+            self._clear_test_modules(package_name)
+
+    def test_import_modules_privately_module_path_filter_preserves_class_identity(self):
+        """
+        Same invariant as above, but with `module_path=[outer, pkg]` filtering, and an
+        unrelated sibling package that should not be touched by the loader.
+        """
+        outer_name = f"outer_{uuid.uuid4().hex[:8]}"
+        sibling_name = f"sibling_{uuid.uuid4().hex[:8]}"
+        try:
+            with tempfile.TemporaryDirectory() as tempdir:
+                outer_dir = os.path.join(tempdir, outer_name)
+                os.makedirs(outer_dir)
+                with open(os.path.join(outer_dir, "__init__.py"), "w"):
+                    pass
+                self._write_consumer_shared_fixture(os.path.join(outer_dir, "pkg"))
+
+                sibling_dir = os.path.join(tempdir, sibling_name)
+                os.makedirs(sibling_dir)
+                with open(os.path.join(sibling_dir, "__init__.py"), "w"):
+                    pass
+                with open(os.path.join(sibling_dir, "should_not_load.py"), "w") as fd:
+                    fd.write("LOADED = True\n")
+
+                import_modules_privately(tempdir, module_path=[outer_name, "pkg"])
+
+                consumer_module = sys.modules[f"{outer_name}.pkg.consumer"]
+                shared_module = sys.modules[f"{outer_name}.pkg.shared"]
+                self.assertIs(consumer_module.CAPTURED, shared_module.Widget)
+
+                self.assertNotIn(f"{sibling_name}.should_not_load", sys.modules)
+        finally:
+            self._clear_test_modules(outer_name, sibling_name)
 
 
 class TestQuerySetUtils(TestCase):

--- a/nautobot/core/tests/test_utils.py
+++ b/nautobot/core/tests/test_utils.py
@@ -1291,6 +1291,69 @@ class TestModuleLoadingUtils(TestCase):
         finally:
             self._clear_test_modules(outer_name, sibling_name)
 
+    def test_import_modules_privately_cleans_up_deleted_submodules(self):
+        """
+        Loading a package with a submodule, deleting that submodule from disk, and reloading should
+        remove the stale entry from sys.modules so subsequent isinstance/import lookups don't see it.
+        """
+        package_name = f"pkg_{uuid.uuid4().hex[:8]}"
+        submodule = f"{package_name}.removable"
+        try:
+            with tempfile.TemporaryDirectory() as tempdir:
+                package_dir = os.path.join(tempdir, package_name)
+                os.makedirs(package_dir)
+                with open(os.path.join(package_dir, "__init__.py"), "w"):
+                    pass
+                removable_path = os.path.join(package_dir, "removable.py")
+                with open(removable_path, "w") as fd:
+                    fd.write("VALUE = 1\n")
+
+                import_modules_privately(tempdir)
+                self.assertIn(submodule, sys.modules)
+                self.assertEqual(sys.modules[submodule].VALUE, 1)
+
+                os.remove(removable_path)
+                import_modules_privately(tempdir)
+                self.assertNotIn(submodule, sys.modules)
+                self.assertIn(package_name, sys.modules)
+        finally:
+            self._clear_test_modules(package_name)
+
+    def test_import_modules_privately_raises_when_ignore_import_errors_false(self):
+        """
+        With ignore_import_errors=False, exceptions raised by either the top-level cascade
+        (Phase 3) or the leaf-sweep (Phase 4) must propagate to the caller.
+        """
+        with self.subTest("Top-level package import error propagates"):
+            package_name = f"pkg_{uuid.uuid4().hex[:8]}"
+            try:
+                with tempfile.TemporaryDirectory() as tempdir:
+                    package_dir = os.path.join(tempdir, package_name)
+                    os.makedirs(package_dir)
+                    with open(os.path.join(package_dir, "__init__.py"), "w") as fd:
+                        fd.write("raise ValueError('boom from __init__')\n")
+                    with self.assertRaisesRegex(ValueError, "boom from __init__"):
+                        import_modules_privately(tempdir, ignore_import_errors=False)
+                    # Same scenario with ignore_import_errors=True should swallow the exception.
+                    self.assertEqual(import_modules_privately(tempdir), [])
+            finally:
+                self._clear_test_modules(package_name)
+
+        with self.subTest("Leaf-sweep import error propagates"):
+            package_name = f"pkg_{uuid.uuid4().hex[:8]}"
+            try:
+                with tempfile.TemporaryDirectory() as tempdir:
+                    package_dir = os.path.join(tempdir, package_name)
+                    os.makedirs(package_dir)
+                    with open(os.path.join(package_dir, "__init__.py"), "w"):
+                        pass
+                    with open(os.path.join(package_dir, "leaf.py"), "w") as fd:
+                        fd.write("raise ValueError('boom from leaf')\n")
+                    with self.assertRaisesRegex(ValueError, "boom from leaf"):
+                        import_modules_privately(tempdir, ignore_import_errors=False)
+            finally:
+                self._clear_test_modules(package_name)
+
 
 class TestQuerySetUtils(TestCase):
     def test_maybe_select_related(self):

--- a/nautobot/core/utils/module_loading.py
+++ b/nautobot/core/utils/module_loading.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 import importlib
-from importlib.util import find_spec, module_from_spec
+from importlib.util import find_spec
 from keyword import iskeyword
 import logging
 import os
@@ -49,15 +49,6 @@ def _temporarily_add_to_sys_path(path):
         sys.path = old_sys_path
 
 
-def clear_module_from_sys_modules(module_name):
-    """
-    Remove the module and all its submodules from sys.modules.
-    """
-    for name in list(sys.modules.keys()):
-        if name == module_name or name.startswith(f"{module_name}."):
-            del sys.modules[name]
-
-
 def check_name_safe_to_import_privately(name: str) -> tuple[bool, str]:
     """
     Make sure the given package/module name is "safe" to import from the filesystem.
@@ -87,6 +78,15 @@ def import_modules_privately(path, module_path=None, ignore_import_errors=True):
     This is used for importing Jobs from `JOBS_ROOT` and `GIT_ROOT` in such a way that they remain relatively
     self-contained and can be easily discarded and reloaded on the fly.
 
+    Loading is done in four phases so that every class defined under `path` has exactly one object identity
+    in `sys.modules` regardless of import order or where `register_jobs(...)` calls live in user code:
+
+    1. Discover every module name under `path` (filtered by `module_path` if set) without importing.
+    2. Bulk-clear all discovered names from `sys.modules` so there is no mixed-generation window.
+    3. Import each top-level discovered name via the standard import machinery, letting transitive
+       `from X import Y` cascades resolve to one consistent object per module.
+    4. Sweep any discovered modules the cascade did not transitively load.
+
     If you find yourself writing new code that uses this method, please pause and reconsider your life choices.
 
     Args:
@@ -96,52 +96,67 @@ def import_modules_privately(path, module_path=None, ignore_import_errors=True):
         ignore_import_errors (bool): Exceptions raised while importing modules will be caught and logged.
             If this is set as False, they will then be re-raised to be handled by the caller of this function.
     """
-    if module_path is None:
-        module_prefix = None
-    else:
-        module_prefix = ".".join(module_path)
+    module_prefix = ".".join(module_path) if module_path else None
 
-    loaded_modules = []
     with _import_lock, _temporarily_add_to_sys_path(path):
-        for finder, discovered_module_name, is_package in pkgutil.walk_packages([path], onerror=logger.error):
+        # Phase 1: discover module names without importing.
+        discovered = []
+        for _finder, name, _is_package in pkgutil.walk_packages([path], onerror=logger.error):
             if module_prefix and not (
-                module_prefix.startswith(f"{discovered_module_name}.")  # my_repo/__init__.py
-                or discovered_module_name == module_prefix  # my_repo/jobs.py
-                or discovered_module_name.startswith(f"{module_prefix}.")  # my_repo/jobs/foobar.py
+                module_prefix.startswith(f"{name}.")  # ancestor of the target, e.g. my_repo/__init__.py
+                or name == module_prefix  # exact match, e.g. my_repo/jobs.py
+                or name.startswith(f"{module_prefix}.")  # descendant, e.g. my_repo/jobs/foobar.py
             ):
                 continue
             try:
-                existing_module = find_spec(discovered_module_name)
+                existing_module = find_spec(name)
             except (ModuleNotFoundError, ValueError):
                 existing_module = None
-            if existing_module is not None:
+            if existing_module is not None and existing_module.origin:
                 existing_module_path = os.path.realpath(existing_module.origin)
                 if not existing_module_path.startswith(path):
                     logger.error(
                         "Unable to load module %s from %s as it conflicts with existing module %s",
-                        discovered_module_name,
+                        name,
                         path,
                         existing_module_path,
                     )
                     continue
+            discovered.append(name)
 
-            if discovered_module_name in sys.modules:
-                clear_module_from_sys_modules(discovered_module_name)
+        if not discovered:
+            return []
 
+        # Phase 2: single bulk clear of every name we are about to load.
+        discovered_set = set(discovered)
+        for cached in list(sys.modules):
+            if cached in discovered_set or any(cached.startswith(f"{n}.") for n in discovered):
+                del sys.modules[cached]
+
+        loaded_modules = []
+
+        # Phase 3: import each top-level discovered name once. Python's import machinery resolves
+        # transitive `from X import Y` cascades, so every shared dependency lands in sys.modules
+        # exactly once.
+        top_level_names = sorted({n for n in discovered if "." not in n})
+        for name in top_level_names:
             try:
-                if not is_package:
-                    spec = finder.find_spec(discovered_module_name)
-                    if spec is None:
-                        raise ValueError("Unable to find module spec")
-                    module = module_from_spec(spec)
-                    sys.modules[discovered_module_name] = module
-                    spec.loader.exec_module(module)
-                else:
-                    module = importlib.import_module(discovered_module_name)
-                importlib.reload(module)
-                loaded_modules.append(module)
+                loaded_modules.append(importlib.import_module(name))
             except Exception as exc:
-                logger.error("Unable to load module %s from %s: %s", discovered_module_name, path, exc)
+                logger.error("Unable to load module %s from %s: %s", name, path, exc)
+                if not ignore_import_errors:
+                    raise
+
+        # Phase 4: any discovered module the cascade did not transitively touch is loaded here.
+        # By now sys.modules has consistent versions of every shared dependency, so these cannot
+        # create divergent class objects.
+        for name in discovered:
+            if name in sys.modules:
+                continue
+            try:
+                loaded_modules.append(importlib.import_module(name))
+            except Exception as exc:
+                logger.error("Unable to load module %s from %s: %s", name, path, exc)
                 if not ignore_import_errors:
                     raise
 

--- a/nautobot/docs/development/jobs/job-structure.md
+++ b/nautobot/docs/development/jobs/job-structure.md
@@ -53,7 +53,7 @@ register_jobs(CleanupDevices, SyncInventory)
 ### Where to Register
 
 - For files in `JOBS_ROOT`, register Jobs directly in the file or from a top-level `__init__.py` that imports submodules.
-- For Git-based Jobs, use the `jobs/__init__.py` file in the repo to register all your Job classes.
+- For Git-based Jobs, registering all Job classes from `jobs/__init__.py` is the recommended pattern, since it gives the repository a single source of truth for which Jobs it exposes.
 - For App-based Jobs, register them in the module defined by your App's `NautobotAppConfig.jobs` property (default: `jobs`).
 
 If you don't call `register_jobs()`, Nautobot will skip your class during startup, even if it's defined correctly.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8988
# What's Changed
This PR changes how we dynamically load python modules from git repositories. It changes the flow from directly importing and clearing during discovery to a flow that discovers all modules to import first, deduplicates the list, removes all duplicates from `sys.modules` and then finally imports them afterward (starting with top-level imports first and idempotently importing sub-modules after). This ensures that only a single copy of each items gets imported.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
|Before|After|
|-|-|
|<img width="1133" height="607" alt="Screenshot 2026-05-19 at 3 57 59 PM" src="https://github.com/user-attachments/assets/70262ae8-efa1-49f6-bd63-5051977a466d" />|<img width="1343" height="793" alt="Screenshot 2026-05-19 at 3 58 16 PM" src="https://github.com/user-attachments/assets/49761ece-95e8-46c6-bb02-fafb2abed25c" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)

NTC-5779