### PR TITLE
Fix collapsed Select2 multi-select width on admin object permission form

### DIFF
--- a/changes/9038.fixed
+++ b/changes/9038.fixed
@@ -1,0 +1,1 @@
+Fixed Select2 multi-select widgets (Object types, Groups, Users) rendering as a collapsed, narrow column on the admin object permission form.

--- a/nautobot/core/templates/admin/base.html
+++ b/nautobot/core/templates/admin/base.html
@@ -35,12 +35,7 @@
             .related-widget-wrapper > select {
                 width: 100%;
             }
-            /*
-             * Select2-enhanced selects (e.g. ObjectPermission's "Object types", "Groups", "Users") are
-             * initialized with width: 'off', so the generated .select2-container relies on CSS for sizing.
-             * The Bootstrap 5 theme only sizes the inner .select2-selection, leaving the container collapsed
-             * in the admin layout. Force the container to full width to match the other admin form widgets.
-             */
+            /* Select2 inits with width: 'off', so the generated container must be sized via CSS. */
             .nautobot-select2-static + .select2-container {
                 width: 100%;
             }

--- a/nautobot/core/templates/admin/base.html
+++ b/nautobot/core/templates/admin/base.html
@@ -35,6 +35,15 @@
             .related-widget-wrapper > select {
                 width: 100%;
             }
+            /*
+             * Select2-enhanced selects (e.g. ObjectPermission's "Object types", "Groups", "Users") are
+             * initialized with width: 'off', so the generated .select2-container relies on CSS for sizing.
+             * The Bootstrap 5 theme only sizes the inner .select2-selection, leaving the container collapsed
+             * in the admin layout. Force the container to full width to match the other admin form widgets.
+             */
+            .nautobot-select2-static + .select2-container {
+                width: 100%;
+            }
             .form-horizontal .control-label {
                 text-align: left;
             }


### PR DESCRIPTION
# Closes #9038

# What's Changed
The **Object types**, **Groups**, and **Users** multi-select fields on the admin Object Permission form (`/admin/users/objectpermission/add/`) rendered as a collapsed, ~40px-wide column, wrapping each option to one word per line.

These fields use Nautobot's static Select2 widget (`nautobot-select2-static`), which is initialized with `width: 'off'` in `nautobot/ui/src/js/select2.js`, so the generated `.select2-container` is sized entirely by CSS. The base `.select2-container` is `display: inline-block` with no width, and the Bootstrap 5 theme only sizes the inner `.select2-selection` — so in the admin layout the container collapsed to its content width. This styling was missed in the Bootstrap 3 → 5 migration.

The admin Bootstrap 5 style shim in `nautobot/core/templates/admin/base.html` already normalizes widths for `textarea`, `.vTextField`, `.selectfilter`, and `.related-widget-wrapper > select`. This PR extends it with one admin-scoped rule that forces the static Select2 container to full width:

```css
.nautobot-select2-static + .select2-container {
    width: 100%;
}
```

**Scope / blast radius:** the rule lives inline in the admin base template (served on admin pages only), and the adjacent-sibling selector targets only Nautobot static Select2 widgets — so there is no impact on the main UI or on other admin widgets.

# Screenshots
<img width="1200" height="419" alt="image (7)" src="https://github.com/user-attachments/assets/7e579843-a98c-48c3-a972-3e561e09f051" />


<img width="811" height="363" alt="Screenshot 2026-06-02 at 10 07 24" src="https://github.com/user-attachments/assets/de837820-b261-4ae8-9d75-0b5d40c558ff" />


# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests — N/A (CSS-only template change; no Python/logic to test)
- [ ] Documentation Updates — N/A
- [ ] Example App Updates — N/A
- [ ] Outline Remaining Work, Constraints from Design — none
