### PR TITLE
Fixed approval workflow bypass in Assume Ownership action

### DIFF
--- a/changes/9013.security
+++ b/changes/9013.security
@@ -1,0 +1,1 @@
+Fixed the Scheduled Job 'Assume Ownership' action to not bypass approval workflows.

--- a/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
@@ -27,7 +27,10 @@ Once a job has been scheduled, the schedule can be deleted by navigating to `Job
 
 Each scheduled job is owned by, and runs as, the user that created it. If that user is removed, the schedule can no longer run and is automatically disabled with a state of `Errored` the next time it would have fired; a failed `JobResult` is also recorded.
 
-Ownership of a scheduled job can be transferred at any time from the `Assume Ownership` action in the Actions dropdown on the Scheduled Job detail view. Clicking it reassigns the schedule to the current user. If the scheduled job was previously disabled due to a failure, the button also re-enables it, and resets its state to `Active`.
+Ownership of a scheduled job can be transferred at any time from the `Assume Ownership` action in the Actions dropdown on the Scheduled Job detail view. The exact effect on the schedule depends on its current state:
+
+- **Errored**: ownership transfers, the schedule is re-enabled, and its state resets to `Active`. This is the recovery path for schedules orphaned by a removed owner.
+- **Active, Pending Approval, Approval Denied, Approval Canceled, Completed**: only the owner changes; the state and `enabled` flag are left unchanged. For a `Pending Approval` schedule, any existing approval responses on the associated workflow are preserved, and the workflow must still complete before the schedule can transition to `Active` and be picked up by the scheduler.
 
 The button is hidden when the requester is already the current owner, and is only visible to users that meet **all** of the following criteria:
 

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -4313,6 +4313,219 @@ class ScheduledJobTestCase(
         sj.refresh_from_db()
         self.assertEqual(sj.user_id, other_user.id)  # unchanged
 
+    def _make_pending_scheduled_job(self, name, *, prior_owner, stage_specs):
+        sj = self._make_scheduled_job(name, user=prior_owner, enabled=False)
+        sj.state = ScheduledJobStateChoices.PENDING
+        sj.save()
+
+        approver_group = Group.objects.create(name=f"approvers_{name}")
+        workflow_definition = ApprovalWorkflowDefinition.objects.create(
+            name=f"workflow_def_{name}",
+            model_content_type=ContentType.objects.get_for_model(ScheduledJob),
+        )
+        workflow = ApprovalWorkflow.objects.create(
+            approval_workflow_definition=workflow_definition,
+            object_under_review_content_type=ContentType.objects.get_for_model(ScheduledJob),
+            object_under_review_object_id=sj.pk,
+            current_state=ApprovalWorkflowStateChoices.PENDING,
+            user=prior_owner,
+        )
+        stages = []
+        for index, (stage_state, approved_usernames) in enumerate(stage_specs, start=1):
+            stage_definition = ApprovalWorkflowStageDefinition.objects.create(
+                approval_workflow_definition=workflow_definition,
+                sequence=index,
+                name=f"stage_{index}_{name}",
+                min_approvers=len(approved_usernames) + 2,
+                approver_group=approver_group,
+            )
+            stage = ApprovalWorkflowStage.objects.create(
+                approval_workflow=workflow,
+                approval_workflow_stage_definition=stage_definition,
+                state=stage_state,
+            )
+            for username in approved_usernames:
+                approver = User.objects.create(username=username, is_active=True)
+                ApprovalWorkflowStageResponse.objects.create(
+                    approval_workflow_stage=stage,
+                    user=approver,
+                    state=ApprovalWorkflowStateChoices.APPROVED,
+                    comments="LGTM",
+                )
+            stages.append(stage)
+        return sj, workflow, stages
+
+    def test_assume_ownership_pending_transfers_owner_only_and_preserves_approvals(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        prior_owner = User.objects.create(username="prior_owner_pending_handoff", is_active=True)
+        sj, workflow, stages = self._make_pending_scheduled_job(
+            "assume_pending_handoff",
+            prior_owner=prior_owner,
+            stage_specs=[(ApprovalWorkflowStateChoices.PENDING, ["approver_pending_handoff"])],
+        )
+        active_stage = stages[0]
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+        self.assertEqual(sj.state, ScheduledJobStateChoices.PENDING)
+        self.assertFalse(sj.enabled)
+
+        workflow.refresh_from_db()
+        self.assertEqual(workflow.user_id, prior_owner.id)
+        self.assertEqual(workflow.current_state, ApprovalWorkflowStateChoices.PENDING)
+
+        active_stage.refresh_from_db()
+        self.assertEqual(active_stage.state, ApprovalWorkflowStateChoices.PENDING)
+        self.assertEqual(
+            ApprovalWorkflowStageResponse.objects.filter(
+                approval_workflow_stage=active_stage,
+                state=ApprovalWorkflowStateChoices.APPROVED,
+            ).count(),
+            1,
+        )
+        self.assertFalse(
+            ApprovalWorkflowStageResponse.objects.filter(
+                approval_workflow_stage=active_stage,
+                user=self.user,
+            ).exists()
+        )
+
+    def test_assume_ownership_pending_when_both_users_are_approvers(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        prior_owner = User.objects.create(username="prior_owner_pending_in_group", is_active=True)
+        sj, workflow, stages = self._make_pending_scheduled_job(
+            "assume_pending_in_group",
+            prior_owner=prior_owner,
+            stage_specs=[(ApprovalWorkflowStateChoices.PENDING, ["approver_pending_in_group"])],
+        )
+        active_stage = stages[0]
+        approver_group = active_stage.approval_workflow_stage_definition.approver_group
+        approver_group.user_set.add(prior_owner, self.user)
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+        self.assertEqual(sj.state, ScheduledJobStateChoices.PENDING)
+        self.assertFalse(sj.enabled)
+
+        workflow.refresh_from_db()
+        self.assertEqual(workflow.user_id, prior_owner.id)
+        self.assertEqual(workflow.current_state, ApprovalWorkflowStateChoices.PENDING)
+
+        active_stage.refresh_from_db()
+        self.assertEqual(active_stage.state, ApprovalWorkflowStateChoices.PENDING)
+        self.assertEqual(
+            ApprovalWorkflowStageResponse.objects.filter(
+                approval_workflow_stage=active_stage,
+                state=ApprovalWorkflowStateChoices.APPROVED,
+            ).count(),
+            1,
+        )
+        self.assertFalse(
+            ApprovalWorkflowStageResponse.objects.filter(
+                approval_workflow_stage=active_stage,
+                user=self.user,
+            ).exists()
+        )
+
+    def test_assume_ownership_pending_preserves_prior_approval_from_new_owner(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        prior_owner = User.objects.create(username="prior_owner_pending_self_approved", is_active=True)
+        sj, workflow, stages = self._make_pending_scheduled_job(
+            "assume_pending_self_approved",
+            prior_owner=prior_owner,
+            stage_specs=[(ApprovalWorkflowStateChoices.PENDING, ["other_approver_pending_self_approved"])],
+        )
+        active_stage = stages[0]
+        approver_group = active_stage.approval_workflow_stage_definition.approver_group
+        approver_group.user_set.add(prior_owner, self.user)
+        self_user_response = ApprovalWorkflowStageResponse.objects.create(
+            approval_workflow_stage=active_stage,
+            user=self.user,
+            state=ApprovalWorkflowStateChoices.APPROVED,
+            comments="LGTM from future owner",
+        )
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+        self.assertEqual(sj.state, ScheduledJobStateChoices.PENDING)
+        self.assertFalse(sj.enabled)
+
+        workflow.refresh_from_db()
+        self.assertEqual(workflow.user_id, prior_owner.id)
+        self.assertEqual(workflow.current_state, ApprovalWorkflowStateChoices.PENDING)
+
+        active_stage.refresh_from_db()
+        self.assertEqual(active_stage.state, ApprovalWorkflowStateChoices.PENDING)
+        self.assertEqual(
+            ApprovalWorkflowStageResponse.objects.filter(
+                approval_workflow_stage=active_stage,
+                state=ApprovalWorkflowStateChoices.APPROVED,
+            ).count(),
+            2,
+        )
+        self_user_response.refresh_from_db()
+        self.assertEqual(self_user_response.state, ApprovalWorkflowStateChoices.APPROVED)
+        self.assertEqual(self_user_response.comments, "LGTM from future owner")
+
+    def _assert_assume_ownership_transfers_owner_only(self, state, prior_owner_username, schedule_name):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        prior_owner = User.objects.create(username=prior_owner_username, is_active=True)
+        sj = self._make_scheduled_job(schedule_name, user=prior_owner, enabled=False)
+        sj.state = state
+        sj.save()
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+        self.assertEqual(sj.state, state)
+        self.assertFalse(sj.enabled)
+
+    def test_assume_ownership_denied_transfers_owner_only(self):
+        self._assert_assume_ownership_transfers_owner_only(
+            ScheduledJobStateChoices.DENIED, "prior_owner_denied_handoff", "assume_denied_handoff"
+        )
+
+    def test_assume_ownership_canceled_transfers_owner_only(self):
+        self._assert_assume_ownership_transfers_owner_only(
+            ScheduledJobStateChoices.CANCELED, "prior_owner_canceled_handoff", "assume_canceled_handoff"
+        )
+
+    def test_assume_ownership_completed_transfers_owner_only(self):
+        self._assert_assume_ownership_transfers_owner_only(
+            ScheduledJobStateChoices.COMPLETED, "prior_owner_completed_handoff", "assume_completed_handoff"
+        )
+
+    def test_assume_ownership_active_transfers_owner_only(self):
+        self.add_permissions("extras.view_scheduledjob", "extras.change_scheduledjob", "extras.run_job")
+        prior_owner = User.objects.create(username="prior_owner_active_handoff", is_active=True)
+        sj = self._make_scheduled_job("assume_active_handoff", user=prior_owner, enabled=True)
+        self.assertEqual(sj.state, ScheduledJobStateChoices.ACTIVE)
+        self.assertTrue(sj.enabled)
+
+        url = reverse("extras:scheduledjob_assume_ownership", kwargs={"pk": sj.pk})
+        response = self.client.post(url, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        sj.refresh_from_db()
+        self.assertEqual(sj.user_id, self.user.id)
+        self.assertEqual(sj.state, ScheduledJobStateChoices.ACTIVE)
+        self.assertTrue(sj.enabled)
+
 
 class JobQueueTestCase(ViewTestCases.PrimaryObjectViewTestCase):
     model = JobQueue

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -3243,9 +3243,11 @@ class ScheduledJobUIViewSet(
         ):
             messages.error(request, f"You do not have permission to run the job '{obj.job_model}'.")
             return redirect(obj.get_absolute_url())
+
         obj.user = request.user
-        obj.enabled = True
-        obj.state = ScheduledJobStateChoices.ACTIVE
+        if obj.state == ScheduledJobStateChoices.ERRORED:
+            obj.enabled = True
+            obj.state = ScheduledJobStateChoices.ACTIVE
         obj.validated_save()
         messages.success(request, f"You are now the owner of scheduled job '{obj.name}'.")
         return redirect(obj.get_absolute_url())


### PR DESCRIPTION
# Closes #9013
# What's Changed

The Assume Ownership action on ScheduledJob unconditionally wrote state=ACTIVE on the target. The Celery Beat scheduler filters only on state=ACTIVE, so a non-approver user with change_scheduledjob + run_job could take over a PENDING schedule awaiting approval and have it executed at the next tick, bypassing the approval workflow entirely.

The fix narrows the state mutation to the cases the documentation actually describes:

- ERRORED: re-enable and reset to ACTIVE (unchanged recovery path).
- All other states (ACTIVE/PENDING/DENIED/CANCELED/COMPLETED): reassign owner only. Leave state and enabled untouched. The Beat scheduler's state=ACTIVE filter therefore remains the sole gate on execution.

For a PENDING handoff, the schedule stays in PENDING and the associated approval workflow is left untouched. ApprovalWorkflow.user is unchanged so the audit trail remains accurate. Only ScheduledJob.user reflects the new owner.
