### PR TITLE
Fixed GraphQL N+1 issues when fetching tags and config contexts

### DIFF
--- a/changes/9015.fixed
+++ b/changes/9015.fixed
@@ -1,0 +1,1 @@
+Fixed N+1 query patterns when resolving `tags` and `config_context` in GraphQL queries.

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -20,7 +20,7 @@ LIST_SEARCH_PARAMS_BY_SCHEMA_TYPE = {}
 
 
 def _graphql_selection_requests_field(info, field_name):
-    """Return True if the immediate selection set of this GraphQL field requests ``field_name``."""
+    """Return True if the immediate selection set of this GraphQL field requests `field_name`."""
     for node in info.field_nodes:
         if not node.selection_set:
             continue

--- a/nautobot/core/graphql/generators.py
+++ b/nautobot/core/graphql/generators.py
@@ -19,6 +19,28 @@ RESOLVER_PREFIX = "resolve_"
 LIST_SEARCH_PARAMS_BY_SCHEMA_TYPE = {}
 
 
+def _graphql_selection_requests_field(info, field_name):
+    """Return True if the immediate selection set of this GraphQL field requests ``field_name``."""
+    for node in info.field_nodes:
+        if not node.selection_set:
+            continue
+        for selection in node.selection_set.selections:
+            if getattr(selection, "name", None) and selection.name.value == field_name:
+                return True
+    return False
+
+
+def optimize_config_context(queryset, info):
+    """Annotate config context data on the root queryset when GraphQL requests config_context.
+
+    ConfigContextModel.get_config_context() short-circuits when config_context_data is annotated,
+    so this eliminates a per-object ConfigContext.get_for_object() query (and its related FK lookups).
+    """
+    if hasattr(queryset, "annotate_config_context_data") and _graphql_selection_requests_field(info, "config_context"):
+        return queryset.annotate_config_context_data()
+    return queryset
+
+
 def generate_restricted_queryset():
     """
     Generate a function to return a restricted queryset compatible with the internal permissions system.
@@ -305,6 +327,7 @@ def generate_single_item_resolver(schema_type, resolver_name):
             queryset = model.objects.all()
             if hasattr(queryset, "restrict"):
                 queryset = queryset.restrict(info.context.user, "view")
+            queryset = optimize_config_context(queryset, info)
             return gql_optimizer.query(queryset.filter(pk=obj_id), info).first()
         return None
 
@@ -341,6 +364,8 @@ def generate_list_resolver(schema_type, resolver_name):
         queryset = model.objects.all()
         if hasattr(queryset, "restrict"):
             queryset = queryset.restrict(info.context.user, "view")
+
+        queryset = optimize_config_context(queryset, info)
 
         if filterset_class is not None:
             resolved_obj = filterset_class(kwargs, queryset)

--- a/nautobot/core/graphql/schema.py
+++ b/nautobot/core/graphql/schema.py
@@ -11,6 +11,7 @@ from django.db.models import ManyToManyField
 from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel, OneToOneRel
 import graphene
 from graphene.types import generic
+import graphene_django_optimizer as gql_optimizer
 
 from nautobot.circuits.graphql.types import CircuitTerminationType
 from nautobot.core.graphql.generators import (
@@ -342,6 +343,7 @@ def extend_schema_type_tags(schema_type, model):
     if "tags" not in fields_name:
         return schema_type
 
+    @gql_optimizer.resolver_hints(prefetch_related="tags")
     def resolve_tags(self, args):
         return self.tags.all()
 

--- a/nautobot/core/tests/test_graphql_n_plus_one.py
+++ b/nautobot/core/tests/test_graphql_n_plus_one.py
@@ -7,6 +7,7 @@ applying a filter does not produce a query-count explosion proportional to the n
 import uuid
 
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 from django.test.client import RequestFactory
 from graphene_django.settings import graphene_settings
@@ -18,6 +19,10 @@ from graphql.type import (
 )
 
 from nautobot.core.testing import AssertNoRepeatedQueries, TestCase
+from nautobot.dcim.choices import InterfaceTypeChoices
+from nautobot.dcim.models import Controller, Device, DeviceType, Interface, Location, Manufacturer, Module
+from nautobot.extras.models import Role, Status, Tag
+from nautobot.ipam.models import IPAddress
 
 User = get_user_model()
 
@@ -152,3 +157,81 @@ class GraphQLNPlusOneTest(TestCase):
                     for err in result.errors:
                         if not isinstance(err.original_error, Exception):
                             self.fail(f"Unexpected hard error for {parent_name}.{nested_name}: {err}")
+
+
+class GraphQLTagsAndConfigContextNPlusOneTest(TestCase):
+    """Regression tests for N+1 query patterns on the `tags` and `config_context` resolvers (issue #9015).
+
+    These resolvers are added dynamically and are not "filterable nested list fields", so they are not covered
+    by `GraphQLNPlusOneTest` above.
+    """
+
+    DEVICE_COUNT = 15
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create(username="n_plus_one_tags_test_user", is_active=True, is_superuser=True)
+
+        # Make the device list deterministic by removing pre-existing fixture objects that reference devices.
+        IPAddress.objects.all().delete()
+        Controller.objects.filter(controller_device__isnull=False).delete()
+        Device.objects.all().delete()
+        Module.objects.all().delete()
+
+        manufacturer = Manufacturer.objects.first()
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="n+1 test device_type")
+        device_role = Role.objects.get_for_model(Device).first()
+        device_status = Status.objects.get_for_model(Device).first()
+        location = Location.objects.filter(location_type__name="Campus").first()
+        interface_status = Status.objects.get_for_model(Interface).first()
+
+        interface_tag = Tag.objects.create(name="n+1 test interface tag")
+        interface_tag.content_types.add(ContentType.objects.get_for_model(Interface))
+
+        # One tagged interface per device. With DEVICE_COUNT > threshold, an un-prefetched `tags` resolver
+        # issues one extras_tag query per interface, and an un-annotated `config_context` resolver issues one
+        # extras_configcontext query per device - both detectable as N+1.
+        for i in range(cls.DEVICE_COUNT):
+            device = Device.objects.create(
+                name=f"n+1-device-{i}",
+                device_type=device_type,
+                role=device_role,
+                location=location,
+                status=device_status,
+            )
+            interface = Interface.objects.create(
+                device=device,
+                name="Vlan4094",
+                type=InterfaceTypeChoices.TYPE_VIRTUAL,
+                status=interface_status,
+            )
+            interface.tags.add(interface_tag)
+
+    def setUp(self):
+        super().setUp()
+        self.schema = graphene_settings.SCHEMA.graphql_schema
+
+    def _execute(self, query):
+        """Execute a GraphQL query with a fresh request context (empty filter cache)."""
+        request = RequestFactory().request(SERVER_NAME="WebRequestContext")
+        request.id = uuid.uuid4()
+        request.user = self.user
+        return execute(schema=self.schema, document=parse(query), context_value=request)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_no_n_plus_one_on_nested_tags(self):
+        """`{ devices { interfaces { tags } } }` must prefetch tags rather than query per interface."""
+        query = "{ devices { interfaces { tags { name } } } }"
+        self._execute(query)  # Prewarm caches (ContentType, etc.)
+        with AssertNoRepeatedQueries(self, threshold=N_PLUS_ONE_THRESHOLD):
+            result = self._execute(query)
+        self.assertFalse(result.errors, msg=str(result.errors))
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_no_n_plus_one_on_config_context(self):
+        """`{ devices { config_context } }` must annotate config context rather than query per device."""
+        query = "{ devices { config_context } }"
+        self._execute(query)  # Prewarm caches (ContentType, etc.)
+        with AssertNoRepeatedQueries(self, threshold=N_PLUS_ONE_THRESHOLD):
+            result = self._execute(query)
+        self.assertFalse(result.errors, msg=str(result.errors))


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #9015
# What's Changed
This PR fixes two N+1 issues that were identified on GraphQL queries. The graphene django optimizer walks the query looking for either a known model field or an optimizer hint and applies `select_related` or `prefetch_related` as applicable.

In the case of tags, we were not advertising any optimizer hint and since it's a `TaggableManager` model it wasn't automatically detected either. This PR adds the optimizer hint as a simple fix.

In the case of config contexts, a simple optimizer hint was not able to fix it. Instead, we just need to identify when we need to add the annotation for config contexts and execute the `.annotate_config_context_data()` method. This PR adds a simple identification method to the GraphQL generator so it can detect when a query is requesting config context data and enable the annotation.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
|Before|After|
|-|-|
|<img width="162" height="149" alt="Screenshot 2026-05-27 at 9 55 19 AM" src="https://github.com/user-attachments/assets/718eb6ef-b46b-42fd-9663-50bb5a108a51" />|<img width="176" height="146" alt="Screenshot 2026-05-27 at 9 55 24 AM" src="https://github.com/user-attachments/assets/29d57f04-9f16-4243-a884-dd30c8b108f4" />|

Note: besides the manual test I used TDD and wrote the tests first to confirm the failure and the fix afterward.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests

NTC-5911