### PR TITLE
Refactor value_widget

### DIFF
--- a/changes/9053.housekeeping
+++ b/changes/9053.housekeeping
@@ -1,0 +1,1 @@
+Moved the ObjectMetadata value-widget to a detail action on `MetadataTypeUIViewSet`.

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -2290,14 +2290,22 @@ class ObjectMetadataCreateForm(ObjectMetadataForm):
         # Persistent HTMX swap target around the value field: when the user changes
         # metadata_type, the wrapper's innerHTML is replaced with the appropriate input
         # widget for that data type. `jsify_form` re-runs to re-init Select2/date pickers.
+        #
+        # The value widget lives on MetadataTypeUIViewSet as a *detail* action, so the
+        # metadata-type pk belongs in the URL path. The selected pk isn't known until the user
+        # picks one, so rather than reverse a detail URL with a throwaway pk, we hand the client
+        # the pk-less list URL and let the config-request handler assemble the detail path from it
+        # plus the current `#id_metadata_type` value (see objectmetadata_create.html).
         if "value" in self.fields:
+            metadata_type_base_url = reverse_lazy("extras:metadatatype_list")
             self.fields["value"].htmx_attrs = {
                 "id": "nb-objectmetadata-value-field",
-                "hx-get": reverse_lazy("extras:objectmetadata_value_widget"),
+                "data-value-widget-base": metadata_type_base_url,
+                "hx-get": metadata_type_base_url,
                 "hx-trigger": "change from:#id_metadata_type",
-                "hx-include": "#id_metadata_type",
                 "hx-target": "this",
                 "hx-swap": "innerHTML",
+                "hx-on::config-request": "objectMetadataValueWidgetConfigRequest(this, event)",
                 "hx-on::after-swap": "if (window.jsify_form) jsify_form(this);",
             }
         initial = kwargs.get("initial", {})

--- a/nautobot/extras/templates/extras/objectmetadata_create.html
+++ b/nautobot/extras/templates/extras/objectmetadata_create.html
@@ -16,6 +16,22 @@
 {% block javascript %}
     {{ block.super }}
     <script type="text/javascript">
+        // Build the value-widget request path from the currently selected metadata_type.
+        // The widget is a *detail* action on MetadataTypeUIViewSet, so the pk lives in the URL
+        // path. We assemble it from the pk-less list URL (`data-value-widget-base`) plus the live
+        // selection: <base>/<pk>/value-widget/. With no metadata_type selected there is no detail
+        // URL, so we clear the widget and cancel the request.
+        window.objectMetadataValueWidgetConfigRequest = (wrapper, event) => {
+            const metadataTypeSelect = document.getElementById("id_metadata_type");
+            const metadataTypeId = metadataTypeSelect ? metadataTypeSelect.value : "";
+            if (!metadataTypeId) {
+                wrapper.innerHTML = "";
+                event.preventDefault();
+                return;
+            }
+            event.detail.path = wrapper.dataset.valueWidgetBase + encodeURIComponent(metadataTypeId) + "/value-widget/";
+        };
+
         document.addEventListener("DOMContentLoaded", () => {
             const dataTypes = {{ metadata_type_data_types|default:"{}"|safe }};
             const contactTeamDataType = "{{ contact_team_data_type }}";

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -3278,6 +3278,48 @@ class MetadataTypeTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         self.form_data["data_type"] = self.model.objects.first().data_type
         return super().test_edit_object_with_permission()
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_value_widget_renders_text_input_for_text_metadata_type(self):
+        """`value_widget` detail action returns a CharField-backed widget for TYPE_TEXT."""
+        text_mdt = MetadataType.objects.create(
+            name="Text MDT for value widget", data_type=MetadataTypeDataTypeChoices.TYPE_TEXT
+        )
+        response = self.client.get(
+            reverse("extras:metadatatype_value_widget", kwargs={"pk": text_mdt.pk}),
+            headers={"HX-Request": "true"},
+        )
+        self.assertHttpStatus(response, 200)
+        content = response.content.decode(response.charset)
+        # TYPE_TEXT renders an <input type="text"> with the field name `value`.
+        self.assertIn('name="value"', content)
+        # Help text mentions the resolved metadata type's display name.
+        self.assertIn(str(text_mdt), content)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_value_widget_returns_empty_for_contact_team_metadata_type(self):
+        """For CONTACT_TEAM types, `MetadataType.to_form_field` returns None, so the value
+        widget endpoint renders an empty fragment (no input). HTMX swaps in nothing, removing
+        any prior value input."""
+        contact_team_mdt = MetadataType.objects.create(
+            name="Contact/Team MDT for value widget", data_type=MetadataTypeDataTypeChoices.TYPE_CONTACT_TEAM
+        )
+        response = self.client.get(
+            reverse("extras:metadatatype_value_widget", kwargs={"pk": contact_team_mdt.pk}),
+            headers={"HX-Request": "true"},
+        )
+        self.assertHttpStatus(response, 200)
+        content = response.content.decode(response.charset).strip()
+        self.assertNotIn('name="value"', content)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_value_widget_returns_404_for_nonexistent_metadata_type(self):
+        """As a detail action, an unknown metadata-type pk resolves via get_object() → 404."""
+        response = self.client.get(
+            reverse("extras:metadatatype_value_widget", kwargs={"pk": "00000000-0000-0000-0000-000000000000"}),
+            headers={"HX-Request": "true"},
+        )
+        self.assertHttpStatus(response, 404)
+
 
 class NoteTestCase(
     ViewTestCases.CreateObjectViewTestCase,
@@ -6424,59 +6466,6 @@ class ObjectMetadataTestCase(
             },
         )
         self.assertRedirects(response, return_url, fetch_redirect_response=False)
-
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
-    def test_value_widget_renders_text_input_for_text_metadata_type(self):
-        """`value_widget` HTMX endpoint returns a CharField-backed widget for TYPE_TEXT."""
-        response = self.client.get(
-            reverse("extras:objectmetadata_value_widget"),
-            data={"metadata_type": str(self.text_mdt.pk)},
-            headers={"HX-Request": "true"},
-        )
-        self.assertHttpStatus(response, 200)
-        content = response.content.decode(response.charset)
-        # TYPE_TEXT renders an <input type="text"> with the field name `value`.
-        self.assertIn('name="value"', content)
-        # Help text mentions the resolved metadata type's display name.
-        self.assertIn(str(self.text_mdt), content)
-
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
-    def test_value_widget_returns_empty_for_contact_team_metadata_type(self):
-        """For CONTACT_TEAM types, `MetadataType.to_form_field` returns None, so the value
-        widget endpoint renders an empty fragment (no input). HTMX swaps in nothing, removing
-        any prior value input."""
-        response = self.client.get(
-            reverse("extras:objectmetadata_value_widget"),
-            data={"metadata_type": str(self.contact_team_mdt.pk)},
-            headers={"HX-Request": "true"},
-        )
-        self.assertHttpStatus(response, 200)
-        content = response.content.decode(response.charset).strip()
-        self.assertNotIn('name="value"', content)
-
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
-    def test_value_widget_returns_empty_for_missing_metadata_type(self):
-        """No `metadata_type` query param → empty fragment, no crash."""
-        response = self.client.get(
-            reverse("extras:objectmetadata_value_widget"),
-            headers={"HX-Request": "true"},
-        )
-        self.assertHttpStatus(response, 200)
-        self.assertNotIn('name="value"', response.content.decode(response.charset))
-
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
-    def test_value_widget_returns_empty_for_invalid_metadata_type(self):
-        """Bogus pk or non-existent metadata_type → swallow via the view's try/except, return
-        an empty fragment instead of raising."""
-        for bogus in ("not-a-uuid", "00000000-0000-0000-0000-000000000000"):
-            with self.subTest(metadata_type=bogus):
-                response = self.client.get(
-                    reverse("extras:objectmetadata_value_widget"),
-                    data={"metadata_type": bogus},
-                    headers={"HX-Request": "true"},
-                )
-                self.assertHttpStatus(response, 200)
-                self.assertNotIn('name="value"', response.content.decode(response.charset))
 
     def test_object_metadata_fields_panel_delegates_value_rendering_to_model(self):
         """The panel's render_value override delegates `_value` rendering to

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -3320,6 +3320,42 @@ class MetadataTypeTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         )
         self.assertHttpStatus(response, 404)
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
+    def test_value_widget_without_permission(self):
+        """A user lacking `extras.view_metadatatype` is denied the value-widget detail action."""
+        mdt = MetadataType.objects.create(name="No-perm", data_type=MetadataTypeDataTypeChoices.TYPE_TEXT)
+        url = reverse("extras:metadatatype_value_widget", kwargs={"pk": mdt.pk})
+        self.assertHttpStatus(self.client.get(url, HTTP_HX_REQUEST="true"), 403, msg=url)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
+    def test_value_widget_with_permission(self):
+        """With `extras.view_metadatatype`, the value widget renders for the metadata type."""
+        self.add_permissions("extras.view_metadatatype")
+        mdt = MetadataType.objects.create(name="View-perm", data_type=MetadataTypeDataTypeChoices.TYPE_TEXT)
+        url = reverse("extras:metadatatype_value_widget", kwargs={"pk": mdt.pk})
+        self.assertBodyContains(self.client.get(url, HTTP_HX_REQUEST="true"), 'name="value"')
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
+    def test_value_widget_with_constrained_permission(self):
+        """A constrained view permission renders the permitted type's widget but 404s others."""
+        permitted_mdt = MetadataType.objects.create(name="Permitted", data_type=MetadataTypeDataTypeChoices.TYPE_TEXT)
+        other_mdt = MetadataType.objects.create(name="Forbidden", data_type=MetadataTypeDataTypeChoices.TYPE_TEXT)
+
+        obj_perm = ObjectPermission(
+            name="Constrained metadata type view",
+            constraints={"pk": permitted_mdt.pk},
+            actions=["view"],
+        )
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ContentType.objects.get_for_model(MetadataType))
+
+        permitted_url = reverse("extras:metadatatype_value_widget", kwargs={"pk": permitted_mdt.pk})
+        self.assertBodyContains(self.client.get(permitted_url, HTTP_HX_REQUEST="true"), 'name="value"')
+
+        other_url = reverse("extras:metadatatype_value_widget", kwargs={"pk": other_mdt.pk})
+        self.assertHttpStatus(self.client.get(other_url, HTTP_HX_REQUEST="true"), 404, msg=other_url)
+
 
 class NoteTestCase(
     ViewTestCases.CreateObjectViewTestCase,

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -4157,6 +4157,37 @@ class MetadataTypeUIViewSet(NautobotUIViewSet):
 
         return obj
 
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="value-widget",
+        url_name="value_widget",
+        custom_view_base_action="view",
+    )
+    def value_widget(self, request, *args, **kwargs):
+        """
+        Render the appropriate `value` input field for this metadata type.
+
+        Called by the ObjectMetadata create form via HTMX when the user changes the metadata_type
+        select, so the input adapts (date picker, choice list, etc.) without a full page reload.
+        The metadata type is identified by the pk in the URL path. Returns an empty fragment for
+        TYPE_CONTACT_TEAM, since those don't use `value`.
+        """
+        mt = self.get_object()
+        field = mt.to_form_field(required=False)
+        bound_field = None
+        if field is not None:
+            field.label = "Value"
+            field.help_text = f"Value for metadata type '{mt}' ({mt.get_data_type_display()})."
+
+            class _ValueOnlyForm(django_forms.Form):
+                pass
+
+            f = _ValueOnlyForm()
+            f.fields["value"] = field
+            bound_field = f["value"]
+        return render(request, "inc/htmx_form_field.html", {"field": bound_field})
+
 
 class _ObjectMetadataFieldsPanel(object_detail.ObjectFieldsPanel):
     def render_value(self, key, value, context):
@@ -4244,45 +4275,6 @@ class ObjectMetadataUIViewSet(
             )
             context["contact_team_data_type"] = MetadataTypeDataTypeChoices.TYPE_CONTACT_TEAM
         return context
-
-    @action(
-        detail=False,
-        methods=["get"],
-        url_path="value-widget",
-        url_name="value_widget",
-        custom_view_base_action="view",
-    )
-    def value_widget(self, request, *args, **kwargs):
-        """
-        Render the appropriate `value` field for a given metadata_type.
-
-        Called by the create template via HTMX when the user changes the metadata_type select,
-        so the input adapts (date picker, choice list, etc.) without a full page reload.
-        Returns an empty fragment for TYPE_CONTACT_TEAM, since those don't use `value`.
-        """
-        mt_id = request.GET.get("metadata_type")
-        mt = None
-        if mt_id:
-            try:
-                mt = MetadataType.objects.get(pk=mt_id)
-            except (MetadataType.DoesNotExist, ValidationError, ValueError, TypeError):
-                mt = None
-        field = None
-        if mt is not None:
-            field = mt.to_form_field(required=False)
-            if field is not None:
-                field.label = "Value"
-                field.help_text = f"Value for metadata type '{mt}' ({mt.get_data_type_display()})."
-
-        class _ValueOnlyForm(django_forms.Form):
-            pass
-
-        bound_field = None
-        if field is not None:
-            f = _ValueOnlyForm()
-            f.fields["value"] = field
-            bound_field = f["value"]
-        return render(request, "inc/htmx_form_field.html", {"field": bound_field})
 
 
 #


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #
[NBOTQA-62](https://networktocode.atlassian.net/browse/NBOTQA-62)
#9030

# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

- View: Moved value_widget from a non-detail action on ObjectMetadataUIViewSet to a detail=True action on MetadataTypeUIViewSet (PK now in the URL path, resolved via self.get_object())
- Form/template: Reworked the HTMX wiring to use the pk-less list URL + a config-request handler that builds {base}/{pk}/value-widget/ from the selected metadata type

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

|Before|After|
|--|--|
|<img width="1115" height="798" alt="image" src="https://github.com/user-attachments/assets/e096d194-26c0-48d1-863e-a257e29dc005" />|<img width="1277" height="545" alt="image" src="https://github.com/user-attachments/assets/60225e39-603f-4866-b7b3-58e6b00a55f0" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design


[NBOTQA-62]: https://networktocode.atlassian.net/browse/NBOTQA-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ