### PR TITLE
Fixed creating ObjectChanges during bulk delete

### DIFF
--- a/changes/8658.fixed
+++ b/changes/8658.fixed
@@ -1,0 +1,1 @@
+Fixed bulk delete operations not creating ObjectChange records for CASCADE-deleted child objects.

--- a/nautobot/extras/tests/test_context_managers.py
+++ b/nautobot/extras/tests/test_context_managers.py
@@ -23,7 +23,7 @@ from nautobot.extras.context_managers import (
     deferred_change_logging_for_bulk_operation,
     web_request_context,
 )
-from nautobot.extras.models import JobHook, Status, Webhook
+from nautobot.extras.models import Contact, ContactAssociation, JobHook, Note, Role, Status, Webhook
 from nautobot.extras.utils import bulk_delete_with_bulk_change_logging
 
 # Use the proper swappable User model
@@ -306,6 +306,79 @@ class BulkEditDeleteChangeLogging(TestCase):
         self.assertEqual(oc_list[0].action, ObjectChangeActionChoices.ACTION_DELETE)
         self.assertEqual(oc_list[0].user, self.user)
         self.assertEqual(oc_list[0].user_name, self.user.username)
+
+    def test_bulk_delete_logs_cascade_children(self):
+        """Bulk delete should log ObjectChanges for CASCADE-deleted child rows, not just queryset members."""
+        location_type = LocationType.objects.get(name="Campus")
+        location_status = Status.objects.get_for_model(Location).first()
+        parent = Location.objects.create(name="Parent BulkDelete", location_type=location_type, status=location_status)
+        child_a = Location.objects.create(
+            name="Child A", location_type=location_type, status=location_status, parent=parent
+        )
+        child_b = Location.objects.create(
+            name="Child B", location_type=location_type, status=location_status, parent=parent
+        )
+        parent_pk, child_a_pk, child_b_pk = parent.pk, child_a.pk, child_b.pk
+
+        with web_request_context(self.user):
+            bulk_delete_with_bulk_change_logging(Location.objects.filter(pk=parent_pk))
+
+        delete_changes = get_changes_for_model(Location).filter(
+            action=ObjectChangeActionChoices.ACTION_DELETE,
+            changed_object_id__in=[parent_pk, child_a_pk, child_b_pk],
+        )
+        self.assertEqual(delete_changes.count(), 3)
+        request_ids = {oc.request_id for oc in delete_changes}
+        self.assertEqual(len(request_ids), 1, "all cascade deletes should share the same request_id")
+        for oc in delete_changes:
+            self.assertEqual(oc.user, self.user)
+            self.assertEqual(oc.user_name, self.user.username)
+
+    def test_bulk_delete_logs_contact_associations(self):
+        """Bulk delete should log an ObjectChange for ContactAssociations the receiver cleans up."""
+        location_type = LocationType.objects.get(name="Campus")
+        location_status = Status.objects.get_for_model(Location).first()
+        location = Location.objects.create(
+            name="Location With Contact", location_type=location_type, status=location_status
+        )
+        contact = Contact.objects.create(name="Test Contact")
+        assoc_role = Role.objects.get_for_model(ContactAssociation).first()
+        assoc_status = Status.objects.get_for_model(ContactAssociation).first()
+        association = ContactAssociation.objects.create(
+            contact=contact,
+            associated_object=location,
+            role=assoc_role,
+            status=assoc_status,
+        )
+        association_pk = association.pk
+
+        with web_request_context(self.user):
+            bulk_delete_with_bulk_change_logging(Location.objects.filter(pk=location.pk))
+
+        assoc_changes = get_changes_for_model(ContactAssociation).filter(
+            action=ObjectChangeActionChoices.ACTION_DELETE, changed_object_id=association_pk
+        )
+        self.assertEqual(assoc_changes.count(), 1)
+        self.assertEqual(assoc_changes.first().user, self.user)
+
+    def test_bulk_delete_logs_notes(self):
+        """Bulk delete should log an ObjectChange for Notes the receiver cleans up."""
+        location_type = LocationType.objects.get(name="Campus")
+        location_status = Status.objects.get_for_model(Location).first()
+        location = Location.objects.create(
+            name="Location With Note", location_type=location_type, status=location_status
+        )
+        note = Note.objects.create(assigned_object=location, user=self.user, note="A note on this location")
+        note_pk = note.pk
+
+        with web_request_context(self.user):
+            bulk_delete_with_bulk_change_logging(Location.objects.filter(pk=location.pk))
+
+        note_changes = get_changes_for_model(Note).filter(
+            action=ObjectChangeActionChoices.ACTION_DELETE, changed_object_id=note_pk
+        )
+        self.assertEqual(note_changes.count(), 1)
+        self.assertEqual(note_changes.first().user, self.user)
 
     def test_create_then_update(self):
         """Test that a create followed by an update is logged as a single create"""

--- a/nautobot/extras/tests/test_context_managers.py
+++ b/nautobot/extras/tests/test_context_managers.py
@@ -1,4 +1,5 @@
 from unittest import mock
+import uuid
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
@@ -318,18 +319,17 @@ class BulkEditDeleteChangeLogging(TestCase):
         child_b = Location.objects.create(
             name="Child B", location_type=location_type, status=location_status, parent=parent
         )
-        parent_pk, child_a_pk, child_b_pk = parent.pk, child_a.pk, child_b.pk
+        expected_pks = {parent.pk, child_a.pk, child_b.pk}
 
-        with web_request_context(self.user):
-            bulk_delete_with_bulk_change_logging(Location.objects.filter(pk=parent_pk))
+        change_id = uuid.uuid4()
+        with web_request_context(self.user, change_id=change_id):
+            bulk_delete_with_bulk_change_logging(Location.objects.filter(pk=parent.pk))
 
         delete_changes = get_changes_for_model(Location).filter(
             action=ObjectChangeActionChoices.ACTION_DELETE,
-            changed_object_id__in=[parent_pk, child_a_pk, child_b_pk],
+            request_id=change_id,
         )
-        self.assertEqual(delete_changes.count(), 3)
-        request_ids = {oc.request_id for oc in delete_changes}
-        self.assertEqual(len(request_ids), 1, "all cascade deletes should share the same request_id")
+        self.assertEqual({oc.changed_object_id for oc in delete_changes}, expected_pks)
         for oc in delete_changes:
             self.assertEqual(oc.user, self.user)
             self.assertEqual(oc.user_name, self.user.username)
@@ -352,13 +352,14 @@ class BulkEditDeleteChangeLogging(TestCase):
         )
         association_pk = association.pk
 
-        with web_request_context(self.user):
+        change_id = uuid.uuid4()
+        with web_request_context(self.user, change_id=change_id):
             bulk_delete_with_bulk_change_logging(Location.objects.filter(pk=location.pk))
 
         assoc_changes = get_changes_for_model(ContactAssociation).filter(
-            action=ObjectChangeActionChoices.ACTION_DELETE, changed_object_id=association_pk
+            action=ObjectChangeActionChoices.ACTION_DELETE, request_id=change_id
         )
-        self.assertEqual(assoc_changes.count(), 1)
+        self.assertEqual({oc.changed_object_id for oc in assoc_changes}, {association_pk})
         self.assertEqual(assoc_changes.first().user, self.user)
 
     def test_bulk_delete_logs_notes(self):
@@ -371,13 +372,14 @@ class BulkEditDeleteChangeLogging(TestCase):
         note = Note.objects.create(assigned_object=location, user=self.user, note="A note on this location")
         note_pk = note.pk
 
-        with web_request_context(self.user):
+        change_id = uuid.uuid4()
+        with web_request_context(self.user, change_id=change_id):
             bulk_delete_with_bulk_change_logging(Location.objects.filter(pk=location.pk))
 
         note_changes = get_changes_for_model(Note).filter(
-            action=ObjectChangeActionChoices.ACTION_DELETE, changed_object_id=note_pk
+            action=ObjectChangeActionChoices.ACTION_DELETE, request_id=change_id
         )
-        self.assertEqual(note_changes.count(), 1)
+        self.assertEqual({oc.changed_object_id for oc in note_changes}, {note_pk})
         self.assertEqual(note_changes.first().user, self.user)
 
     def test_create_then_update(self):

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -17,6 +17,7 @@ from django.core.cache import cache
 from django.core.validators import ValidationError
 from django.db import transaction
 from django.db.models import Model, Q
+from django.db.models.deletion import Collector
 from django.template.loader import get_template, TemplateDoesNotExist
 from django.utils.deconstruct import deconstructible
 import kubernetes.client
@@ -26,6 +27,7 @@ from nautobot.core.celery.encoders import NautobotKombuJSONEncoder
 from nautobot.core.choices import ColorChoices
 from nautobot.core.constants import CHARFIELD_MAX_LENGTH
 from nautobot.core.exceptions import FilterSetFieldNotFound
+from nautobot.core.models import BaseModel
 from nautobot.core.models.managers import TagsManager
 from nautobot.core.models.utils import find_models_with_matching_fields
 from nautobot.core.utils.cache import construct_cache_key
@@ -933,36 +935,90 @@ def migrate_role_data(
 
 def bulk_delete_with_bulk_change_logging(qs, batch_size=1000):
     """
-    Deletes objects in the provided queryset and creates ObjectChange instances in bulk to improve performance.
-    For use with bulk delete views. This operation is wrapped in an atomic transaction.
+    Delete objects in the provided queryset and create ObjectChange instances in bulk for performance.
+
+    In addition to logging the queryset members, this also logs every CASCADE-deleted child Django's
+    Collector would remove, plus any Note rows that the pre_delete signal handler cleans up.
+    Parents are processed in chunks of ``batch_size`` to keep peak memory bounded.
+    The whole operation is wrapped in an atomic transaction.
     """
-    from nautobot.extras.models import ObjectChange
+    # Lazy imports to avoid circular imports.
+    # extras.models and extras.signals transitively re-enter extras.utils during app load.
+    from nautobot.extras.models import Note, ObjectChange
     from nautobot.extras.signals import change_context_state
 
     change_context = change_context_state.get()
     if change_context is None:
         raise ValueError("Change logging must be enabled before using bulk_delete_with_bulk_change_logging")
 
+    user = change_context.get_user()
+    model = qs.model
+
+    def _build_objectchange(obj):
+        if not hasattr(obj, "to_objectchange"):
+            return None
+        oc = obj.to_objectchange(ObjectChangeActionChoices.ACTION_DELETE)
+        if oc is None:
+            return None
+        oc.user = user
+        oc.user_name = user.username if user is not None else ""
+        oc.request_id = change_context.change_id
+        oc.change_context = change_context.context
+        oc.change_context_detail = change_context.context_detail[:CHANGELOG_MAX_CHANGE_CONTEXT_DETAIL]
+        return oc
+
     with transaction.atomic():
         try:
-            queued_object_changes = []
             change_context.defer_object_changes = True
-            for obj in qs.iterator(chunk_size=1000):
-                if not hasattr(obj, "to_objectchange"):
-                    break
-                if len(queued_object_changes) >= batch_size:
-                    ObjectChange.objects.bulk_create(queued_object_changes)
-                    queued_object_changes = []
-                oc = obj.to_objectchange(ObjectChangeActionChoices.ACTION_DELETE)
-                if oc is not None:
-                    oc.user = change_context.get_user()
-                    oc.user_name = oc.user.username
-                    oc.request_id = change_context.change_id
-                    oc.change_context = change_context.context
-                    oc.change_context_detail = change_context.context_detail[:CHANGELOG_MAX_CHANGE_CONTEXT_DETAIL]
-                    queued_object_changes.append(oc)
-            ObjectChange.objects.bulk_create(queued_object_changes)
-            return qs.delete()
+
+            # Snapshot parent PKs first so deletes in earlier batches do not shift later ones.
+            parent_pks = list(qs.values_list("pk", flat=True))
+
+            total_deleted = 0
+            deleted_by_label = {}
+
+            for offset in range(0, len(parent_pks), batch_size):
+                batch_pks = parent_pks[offset : offset + batch_size]
+                batch_qs = model.objects.filter(pk__in=batch_pks)
+
+                # Collector identifies the parent rows and every row Django will CASCADE-delete for this batch.
+                collector = Collector(using=batch_qs.db)
+                collector.collect(list(batch_qs))
+
+                queued = []
+                ct_to_pks = {}
+
+                for cascade_model, instances in collector.data.items():
+                    if not issubclass(cascade_model, BaseModel):
+                        continue
+                    ct = ContentType.objects.get_for_model(cascade_model)
+                    pks = ct_to_pks.setdefault(ct, [])
+                    for obj in instances:
+                        pks.append(obj.pk)
+                        oc = _build_objectchange(obj)
+                        if oc is not None:
+                            queued.append(oc)
+
+                # Notes are not in Collector.data because NotesMixin does not declare a GenericRelation;
+                # the pre_delete signal handler removes them explicitly, so log them ourselves.
+                for ct, pks in ct_to_pks.items():
+                    for note in Note.objects.filter(assigned_object_type=ct, assigned_object_id__in=pks):
+                        oc = _build_objectchange(note)
+                        if oc is not None:
+                            queued.append(oc)
+
+                if queued:
+                    ObjectChange.objects.bulk_create(queued, batch_size=batch_size)
+
+                batch_deleted, batch_info = batch_qs.delete()
+                total_deleted += batch_deleted
+                for label, count in batch_info.items():
+                    deleted_by_label[label] = deleted_by_label.get(label, 0) + count
+
+                # Drop per-batch deferred entries so the dict does not grow across batches.
+                change_context.reset_deferred_object_changes()
+
+            return total_deleted, deleted_by_label
         finally:
             change_context.defer_object_changes = False
             change_context.reset_deferred_object_changes()

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -952,6 +952,10 @@ def bulk_delete_with_bulk_change_logging(qs, batch_size=1000):
         raise ValueError("Change logging must be enabled before using bulk_delete_with_bulk_change_logging")
 
     user = change_context.get_user()
+    user_name = user.username if user is not None else ""
+    request_id = change_context.change_id
+    context = change_context.context
+    context_detail = change_context.context_detail[:CHANGELOG_MAX_CHANGE_CONTEXT_DETAIL]
     model = qs.model
 
     def _build_objectchange(obj):
@@ -961,10 +965,10 @@ def bulk_delete_with_bulk_change_logging(qs, batch_size=1000):
         if oc is None:
             return None
         oc.user = user
-        oc.user_name = user.username if user is not None else ""
-        oc.request_id = change_context.change_id
-        oc.change_context = change_context.context
-        oc.change_context_detail = change_context.context_detail[:CHANGELOG_MAX_CHANGE_CONTEXT_DETAIL]
+        oc.user_name = user_name
+        oc.request_id = request_id
+        oc.change_context = context
+        oc.change_context_detail = context_detail
         return oc
 
     with transaction.atomic():

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -989,6 +989,9 @@ def bulk_delete_with_bulk_change_logging(qs, batch_size=1000):
                 ct_to_pks = {}
 
                 for cascade_model, instances in collector.data.items():
+                    # Gate on BaseModel (not ChangeLoggedModel) because BaseModel is what guarantees a UUID pk,
+                    # which the Note discovery below relies on. Whether a given object actually gets an ObjectChange
+                    # is decided by the guard in _build_objectchange.
                     if not issubclass(cascade_model, BaseModel):
                         continue
                     ct = ContentType.objects.get_for_model(cascade_model)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8658
# What's Changed
During bulk delete operations, we are setting `defer_object_changes = True` to disable individual ObjectChange creation and bulk creating our own objects instead. Afterward we set `defer_object_changes = False` to re-enable them and then `reset_deferred_object_changes()` to clear out the duplicates that would have been created.

The current implementation only bulk creates ObjectChange objects for the provided queryset. This PR aims to use Django's Collector to collect all objects that would have been deleted because of `on_delete=CASCADE` and create an ObjectChange for them as well. In addition, Notes are not automatically collected via the Collector because of the lack of a `GenericRelation`, so we discover the notes as well manually.

In addition, although the current implementation uses batch sizes for chunking the ObjectChange creation, it still had to load all objects into memory when it was doing the `qs.delete()` at the end. I have refactored it to now use batches through the whole process in case of a very large number of bulk delete objects.
# Screenshots
|Before|After|
|-|-|
|<img width="1118" height="215" alt="Screenshot 2026-05-22 at 8 33 22 AM" src="https://github.com/user-attachments/assets/28707c53-a72f-451a-bfe3-f68da145e9ef" />|<img width="1131" height="291" alt="Screenshot 2026-05-22 at 8 31 58 AM" src="https://github.com/user-attachments/assets/7782da49-d507-4c45-98a0-ed74ac3af056" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests

NTC-5279