### PR TITLE
Use request.POST in ComponentCreateView

### DIFF
--- a/changes/9047.fixed
+++ b/changes/9047.fixed
@@ -1,1 +1,2 @@
-Fixed bug that caused the application to crash when creating Interface even with a provided value for a required Custom Field.
+Fixed a bug that caused the application to crash when creating an Interface with a required Custom Field despite providing a value for it.
+Fixed application crashes from errors on fields that are not declared in some forms.

--- a/changes/9047.fixed
+++ b/changes/9047.fixed
@@ -1,0 +1,1 @@
+Fixed bug that caused the application to crash when creating Interface even with a provided value for a required Custom Field.

--- a/nautobot/core/testing/views.py
+++ b/nautobot/core/testing/views.py
@@ -2192,6 +2192,31 @@ class ViewTestCases:
             self.assertEqual(matching_count, self.bulk_create_count)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+        def test_create_components_with_required_custom_field(self):
+            """A required custom field must be carried through to each component created via the add form (#9047)."""
+            custom_field = extras_models.CustomField.objects.create(
+                type=extras_choices.CustomFieldTypeChoices.TYPE_TEXT,
+                label="Mandatory Component Field",
+                required=True,
+            )
+            custom_field.content_types.set([ContentType.objects.get_for_model(self.model)])
+            self.addCleanup(custom_field.delete)
+
+            self.add_permissions(f"{self.model._meta.app_label}.add_{self.model._meta.model_name}")
+
+            data = self.bulk_create_data.copy()
+            data[custom_field.add_prefix_to_cf_key()] = "expected value"
+            initial_pks = set(self._get_queryset().values_list("pk", flat=True))
+
+            response = self.client.post(self._get_url("add"), data=utils.post_data(data))
+            self.assertHttpStatus(response, 302)
+
+            new_objects = self._get_queryset().exclude(pk__in=initial_pks)
+            self.assertEqual(new_objects.count(), self.bulk_create_count)
+            for instance in new_objects:
+                self.assertEqual(instance.cf[custom_field.key], "expected value")
+
+        @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
         def test_modular_component_create_form_fields(self):
             """Test that the modular component create form has the expected fields."""
             if self.model._meta.label_lower == "virtualization.vminterface":

--- a/nautobot/core/testing/views.py
+++ b/nautobot/core/testing/views.py
@@ -2200,7 +2200,6 @@ class ViewTestCases:
                 required=True,
             )
             custom_field.content_types.set([ContentType.objects.get_for_model(self.model)])
-            self.addCleanup(custom_field.delete)
 
             self.add_permissions(f"{self.model._meta.app_label}.add_{self.model._meta.model_name}")
 

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -1448,7 +1448,7 @@ class ComponentCreateView(UIComponentsMixin, GetReturnURLMixin, ObjectPermission
 
         if form.is_valid():
             new_components = []
-            data = deepcopy(form.cleaned_data)
+            data = deepcopy(request.POST)
 
             names = form.cleaned_data["name_pattern"]
             labels = form.cleaned_data.get("label_pattern")

--- a/nautobot/core/views/generic.py
+++ b/nautobot/core/views/generic.py
@@ -1448,7 +1448,27 @@ class ComponentCreateView(UIComponentsMixin, GetReturnURLMixin, ObjectPermission
 
         if form.is_valid():
             new_components = []
-            data = deepcopy(request.POST)
+            data = deepcopy(form.cleaned_data)
+
+            # The component create form (`self.form`) is a plain form that does not declare the "extras" fields
+            # (custom fields, relationships, notes, dynamic group assignments) that are added dynamically
+            # to the model form (`self.model_form`) and rendered alongside it. Those fields are therefore
+            # absent from `form.cleaned_data`, so we copy their values directly from the POST data; otherwise a
+            # required custom field or relationship rendered from the model form has nowhere to flow through
+            # and component creation fails. We are being explicit here about which fields are copied
+            # so that model fields deliberately omitted from the create UI cannot be set
+            # (intentionally or inadvertently) via a crafted POST request.
+            extras_field_names = set(getattr(model_form, "custom_fields", [])) | set(
+                getattr(model_form, "relationships", [])
+            )
+            extras_field_names |= {"object_note", "dynamic_groups"}.intersection(model_form.fields)
+            for field_name in extras_field_names:
+                if field_name not in request.POST:
+                    continue
+                if getattr(model_form.fields[field_name].widget, "allow_multiple_selected", False):
+                    data[field_name] = request.POST.getlist(field_name)
+                else:
+                    data[field_name] = request.POST.get(field_name)
 
             names = form.cleaned_data["name_pattern"]
             labels = form.cleaned_data.get("label_pattern")
@@ -1474,7 +1494,11 @@ class ComponentCreateView(UIComponentsMixin, GetReturnURLMixin, ObjectPermission
                             field = "label_pattern"
                         for e in errors:
                             err_str = ", ".join(e)
-                            form.add_error(field, f"{name}: {err_str}")
+                            if field not in form.fields:
+                                # Add generic errors for fields of the model form that are not declared in the create form.
+                                form.add_error(None, f"{name}: {field}: {err_str}")
+                            else:
+                                form.add_error(field, f"{name}: {err_str}")
 
             if not form.errors:
                 try:
@@ -1598,10 +1622,11 @@ class BulkComponentCreateView(UIComponentsMixin, GetReturnURLMixin, ObjectPermis
                                     ) in component_form.errors.as_data().items():
                                         for e in errors:
                                             err_str = ", ".join(e)
-                                            form.add_error(
-                                                field,
-                                                f"{obj} {name}: {err_str}",
-                                            )
+                                            if field not in form.fields:
+                                                # Add generic errors for fields of the model form that are not declared in the create form.
+                                                form.add_error(None, f"{obj} {name}: {field}: {err_str}")
+                                            else:
+                                                form.add_error(field, f"{obj} {name}: {err_str}")
 
                         # Enforce object-level permissions
                         if self.queryset.filter(pk__in=[obj.pk for obj in new_components]).count() != len(

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -3671,6 +3671,29 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
         self.assertNotIn(invalid_ipaddress_link, response_content)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_create_multiple_components_with_required_custom_field(self):
+        """A required custom field value must be carried through to each component created via the bulk-add form."""
+        custom_field = CustomField.objects.create(
+            type=CustomFieldTypeChoices.TYPE_TEXT,
+            label="Mandatory Interface Field",
+            required=True,
+        )
+        custom_field.content_types.set([ContentType.objects.get_for_model(Interface)])
+
+        self.add_permissions("dcim.add_interface")
+        data = self.bulk_create_data.copy()
+        data[custom_field.add_prefix_to_cf_key()] = "expected value"
+        request = {
+            "path": self._get_url("add"),
+            "data": post_data(data),
+        }
+        self.assertHttpStatus(self.client.post(**request), 302)
+        created = self._get_queryset().filter(name__in=["Interface 4", "Interface 5", "Interface 6"])
+        self.assertEqual(created.count(), 3)
+        for instance in created:
+            self.assertEqual(instance.cf[custom_field.key], "expected value")
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_create_virtual_interface_with_port_type_fails(self):
         """Test that a virtual interface cannot have a port type"""
         self.add_permissions("dcim.add_interface")

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -3671,27 +3671,37 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
         self.assertNotIn(invalid_ipaddress_link, response_content)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
-    def test_create_multiple_components_with_required_custom_field(self):
-        """A required custom field value must be carried through to each component created via the bulk-add form."""
-        custom_field = CustomField.objects.create(
-            type=CustomFieldTypeChoices.TYPE_TEXT,
-            label="Mandatory Interface Field",
-            required=True,
+    def test_create_component_with_required_relationship_does_not_crash(self):
+        """A required relationship the create form can't render yields a graceful error, not a 500 ValueError (#9047).
+
+        The custom-field happy path is covered generically by
+        ViewTestCases.DeviceComponentViewTestCase.test_create_components_with_required_custom_field; this case
+        exercises the error-attribution guard for a field that exists only on the per-component model form.
+        """
+        relationship = Relationship(
+            label="Interface requires a device relationship",
+            key="test_interface_required_device",
+            type=RelationshipTypeChoices.TYPE_ONE_TO_MANY,
+            source_type=ContentType.objects.get_for_model(Interface),
+            destination_type=ContentType.objects.get_for_model(Device),
+            required_on="source",
         )
-        custom_field.content_types.set([ContentType.objects.get_for_model(Interface)])
+        relationship.validated_save()
+        self.addCleanup(relationship.delete)
 
         self.add_permissions("dcim.add_interface")
-        data = self.bulk_create_data.copy()
-        data[custom_field.add_prefix_to_cf_key()] = "expected value"
-        request = {
-            "path": self._get_url("add"),
-            "data": post_data(data),
-        }
-        self.assertHttpStatus(self.client.post(**request), 302)
-        created = self._get_queryset().filter(name__in=["Interface 4", "Interface 5", "Interface 6"])
-        self.assertEqual(created.count(), 3)
-        for instance in created:
-            self.assertEqual(instance.cf[custom_field.key], "expected value")
+
+        # Single-component add (ComponentCreateView): the required `cr_*` field exists only on the
+        # model form, so leaving it empty previously raised ValueError from form.add_error.
+        response = self.client.post(self._get_url("add"), data=post_data(self.bulk_create_data.copy()))
+        self.assertHttpStatus(response, 200)
+
+        # Bulk-add to devices (BulkComponentCreateView): same guard.
+        bulk_data = self.bulk_create_data.copy()
+        bulk_data["pk"] = bulk_data.pop("device")
+        bulk_data["_create"] = ""
+        response = self.client.post(reverse("dcim:device_bulk_add_interface"), data=post_data(bulk_data))
+        self.assertHttpStatus(response, 200)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_create_virtual_interface_with_port_type_fails(self):

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -3687,7 +3687,6 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             required_on="source",
         )
         relationship.validated_save()
-        self.addCleanup(relationship.delete)
 
         self.add_permissions("dcim.add_interface")
 

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -3893,10 +3893,11 @@ class BulkComponentCreateUIViewSetMixin:
                                     ) in component_form.errors.as_data().items():
                                         for e in errors:
                                             err_str = ", ".join(e)
-                                            form.add_error(
-                                                field,
-                                                f"{obj} {name}: {err_str}",
-                                            )
+                                            if field not in form.fields:
+                                                # Add generic errors for fields of the model form that are not declared in the create form.
+                                                form.add_error(None, f"{obj} {name}: {field}: {err_str}")
+                                            else:
+                                                form.add_error(field, f"{obj} {name}: {err_str}")
 
                         # Enforce object-level permissions
                         if component_queryset.filter(pk__in=[obj.pk for obj in new_components]).count() != len(


### PR DESCRIPTION
# Closes #9047 
# What's Changed
Replaced `data = deepcopy(form.cleaned_data)` with `data = deepcopy(request.POST)` under `ComponentCreateView`.

# TODO
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Unit, Integration Tests
