### PR TITLE
Fixed more filter fields that overlap with `graphene.Field` reserved kwargs

### DIFF
--- a/changes/9021.fixed
+++ b/changes/9021.fixed
@@ -1,0 +1,1 @@
+Fixed a GraphQL schema build failure when a model's filterset exposes a filter whose name collides with a reserved `graphene.Field` keyword argument.

--- a/examples/example_app/example_app/filters.py
+++ b/examples/example_app/example_app/filters.py
@@ -1,3 +1,5 @@
+import django_filters
+
 from nautobot.apps.filters import BaseFilterSet, SearchFilter
 
 from example_app.models import AnotherExampleModel, ExampleModel
@@ -12,6 +14,12 @@ class ExampleModelFilterSet(BaseFilterSet):
             "number": "icontains",
         },
     )
+    # Filters whose names collide with reserved `graphene.Field.__init__` keyword arguments.
+    # These exercise the relocation logic in `get_filtering_args_from_filterset()` so the
+    # GraphQL schema can be built without crashing (NTC-5456 / #9021).
+    default_value = django_filters.NumberFilter(field_name="number")
+    required = django_filters.NumberFilter(field_name="number")
+    resolver = django_filters.NumberFilter(field_name="number")
 
     class Meta:
         model = ExampleModel

--- a/nautobot/core/graphql/utils.py
+++ b/nautobot/core/graphql/utils.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 
 from django_filters.filters import BooleanFilter, MultipleChoiceFilter, NumberFilter
@@ -12,6 +13,40 @@ from nautobot.core.filters import (
 from nautobot.core.models.fields import slugify_dashes_to_underscores
 
 logger = logging.getLogger(__name__)
+
+
+def _build_reserved_graphene_field_kwargs():
+    """Build the set of filter names that must not be splatted as top-level `graphene.Field` kwargs.
+
+    Filter arguments are passed into `graphene.List(schema_type, **search_params)` and mounted as a
+    `graphene.Field`. Any filter whose name matches a reserved `graphene.Field.__init__` keyword
+    argument would be consumed as that Field attribute instead of being mounted as a GraphQL argument.
+    Such names are instead relocated into the nested `args` mapping.
+
+    The set is derived dynamically from the signature so reserved kwargs added in future graphene
+    releases are handled automatically (see #9021).
+    """
+    signature = inspect.signature(graphene.types.field.Field.__init__)
+    params = {
+        name
+        for name, param in signature.parameters.items()
+        if param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY)
+    }
+    excluded_names = {
+        # `args` is the key of the nested GraphQL-arguments mapping itself (see `args = {"args": {}}`
+        # below), so it must never be relocated -- doing so would pop that container mid-loop.
+        "args",
+        # Graphene already auto-handles `Argument` values for name and source, and relocating them would change
+        # schema behavior for the many models that expose a `name` or `source` filter (and break existing tests).
+        "name",
+        "source",
+    }
+    # Any other reserved name that is probably not a real filter (e.g. `self`, `type_`, `_creation_counter`)
+    # stays in the set but simply doesn't match; if one ever did, relocating it is the safer outcome.
+    return params - excluded_names
+
+
+RESERVED_GRAPHENE_FIELD_KWARGS = _build_reserved_graphene_field_kwargs()
 
 
 def str_to_var_name(verbose_name):
@@ -81,9 +116,14 @@ def get_filtering_args_from_filterset(filterset_class):
             required=False,
         )
 
-    # Hack to avoid conflict with `graphene.types.field.Field.description`.
-    if "description" in args:
-        args["args"].update({"description": args.pop("description")})
+    # Relocate filters whose names collide with reserved `graphene.Field.__init__` kwargs into the
+    # nested `args` mapping (the field's GraphQL arguments) instead of letting them be splatted as
+    # top-level kwargs, which graphene would otherwise consume as Field attributes.
+    # Ref: https://docs.graphene-python.org/en/latest/types/objecttypes/#resolverparamgraphqlarguments
+    for reserved_name in RESERVED_GRAPHENE_FIELD_KWARGS:
+        if reserved_name in args:
+            args["args"][reserved_name] = args.pop(reserved_name)
+
     if "type" in args:
         # for backwards compatibility with our filters in graphene v2 where `type` was a reserved keyword
         args["args"].update({"_type": args["type"]})

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -25,6 +25,7 @@ from nautobot.circuits.models import CircuitTermination, Provider
 from nautobot.core.graphql import execute_query, execute_saved_query
 from nautobot.core.graphql.generators import (
     _make_filter_cache_key,
+    generate_attrs_for_schema_type,
     generate_list_search_parameters,
     generate_schema_type,
 )
@@ -37,7 +38,7 @@ from nautobot.core.graphql.schema import (
     extend_schema_type_tags,
 )
 from nautobot.core.graphql.types import DateType, OptimizedNautobotObjectType
-from nautobot.core.graphql.utils import str_to_var_name
+from nautobot.core.graphql.utils import get_filtering_args_from_filterset, str_to_var_name
 from nautobot.core.testing import AssertNoRepeatedQueries, create_test_user, NautobotTestClient, TestCase
 from nautobot.core.utils.cache import construct_cache_key
 from nautobot.dcim.choices import ConsolePortTypeChoices, InterfaceModeChoices, InterfaceTypeChoices, PortTypeChoices
@@ -548,6 +549,42 @@ class GraphQLSearchParameters(GraphQLTestCaseBase):
                 self.assertIn(field, params["args"].keys())
             else:
                 self.assertIn(field, params.keys())
+
+
+class GraphQLReservedFieldKwargFilters(TestCase):
+    """Regression tests for filters whose names collide with reserved `graphene.Field` kwargs (#9021).
+
+    The `example_app.ExampleModelFilterSet` declares `default_value`, `required`, and `resolver`
+    filters specifically to exercise this path.
+    """
+
+    reserved_filter_names = ("default_value", "required", "resolver")
+
+    def test_reserved_filter_names_relocated_to_args(self):
+        from example_app.filters import ExampleModelFilterSet
+
+        args = get_filtering_args_from_filterset(ExampleModelFilterSet)
+        for reserved in self.reserved_filter_names:
+            # Relocated out of the top-level Field kwargs...
+            self.assertNotIn(reserved, args)
+            # ...but still exposed as a GraphQL argument.
+            self.assertIn(reserved, args["args"])
+
+    def test_schema_type_builds_with_reserved_filter_names(self):
+        from example_app.models import ExampleModel
+
+        schema_type = generate_schema_type(app_name="example_app", model=ExampleModel)
+
+        # The list query field exposes the reserved filter names as arguments.
+        search_params = generate_list_search_parameters(schema_type)
+        for reserved in self.reserved_filter_names:
+            self.assertIn(reserved, search_params["args"])
+
+        # Mounting the generated attrs onto an ObjectType triggers graphene's make_dataclass(),
+        # which raised `ValueError: mutable default ... Argument` before the fix.
+        attrs = generate_attrs_for_schema_type(schema_type)
+        query = type("ExampleModelReservedKwargQuery", (graphene.types.ObjectType,), attrs)
+        self.assertIn("example_models", query._meta.fields)
 
 
 class GraphQLAPIPermissionTest(GraphQLTestCaseBase):

--- a/nautobot/core/tests/test_graphql.py
+++ b/nautobot/core/tests/test_graphql.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.db.models import Count, Q
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.test.client import RequestFactory
 from django.urls import reverse
 import graphene.types
@@ -551,6 +551,7 @@ class GraphQLSearchParameters(GraphQLTestCaseBase):
                 self.assertIn(field, params.keys())
 
 
+@tag("example_app")
 class GraphQLReservedFieldKwargFilters(TestCase):
     """Regression tests for filters whose names collide with reserved `graphene.Field` kwargs (#9021).
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #9021
# What's Changed
This PR is a follow up for #7150 with a more enhanced fix. In that PR, we explicitly popped `description` out of the `*args` that get sent to `graphene.Field.__init__`. In #9021, we got the report that another reserved kwarg needed the same treatment. Instead of just adding to the existing list, I added a dynamic inspection that will build the list of reserved keyword arguments and shift them automatically in the same way we were treating `description`.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests

NTC-5456