### PR TITLE
Enable JobResult list view to display Queue Name as a field

### DIFF
--- a/changes/9067.added
+++ b/changes/9067.added
@@ -1,0 +1,1 @@
+Added a "Queue Name" column to the Job Results table, displaying the Celery queue each job result was dispatched to.

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -1318,6 +1318,7 @@ class JobResultTable(BaseTable):
     duration = tables.Column(orderable=False)
     actions = ButtonsColumn(JobResult, buttons=("delete",), prepend_template=JOB_RESULT_BUTTONS)
     console_log = BooleanColumn(order_by=("celery_kwargs__nautobot_job_console_log",))
+    queue_name = tables.Column(accessor="queue", verbose_name="Queue Name", order_by=("celery_kwargs__queue",))
 
     def render_summary(self, record):
         """
@@ -1363,6 +1364,7 @@ class JobResultTable(BaseTable):
             "summary",
             "actions",
             "console_log",
+            "queue_name",
         )
         default_columns = (
             "pk",

--- a/nautobot/extras/tests/test_tables.py
+++ b/nautobot/extras/tests/test_tables.py
@@ -2,8 +2,8 @@ from django.utils.html import escape
 from jsonschema import Draft7Validator
 
 from nautobot.core.testing import TestCase
-from nautobot.extras.models import ConfigContext, ConfigContextSchema
-from nautobot.extras.tables import ConfigContextSchemaValidationStateColumn
+from nautobot.extras.models import ConfigContext, ConfigContextSchema, JobResult
+from nautobot.extras.tables import ConfigContextSchemaValidationStateColumn, JobResultTable
 
 
 class ConfigContextSchemaValidationStateColumnTestCase(TestCase):
@@ -39,3 +39,26 @@ class ConfigContextSchemaValidationStateColumnTestCase(TestCase):
         self.assertIn("mdi-close-thick", rendered)
         self.assertIn("text-danger", rendered)
         self.assertIn("No schema available", rendered)
+
+
+class JobResultTableTestCase(TestCase):
+    def test_queue_name_column_renders_queue_from_celery_kwargs(self):
+        """The Queue Name column reads the queue from a JobResult's celery_kwargs."""
+        job_result = JobResult.objects.create(
+            name="queued.TestQueuedJob",
+            celery_kwargs={"queue": "test-queue-name"},
+        )
+        table = JobResultTable(JobResult.objects.filter(pk=job_result.pk))
+
+        cell = next(iter(table.rows)).get_cell("queue_name")
+
+        self.assertEqual(cell, "test-queue-name")
+
+    def test_queue_name_column_renders_placeholder_without_queue(self):
+        """The Queue Name column renders the empty placeholder when no queue is set."""
+        job_result = JobResult.objects.create(name="no_queue.TestNoQueueJob")
+        table = JobResultTable(JobResult.objects.filter(pk=job_result.pk))
+
+        cell = next(iter(table.rows)).get_cell("queue_name")
+
+        self.assertEqual(cell, table.default)


### PR DESCRIPTION
# Closes #9067

# What's Changed

Added a **Queue Name** column to the Job Results list view so users can see which Celery queue each job result was dispatched to.

- Added a `queue_name` column to `JobResultTable` that reads the queue from `JobResult.celery_kwargs["queue"]` (via the model's `queue` property), with sorting backed by `celery_kwargs__queue`.
- The column is available as a configurable (non-default) column, matching the existing `console_log` column pattern — users enable it from the list view's column configuration.
- Added table-level regression tests covering both the populated and empty-queue cases.

# Screenshots

<img width="1256" height="431" alt="image" src="https://github.com/user-attachments/assets/b5e7b37c-9524-4c5d-9427-a512b855ed82" />


# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
