### PR TITLE
Three fixes for interface redundancy group model.

### DIFF
--- a/changes/9072.fixed
+++ b/changes/9072.fixed
@@ -1,3 +1,2 @@
 Fixed the REST API incorrectly requiring the `protocol` field when creating or updating an Interface Redundancy Group.
 Fixed a `NoReverseMatch` server error when viewing an Interface or Interface Redundancy Group detail page.
-Fixed incorrect form fill in for new Interface Redundancy Group Associations.

--- a/changes/9072.fixed
+++ b/changes/9072.fixed
@@ -1,0 +1,3 @@
+Fixed the REST API incorrectly requiring the `protocol` field when creating or updating an Interface Redundancy Group.
+Fixed a `NoReverseMatch` server error when viewing an Interface or Interface Redundancy Group detail page.
+Fixed incorrect form fill in for new Interface Redundancy Group Associations.

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -424,7 +424,7 @@ class InterfaceRedundancyGroupAssociationSerializer(ValidatedModelSerializer):
 class InterfaceRedundancyGroupSerializer(TaggedModelSerializerMixin, NautobotModelSerializer):
     """InterfaceRedundancyGroup Serializer."""
 
-    protocol = ChoiceField(choices=InterfaceRedundancyGroupProtocolChoices)
+    protocol = ChoiceField(choices=InterfaceRedundancyGroupProtocolChoices, allow_blank=True, required=False)
 
     class Meta:
         """Meta attributes."""

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -1338,7 +1338,7 @@ class InterfaceRedundancyGroupAssociationTable(BaseTable):
         orderable=False,
         verbose_name="IP Addresses",
     )
-    actions = ButtonsColumn(model=InterfaceRedundancyGroupAssociation)
+    actions = ButtonsColumn(model=InterfaceRedundancyGroupAssociation, buttons=["edit", "delete"])
 
     class Meta(BaseTable.Meta):
         """Meta attributes."""

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -3877,6 +3877,22 @@ class InterfaceRedundancyGroupTestCase(APIViewTestCases.APIViewTestCase):
                 "secrets_group": None,
                 "virtual_ip": ips[1].pk,
             },
+            # Ensure protocol remains optional
+            {
+                "name": "Interface Redundancy Group 7",
+                "status": statuses[0].pk,
+                "protocol_group_id": "10",
+                "secrets_group": None,
+                "virtual_ip": None,
+            },
+            {
+                "name": "Interface Redundancy Group 8",
+                "protocol": "",
+                "status": statuses[1].pk,
+                "protocol_group_id": "11",
+                "secrets_group": None,
+                "virtual_ip": None,
+            },
         ]
         cls.bulk_update_data = {
             "protocol": "carp",

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -5024,7 +5024,7 @@ class InterfaceRedundancyGroupTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             Interface.objects.create(device=device, name="Interface A3", status=intf_status, role=intf_role),
         )
 
-       # Regression test for #8970
+        # Regression test for #8970
         cls.interface_redundancy_groups[0].add_interface(cls.interfaces[2], priority=100)
 
         cls.form_data = {

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -3503,6 +3503,17 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
         cls.selected_objects = interfaces
         cls.selected_objects_parent_name = device.name
 
+        # Regression test for #8970
+        interface_redundancy_group = InterfaceRedundancyGroup(
+            name="Interface Redundancy Group 1",
+            protocol=InterfaceRedundancyGroupProtocolChoices.HSRP,
+            status=Status.objects.get_for_model(InterfaceRedundancyGroup).first(),
+            protocol_group_id="1",
+        )
+        interface_redundancy_group.validated_save()
+        for priority, interface in enumerate(interfaces, start=1):
+            interface_redundancy_group.add_interface(interface, priority=priority * 10)
+
         vlan_status = Status.objects.get_for_model(VLAN).first()
         vlan_group = VLANGroup.objects.first()
         vlans = (
@@ -5012,6 +5023,9 @@ class InterfaceRedundancyGroupTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             Interface.objects.create(device=device, name="Interface A2", status=intf_status),
             Interface.objects.create(device=device, name="Interface A3", status=intf_status, role=intf_role),
         )
+
+       # Regression test for #8970
+        cls.interface_redundancy_groups[0].add_interface(cls.interfaces[2], priority=100)
 
         cls.form_data = {
             "name": "IRG χ",

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -6027,7 +6027,7 @@ class InterfaceRedundancyGroupUIViewSet(NautobotUIViewSet):
                 prefetch_related_fields=["interface"],
                 order_by_fields=["priority"],
                 table_title="Interfaces",
-                related_field_name="interface_redundancy_groups",
+                related_field_name="interface_redundancy_group",
                 related_list_url_name="dcim:interface_list",
                 include_columns=[
                     "interface__device",

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -6027,7 +6027,7 @@ class InterfaceRedundancyGroupUIViewSet(NautobotUIViewSet):
                 prefetch_related_fields=["interface"],
                 order_by_fields=["priority"],
                 table_title="Interfaces",
-                related_field_name="interface_redundancy_group",
+                related_field_name="interface_redundancy_groups",
                 related_list_url_name="dcim:interface_list",
                 include_columns=[
                     "interface__device",


### PR DESCRIPTION
Fixed the REST API incorrectly requiring the `protocol` field when creating or updating an Interface Redundancy Group.
Fixed a `NoReverseMatch` server error when viewing an Interface or Interface Redundancy Group detail page.
Fixed incorrect form fill in for new Interface Redundancy Group Associations.