### PR TITLE
Standardize device-component icon usage

### DIFF
--- a/changes/9093.added
+++ b/changes/9093.added
@@ -1,0 +1,1 @@
+Added "Cable Peer" and "Connection" columns to `CircuitTerminationTable`.

--- a/changes/9093.changed
+++ b/changes/9093.changed
@@ -1,0 +1,4 @@
+Improved rendering of `terminations_a` and `terminations_b` columns in `CableTable`.
+Adjusted rendering of `cable_peer` and `connection` columns in cable termination tables.
+Standardized device component icons across various tables and menus.
+Updated styling of populated rows in device DeviceBay and ModuleBay tables.

--- a/changes/9093.fixed
+++ b/changes/9093.fixed
@@ -1,0 +1,1 @@
+Fixed incorrect logic for selecting variant icons for Interfaces in `DeviceModuleInterfaceTable`.

--- a/changes/9093.housekeeping
+++ b/changes/9093.housekeeping
@@ -1,0 +1,2 @@
+Consolidated most icon-selection logic for device component rendering in tables and menus.
+Changed `termination_type_icon` template-tag method from a tag to a filter for simpler usage.

--- a/nautobot/circuits/tables.py
+++ b/nautobot/circuits/tables.py
@@ -8,6 +8,7 @@ from nautobot.core.tables import (
     TagColumn,
     ToggleColumn,
 )
+from nautobot.dcim.tables.devices import PathEndpointTable
 from nautobot.extras.tables import StatusTableMixin
 from nautobot.tenancy.tables import TenantColumn
 
@@ -164,16 +165,13 @@ class CircuitTable(StatusTableMixin, BaseTable):
 #
 
 
-class CircuitTerminationTable(BaseTable):
+class CircuitTerminationTable(PathEndpointTable):
     pk = ToggleColumn()
     circuit = tables.Column(linkify=True)
     term_side = tables.Column(linkify=True)
     location = tables.Column(linkify=True)
     provider_network = tables.Column(linkify=True)
     cloud_network = tables.Column(linkify=True)
-    # `cable` is a property on CableTermination subclasses (resolved via the cable_termination
-    # join row), not a real model field, so the column is not DB-orderable.
-    cable = tables.Column(linkify=True, orderable=False)
 
     class Meta(BaseTable.Meta):
         model = CircuitTermination
@@ -185,6 +183,8 @@ class CircuitTerminationTable(BaseTable):
             "provider_network",
             "cloud_network",
             "cable",
+            "cable_peer",
+            "connection",
             "port_speed",
             "upstream_speed",
             "xconnect_id",

--- a/nautobot/dcim/constants.py
+++ b/nautobot/dcim/constants.py
@@ -78,6 +78,32 @@ CABLE_TERMINATION_MODELS = Q(
     )
 )
 
+DEVICE_COMPONENT_ICONS = {
+    "circuittermination": "mdi-cable-data",
+    "consoleport": "mdi-console",
+    "consoleporttemplate": "mdi-console",
+    "consoleserverport": "mdi-console-network-outline",
+    "consoleserverporttemplate": "mdi-console-network-outline",
+    "devicebay": "mdi-circle-outline",  # DeviceDeviceBayTable overrides -> mdi-circle-slice-8 for populated bays
+    "devicebaytemplate": "mdi-circle-outline",
+    "frontport": "mdi-arrow-right-bold-box-outline",
+    "frontporttemplate": "mdi-arrow-right-bold-box-outline",
+    "interface": "mdi-ethernet",
+    "interfacetemplate": "mdi-ethernet",
+    "inventoryitem": "mdi-invoice-list-outline",
+    "modulebay": "mdi-tray",  # DeviceModuleBayTable overrides -> mdi-expansion-card-variant for populated bays
+    "modulebaytemplate": "mdi-tray",
+    "powerfeed": "mdi-flash",
+    "poweroutlet": "mdi-power-socket",
+    "poweroutlettemplate": "mdi-power-socket",
+    "powerport": "mdi-power-plug-outline",
+    "powerporttemplate": "mdi-power-plug-outline",
+    "rearport": "mdi-arrow-left-bold-box-outline",
+    "rearporttemplate": "mdi-arrow-left-bold-box-outline",
+}
+
+CABLE_TERMINATION_GENERIC_ICON = "mdi-cable-data"
+
 # Maps each cable-termination type to the list of types its other end may connect to. List order is
 # significant: the first entry is used as the default B-side type when creating a cable from a given
 # A-side type (see `CableForm._init_lane_fields`), so each list should lead with the most natural /

--- a/nautobot/dcim/models/cables.py
+++ b/nautobot/dcim/models/cables.py
@@ -651,8 +651,6 @@ class Cable(PrimaryModel):
                     "b": b_info,
                     "a_rowspan": a_rowspan,
                     "b_rowspan": b_rowspan,
-                    "_a_connector": a_connector,
-                    "_b_connector": b_connector,
                 }
             )
 
@@ -661,6 +659,34 @@ class Cable(PrimaryModel):
             "is_breakout": True,
             "a_connector_count": cable_type.a_connectors,
             "b_connector_count": cable_type.b_connectors,
+        }
+
+    def get_connections_a(self):
+        data = self.get_connections()
+        return {
+            "rows": [
+                {
+                    "info": row["a"],
+                    "rowspan": row["a_rowspan"],
+                }
+                for row in data["rows"]
+            ],
+            "is_breakout": data["is_breakout"],
+            "connector_count": data["a_connector_count"],
+        }
+
+    def get_connections_b(self):
+        data = self.get_connections()
+        return {
+            "rows": [
+                {
+                    "info": row["b"],
+                    "rowspan": row["b_rowspan"],
+                }
+                for row in data["rows"]
+            ],
+            "is_breakout": data["is_breakout"],
+            "connector_count": data["b_connector_count"],
         }
 
     # ─── Validation ───

--- a/nautobot/dcim/tables/__init__.py
+++ b/nautobot/dcim/tables/__init__.py
@@ -132,6 +132,7 @@ __all__ = (
     "VirtualDeviceContextTable",
 )
 
+
 #
 # Device connections
 #

--- a/nautobot/dcim/tables/cables.py
+++ b/nautobot/dcim/tables/cables.py
@@ -13,7 +13,7 @@ from nautobot.core.tables import (
 from nautobot.dcim.models import Cable, CableType
 from nautobot.extras.tables import StatusTableMixin
 
-from .template_code import CABLE_LENGTH, CABLE_TERMINATION_PARENT, CABLE_TERMINATIONS_MULTI
+from .template_code import CABLE_LENGTH, CABLE_TERMINATIONS_MULTI
 
 __all__ = ("CableTable", "CableTypeTable")
 
@@ -78,37 +78,39 @@ class CableTable(StatusTableMixin, BaseTable):
     pk = ToggleColumn()
     id = tables.Column(linkify=True, verbose_name="ID")
     cable_type = tables.Column(linkify=True, verbose_name="Cable Type")
-    termination_a_parent = tables.TemplateColumn(
-        template_code=CABLE_TERMINATION_PARENT,
-        accessor=Accessor("termination_a"),
+    termination_a_parent = tables.Column(
+        linkify=True,
+        accessor=Accessor("termination_a__parent"),
         orderable=False,
-        verbose_name="Side A",
+        verbose_name="Termination A Parent",
     )
-    termination_a = tables.LinkColumn(
+    termination_a = tables.Column(
+        linkify=True,
         accessor=Accessor("termination_a"),
         orderable=False,
         verbose_name="Termination A",
     )
     terminations_a = tables.TemplateColumn(
         template_code=CABLE_TERMINATIONS_MULTI,
-        accessor=Accessor("terminations_a"),
+        accessor=Accessor("get_connections_a"),
         orderable=False,
         verbose_name="A-Side Terminations",
     )
-    termination_b_parent = tables.TemplateColumn(
-        template_code=CABLE_TERMINATION_PARENT,
-        accessor=Accessor("termination_b"),
+    termination_b_parent = tables.Column(
+        linkify=True,
+        accessor=Accessor("termination_b__parent"),
         orderable=False,
-        verbose_name="Side B",
+        verbose_name="Termination B Parent",
     )
-    termination_b = tables.LinkColumn(
+    termination_b = tables.Column(
+        linkify=True,
         accessor=Accessor("termination_b"),
         orderable=False,
         verbose_name="Termination B",
     )
     terminations_b = tables.TemplateColumn(
         template_code=CABLE_TERMINATIONS_MULTI,
-        accessor=Accessor("terminations_b"),
+        accessor=Accessor("get_connections_b"),
         orderable=False,
         verbose_name="B-Side Terminations",
     )

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -46,6 +46,7 @@ from .template_code import (
     CABLETERMINATION,
     DEVICE_LINK,
     DEVICEBAY_BUTTONS,
+    DeviceComponentNameColumn,
     INTERFACE_BUTTONS,
     INTERFACE_IPADDRESSES,
     INTERFACE_REDUNDANCY_GROUP_INTERFACES,
@@ -180,7 +181,7 @@ class DeviceTable(StatusTableMixin, RoleTableMixin, BaseTable):
     tenant = TenantColumn()
     location = tables.Column(linkify=True)
     rack = tables.Column(linkify=True)
-    device_type = tables.LinkColumn(
+    device_type = tables.LinkColumn(  # used because tables.Column() doesn't support `text` lambda
         viewname="dcim:devicetype",
         args=[Accessor("device_type__pk")],
         verbose_name="Type",
@@ -194,7 +195,7 @@ class DeviceTable(StatusTableMixin, RoleTableMixin, BaseTable):
         url_params={"devices": "pk"},
         verbose_name="Clusters",
     )
-    virtual_chassis = tables.LinkColumn(viewname="dcim:virtualchassis", args=[Accessor("virtual_chassis__pk")])
+    virtual_chassis = tables.Column(linkify=True)
     vc_position = tables.Column(verbose_name="VC Position")
     vc_priority = tables.Column(verbose_name="VC Priority")
     device_redundancy_group = tables.Column(linkify=True)
@@ -453,10 +454,7 @@ class ConsolePortTable(ModularDeviceComponentTable, PathEndpointTable):
 
 
 class DeviceModuleConsolePortTable(ConsolePortTable):
-    name = tables.TemplateColumn(
-        template_code='<i class="mdi mdi-console"></i> <a href="{{ record.get_absolute_url }}">{{ value }}</a>',
-        attrs={"td": {"class": "text-nowrap"}},
-    )
+    name = DeviceComponentNameColumn(modelname="consoleport")
 
     class Meta(ModularDeviceComponentTable.Meta):
         model = ConsolePort
@@ -513,11 +511,7 @@ class ConsoleServerPortTable(ModularDeviceComponentTable, PathEndpointTable):
 
 
 class DeviceModuleConsoleServerPortTable(ConsoleServerPortTable):
-    name = tables.TemplateColumn(
-        template_code='<i class="mdi mdi-console-network-outline"></i> '
-        '<a href="{{ record.get_absolute_url }}">{{ value }}</a>',
-        attrs={"td": {"class": "text-nowrap"}},
-    )
+    name = DeviceComponentNameColumn(modelname="consoleserverport")
 
     class Meta(ModularDeviceComponentTable.Meta):
         model = ConsoleServerPort
@@ -588,11 +582,7 @@ class PowerPortTable(ModularDeviceComponentTable, PathEndpointTable):
 
 
 class DeviceModulePowerPortTable(PowerPortTable):
-    name = tables.TemplateColumn(
-        template_code='<i class="mdi mdi-power-plug-outline"></i> <a href="{{ record.get_absolute_url }}">'
-        "{{ value }}</a>",
-        attrs={"td": {"class": "text-nowrap"}},
-    )
+    name = DeviceComponentNameColumn(modelname="powerport")
 
     class Meta(ModularDeviceComponentTable.Meta):
         model = PowerPort
@@ -666,10 +656,7 @@ class PowerOutletTable(ModularDeviceComponentTable, PathEndpointTable):
 
 
 class DeviceModulePowerOutletTable(PowerOutletTable):
-    name = tables.TemplateColumn(
-        template_code='<i class="mdi mdi-power-socket"></i> <a href="{{ record.get_absolute_url }}">{{ value }}</a>',
-        attrs={"td": {"class": "text-nowrap"}},
-    )
+    name = DeviceComponentNameColumn(modelname="poweroutlet")
 
     class Meta(ModularDeviceComponentTable.Meta):
         model = PowerOutlet
@@ -784,11 +771,17 @@ class InterfaceTable(ModularDeviceComponentTable, BaseInterfaceTable, PathEndpoi
 
 
 class DeviceModuleInterfaceTable(InterfaceTable):
-    name = tables.TemplateColumn(
-        template_code='<i class="mdi mdi-{% if iface.mgmt_only %}wrench{% elif iface.is_lag %}drag-horizontal-variant'
-        "{% elif iface.is_virtual %}circle{% elif iface.is_wireless %}wifi{% else %}ethernet"
-        '{% endif %}"></i> <a href="{{ record.get_absolute_url }}">{{ value }}</a>',
-        attrs={"td": {"class": "text-nowrap"}},
+    name = DeviceComponentNameColumn(
+        modelname="interface",
+        template_code=(
+            '<span class="mdi mdi-'
+            "{% if record.mgmt_only %}wrench"
+            "{% elif record.is_lag %}drag-horizontal-variant"
+            "{% elif record.is_virtual %}circle"
+            "{% elif record.is_wireless %}wifi"
+            '{% else %}ethernet{% endif %}"></span> '
+            '<a href="{{ record.get_absolute_url }}">{{ value }}</a>'
+        ),
     )
     parent_interface = tables.Column(linkify=True, verbose_name="Parent")
     bridge = tables.Column(linkify=True)
@@ -898,10 +891,12 @@ class FrontPortTable(ModularDeviceComponentTable, CableTerminationTable):
 
 
 class DeviceModuleFrontPortTable(FrontPortTable):
-    name = tables.TemplateColumn(
-        template_code='<i class="mdi mdi-square-rounded{% if not record.cable %}-outline{% endif %}"></i> '
-        '<a href="{{ record.get_absolute_url }}">{{ value }}</a>',
-        attrs={"td": {"class": "text-nowrap"}},
+    name = DeviceComponentNameColumn(
+        modelname="frontport",
+        template_code=(
+            '<span class="mdi mdi-arrow-right-bold-box{% if not record.cable %}-outline{% endif %}"></span> '
+            '<a href="{{ record.get_absolute_url }}">{{ value }}</a>'
+        ),
     )
 
     class Meta(ModularDeviceComponentTable.Meta):
@@ -960,10 +955,12 @@ class RearPortTable(ModularDeviceComponentTable, CableTerminationTable):
 
 
 class DeviceModuleRearPortTable(RearPortTable):
-    name = tables.TemplateColumn(
-        template_code='<i class="mdi mdi-square-rounded{% if not record.cable %}-outline{% endif %}"></i> '
-        '<a href="{{ record.get_absolute_url }}">{{ value }}</a>',
-        attrs={"td": {"class": "text-nowrap"}},
+    name = DeviceComponentNameColumn(
+        modelname="rearport",
+        template_code=(
+            '<span class="mdi mdi-arrow-left-bold-box{% if not record.cable %}-outline{% endif %}"></span> '
+            '<a href="{{ record.get_absolute_url }}">{{ value }}</a>'
+        ),
     )
 
     class Meta(ModularDeviceComponentTable.Meta):
@@ -1080,10 +1077,12 @@ class ModuleBayTable(BaseTable):
 
 
 class DeviceDeviceBayTable(DeviceBayTable):
-    name = tables.TemplateColumn(
-        template_code='<i class="mdi mdi-circle-{% if record.installed_device %}slice-8{% else %}outline{% endif %}'
-        '"></i> <a href="{{ record.get_absolute_url }}">{{ value }}</a>',
-        attrs={"td": {"class": "text-nowrap"}},
+    name = DeviceComponentNameColumn(
+        modelname="devicebay",
+        template_code=(
+            '<span class="mdi mdi-circle-{% if record.installed_device %}slice-8{% else %}outline{% endif %}">'
+            '</span> <a href="{{ record.get_absolute_url }}">{{ value }}</a>'
+        ),
     )
 
     class Meta(DeviceComponentTable.Meta):
@@ -1107,13 +1106,18 @@ class DeviceDeviceBayTable(DeviceBayTable):
             "description",
             "actions",
         )
+        row_attrs = {
+            "class": lambda record: "table-success" if record.installed_device else "",
+        }
 
 
 class DeviceModuleBayTable(ModuleBayTable):
-    name = tables.TemplateColumn(
-        template_code='<i class="mdi mdi-{% if record.installed_module %}expansion-card-variant{% else %}tray{% endif %}'
-        '"></i> <a href="{{ record.get_absolute_url }}">{{ value }}</a>',
-        attrs={"td": {"class": "text-nowrap"}},
+    name = DeviceComponentNameColumn(
+        modelname="modulebay",
+        template_code=(
+            '<span class="mdi mdi-{% if record.installed_module %}expansion-card-variant{% else %}tray{% endif %}'
+            '"></span> <a href="{{ record.get_absolute_url }}">{{ value }}</a>'
+        ),
     )
     module_family = tables.Column(linkify=True, verbose_name="Family")
     installed_module = tables.Column(linkify=True, verbose_name="Installed Module")
@@ -1145,6 +1149,9 @@ class DeviceModuleBayTable(ModuleBayTable):
             "installed_module__status",
             "actions",
         )
+        row_attrs = {
+            "class": lambda record: "table-success" if record.installed_module else "",
+        }
 
 
 class ModuleModuleBayTable(DeviceModuleBayTable):
@@ -1188,10 +1195,14 @@ class InventoryItemTable(DeviceComponentTable):
 
 
 class DeviceInventoryItemTable(InventoryItemTable):
-    name = tables.TemplateColumn(
-        template_code='<a href="{{ record.get_absolute_url }}" style="padding-left: {{ record.tree_depth }}0px">'
-        "{{ value }}</a>",
-        attrs={"td": {"class": "text-nowrap"}},
+    name = DeviceComponentNameColumn(
+        modelname="inventoryitem",
+        template_code=(
+            "{% load cables %}"
+            '<span class="mdi {{ record|termination_type_icon }}" style="padding-left: {{ record.tree_depth }}0px">'
+            "</span> "
+            '<a href="{{ record.get_absolute_url }}">{{ value }}</a>'
+        ),
     )
     actions = ButtonsColumn(model=InventoryItem)
 

--- a/nautobot/dcim/tables/devicetypes.py
+++ b/nautobot/dcim/tables/devicetypes.py
@@ -24,6 +24,7 @@ from nautobot.dcim.models import (
     PowerPortTemplate,
     RearPortTemplate,
 )
+from nautobot.dcim.tables.template_code import DeviceComponentNameColumn
 
 __all__ = (
     "ConsolePortTemplateTable",
@@ -199,6 +200,7 @@ class ComponentTemplateTable(BaseTable):
 
 
 class ConsolePortTemplateTable(ComponentTemplateTable):
+    name = DeviceComponentNameColumn(modelname="consoleporttemplate")
     actions = ButtonsColumn(
         model=ConsolePortTemplate,
         buttons=("edit", "delete"),
@@ -212,6 +214,7 @@ class ConsolePortTemplateTable(ComponentTemplateTable):
 
 
 class ConsoleServerPortTemplateTable(ComponentTemplateTable):
+    name = DeviceComponentNameColumn(modelname="consoleserverporttemplate")
     actions = ButtonsColumn(
         model=ConsoleServerPortTemplate,
         buttons=("edit", "delete"),
@@ -225,6 +228,7 @@ class ConsoleServerPortTemplateTable(ComponentTemplateTable):
 
 
 class PowerPortTemplateTable(ComponentTemplateTable):
+    name = DeviceComponentNameColumn(modelname="powerporttemplate")
     actions = ButtonsColumn(
         model=PowerPortTemplate,
         buttons=("edit", "delete"),
@@ -248,6 +252,7 @@ class PowerPortTemplateTable(ComponentTemplateTable):
 
 
 class PowerOutletTemplateTable(ComponentTemplateTable):
+    name = DeviceComponentNameColumn(modelname="poweroutlettemplate")
     actions = ButtonsColumn(
         model=PowerOutletTemplate,
         buttons=("edit", "delete"),
@@ -270,6 +275,7 @@ class PowerOutletTemplateTable(ComponentTemplateTable):
 
 
 class InterfaceTemplateTable(ComponentTemplateTable):
+    name = DeviceComponentNameColumn(modelname="interfacetemplate")
     mgmt_only = BooleanColumn(verbose_name="Management Only")
     speed = tables.Column(verbose_name="Speed", accessor="speed")
     duplex = tables.Column(verbose_name="Duplex", accessor="duplex")
@@ -290,6 +296,7 @@ class InterfaceTemplateTable(ComponentTemplateTable):
 
 
 class FrontPortTemplateTable(ComponentTemplateTable):
+    name = DeviceComponentNameColumn(modelname="frontporttemplate")
     rear_port_position = tables.Column(verbose_name="Position")
     actions = ButtonsColumn(
         model=FrontPortTemplate,
@@ -313,6 +320,7 @@ class FrontPortTemplateTable(ComponentTemplateTable):
 
 
 class RearPortTemplateTable(ComponentTemplateTable):
+    name = DeviceComponentNameColumn(modelname="rearporttemplate")
     actions = ButtonsColumn(
         model=RearPortTemplate,
         buttons=("edit", "delete"),
@@ -326,6 +334,7 @@ class RearPortTemplateTable(ComponentTemplateTable):
 
 
 class DeviceBayTemplateTable(ComponentTemplateTable):
+    name = DeviceComponentNameColumn(modelname="devicebaytemplate")
     actions = ButtonsColumn(
         model=DeviceBayTemplate,
         buttons=("edit", "delete"),
@@ -339,6 +348,7 @@ class DeviceBayTemplateTable(ComponentTemplateTable):
 
 
 class ModuleBayTemplateTable(ComponentTemplateTable):
+    name = DeviceComponentNameColumn(modelname="modulebaytemplate")
     actions = ButtonsColumn(
         model=ModuleBayTemplate,
         buttons=("edit", "delete"),

--- a/nautobot/dcim/tables/template_code.py
+++ b/nautobot/dcim/tables/template_code.py
@@ -1,8 +1,29 @@
+import django_tables2 as tables
+
+from nautobot.dcim.constants import DEVICE_COMPONENT_ICONS
+
+
+class DeviceComponentNameColumn(tables.TemplateColumn):
+    def __init__(self, *args, modelname, **kwargs):
+        self.modelname = modelname
+        self.icon = DEVICE_COMPONENT_ICONS[modelname]
+        kwargs.setdefault(
+            "template_code",
+            (f'<span class="mdi {self.icon}"></span> <a href="{{{{ record.get_absolute_url }}}}">{{{{ value }}}}</a>'),
+        )
+        kwargs.setdefault("attrs", {}).setdefault("td", {})["class"] = "text-nowrap"
+        kwargs.setdefault("order_by", ("_name",))
+        super().__init__(*args, **kwargs)
+
+
 CABLETERMINATION = """
+{% load cables %}
+{% load helpers %}
 {% if value %}
     {% for peer in value %}
         <a href="{{ peer.parent.get_absolute_url }}">{{ peer.parent }}</a>
-        <span class="mdi mdi-chevron-right"></span>
+        /
+        <span class="mdi {{ peer|termination_type_icon }}" title="{{ peer|meta:'verbose_name'|capfirst }}"></span>
         <a href="{{ peer.get_absolute_url }}">{{ peer }}</a>
         {% if not forloop.last %}<br>{% endif %}
     {% endfor %}
@@ -12,10 +33,13 @@ CABLETERMINATION = """
 """
 
 PATHENDPOINT = """
+{% load cables %}
+{% load helpers %}
 {% if value %}
     {% for endpoint in value %}
         <a href="{{ endpoint.parent.get_absolute_url }}">{{ endpoint.parent }}</a>
-        <span class="mdi mdi-chevron-right"></span>
+        /
+        <span class="mdi {{ endpoint|termination_type_icon }}" title="{{ endpoint|meta:'verbose_name'|capfirst }}"></span>
         <a href="{{ endpoint.get_absolute_url }}">{{ endpoint }}</a>
         {% if not forloop.last %}<br>{% endif %}
     {% endfor %}
@@ -41,21 +65,20 @@ CABLE_TERMINATION_PARENT = """
 CABLE_TERMINATIONS_MULTI = """
 {% load cables %}
 {% load helpers %}
-{% for endpoint in value %}
-    {% with term=endpoint.termination %}
-        {% if term %}
-            {% termination_type_icon term as t_icon %}
-            <span class="mdi {{ t_icon }}" title="{{ term|meta:'verbose_name'|capfirst }}"></span>
-            {% if term.parent %}
-                <a href="{{ term.parent.get_absolute_url }}">{{ term.parent }}</a> /
+{% for row in value.rows %}
+    {% if row.rowspan %}
+        {% if row.info.termination %}
+            {% if row.info.termination.parent %}
+                {{ row.info.termination.parent|hyperlinked_object }} /
             {% endif %}
-            <a href="{{ term.get_absolute_url }}">{{ term }}</a>
-            {% if endpoint.connector is not None %}
-                <small class="text-muted">({{ endpoint.cable_end }}{{ endpoint.connector }})</small>
-            {% endif %}
-            {% if not forloop.last %}<br>{% endif %}
+            <span class="mdi {{ row.info.termination|termination_type_icon }}" title="{{ row.info.termination|meta:'verbose_name'|capfirst }}"></span>
         {% endif %}
-    {% endwith %}
+        {{ row.info.termination|hyperlinked_object }}
+        {% if value.is_breakout %}
+            <small class="text-secondary">({{ row.info.side }}{{ row.info.connector }})</small>
+        {% endif %}
+    {% endif %}
+    {% if not forloop.last %}<br>{% endif %}
 {% empty %}
     <span class="text-secondary">&mdash;</span>
 {% endfor %}
@@ -158,19 +181,6 @@ LOCATION_TREE_LINK = """
 {% endspaceless %}
 """
 
-
-POWERFEED_CABLE = """
-<a href="{{ value.get_absolute_url }}">{{ value }}</a>
-<a href="{% url 'dcim:powerfeed_trace' pk=record.pk %}" class="btn btn-primary btn-sm" title="Trace">
-    <span class="mdi mdi-transit-connection-variant" aria-hidden="true"></span>
-</a>
-"""
-
-POWERFEED_CABLETERMINATION = """
-<a href="{{ value.parent.get_absolute_url }}">{{ value.parent }}</a>
-<span class="mdi mdi-chevron-right"></span>
-<a href="{{ value.get_absolute_url }}">{{ value }}</a>
-"""
 
 RACKGROUP_ELEVATIONS = """
 <li>

--- a/nautobot/dcim/templates/dcim/device_list.html
+++ b/nautobot/dcim/templates/dcim/device_list.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object_list.html' %}
+{% load cables %}
 
 {% block bulk_buttons %}
     {% if perms.dcim.change_device %}
@@ -11,7 +12,7 @@
                     <li>
                         <a href="{% url 'dcim:device_bulk_add_consoleport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="formaction dropdown-item">
-                            <span class="mdi mdi-console" aria-hidden="true"></span> Console Ports
+                            <span class="mdi {{ 'consoleport'|termination_type_icon }}" aria-hidden="true"></span> Console Ports
                         </a>
                     </li>
                 {% endif %}
@@ -19,7 +20,7 @@
                     <li>
                         <a href="{% url 'dcim:device_bulk_add_consoleserverport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="formaction dropdown-item">
-                            <span class="mdi mdi-console-network-outline" aria-hidden="true"></span> Console Server Ports
+                            <span class="mdi {{ 'consoleserverport'|termination_type_icon }}" aria-hidden="true"></span> Console Server Ports
                         </a>
                     </li>
                 {% endif %}
@@ -27,7 +28,7 @@
                     <li>
                         <a href="{% url 'dcim:device_bulk_add_powerport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="formaction dropdown-item">
-                            <span class="mdi mdi-power-plug-outline" aria-hidden="true"></span> Power Ports
+                            <span class="mdi {{ 'powerport'|termination_type_icon }}" aria-hidden="true"></span> Power Ports
                         </a>
                     </li>
                 {% endif %}
@@ -35,7 +36,7 @@
                     <li>
                         <a href="{% url 'dcim:device_bulk_add_poweroutlet' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="formaction dropdown-item">
-                            <span class="mdi mdi-power-socket" aria-hidden="true"></span> Power Outlets
+                            <span class="mdi {{ 'poweroutlet'|termination_type_icon }}" aria-hidden="true"></span> Power Outlets
                         </a>
                     </li>
                 {% endif %}
@@ -43,7 +44,7 @@
                     <li>
                         <a href="{% url 'dcim:device_bulk_add_interface' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="formaction dropdown-item">
-                            <span class="mdi mdi-ethernet" aria-hidden="true"></span> Interfaces
+                            <span class="mdi {{ 'interface'|termination_type_icon }}" aria-hidden="true"></span> Interfaces
                         </a>
                     </li>
                 {% endif %}
@@ -51,7 +52,7 @@
                     <li>
                         <a href="{% url 'dcim:device_bulk_add_rearport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="formaction dropdown-item">
-                            <span class="mdi mdi-square-rounded-outline" aria-hidden="true"></span> Rear Ports
+                            <span class="mdi {{ 'rearport'|termination_type_icon }}" aria-hidden="true"></span> Rear Ports
                         </a>
                     </li>
                 {% endif %}
@@ -59,7 +60,7 @@
                     <li>
                         <a href="{% url 'dcim:device_bulk_add_devicebay' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="formaction dropdown-item">
-                            <span class="mdi mdi-circle-outline" aria-hidden="true"></span> Device Bays
+                            <span class="mdi {{ 'devicebay'|termination_type_icon }}" aria-hidden="true"></span> Device Bays
                         </a>
                     </li>
                 {% endif %}
@@ -67,7 +68,7 @@
                     <li>
                         <a href="{% url 'dcim:device_bulk_add_modulebay' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="formaction dropdown-item">
-                            <span class="mdi mdi-tray" aria-hidden="true"></span> Module Bays
+                            <span class="mdi {{ 'modulebay'|termination_type_icon }}" aria-hidden="true"></span> Module Bays
                         </a>
                     </li>
                 {% endif %}
@@ -75,7 +76,7 @@
                     <li>
                         <a href="{% url 'dcim:device_bulk_add_inventoryitem' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="formaction dropdown-item">
-                            <span class="mdi mdi-invoice-list-outline" aria-hidden="true"></span> Inventory Items
+                            <span class="mdi {{ 'inventoryitem'|termination_type_icon }}" aria-hidden="true"></span> Inventory Items
                         </a>
                     </li>
                 {% endif %}

--- a/nautobot/dcim/templates/dcim/inc/cable_connection_termination.html
+++ b/nautobot/dcim/templates/dcim/inc/cable_connection_termination.html
@@ -2,8 +2,7 @@
 {% load helpers %}
 {% comment %}Render a single cable connection termination with type icon, parent, and link.{% endcomment %}
 {% if term %}
-    {% termination_type_icon term as t_icon %}
-    <span class="mdi {{ t_icon }}" title="{{ term|meta:'verbose_name'|capfirst }}"></span>
+    <span class="mdi {{ term|termination_type_icon }}" title="{{ term|meta:'verbose_name'|capfirst }}"></span>
     {% if term.parent %}
         {{ term.parent|hyperlinked_object }} /
     {% endif %}

--- a/nautobot/dcim/templates/dcim/inc/connection_body.html
+++ b/nautobot/dcim/templates/dcim/inc/connection_body.html
@@ -39,7 +39,7 @@ framework panel body wrapper.
                         {% if is_breakout %}<td title="Cable connector" style="width: 1%; white-space: nowrap;">{{ peer.cable_termination.connector }}</td>{% endif %}
                         <td>{{ peer.parent|hyperlinked_object }}</td>
                         <td colspan="2">
-                            <span class="mdi {% termination_type_icon peer %}" title="{{ peer|meta:'verbose_name'|capfirst }}" aria-hidden="true"></span>
+                            <span class="mdi {{ peer|termination_type_icon }}" title="{{ peer|meta:'verbose_name'|capfirst }}" aria-hidden="true"></span>
                             {{ peer|hyperlinked_object }}
                         </td>
                     </tr>
@@ -58,7 +58,7 @@ framework panel body wrapper.
                         {% if path.destination %}
                             <td>{{ path.destination.parent|hyperlinked_object }}</td>
                             <td>
-                                <span class="mdi {% termination_type_icon path.destination %}" title="{{ path.destination|meta:'verbose_name'|capfirst }}" aria-hidden="true"></span>
+                                <span class="mdi {{ path.destination|termination_type_icon }}" title="{{ path.destination|meta:'verbose_name'|capfirst }}" aria-hidden="true"></span>
                                 {{ path.destination|hyperlinked_object }}
                             </td>
                             <td>

--- a/nautobot/dcim/templates/dcim/module/base.html
+++ b/nautobot/dcim/templates/dcim/module/base.html
@@ -1,5 +1,6 @@
 {% extends 'generic/object_retrieve.html' %}
 {% load buttons %}
+{% load cables %}
 {% load helpers %}
 
 {% block extra_buttons %}
@@ -13,7 +14,7 @@
                     <li>
                         <a class="dropdown-item"
                            href="{% url 'dcim:consoleport_add' %}?module={{ object.pk }}&return_url={% url 'dcim:module_consoleports' pk=object.pk %}">
-                            <span class="mdi mdi-console" aria-hidden="true"></span> Console Ports
+                            <span class="mdi {{ 'consoleport'|termination_type_icon }}" aria-hidden="true"></span> Console Ports
                         </a>
                     </li>
                 {% endif %}
@@ -21,7 +22,7 @@
                     <li>
                         <a class="dropdown-item"
                            href="{% url 'dcim:consoleserverport_add' %}?module={{ object.pk }}&return_url={% url 'dcim:module_consoleserverports' pk=object.pk %}">
-                            <span class="mdi mdi-console-network-outline" aria-hidden="true"></span> Console Server Ports
+                            <span class="mdi {{ 'consoleserverport'|termination_type_icon }}" aria-hidden="true"></span> Console Server Ports
                         </a>
                     </li>
                 {% endif %}
@@ -29,7 +30,7 @@
                     <li>
                         <a class="dropdown-item"
                            href="{% url 'dcim:powerport_add' %}?module={{ object.pk }}&return_url={% url 'dcim:module_powerports' pk=object.pk %}">
-                            <span class="mdi mdi-power-plug-outline" aria-hidden="true"></span> Power Ports
+                            <span class="mdi {{ 'powerport'|termination_type_icon }}" aria-hidden="true"></span> Power Ports
                         </a>
                     </li>
                 {% endif %}
@@ -37,7 +38,7 @@
                     <li>
                         <a class="dropdown-item"
                            href="{% url 'dcim:poweroutlet_add' %}?module={{ object.pk }}&return_url={% url 'dcim:module_poweroutlets' pk=object.pk %}">
-                            <span class="mdi mdi-power-socket" aria-hidden="true"></span> Power Outlets
+                            <span class="mdi {{ 'poweroutlet'|termination_type_icon }}" aria-hidden="true"></span> Power Outlets
                         </a>
                     </li>
                 {% endif %}
@@ -45,7 +46,7 @@
                     <li>
                         <a class="dropdown-item"
                            href="{% url 'dcim:interface_add' %}?module={{ object.pk }}&return_url={% url 'dcim:module_interfaces' pk=object.pk %}">
-                            <span class="mdi mdi-ethernet" aria-hidden="true"></span> Interfaces
+                            <span class="mdi {{ 'interface'|termination_type_icon }}" aria-hidden="true"></span> Interfaces
                         </a>
                     </li>
                 {% endif %}
@@ -53,7 +54,7 @@
                     <li>
                         <a class="dropdown-item"
                            href="{% url 'dcim:frontport_add' %}?module={{ object.pk }}&return_url={% url 'dcim:module_frontports' pk=object.pk %}">
-                            <span class="mdi mdi-square-rounded-outline" aria-hidden="true"></span> Front Ports
+                            <span class="mdi {{ 'frontport'|termination_type_icon }}" aria-hidden="true"></span> Front Ports
                         </a>
                     </li>
                 {% endif %}
@@ -61,7 +62,7 @@
                     <li>
                         <a class="dropdown-item"
                            href="{% url 'dcim:rearport_add' %}?module={{ object.pk }}&return_url={% url 'dcim:module_rearports' pk=object.pk %}">
-                            <span class="mdi mdi-square-rounded-outline" aria-hidden="true"></span> Rear Ports
+                            <span class="mdi {{ 'rearport'|termination_type_icon }}" aria-hidden="true"></span> Rear Ports
                         </a>
                     </li>
                 {% endif %}
@@ -69,7 +70,7 @@
                     <li>
                         <a class="dropdown-item"
                            href="{% url 'dcim:modulebay_add' %}?parent_module={{ object.pk }}&return_url={% url 'dcim:module_modulebays' pk=object.pk %}">
-                            <span class="mdi mdi-tray" aria-hidden="true"></span> Module Bays
+                            <span class="mdi {{ 'modulebay'|termination_type_icon }}" aria-hidden="true"></span> Module Bays
                         </a>
                     </li>
                 {% endif %}

--- a/nautobot/dcim/templates/dcim/module_list.html
+++ b/nautobot/dcim/templates/dcim/module_list.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object_list.html' %}
+{% load cables %}
 
 {% block bulk_buttons %}
     {% if perms.dcim.change_module %}
@@ -11,7 +12,7 @@
                     <li>
                         <a href="{% url 'dcim:module_bulk_add_consoleport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="dropdown-item formaction">
-                            <span class="mdi mdi-console" aria-hidden="true"></span> Console Ports
+                            <span class="mdi {{ 'consoleport'|termination_type_icon }}" aria-hidden="true"></span> Console Ports
                         </a>
                     </li>
                 {% endif %}
@@ -19,7 +20,7 @@
                     <li>
                         <a href="{% url 'dcim:module_bulk_add_consoleserverport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="dropdown-item formaction">
-                            <span class="mdi mdi-console-network-outline" aria-hidden="true"></span> Console Server Ports
+                            <span class="mdi {{ 'consoleserverport'|termination_type_icon }}" aria-hidden="true"></span> Console Server Ports
                         </a>
                     </li>
                 {% endif %}
@@ -27,7 +28,7 @@
                     <li>
                         <a href="{% url 'dcim:module_bulk_add_powerport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="dropdown-item formaction">
-                            <span class="mdi mdi-power-plug-outline" aria-hidden="true"></span> Power Ports
+                            <span class="mdi {{ 'powerport'|termination_type_icon }}" aria-hidden="true"></span> Power Ports
                         </a>
                     </li>
                 {% endif %}
@@ -35,7 +36,7 @@
                     <li>
                         <a href="{% url 'dcim:module_bulk_add_poweroutlet' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="dropdown-item formaction">
-                            <span class="mdi mdi-power-socket" aria-hidden="true"></span> Power Outlets
+                            <span class="mdi {{ 'poweroutlet'|termination_type_icon }}" aria-hidden="true"></span> Power Outlets
                         </a>
                     </li>
                 {% endif %}
@@ -43,7 +44,7 @@
                     <li>
                         <a href="{% url 'dcim:module_bulk_add_interface' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="dropdown-item formaction">
-                            <span class="mdi mdi-ethernet" aria-hidden="true"></span> Interfaces
+                            <span class="mdi {{ 'interface'|termination_type_icon }}" aria-hidden="true"></span> Interfaces
                         </a>
                     </li>
                 {% endif %}
@@ -51,7 +52,7 @@
                     <li>
                         <a href="{% url 'dcim:module_bulk_add_rearport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="dropdown-item formaction">
-                            <span class="mdi mdi-square-rounded-outline" aria-hidden="true"></span> Rear Ports
+                            <span class="mdi {{ 'rearport'|termination_type_icon }}" aria-hidden="true"></span> Rear Ports
                         </a>
                     </li>
                 {% endif %}
@@ -59,7 +60,7 @@
                     <li>
                         <a href="{% url 'dcim:module_bulk_add_modulebay' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                            class="dropdown-item formaction">
-                            <span class="mdi mdi-tray" aria-hidden="true"></span> Module Bays
+                            <span class="mdi {{ 'modulebay'|termination_type_icon }}" aria-hidden="true"></span> Module Bays
                         </a>
                     </li>
                 {% endif %}

--- a/nautobot/dcim/templatetags/cables.py
+++ b/nautobot/dcim/templatetags/cables.py
@@ -1,23 +1,19 @@
 from django import template
+from django_jinja import library
+
+from nautobot.dcim.constants import CABLE_TERMINATION_GENERIC_ICON, DEVICE_COMPONENT_ICONS
 
 register = template.Library()
 
 
-@register.simple_tag()
+@library.filter()
+@register.filter()
 def termination_type_icon(termination):
-    """Return an MDI icon class string for a cable termination object based on its type."""
+    """Return an MDI icon class string for a cable termination object or modelname based on its type."""
     if termination is None:
         return "mdi-help-circle-outline"
-    model_name = termination._meta.model_name
-    icons = {
-        "interface": "mdi-ethernet",
-        "frontport": "mdi-arrow-right-bold-box",
-        "rearport": "mdi-arrow-left-bold-box",
-        "consoleport": "mdi-console",
-        "consoleserverport": "mdi-console-network",
-        "powerport": "mdi-power-plug",
-        "poweroutlet": "mdi-power-socket",
-        "powerfeed": "mdi-flash",
-        "circuittermination": "mdi-cable-data",
-    }
-    return icons.get(model_name, "mdi-cable-data")
+    if isinstance(termination, str):
+        model_name = termination
+    else:
+        model_name = termination._meta.model_name
+    return DEVICE_COMPONENT_ICONS.get(model_name, CABLE_TERMINATION_GENERIC_ICON)

--- a/nautobot/dcim/tests/test_templatetags.py
+++ b/nautobot/dcim/tests/test_templatetags.py
@@ -14,11 +14,11 @@ class TerminationTypeIconTestCase(TestCase):
         """Each registered model_name maps to its specific MDI icon class."""
         expected = {
             "interface": "mdi-ethernet",
-            "frontport": "mdi-arrow-right-bold-box",
-            "rearport": "mdi-arrow-left-bold-box",
+            "frontport": "mdi-arrow-right-bold-box-outline",
+            "rearport": "mdi-arrow-left-bold-box-outline",
             "consoleport": "mdi-console",
-            "consoleserverport": "mdi-console-network",
-            "powerport": "mdi-power-plug",
+            "consoleserverport": "mdi-console-network-outline",
+            "powerport": "mdi-power-plug-outline",
             "poweroutlet": "mdi-power-socket",
             "powerfeed": "mdi-flash",
             "circuittermination": "mdi-cable-data",

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -5640,7 +5640,11 @@ class VirtualChassisTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             strip_spaces_between_tags(extract_page_body(response.content.decode(response.charset))),
         )
         # Sanity check:
-        self.assertBodyContains(response, '<th class="orderable"><a href="?sort=name">Name</a></th>', html=True)
+        self.assertBodyContains(
+            response,
+            '<th class="asc orderable"><a href="?sort=-name">Name<span class="mdi mdi-arrow-up-thin"></a></th>',
+            html=True,
+        )
 
     def test_set_master_after_adding_member(self):
         """Ensure master can be set for a member that was added via the Add Member flow."""

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -79,7 +79,7 @@ from nautobot.core.views.paginator import EnhancedPaginator, get_paginate_count
 from nautobot.core.views.utils import common_detail_view_context, get_obj_from_context, handle_protectederror
 from nautobot.core.views.viewsets import NautobotUIViewSet
 from nautobot.dcim.choices import LocationDataToContactActionChoices
-from nautobot.dcim.constants import TERMINATION_FK_FIELDS
+from nautobot.dcim.constants import DEVICE_COMPONENT_ICONS, TERMINATION_FK_FIELDS
 from nautobot.dcim.forms import LocationMigrateDataToContactForm
 from nautobot.dcim.utils import (
     generate_cable_breakout_mapping,
@@ -1646,63 +1646,63 @@ class DeviceTypeUIViewSet(NautobotUIViewSet):
                         weight=100,
                         link_name="dcim:devicetype_consoleporttemplate_add",
                         label="Console Ports",
-                        icon="mdi-console",
+                        icon=DEVICE_COMPONENT_ICONS["consoleporttemplate"],
                         required_permissions=["dcim.add_consoleporttemplate"],
                     ),
                     object_detail.Button(
                         weight=200,
                         link_name="dcim:devicetype_consoleserverporttemplate_add",
                         label="Console Server Ports",
-                        icon="mdi-console-network-outline",
+                        icon=DEVICE_COMPONENT_ICONS["consoleserverporttemplate"],
                         required_permissions=["dcim.add_consoleserverporttemplate"],
                     ),
                     object_detail.Button(
                         weight=300,
                         link_name="dcim:devicetype_powerporttemplate_add",
                         label="Power Ports",
-                        icon="mdi-power-plug-outline",
+                        icon=DEVICE_COMPONENT_ICONS["powerporttemplate"],
                         required_permissions=["dcim.add_powerporttemplate"],
                     ),
                     object_detail.Button(
                         weight=400,
                         link_name="dcim:devicetype_poweroutlettemplate_add",
                         label="Power Outlets",
-                        icon="mdi-power-socket",
+                        icon=DEVICE_COMPONENT_ICONS["poweroutlettemplate"],
                         required_permissions=["dcim.add_poweroutlettemplate"],
                     ),
                     object_detail.Button(
                         weight=500,
                         link_name="dcim:devicetype_interfacetemplate_add",
                         label="Interfaces",
-                        icon="mdi-ethernet",
+                        icon=DEVICE_COMPONENT_ICONS["interfacetemplate"],
                         required_permissions=["dcim.add_interfacetemplate"],
                     ),
                     object_detail.Button(
                         weight=600,
                         link_name="dcim:devicetype_frontporttemplate_add",
                         label="Front Ports",
-                        icon="mdi-square-rounded-outline",
+                        icon=DEVICE_COMPONENT_ICONS["frontporttemplate"],
                         required_permissions=["dcim.add_frontporttemplate"],
                     ),
                     object_detail.Button(
                         weight=700,
                         link_name="dcim:devicetype_rearporttemplate_add",
                         label="Rear Ports",
-                        icon="mdi-square-rounded-outline",
+                        icon=DEVICE_COMPONENT_ICONS["rearporttemplate"],
                         required_permissions=["dcim.add_rearporttemplate"],
                     ),
                     object_detail.Button(
                         weight=800,
                         link_name="dcim:devicetype_devicebaytemplate_add",
                         label="Device Bays",
-                        icon="mdi-circle-outline",
+                        icon=DEVICE_COMPONENT_ICONS["devicebaytemplate"],
                         required_permissions=["dcim.add_devicebaytemplate"],
                     ),
                     object_detail.Button(
                         weight=900,
                         link_name="dcim:devicetype_modulebaytemplate_add",
                         label="Module Bays",
-                        icon="mdi-tray",
+                        icon=DEVICE_COMPONENT_ICONS["modulebaytemplate"],
                         required_permissions=["dcim.add_modulebaytemplate"],
                     ),
                 ),
@@ -1952,7 +1952,7 @@ class ModuleTypeUIViewSet(
                         link_name="dcim:consoleporttemplate_add",
                         tab="consoleports",
                         label="Console Ports",
-                        icon="mdi-console",
+                        icon=DEVICE_COMPONENT_ICONS["consoleporttemplate"],
                         required_permissions=["dcim.add_consoleporttemplate"],
                     ),
                     ModuleTypeComponentAddButton(
@@ -1960,7 +1960,7 @@ class ModuleTypeUIViewSet(
                         link_name="dcim:consoleserverporttemplate_add",
                         tab="consoleserverports",
                         label="Console Server Ports",
-                        icon="mdi-console-network-outline",
+                        icon=DEVICE_COMPONENT_ICONS["consoleserverporttemplate"],
                         required_permissions=["dcim.add_consoleserverporttemplate"],
                     ),
                     ModuleTypeComponentAddButton(
@@ -1968,7 +1968,7 @@ class ModuleTypeUIViewSet(
                         link_name="dcim:powerporttemplate_add",
                         tab="powerports",
                         label="Power Ports",
-                        icon="mdi-power-plug-outline",
+                        icon=DEVICE_COMPONENT_ICONS["powerporttemplate"],
                         required_permissions=["dcim.add_powerporttemplate"],
                     ),
                     ModuleTypeComponentAddButton(
@@ -1976,7 +1976,7 @@ class ModuleTypeUIViewSet(
                         link_name="dcim:poweroutlettemplate_add",
                         tab="poweroutlets",
                         label="Power Outlets",
-                        icon="mdi-power-socket",
+                        icon=DEVICE_COMPONENT_ICONS["poweroutlettemplate"],
                         required_permissions=["dcim.add_poweroutlettemplate"],
                     ),
                     ModuleTypeComponentAddButton(
@@ -1984,7 +1984,7 @@ class ModuleTypeUIViewSet(
                         link_name="dcim:interfacetemplate_add",
                         tab="interfaces",
                         label="Interfaces",
-                        icon="mdi-ethernet",
+                        icon=DEVICE_COMPONENT_ICONS["interfacetemplate"],
                         required_permissions=["dcim.add_interfacetemplate"],
                     ),
                     ModuleTypeComponentAddButton(
@@ -1992,7 +1992,7 @@ class ModuleTypeUIViewSet(
                         link_name="dcim:frontporttemplate_add",
                         tab="frontports",
                         label="Front Ports",
-                        icon="mdi-square-rounded-outline",
+                        icon=DEVICE_COMPONENT_ICONS["frontporttemplate"],
                         required_permissions=["dcim.add_frontporttemplate"],
                     ),
                     ModuleTypeComponentAddButton(
@@ -2000,7 +2000,7 @@ class ModuleTypeUIViewSet(
                         link_name="dcim:rearporttemplate_add",
                         tab="rearports",
                         label="Rear Ports",
-                        icon="mdi-square-rounded-outline",
+                        icon=DEVICE_COMPONENT_ICONS["rearporttemplate"],
                         required_permissions=["dcim.add_rearporttemplate"],
                     ),
                     ModuleTypeComponentAddButton(
@@ -2008,7 +2008,7 @@ class ModuleTypeUIViewSet(
                         link_name="dcim:modulebaytemplate_add",
                         tab="modulebays",
                         label="Module Bays",
-                        icon="mdi-tray",
+                        icon=DEVICE_COMPONENT_ICONS["modulebaytemplate"],
                         required_permissions=["dcim.add_modulebaytemplate"],
                     ),
                 ),
@@ -3148,70 +3148,70 @@ class DeviceUIViewSet(NautobotUIViewSet):
                         weight=100,
                         link_name="dcim:device_consoleports_add",
                         label="Console Ports",
-                        icon="mdi-console",
+                        icon=DEVICE_COMPONENT_ICONS["consoleport"],
                         required_permissions=["dcim.add_consoleport"],
                     ),
                     object_detail.Button(
                         weight=200,
                         link_name="dcim:device_consoleserverports_add",
                         label="Console Server Ports",
-                        icon="mdi-console-network-outline",
+                        icon=DEVICE_COMPONENT_ICONS["consoleserverport"],
                         required_permissions=["dcim.add_consoleserverport"],
                     ),
                     object_detail.Button(
                         weight=300,
                         link_name="dcim:device_powerports_add",
                         label="Power Ports",
-                        icon="mdi-power-plug-outline",
+                        icon=DEVICE_COMPONENT_ICONS["powerport"],
                         required_permissions=["dcim.add_powerport"],
                     ),
                     object_detail.Button(
                         weight=400,
                         link_name="dcim:device_poweroutlets_add",
                         label="Power Outlets",
-                        icon="mdi-power-socket",
+                        icon=DEVICE_COMPONENT_ICONS["poweroutlet"],
                         required_permissions=["dcim.add_poweroutlet"],
                     ),
                     object_detail.Button(
                         weight=500,
                         link_name="dcim:device_interfaces_add",
                         label="Interfaces",
-                        icon="mdi-ethernet",
+                        icon=DEVICE_COMPONENT_ICONS["interface"],
                         required_permissions=["dcim.add_interface"],
                     ),
                     object_detail.Button(
                         weight=600,
                         link_name="dcim:device_frontports_add",
                         label="Front Ports",
-                        icon="mdi-square-rounded-outline",
+                        icon=DEVICE_COMPONENT_ICONS["frontport"],
                         required_permissions=["dcim.add_frontport"],
                     ),
                     object_detail.Button(
                         weight=700,
                         link_name="dcim:device_rearports_add",
                         label="Rear Ports",
-                        icon="mdi-square-rounded-outline",
+                        icon=DEVICE_COMPONENT_ICONS["rearport"],
                         required_permissions=["dcim.add_rearport"],
                     ),
                     object_detail.Button(
                         weight=800,
                         link_name="dcim:device_devicebays_add",
                         label="Device Bays",
-                        icon="mdi-circle-outline",
+                        icon=DEVICE_COMPONENT_ICONS["devicebay"],
                         required_permissions=["dcim.add_devicebay"],
                     ),
                     object_detail.Button(
                         weight=900,
                         link_name="dcim:device_modulebays_add",
                         label="Module Bays",
-                        icon="mdi-tray",
+                        icon=DEVICE_COMPONENT_ICONS["modulebay"],
                         required_permissions=["dcim.add_modulebay"],
                     ),
                     object_detail.Button(
                         weight=1000,
                         link_name="dcim:device_inventoryitems_add",
                         label="Inventory Items",
-                        icon="mdi-invoice-list-outline",
+                        icon=DEVICE_COMPONENT_ICONS["inventoryitem"],
                         required_permissions=["dcim.add_inventoryitem"],
                     ),
                 ),
@@ -5634,7 +5634,7 @@ class CableUIViewSet(NautobotUIViewSet):
     form_class = forms.CableForm
     serializer_class = serializers.CableSerializer
     table_class = tables.CableTable
-    queryset = Cable.objects.prefetch_related(
+    queryset = Cable.objects.select_related("cable_type").prefetch_related(
         Prefetch(
             "terminations",
             # `select_related`-ing the per-type FK columns lets the table's `terminations_a` /


### PR DESCRIPTION
# What's Changed

- Consolidate most device-component icon selection into `nautobot.dcim.constants.DEVICE_COMPONENT_ICONS` and the `termination_type_icon` template helper function. Updated areas include:
   - "Add component" menus on device-type, device, module-type, and module detail views
   - "Bulk add component" menus on device and module list views
   - "Name" column on device-component, module-component, device-type-component-template, and module-type-component-template tables
   - `terminations_a` and `terminations_b` columns on Cable table
   - `cable_peer` and `connection` columns on CableTermination subclass tables
- Change `termination_type_icon` from a template tag (`{% termination_type_icon record %}`) to a template filter (`{{ record|termination_type_icon }}`) and enhance it to also support providing a modelname (`"consoleport"`) as an alternative to an actual object instance.
- Add missing `cable_peer` and `connection` columns to CircuitTerminationTable
- Enhance CableTable `terminations_a` and `terminations_b` rendering to include non-terminated connectors
- Fix logic in `InterfaceTable.name` column to correctly vary the rendered icon based on interface properties
- Add logic to `DeviceModuleBayTable` and `DeviceDeviceBayTable` to highlight rows with an installed module/device.

NAUTOBOT-1374
# Screenshots

Updated `terminations_a` and `terminations_b` columns on CableTable:

<img width="531" height="395" alt="image" src="https://github.com/user-attachments/assets/53cccb5c-acf0-47a3-98ff-d7eb0c0f22a9" />

Updated "Name" rendering on device rear ports:

<img width="264" height="566" alt="image" src="https://github.com/user-attachments/assets/26ae74e4-7f51-4d2b-9dff-6ff397d57b6f" />

Updated "Add Components" menu:

<img width="258" height="361" alt="image" src="https://github.com/user-attachments/assets/c4dff3c9-8943-4cd3-8dff-0baeee0e4a94" />

Updated "Bulk add components" menu:

<img width="264" height="331" alt="image" src="https://github.com/user-attachments/assets/c0d1e97b-9d77-4209-9d47-98b3f6e9e652" />

Updated device-bay table:

<img width="1071" height="291" alt="image" src="https://github.com/user-attachments/assets/8d0e0948-a5ee-402e-ae2a-0c8908cff650" />


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
