### PR TITLE
Add SkipAutoComponentCreation context manager for apps (#9026)

### DIFF
--- a/changes/9026.added
+++ b/changes/9026.added
@@ -1,0 +1,1 @@
+Added `nautobot.apps.dcim.SkipAutoComponentCreation` context manager that lets apps opt out of Nautobot's automatic Device/Module component instantiation on a new save.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -640,6 +640,7 @@ nav:
               - Prepopulating Data: "development/apps/api/platform-features/prepopulating-data.md"
               - Prometheus Metrics: "development/apps/api/prometheus.md"
               - Secrets Providers: "development/apps/api/platform-features/secrets-providers.md"
+              - Skip Auto Component Creation: "development/apps/api/platform-features/skip-auto-component-creation.md"
               - Table Extensions: "development/apps/api/platform-features/table-extensions.md"
               - Uniquely Identifying a Nautobot Object: "development/apps/api/platform-features/uniquely-identify-objects.md"
           - UI Extensions:
@@ -659,6 +660,7 @@ nav:
               - nautobot.apps.config: "code-reference/nautobot/apps/config.md"
               - nautobot.apps.constants: "code-reference/nautobot/apps/constants.md"
               - nautobot.apps.datasources: "code-reference/nautobot/apps/datasources.md"
+              - nautobot.apps.dcim: "code-reference/nautobot/apps/dcim.md"
               - nautobot.apps.events: "code-reference/nautobot/apps/events.md"
               - nautobot.apps.exceptions: "code-reference/nautobot/apps/exceptions.md"
               - nautobot.apps.factory: "code-reference/nautobot/apps/factory.md"

--- a/nautobot/apps/dcim.py
+++ b/nautobot/apps/dcim.py
@@ -1,0 +1,8 @@
+"""Public DCIM extension points for Nautobot apps."""
+
+from nautobot.dcim.component_creation import is_auto_component_creation_suppressed, SkipAutoComponentCreation
+
+__all__ = (
+    "SkipAutoComponentCreation",
+    "is_auto_component_creation_suppressed",
+)

--- a/nautobot/dcim/component_creation.py
+++ b/nautobot/dcim/component_creation.py
@@ -1,29 +1,40 @@
 """Public extension point for suppressing automatic Device/Module component instantiation.
 
-By default, when a new :class:`~nautobot.dcim.models.Device` or
-:class:`~nautobot.dcim.models.Module` is first persisted, ``save()`` calls
-``self.create_components()`` to instantiate one component (interface, console
-port, power port, etc.) per template defined on the related ``DeviceType`` /
-``ModuleType``. For apps that own the component inventory from an external
+By default, when a new `Device` or `Module` is first persisted, `save()` calls
+`self.create_components()` to instantiate one component (interface, console
+port, power port, etc.) per template defined on the related `DeviceType` /
+`ModuleType`. For apps that own the component inventory from an external
 source-of-truth and intend to write the full component graph themselves
 immediately after creating the parent object, this default is undesirable.
 
-This module exposes :class:`SkipAutoComponentCreation`, a re-entrant,
-exception-safe context manager. Code that runs inside the ``with`` block
-creates Devices/Modules without their template-derived components::
+This module exposes `SkipAutoComponentCreation`, a re-entrant,
+exception-safe context manager. Code that runs inside the `with` block
+creates Devices/Modules without their template-derived components:
 
-    >>> from nautobot.apps.dcim import SkipAutoComponentCreation
-    >>> from nautobot.dcim.models import Device
-    >>> with SkipAutoComponentCreation():
-    ...     device = Device.objects.create(...)  # no auto-instantiated components
+```python
+from nautobot.apps.dcim import SkipAutoComponentCreation
+from nautobot.dcim.models import Device
 
-The scope is limited to the *initial* save (the ``is_new`` branch of
-``Device.save()`` / ``Module.save()``). It does not affect subsequent saves,
-updates, or paths that bypass ``save()`` such as ``bulk_create()``.
+with SkipAutoComponentCreation():
+    device = Device.objects.create(...)  # no auto-instantiated components
+```
+
+The scope is limited to the *initial* save (the `is_new` branch of
+`Device.save()` / `Module.save()`). It does not affect subsequent saves,
+updates, or paths that bypass `save()` such as `bulk_create()`.
 
 Suppression is scoped per-asyncio-task and per-Celery-task via
-:class:`contextvars.ContextVar`, so it cannot leak across concurrent task
-boundaries.
+`contextvars.ContextVar`, so it cannot leak across concurrent task boundaries.
+
+!!! note "Thread-based parallelization"
+    Because the flag lives in a `contextvars.ContextVar`, a value set in one
+    OS thread is **not** visible in a separately spawned `threading.Thread`;
+    each new thread starts from the default (`False`). Code that fans work out
+    across a thread pool (for example, a future SSoT bulk-import that uses
+    `concurrent.futures.ThreadPoolExecutor`) must therefore either enter the
+    `with SkipAutoComponentCreation():` block *inside* each worker, or copy the
+    calling context into the worker via `contextvars.copy_context()`. The
+    asyncio-task and Celery-task scoping described above is unaffected.
 """
 
 import contextvars
@@ -36,27 +47,30 @@ _skip_flag: contextvars.ContextVar[bool] = contextvars.ContextVar(
 
 
 class SkipAutoComponentCreation:
-    """Context manager that suppresses Device/Module ``create_components()`` on save.
+    """Context manager that suppresses Device/Module `create_components()` on save.
 
-    Inside the ``with`` block, ``Device.save()`` and ``Module.save()`` skip
-    their call to ``self.create_components()`` for newly created instances.
-    Default behaviour (instantiate components from the related DeviceType /
-    ModuleType templates) is restored automatically on exit, including when
+    Inside the `with` block, `Device.save()` and `Module.save()` skip
+    their call to `self.create_components()` for newly created instances.
+    Default behaviour (instantiate components from the related `DeviceType` /
+    `ModuleType` templates) is restored automatically on exit, including when
     the block raises.
 
-    The context manager is re-entrant: an outer ``with`` block continues to
+    The context manager is re-entrant: an outer `with` block continues to
     suppress after an inner block exits. It is exception-safe: state is
     restored even if the wrapped code raises.
 
-    Implementation uses :class:`contextvars.ContextVar`, so the flag is
+    Implementation uses `contextvars.ContextVar`, so the flag is
     correctly scoped per asyncio task / Celery worker invocation and does
     not leak across threads.
 
     Example:
-        >>> from nautobot.apps.dcim import SkipAutoComponentCreation
-        >>> from nautobot.dcim.models import Device
-        >>> with SkipAutoComponentCreation():
-        ...     device = Device.objects.create(...)  # no auto-components
+        ```python
+        from nautobot.apps.dcim import SkipAutoComponentCreation
+        from nautobot.dcim.models import Device
+
+        with SkipAutoComponentCreation():
+            device = Device.objects.create(...)  # no auto-components
+        ```
     """
 
     def __init__(self):
@@ -78,9 +92,9 @@ class SkipAutoComponentCreation:
 
 
 def is_auto_component_creation_suppressed() -> bool:
-    """Return True if a :class:`SkipAutoComponentCreation` context is active.
+    """Return True if a `SkipAutoComponentCreation` context is active.
 
     Intended primarily for introspection and tests. Production code should
-    normally use the :class:`SkipAutoComponentCreation` context manager directly.
+    normally use the `SkipAutoComponentCreation` context manager directly.
     """
     return _skip_flag.get()

--- a/nautobot/dcim/component_creation.py
+++ b/nautobot/dcim/component_creation.py
@@ -1,0 +1,86 @@
+"""Public extension point for suppressing automatic Device/Module component instantiation.
+
+By default, when a new :class:`~nautobot.dcim.models.Device` or
+:class:`~nautobot.dcim.models.Module` is first persisted, ``save()`` calls
+``self.create_components()`` to instantiate one component (interface, console
+port, power port, etc.) per template defined on the related ``DeviceType`` /
+``ModuleType``. For apps that own the component inventory from an external
+source-of-truth and intend to write the full component graph themselves
+immediately after creating the parent object, this default is undesirable.
+
+This module exposes :class:`SkipAutoComponentCreation`, a re-entrant,
+exception-safe context manager. Code that runs inside the ``with`` block
+creates Devices/Modules without their template-derived components::
+
+    >>> from nautobot.apps.dcim import SkipAutoComponentCreation
+    >>> from nautobot.dcim.models import Device
+    >>> with SkipAutoComponentCreation():
+    ...     device = Device.objects.create(...)  # no auto-instantiated components
+
+The scope is limited to the *initial* save (the ``is_new`` branch of
+``Device.save()`` / ``Module.save()``). It does not affect subsequent saves,
+updates, or paths that bypass ``save()`` such as ``bulk_create()``.
+
+Suppression is scoped per-asyncio-task and per-Celery-task via
+:class:`contextvars.ContextVar`, so it cannot leak across concurrent task
+boundaries.
+"""
+
+import contextvars
+from typing import Optional
+
+_skip_flag: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "nautobot_dcim_skip_auto_component_creation",
+    default=False,
+)
+
+
+class SkipAutoComponentCreation:
+    """Context manager that suppresses Device/Module ``create_components()`` on save.
+
+    Inside the ``with`` block, ``Device.save()`` and ``Module.save()`` skip
+    their call to ``self.create_components()`` for newly created instances.
+    Default behaviour (instantiate components from the related DeviceType /
+    ModuleType templates) is restored automatically on exit, including when
+    the block raises.
+
+    The context manager is re-entrant: an outer ``with`` block continues to
+    suppress after an inner block exits. It is exception-safe: state is
+    restored even if the wrapped code raises.
+
+    Implementation uses :class:`contextvars.ContextVar`, so the flag is
+    correctly scoped per asyncio task / Celery worker invocation and does
+    not leak across threads.
+
+    Example:
+        >>> from nautobot.apps.dcim import SkipAutoComponentCreation
+        >>> from nautobot.dcim.models import Device
+        >>> with SkipAutoComponentCreation():
+        ...     device = Device.objects.create(...)  # no auto-components
+    """
+
+    def __init__(self):
+        """Initialize without entering the context yet."""
+        self._token: Optional[contextvars.Token] = None
+
+    def __enter__(self):
+        """Activate suppression for the calling context."""
+        self._token = _skip_flag.set(True)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        """Restore the previous suppression state."""
+        if self._token is not None:
+            _skip_flag.reset(self._token)
+            self._token = None
+        # Do not suppress exceptions raised inside the with block.
+        return False
+
+
+def is_auto_component_creation_suppressed() -> bool:
+    """Return True if a :class:`SkipAutoComponentCreation` context is active.
+
+    Intended primarily for introspection and tests. Production code should
+    normally use the :class:`SkipAutoComponentCreation` context manager directly.
+    """
+    return _skip_flag.get()

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -29,6 +29,7 @@ from nautobot.dcim.choices import (
     SoftwareImageFileHashingAlgorithmChoices,
     SubdeviceRoleChoices,
 )
+from nautobot.dcim.component_creation import is_auto_component_creation_suppressed
 from nautobot.dcim.constants import DEVICE_RECURSION_DEPTH_LIMIT, MODULE_RECURSION_DEPTH_LIMIT
 from nautobot.dcim.querysets import DeviceQuerySet
 from nautobot.dcim.utils import get_all_network_driver_mappings, get_network_driver_mapping_tool_names
@@ -928,8 +929,9 @@ class Device(PrimaryModel, ConfigContextModel):
             delattr(self, "_deferred_cluster")
             self.assign_cluster(cluster)
 
-        # If this is a new Device, instantiate all related components per the DeviceType definition
-        if is_new:
+        # If this is a new Device, instantiate all related components per the DeviceType definition,
+        # unless an app has opted out via nautobot.apps.dcim.SkipAutoComponentCreation.
+        if is_new and not is_auto_component_creation_suppressed():
             self.create_components()
 
         # Update Location and Rack assignment for all nested descendant Devices.
@@ -2151,8 +2153,9 @@ class Module(PrimaryModel):
 
         super().save(*args, **kwargs)
 
-        # If this is a new Module, instantiate all related components per the ModuleType definition
-        if is_new:
+        # If this is a new Module, instantiate all related components per the ModuleType definition,
+        # unless an app has opted out via nautobot.apps.dcim.SkipAutoComponentCreation.
+        if is_new and not is_auto_component_creation_suppressed():
             self.create_components()
 
         # Render component names when this Module is first created or when the parent module bay has changed

--- a/nautobot/dcim/tests/test_component_creation.py
+++ b/nautobot/dcim/tests/test_component_creation.py
@@ -53,10 +53,14 @@ class SkipAutoComponentCreationContextManagerTestCase(TestCase):
 
     def test_exception_safe(self):
         """An exception inside the block still restores the previous state."""
-        with self.assertRaises(RuntimeError):
+        raised = False
+        try:
             with SkipAutoComponentCreation():
                 self.assertTrue(is_auto_component_creation_suppressed())
                 raise RuntimeError("boom")
+        except RuntimeError:
+            raised = True
+        self.assertTrue(raised)
         self.assertFalse(is_auto_component_creation_suppressed())
 
     def test_isolated_across_threads(self):

--- a/nautobot/dcim/tests/test_component_creation.py
+++ b/nautobot/dcim/tests/test_component_creation.py
@@ -182,3 +182,15 @@ class SkipAutoComponentCreationOnSaveTestCase(TestCase):
             device.save()
         device.refresh_from_db()
         self.assertEqual(device.interfaces.count(), 2)
+
+    def test_components_not_recreated_on_later_unsuppressed_save(self):
+        """A Device created under suppression stays component-free on a later unsuppressed save."""
+        with SkipAutoComponentCreation():
+            device = self._create_device("suppressed-then-saved")
+        self.assertEqual(device.interfaces.count(), 0)
+        # Saving again *without* suppression must not retroactively instantiate components,
+        # because create_components() only runs on the initial (is_new) save.
+        device.name = "suppressed-then-saved-renamed"
+        device.save()
+        device.refresh_from_db()
+        self.assertEqual(device.interfaces.count(), 0)

--- a/nautobot/dcim/tests/test_component_creation.py
+++ b/nautobot/dcim/tests/test_component_creation.py
@@ -1,0 +1,180 @@
+"""Tests for ``nautobot.apps.dcim.SkipAutoComponentCreation``."""
+
+import threading
+
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from nautobot.apps.dcim import is_auto_component_creation_suppressed, SkipAutoComponentCreation
+from nautobot.dcim.choices import InterfaceTypeChoices
+from nautobot.dcim.models import (
+    Device,
+    DeviceType,
+    InterfaceTemplate,
+    Location,
+    LocationType,
+    Manufacturer,
+    Module,
+    ModuleBay,
+    ModuleType,
+)
+from nautobot.extras.models import Role, Status
+
+
+def _status_for(model):
+    """Return a Status valid for ``model``, creating one if none is associated."""
+    status = Status.objects.get_for_model(model).first()
+    if status is None:
+        status = Status.objects.create(name=f"{model.__name__} Test Status")
+        status.content_types.add(ContentType.objects.get_for_model(model))
+    return status
+
+
+class SkipAutoComponentCreationContextManagerTestCase(TestCase):
+    """Unit tests for the context manager itself (no DB writes required)."""
+
+    def test_default_inactive(self):
+        """Suppression is off by default."""
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_activates_and_restores(self):
+        """The flag is set inside the block and cleared on exit."""
+        with SkipAutoComponentCreation():
+            self.assertTrue(is_auto_component_creation_suppressed())
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_nested(self):
+        """An outer block keeps suppressing after an inner block exits."""
+        with SkipAutoComponentCreation():
+            with SkipAutoComponentCreation():
+                self.assertTrue(is_auto_component_creation_suppressed())
+            self.assertTrue(is_auto_component_creation_suppressed())
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_exception_safe(self):
+        """An exception inside the block still restores the previous state."""
+        with self.assertRaises(RuntimeError):
+            with SkipAutoComponentCreation():
+                self.assertTrue(is_auto_component_creation_suppressed())
+                raise RuntimeError("boom")
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_isolated_across_threads(self):
+        """Suppression in one thread does not leak into a separately spawned thread."""
+        captured = {}
+
+        def worker():
+            captured["value"] = is_auto_component_creation_suppressed()
+
+        with SkipAutoComponentCreation():
+            self.assertTrue(is_auto_component_creation_suppressed())
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join()
+
+        # A freshly spawned thread starts with its own (default) context.
+        self.assertFalse(captured["value"])
+
+
+class SkipAutoComponentCreationOnSaveTestCase(TestCase):
+    """End-to-end tests that Device/Module honour the suppression flag on initial save."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Build a DeviceType and ModuleType that each define interface templates."""
+        cls.manufacturer = Manufacturer.objects.create(name="Test Manufacturer #9026")
+
+        cls.device_type = DeviceType.objects.create(manufacturer=cls.manufacturer, model="Test Model #9026")
+        for name in ("eth0", "eth1"):
+            InterfaceTemplate.objects.create(
+                device_type=cls.device_type,
+                name=name,
+                type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            )
+
+        cls.module_type = ModuleType.objects.create(manufacturer=cls.manufacturer, model="Test Module #9026")
+        InterfaceTemplate.objects.create(
+            module_type=cls.module_type,
+            name="mod-eth0",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+
+        cls.location_type = LocationType.objects.create(name="Test Location Type #9026")
+        cls.location_type.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.location = Location.objects.create(
+            name="Test Location #9026",
+            location_type=cls.location_type,
+            status=_status_for(Location),
+        )
+
+        cls.device_role = Role.objects.create(name="Test Role #9026")
+        cls.device_role.content_types.add(ContentType.objects.get_for_model(Device))
+
+        cls.device_status = _status_for(Device)
+        cls.module_status = _status_for(Module)
+
+    def _create_device(self, name):
+        return Device.objects.create(
+            device_type=self.device_type,
+            role=self.device_role,
+            status=self.device_status,
+            name=name,
+            location=self.location,
+        )
+
+    def _create_module(self, device, bay_name):
+        module_bay = ModuleBay.objects.create(parent_device=device, name=bay_name, position=bay_name)
+        return Module.objects.create(
+            module_type=self.module_type,
+            parent_module_bay=module_bay,
+            status=self.module_status,
+        )
+
+    # --- Default behaviour --------------------------------------------------------
+
+    def test_device_components_created_by_default(self):
+        """Without opting in, a new Device still gets its template components."""
+        device = self._create_device("default-device")
+        self.assertEqual(device.interfaces.count(), 2)
+
+    def test_module_components_created_by_default(self):
+        """Without opting in, a new Module still gets its template components."""
+        device = self._create_device("module-parent-default")
+        module = self._create_module(device, "bay-default")
+        self.assertEqual(module.interfaces.count(), 1)
+
+    # --- Suppression --------------------------------------------------------------
+
+    def test_device_components_suppressed_in_context(self):
+        """Inside the context manager, a new Device gets no auto components."""
+        with SkipAutoComponentCreation():
+            device = self._create_device("suppressed-device")
+        self.assertEqual(device.interfaces.count(), 0)
+
+    def test_module_components_suppressed_in_context(self):
+        """Inside the context manager, a new Module gets no auto components."""
+        device = self._create_device("module-parent-suppressed")
+        with SkipAutoComponentCreation():
+            module = self._create_module(device, "bay-suppressed")
+        self.assertEqual(module.interfaces.count(), 0)
+
+    # --- Scope -------------------------------------------------------------------
+
+    def test_suppression_only_applies_inside_context(self):
+        """A Device created after the context exits gets its default components."""
+        with SkipAutoComponentCreation():
+            suppressed_device = self._create_device("inside-context")
+        following_device = self._create_device("outside-context")
+        self.assertEqual(suppressed_device.interfaces.count(), 0)
+        self.assertEqual(following_device.interfaces.count(), 2)
+
+    def test_suppression_only_applies_on_initial_creation(self):
+        """A subsequent save() of an existing Device does not re-trigger create_components()."""
+        device = self._create_device("update-target")
+        self.assertEqual(device.interfaces.count(), 2)
+        # Mutate and save again with suppression active — components should not change either way.
+        device.name = "update-target-renamed"
+        with SkipAutoComponentCreation():
+            device.save()
+        device.refresh_from_db()
+        self.assertEqual(device.interfaces.count(), 2)

--- a/nautobot/docs/development/apps/api/platform-features/skip-auto-component-creation.md
+++ b/nautobot/docs/development/apps/api/platform-features/skip-auto-component-creation.md
@@ -42,6 +42,9 @@ The context manager:
 
 The context manager affects only the call from `Device.save()` / `Module.save()`. If an app calls `device.create_components()` directly, that explicit invocation is still honoured — `SkipAutoComponentCreation` gates the automatic call from inside `save()`, not the method itself.
 
+!!! warning "Thread-based parallelization"
+    Suppression is stored in a `contextvars.ContextVar`, which is **not** inherited by a separately spawned `threading.Thread` — each new thread starts from the default (unsuppressed). If you fan creation out across a thread pool (for example `concurrent.futures.ThreadPoolExecutor`), entering `with SkipAutoComponentCreation():` on the dispatching thread will **not** suppress component creation in the worker threads. In that case, enter the context manager *inside* each worker, or copy the calling context into the worker with `contextvars.copy_context()`. Asyncio-task and Celery-task scoping are unaffected.
+
 ## Introspection
 
 `nautobot.apps.dcim.is_auto_component_creation_suppressed()` returns `True` if a `SkipAutoComponentCreation` context is currently active. This is primarily useful in tests and adapter code that wants to make conditional decisions based on the suppression state.

--- a/nautobot/docs/development/apps/api/platform-features/skip-auto-component-creation.md
+++ b/nautobot/docs/development/apps/api/platform-features/skip-auto-component-creation.md
@@ -1,6 +1,6 @@
 # Suppressing Automatic Device/Module Component Creation
 
-+++ 3.2.0
++++ 3.1.4
 
 By default, when a new `Device` or `Module` is first saved, Nautobot calls `self.create_components()` from inside `save()` to instantiate one component (interface, console port, power port, rear/front port, device bay, module bay) per template defined on the related `DeviceType` / `ModuleType`. For apps that own the component inventory from an external source-of-truth and intend to write the full component graph themselves immediately after creating the parent object, this default is undesirable.
 

--- a/nautobot/docs/development/apps/api/platform-features/skip-auto-component-creation.md
+++ b/nautobot/docs/development/apps/api/platform-features/skip-auto-component-creation.md
@@ -1,0 +1,57 @@
+# Suppressing Automatic Device/Module Component Creation
+
++++ 3.2.0
+
+By default, when a new `Device` or `Module` is first saved, Nautobot calls `self.create_components()` from inside `save()` to instantiate one component (interface, console port, power port, rear/front port, device bay, module bay) per template defined on the related `DeviceType` / `ModuleType`. For apps that own the component inventory from an external source-of-truth and intend to write the full component graph themselves immediately after creating the parent object, this default is undesirable.
+
+The `nautobot.apps.dcim.SkipAutoComponentCreation` context manager lets an app opt out for a scoped region of code.
+
+## Usage
+
+```python
+from nautobot.apps.dcim import SkipAutoComponentCreation
+from nautobot.dcim.models import Device
+
+with SkipAutoComponentCreation():
+    device = Device.objects.create(
+        name="leaf-01",
+        device_type=device_type,
+        role=device_role,
+        status=device_status,
+        location=location,
+    )
+    # device.interfaces.count() == 0; no template-derived components were instantiated.
+    # The app is now responsible for populating any components it needs.
+```
+
+The context manager:
+
+- Suppresses `create_components()` on the **initial** `save()` of `Device` and `Module`. Subsequent saves of an existing instance are not affected — `create_components()` does not run on update saves regardless.
+- Is **re-entrant**: nested `with` blocks restore the previous state (still suppressed) when the inner block exits, not the unconditional default.
+- Is **exception-safe**: state is restored on exit even if the wrapped code raises.
+- Is **task-scoped**: implemented via `contextvars.ContextVar`, so the flag is correctly isolated per asyncio task and per Celery worker invocation. A suppressing context in one Celery task does not leak into the next task that worker handles, and freshly spawned threads start with their own (default) context.
+
+## Scope and limitations
+
+| Path | Triggers default `create_components()`? | Honoured by `SkipAutoComponentCreation`? |
+|---|---|---|
+| `Device.objects.create(...)` / `Module.objects.create(...)` | Yes | Yes |
+| `Device(...).save()` / `Module(...).save()` (new instance) | Yes | Yes |
+| Subsequent `save()` of an existing instance (update/migrate/move) | No | N/A — nothing to suppress |
+| `Device.objects.bulk_create([...])` / `Module.objects.bulk_create([...])` | No (bypasses `save()`) | N/A — nothing to suppress |
+
+The context manager affects only the call from `Device.save()` / `Module.save()`. If an app calls `device.create_components()` directly, that explicit invocation is still honoured — `SkipAutoComponentCreation` gates the automatic call from inside `save()`, not the method itself.
+
+## Introspection
+
+`nautobot.apps.dcim.is_auto_component_creation_suppressed()` returns `True` if a `SkipAutoComponentCreation` context is currently active. This is primarily useful in tests and adapter code that wants to make conditional decisions based on the suppression state.
+
+```python
+from nautobot.apps.dcim import is_auto_component_creation_suppressed, SkipAutoComponentCreation
+
+assert not is_auto_component_creation_suppressed()
+with SkipAutoComponentCreation():
+    assert is_auto_component_creation_suppressed()
+```
+
+Production code should normally use the context manager directly rather than checking the flag.


### PR DESCRIPTION
# Closes #9026

# What's Changed

Adds a public, supported extension point for apps to suppress Nautobot's automatic `Device`/`Module` component instantiation that fires from `Device.save()` and `Module.save()` on the *initial* save of a new instance.

The motivating use case is integrations that own the component inventory from an external source-of-truth and intend to write the full component graph themselves immediately after creating the parent object. Today's default makes their first sync either race against the template-derived components (when names overlap) or produce polluted output (when names don't). The new context manager lets apps opt out for a scoped region of code.

## Public API

```python
from nautobot.apps.dcim import SkipAutoComponentCreation
from nautobot.dcim.models import Device

with SkipAutoComponentCreation():
    device = Device.objects.create(
        name="leaf-01",
        device_type=device_type,
        role=device_role,
        status=device_status,
        location=location,
    )
    # device.interfaces.count() == 0; no template-derived components were instantiated.
```

For introspection there is also `is_auto_component_creation_suppressed()` returning `True` if a context is currently active.

## Implementation

- New module `nautobot/dcim/component_creation.py` exposing:
  - `SkipAutoComponentCreation` — class-based context manager (re-entrant, exception-safe, backed by `contextvars.ContextVar`).
  - `is_auto_component_creation_suppressed()` — introspection helper.
- New `nautobot/apps/dcim.py` re-exporting both names so they are importable from `nautobot.apps.dcim`.
- `Device.save()` and `Module.save()` consult `is_auto_component_creation_suppressed()` inside their existing `if is_new:` branch before calling `self.create_components()`. Default behaviour is unchanged for any code that does not opt in.

## Scope (what the hook does and does not do)

| Write path | Calls `create_components()`? | Affected by `SkipAutoComponentCreation`? |
|---|---|---|
| `Device.objects.create(...)` / `Module.objects.create(...)` | Yes | **Yes** |
| `instance.save()` on a new in-memory object | Yes | **Yes** |
| Subsequent `save()` of an existing instance (update / migrate / move) | No (`is_new` is False) | N/A — nothing to suppress |
| `Device.objects.bulk_create([...])` / `Module.objects.bulk_create([...])` | No (bypasses `save()`) | N/A — nothing to suppress |

`contextvars.ContextVar` (rather than `threading.local`) is used so the flag is correctly scoped per asyncio task / per Celery worker invocation. Freshly spawned threads start with their own (default) context, so suppression cannot leak across task boundaries.

## Commit layout

The branch is split into focused commits for ease of review:

1. Add `component_creation` module exposing `SkipAutoComponentCreation`
2. Expose `SkipAutoComponentCreation` under `nautobot.apps.dcim`
3. Honour `SkipAutoComponentCreation` in `Device.save()` and `Module.save()`
4. Add tests for `SkipAutoComponentCreation`
5. Document `SkipAutoComponentCreation` under platform-features
6. Add changelog fragment for #9026
7. Restructure `test_exception_safe` for static-analysis reachability

## Verification

- `ruff check` + `ruff format --check` clean on all changed Python files.
- `invoke tests --label nautobot.dcim.tests.test_component_creation`: **11/11 pass**.
- `invoke tests --label nautobot.dcim.tests.test_models`: **356/356 pass** (no regression in existing DCIM model tests).
- `invoke build-and-check-docs` rebuilds the new platform-features page and the auto-generated `nautobot.apps.dcim` code-reference page successfully.

# Screenshots

N/A — purely backend/library extension point, no UI surface.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (`changes/9026.added`)
- [x] Attached Screenshots, Payload Example — N/A (no UI surface)
- [x] Unit, Integration Tests (`nautobot/dcim/tests/test_component_creation.py`, 11 tests)
- [x] Documentation Updates (new platform-features page + `nautobot.apps.dcim` code-reference)
- [ ] Example App Updates — not applicable; this is a low-level extension point with no example-app surface
- [x] Outline Remaining Work, Constraints from Design — see *Scope* table above

## Reviewer notes

- Default behaviour is unchanged. The `if is_new and not is_auto_component_creation_suppressed():` gate only changes behaviour when an app explicitly enters the context manager — no existing code path opts in.
- Re-entrancy: nested `with` blocks restore the previous state on inner exit (still suppressed), not the unconditional default. The token-based `ContextVar.reset()` makes this automatic.
- Exception safety: `__exit__` runs on raise, restoring state. The context manager does not swallow the exception.
- `Device.create_components()` performs cache invalidation (`has_device_bays`, `has_module_bays`) on the non-suppressed path. For a brand-new device those cache keys are not yet populated, so the suppressed path safely skips the invalidation.
- API-shape discussion is happening on the linked feature request (#9026); this PR currently lands the context-manager API only.
