### PR TITLE
Fix AttributeError in render_markdown for null values

### DIFF
--- a/changes/6327.fixed
+++ b/changes/6327.fixed
@@ -1,0 +1,1 @@
+Fixed an `AttributeError` ('NoneType' object has no attribute 'strip') raised by the `render_markdown` template filter when rendering a null value.

--- a/nautobot/core/templatetags/helpers.py
+++ b/nautobot/core/templatetags/helpers.py
@@ -219,6 +219,10 @@ def render_markdown(value):
     Example:
         {{ text | render_markdown }}
     """
+    # Gracefully handle null values
+    if value is None:
+        value = ""
+
     # Render Markdown
     html = markdown(value, extensions=["fenced_code", "tables"])
 

--- a/nautobot/core/tests/test_templatetags_helpers.py
+++ b/nautobot/core/tests/test_templatetags_helpers.py
@@ -97,6 +97,8 @@ class NautobotTemplatetagsHelperTest(TestCase):
             helpers.render_markdown("[I am a link](https://www.example.com)"),
             '<p><a href="https://www.example.com" rel="noopener noreferrer">I am a link</a></p>',
         )
+        self.assertEqual(helpers.render_markdown(None), "")
+        self.assertEqual(helpers.render_markdown(""), "")
 
     def test_render_markdown_security(self):
         self.assertEqual(helpers.render_markdown('<script>alert("XSS")</script>'), "")


### PR DESCRIPTION
Closes #6327
# What's Changed
Fixed `AttributeError: 'NoneType' object has no attribute 'strip'` in the render_markdown template filter by coercing null values to an empty string before rendering.
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
