### PR TITLE
[LTM Backport] Add SkipAutoComponentCreation context manager for apps

### DIFF
--- a/changes/9026.added
+++ b/changes/9026.added
@@ -1,0 +1,1 @@
+Added `nautobot.apps.dcim.SkipAutoComponentCreation` context manager that lets apps opt out of Nautobot's automatic Device/Module component instantiation on a new save.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -601,6 +601,7 @@ nav:
               - Prepopulating Data: "development/apps/api/platform-features/prepopulating-data.md"
               - Prometheus Metrics: "development/apps/api/prometheus.md"
               - Secrets Providers: "development/apps/api/platform-features/secrets-providers.md"
+              - Skip Auto Component Creation: "development/apps/api/platform-features/skip-auto-component-creation.md"
               - Table Extensions: "development/apps/api/platform-features/table-extensions.md"
               - Uniquely Identifying a Nautobot Object: "development/apps/api/platform-features/uniquely-identify-objects.md"
           - UI Extensions:
@@ -620,6 +621,7 @@ nav:
               - nautobot.apps.config: "code-reference/nautobot/apps/config.md"
               - nautobot.apps.constants: "code-reference/nautobot/apps/constants.md"
               - nautobot.apps.datasources: "code-reference/nautobot/apps/datasources.md"
+              - nautobot.apps.dcim: "code-reference/nautobot/apps/dcim.md"
               - nautobot.apps.events: "code-reference/nautobot/apps/events.md"
               - nautobot.apps.exceptions: "code-reference/nautobot/apps/exceptions.md"
               - nautobot.apps.factory: "code-reference/nautobot/apps/factory.md"

--- a/nautobot/apps/dcim.py
+++ b/nautobot/apps/dcim.py
@@ -1,0 +1,8 @@
+"""Public DCIM extension points for Nautobot apps."""
+
+from nautobot.dcim.component_creation import is_auto_component_creation_suppressed, SkipAutoComponentCreation
+
+__all__ = (
+    "SkipAutoComponentCreation",
+    "is_auto_component_creation_suppressed",
+)

--- a/nautobot/dcim/component_creation.py
+++ b/nautobot/dcim/component_creation.py
@@ -1,0 +1,100 @@
+"""Public extension point for suppressing automatic Device/Module component instantiation.
+
+By default, when a new `Device` or `Module` is first persisted, `save()` calls
+`self.create_components()` to instantiate one component (interface, console
+port, power port, etc.) per template defined on the related `DeviceType` /
+`ModuleType`. For apps that own the component inventory from an external
+source-of-truth and intend to write the full component graph themselves
+immediately after creating the parent object, this default is undesirable.
+
+This module exposes `SkipAutoComponentCreation`, a re-entrant,
+exception-safe context manager. Code that runs inside the `with` block
+creates Devices/Modules without their template-derived components:
+
+```python
+from nautobot.apps.dcim import SkipAutoComponentCreation
+from nautobot.dcim.models import Device
+
+with SkipAutoComponentCreation():
+    device = Device.objects.create(...)  # no auto-instantiated components
+```
+
+The scope is limited to the *initial* save (the `is_new` branch of
+`Device.save()` / `Module.save()`). It does not affect subsequent saves,
+updates, or paths that bypass `save()` such as `bulk_create()`.
+
+Suppression is scoped per-asyncio-task and per-Celery-task via
+`contextvars.ContextVar`, so it cannot leak across concurrent task boundaries.
+
+!!! note "Thread-based parallelization"
+    Because the flag lives in a `contextvars.ContextVar`, a value set in one
+    OS thread is **not** visible in a separately spawned `threading.Thread`;
+    each new thread starts from the default (`False`). Code that fans work out
+    across a thread pool (for example, a future SSoT bulk-import that uses
+    `concurrent.futures.ThreadPoolExecutor`) must therefore either enter the
+    `with SkipAutoComponentCreation():` block *inside* each worker, or copy the
+    calling context into the worker via `contextvars.copy_context()`. The
+    asyncio-task and Celery-task scoping described above is unaffected.
+"""
+
+import contextvars
+from typing import Optional
+
+_skip_flag: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "nautobot_dcim_skip_auto_component_creation",
+    default=False,
+)
+
+
+class SkipAutoComponentCreation:
+    """Context manager that suppresses Device/Module `create_components()` on save.
+
+    Inside the `with` block, `Device.save()` and `Module.save()` skip
+    their call to `self.create_components()` for newly created instances.
+    Default behaviour (instantiate components from the related `DeviceType` /
+    `ModuleType` templates) is restored automatically on exit, including when
+    the block raises.
+
+    The context manager is re-entrant: an outer `with` block continues to
+    suppress after an inner block exits. It is exception-safe: state is
+    restored even if the wrapped code raises.
+
+    Implementation uses `contextvars.ContextVar`, so the flag is
+    correctly scoped per asyncio task / Celery worker invocation and does
+    not leak across threads.
+
+    Example:
+        ```python
+        from nautobot.apps.dcim import SkipAutoComponentCreation
+        from nautobot.dcim.models import Device
+
+        with SkipAutoComponentCreation():
+            device = Device.objects.create(...)  # no auto-components
+        ```
+    """
+
+    def __init__(self):
+        """Initialize without entering the context yet."""
+        self._token: Optional[contextvars.Token] = None
+
+    def __enter__(self):
+        """Activate suppression for the calling context."""
+        self._token = _skip_flag.set(True)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        """Restore the previous suppression state."""
+        if self._token is not None:
+            _skip_flag.reset(self._token)
+            self._token = None
+        # Do not suppress exceptions raised inside the with block.
+        return False
+
+
+def is_auto_component_creation_suppressed() -> bool:
+    """Return True if a `SkipAutoComponentCreation` context is active.
+
+    Intended primarily for introspection and tests. Production code should
+    normally use the `SkipAutoComponentCreation` context manager directly.
+    """
+    return _skip_flag.get()

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -26,6 +26,7 @@ from nautobot.dcim.choices import (
     SoftwareImageFileHashingAlgorithmChoices,
     SubdeviceRoleChoices,
 )
+from nautobot.dcim.component_creation import is_auto_component_creation_suppressed
 from nautobot.dcim.constants import MODULE_RECURSION_DEPTH_LIMIT
 from nautobot.dcim.utils import get_all_network_driver_mappings, get_network_driver_mapping_tool_names
 from nautobot.extras.models import ChangeLoggedModel, ConfigContextModel, RoleField, StatusField
@@ -863,8 +864,9 @@ class Device(PrimaryModel, ConfigContextModel):
 
         super().save(*args, **kwargs)
 
-        # If this is a new Device, instantiate all related components per the DeviceType definition
-        if is_new:
+        # If this is a new Device, instantiate all related components per the DeviceType definition,
+        # unless an app has opted out via nautobot.apps.dcim.SkipAutoComponentCreation.
+        if is_new and not is_auto_component_creation_suppressed():
             self.create_components()
 
         # Update Location and Rack assignment for any child Devices
@@ -1951,8 +1953,9 @@ class Module(PrimaryModel):
 
         super().save(*args, **kwargs)
 
-        # If this is a new Module, instantiate all related components per the ModuleType definition
-        if is_new:
+        # If this is a new Module, instantiate all related components per the ModuleType definition,
+        # unless an app has opted out via nautobot.apps.dcim.SkipAutoComponentCreation.
+        if is_new and not is_auto_component_creation_suppressed():
             self.create_components()
 
         # Render component names when this Module is first created or when the parent module bay has changed

--- a/nautobot/dcim/tests/test_component_creation.py
+++ b/nautobot/dcim/tests/test_component_creation.py
@@ -1,0 +1,196 @@
+"""Tests for ``nautobot.apps.dcim.SkipAutoComponentCreation``."""
+
+import threading
+
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from nautobot.apps.dcim import is_auto_component_creation_suppressed, SkipAutoComponentCreation
+from nautobot.dcim.choices import InterfaceTypeChoices
+from nautobot.dcim.models import (
+    Device,
+    DeviceType,
+    InterfaceTemplate,
+    Location,
+    LocationType,
+    Manufacturer,
+    Module,
+    ModuleBay,
+    ModuleType,
+)
+from nautobot.extras.models import Role, Status
+
+
+def _status_for(model):
+    """Return a Status valid for ``model``, creating one if none is associated."""
+    status = Status.objects.get_for_model(model).first()
+    if status is None:
+        status = Status.objects.create(name=f"{model.__name__} Test Status")
+        status.content_types.add(ContentType.objects.get_for_model(model))
+    return status
+
+
+class SkipAutoComponentCreationContextManagerTestCase(TestCase):
+    """Unit tests for the context manager itself (no DB writes required)."""
+
+    def test_default_inactive(self):
+        """Suppression is off by default."""
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_activates_and_restores(self):
+        """The flag is set inside the block and cleared on exit."""
+        with SkipAutoComponentCreation():
+            self.assertTrue(is_auto_component_creation_suppressed())
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_nested(self):
+        """An outer block keeps suppressing after an inner block exits."""
+        with SkipAutoComponentCreation():
+            with SkipAutoComponentCreation():
+                self.assertTrue(is_auto_component_creation_suppressed())
+            self.assertTrue(is_auto_component_creation_suppressed())
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_exception_safe(self):
+        """An exception inside the block still restores the previous state."""
+        raised = False
+        try:
+            with SkipAutoComponentCreation():
+                self.assertTrue(is_auto_component_creation_suppressed())
+                raise RuntimeError("boom")
+        except RuntimeError:
+            raised = True
+        self.assertTrue(raised)
+        self.assertFalse(is_auto_component_creation_suppressed())
+
+    def test_isolated_across_threads(self):
+        """Suppression in one thread does not leak into a separately spawned thread."""
+        captured = {}
+
+        def worker():
+            captured["value"] = is_auto_component_creation_suppressed()
+
+        with SkipAutoComponentCreation():
+            self.assertTrue(is_auto_component_creation_suppressed())
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join()
+
+        # A freshly spawned thread starts with its own (default) context.
+        self.assertFalse(captured["value"])
+
+
+class SkipAutoComponentCreationOnSaveTestCase(TestCase):
+    """End-to-end tests that Device/Module honour the suppression flag on initial save."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Build a DeviceType and ModuleType that each define interface templates."""
+        cls.manufacturer = Manufacturer.objects.create(name="Test Manufacturer #9026")
+
+        cls.device_type = DeviceType.objects.create(manufacturer=cls.manufacturer, model="Test Model #9026")
+        for name in ("eth0", "eth1"):
+            InterfaceTemplate.objects.create(
+                device_type=cls.device_type,
+                name=name,
+                type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            )
+
+        cls.module_type = ModuleType.objects.create(manufacturer=cls.manufacturer, model="Test Module #9026")
+        InterfaceTemplate.objects.create(
+            module_type=cls.module_type,
+            name="mod-eth0",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+
+        cls.location_type = LocationType.objects.create(name="Test Location Type #9026")
+        cls.location_type.content_types.add(ContentType.objects.get_for_model(Device))
+        cls.location = Location.objects.create(
+            name="Test Location #9026",
+            location_type=cls.location_type,
+            status=_status_for(Location),
+        )
+
+        cls.device_role = Role.objects.create(name="Test Role #9026")
+        cls.device_role.content_types.add(ContentType.objects.get_for_model(Device))
+
+        cls.device_status = _status_for(Device)
+        cls.module_status = _status_for(Module)
+
+    def _create_device(self, name):
+        return Device.objects.create(
+            device_type=self.device_type,
+            role=self.device_role,
+            status=self.device_status,
+            name=name,
+            location=self.location,
+        )
+
+    def _create_module(self, device, bay_name):
+        module_bay = ModuleBay.objects.create(parent_device=device, name=bay_name, position=bay_name)
+        return Module.objects.create(
+            module_type=self.module_type,
+            parent_module_bay=module_bay,
+            status=self.module_status,
+        )
+
+    # --- Default behaviour --------------------------------------------------------
+
+    def test_device_components_created_by_default(self):
+        """Without opting in, a new Device still gets its template components."""
+        device = self._create_device("default-device")
+        self.assertEqual(device.interfaces.count(), 2)
+
+    def test_module_components_created_by_default(self):
+        """Without opting in, a new Module still gets its template components."""
+        device = self._create_device("module-parent-default")
+        module = self._create_module(device, "bay-default")
+        self.assertEqual(module.interfaces.count(), 1)
+
+    # --- Suppression --------------------------------------------------------------
+
+    def test_device_components_suppressed_in_context(self):
+        """Inside the context manager, a new Device gets no auto components."""
+        with SkipAutoComponentCreation():
+            device = self._create_device("suppressed-device")
+        self.assertEqual(device.interfaces.count(), 0)
+
+    def test_module_components_suppressed_in_context(self):
+        """Inside the context manager, a new Module gets no auto components."""
+        device = self._create_device("module-parent-suppressed")
+        with SkipAutoComponentCreation():
+            module = self._create_module(device, "bay-suppressed")
+        self.assertEqual(module.interfaces.count(), 0)
+
+    # --- Scope -------------------------------------------------------------------
+
+    def test_suppression_only_applies_inside_context(self):
+        """A Device created after the context exits gets its default components."""
+        with SkipAutoComponentCreation():
+            suppressed_device = self._create_device("inside-context")
+        following_device = self._create_device("outside-context")
+        self.assertEqual(suppressed_device.interfaces.count(), 0)
+        self.assertEqual(following_device.interfaces.count(), 2)
+
+    def test_suppression_only_applies_on_initial_creation(self):
+        """A subsequent save() of an existing Device does not re-trigger create_components()."""
+        device = self._create_device("update-target")
+        self.assertEqual(device.interfaces.count(), 2)
+        # Mutate and save again with suppression active — components should not change either way.
+        device.name = "update-target-renamed"
+        with SkipAutoComponentCreation():
+            device.save()
+        device.refresh_from_db()
+        self.assertEqual(device.interfaces.count(), 2)
+
+    def test_components_not_recreated_on_later_unsuppressed_save(self):
+        """A Device created under suppression stays component-free on a later unsuppressed save."""
+        with SkipAutoComponentCreation():
+            device = self._create_device("suppressed-then-saved")
+        self.assertEqual(device.interfaces.count(), 0)
+        # Saving again *without* suppression must not retroactively instantiate components,
+        # because create_components() only runs on the initial (is_new) save.
+        device.name = "suppressed-then-saved-renamed"
+        device.save()
+        device.refresh_from_db()
+        self.assertEqual(device.interfaces.count(), 0)

--- a/nautobot/docs/development/apps/api/platform-features/skip-auto-component-creation.md
+++ b/nautobot/docs/development/apps/api/platform-features/skip-auto-component-creation.md
@@ -1,0 +1,60 @@
+# Suppressing Automatic Device/Module Component Creation
+
++++ 2.4.36
+
+By default, when a new `Device` or `Module` is first saved, Nautobot calls `self.create_components()` from inside `save()` to instantiate one component (interface, console port, power port, rear/front port, device bay, module bay) per template defined on the related `DeviceType` / `ModuleType`. For apps that own the component inventory from an external source-of-truth and intend to write the full component graph themselves immediately after creating the parent object, this default is undesirable.
+
+The `nautobot.apps.dcim.SkipAutoComponentCreation` context manager lets an app opt out for a scoped region of code.
+
+## Usage
+
+```python
+from nautobot.apps.dcim import SkipAutoComponentCreation
+from nautobot.dcim.models import Device
+
+with SkipAutoComponentCreation():
+    device = Device.objects.create(
+        name="leaf-01",
+        device_type=device_type,
+        role=device_role,
+        status=device_status,
+        location=location,
+    )
+    # device.interfaces.count() == 0; no template-derived components were instantiated.
+    # The app is now responsible for populating any components it needs.
+```
+
+The context manager:
+
+- Suppresses `create_components()` on the **initial** `save()` of `Device` and `Module`. Subsequent saves of an existing instance are not affected — `create_components()` does not run on update saves regardless.
+- Is **re-entrant**: nested `with` blocks restore the previous state (still suppressed) when the inner block exits, not the unconditional default.
+- Is **exception-safe**: state is restored on exit even if the wrapped code raises.
+- Is **task-scoped**: implemented via `contextvars.ContextVar`, so the flag is correctly isolated per asyncio task and per Celery worker invocation. A suppressing context in one Celery task does not leak into the next task that worker handles, and freshly spawned threads start with their own (default) context.
+
+## Scope and limitations
+
+| Path | Triggers default `create_components()`? | Honoured by `SkipAutoComponentCreation`? |
+|---|---|---|
+| `Device.objects.create(...)` / `Module.objects.create(...)` | Yes | Yes |
+| `Device(...).save()` / `Module(...).save()` (new instance) | Yes | Yes |
+| Subsequent `save()` of an existing instance (update/migrate/move) | No | N/A — nothing to suppress |
+| `Device.objects.bulk_create([...])` / `Module.objects.bulk_create([...])` | No (bypasses `save()`) | N/A — nothing to suppress |
+
+The context manager affects only the call from `Device.save()` / `Module.save()`. If an app calls `device.create_components()` directly, that explicit invocation is still honoured — `SkipAutoComponentCreation` gates the automatic call from inside `save()`, not the method itself.
+
+!!! warning "Thread-based parallelization"
+    Suppression is stored in a `contextvars.ContextVar`, which is **not** inherited by a separately spawned `threading.Thread` — each new thread starts from the default (unsuppressed). If you fan creation out across a thread pool (for example `concurrent.futures.ThreadPoolExecutor`), entering `with SkipAutoComponentCreation():` on the dispatching thread will **not** suppress component creation in the worker threads. In that case, enter the context manager *inside* each worker, or copy the calling context into the worker with `contextvars.copy_context()`. Asyncio-task and Celery-task scoping are unaffected.
+
+## Introspection
+
+`nautobot.apps.dcim.is_auto_component_creation_suppressed()` returns `True` if a `SkipAutoComponentCreation` context is currently active. This is primarily useful in tests and adapter code that wants to make conditional decisions based on the suppression state.
+
+```python
+from nautobot.apps.dcim import is_auto_component_creation_suppressed, SkipAutoComponentCreation
+
+assert not is_auto_component_creation_suppressed()
+with SkipAutoComponentCreation():
+    assert is_auto_component_creation_suppressed()
+```
+
+Production code should normally use the context manager directly rather than checking the flag.


### PR DESCRIPTION
# Closes #9026 (LTM backport)

# What's Changed

LTM (2.4) backport of #9027, which added the public `nautobot.apps.dcim.SkipAutoComponentCreation` extension point on `develop`. This lets apps suppress Nautobot's automatic `Device`/`Module` component instantiation that fires from `Device.save()` and `Module.save()` on the initial save of a new instance.

Cherry-picked from the merged `develop` commit (`a8ab52a08`) with conflict resolution in `nautobot/dcim/models/devices.py` (the LTM `Device.save()` differs from `develop`), and one LTM-specific adjustment to the docs version annotation (`+++ 2.4.36`).

## Public API

```python
from nautobot.apps.dcim import SkipAutoComponentCreation
from nautobot.dcim.models import Device

with SkipAutoComponentCreation():
    device = Device.objects.create(...)   # no template-derived components
```

`is_auto_component_creation_suppressed()` is also exported for introspection.

## Files

- `nautobot/dcim/component_creation.py` *(new)* — `SkipAutoComponentCreation` context manager (re-entrant, exception-safe, `contextvars`-backed) + `is_auto_component_creation_suppressed()`.
- `nautobot/apps/dcim.py` *(new)* — public re-export.
- `nautobot/dcim/models/devices.py` — `Device.save()` and `Module.save()` consult the flag in their `is_new` branch before calling `self.create_components()`.
- `nautobot/dcim/tests/test_component_creation.py` *(new)* — 12 tests.
- New platform-features doc page + `mkdocs.yml` nav entries.
- `changes/9026.added`.

## Scope

The hook only suppresses the automatic call from `save()` on initial creation. Update saves do not trigger `create_components()` and are unaffected; `bulk_create()` bypasses `save()` and is similarly unaffected. Default behaviour is unchanged for any code that does not opt in.

# Screenshots

N/A — backend/library extension point, no UI surface.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (`changes/9026.added`)
- [x] Attached Screenshots, Payload Example — N/A (no UI surface)
- [x] Unit, Integration Tests (`nautobot/dcim/tests/test_component_creation.py`, 12 tests)
- [x] Documentation Updates (new platform-features page + `nautobot.apps.dcim` code-reference)
- [ ] Example App Updates — not applicable; low-level extension point with no example-app surface
- [x] Outline Remaining Work, Constraints from Design — see *Scope* above

## Verification (against the 2.4 dev stack)

- `ruff check` + `ruff format --check` clean on all changed Python files.
- `invoke tests --label nautobot.dcim.tests.test_component_creation`: **12/12 pass**.
- `invoke tests --label nautobot.dcim.tests.test_models`: **322/322 pass** (1 skipped) — no regression.
- `invoke build-and-check-docs` strict build succeeds.

## Backport notes

- Conflict in `nautobot/dcim/models/devices.py` resolved by keeping the LTM-specific `save()` structure and applying only the import and the `and not is_auto_component_creation_suppressed()` gate at both the `Device` and `Module` call sites.
- Docs version annotation set to `+++ 2.4.36` (next LTM patch release) rather than the `develop` value.
