### PR TITLE
Fix _translate_select_related_fields not accounting for None

### DIFF
--- a/changes/9130.fixed
+++ b/changes/9130.fixed
@@ -1,0 +1,1 @@
+Fixed an error when trying to serialize a many-to-many relationship to a model that supports cable terminations.

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -281,6 +281,7 @@ class CableTerminationQuerySet(RestrictedQuerySet):
     def _translate_select_related_fields(cls, fields):
         if fields == (None,):
             return fields
+
         translated = []
         for field in fields:
             if field == "cable":

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -279,11 +279,11 @@ class CableTerminationQuerySet(RestrictedQuerySet):
 
     @classmethod
     def _translate_select_related_fields(cls, fields):
+        if fields == (None,):
+            return fields
         translated = []
         for field in fields:
-            if field is None:
-                translated.append(None)
-            elif field == "cable":
+            if field == "cable":
                 cls._warn('select_related("cable")', 'select_related("cable_termination__cable")')
                 translated.append("cable_termination__cable")
             elif field.startswith("cable__"):

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -281,7 +281,9 @@ class CableTerminationQuerySet(RestrictedQuerySet):
     def _translate_select_related_fields(cls, fields):
         translated = []
         for field in fields:
-            if field == "cable":
+            if field is None:
+                translated.append(None)
+            elif field == "cable":
                 cls._warn('select_related("cable")', 'select_related("cable_termination__cable")')
                 translated.append("cable_termination__cable")
             elif field.startswith("cable__"):

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -3970,6 +3970,20 @@ class CableTestCase(ModelTestCases.BaseModelTestCase):
             list(qs[:1])
         self.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))
 
+    def test_select_related_none_clears_without_warning(self):
+        """`select_related(None)` passes through untouched and does not warn.
+
+        Regression test: the translation previously called `field.startswith(...)` on every field,
+        which raised `AttributeError` for the `None` sentinel that Django passes to clear
+        select_related.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            qs = Interface.objects.select_related("device").select_related(None)
+            list(qs[:1])  # force evaluation
+        self.assertEqual(qs.query.select_related, False)
+        self.assertFalse(any(issubclass(w.category, DeprecationWarning) for w in caught))
+
     def test_filter_cable_none_translates_to_isnull_true(self):
         """`filter(cable=None)` is treated as "uncabled" — translates to `cable_termination__isnull=True`."""
         with warnings.catch_warnings(record=True) as caught:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes DNE
# What's Changed

This has been causing failures in upstream testing for the last few weeks and I finally got around to fixing it. Django calls `select_related(None)` when serializing the m2m between firewall models' `Zone` model and `Interface`: https://github.com/django/django/blob/2b3093ff431de73cd23023110ccd86f310d3d29d/django/core/serializers/python.py#L89

See the traceback below from firewall models:

```py
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
    return view_func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/nautobot/core/api/views.py", line 322, in dispatch
    return super().dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/rest_framework/views.py", line 515, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/rest_framework/views.py", line 475, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.12/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.12/site-packages/rest_framework/views.py", line 512, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/rest_framework/mixins.py", line 68, in update
    self.perform_update(serializer)
  File "/usr/local/lib/python3.12/site-packages/nautobot/core/api/views.py", line 384, in perform_update
    instance = serializer.save()
               ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/rest_framework/serializers.py", line 205, in save
    self.instance = self.update(self.instance, validated_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/nautobot/core/api/serializers.py", line 832, in update
    instance = super().update(instance, validated_data)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/nautobot/extras/api/mixins.py", line 32, in update
    instance = super().update(instance, validated_data)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/rest_framework/serializers.py", line 1055, in update
    instance.save()
  File "/usr/local/lib/python3.12/site-packages/django/db/models/base.py", line 902, in save
    self.save_base(
  File "/usr/local/lib/python3.12/site-packages/django/db/models/base.py", line 988, in save_base
    pre_save.send(
  File "/usr/local/lib/python3.12/site-packages/django/dispatch/dispatcher.py", line 189, in send
    response = receiver(signal=self, sender=sender, **named)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/nautobot/extras/signals.py", line 252, in _handle_changed_object_pre_save
    _cache_obj_data_in_change_context(ObjectChangeActionChoices.ACTION_UPDATE, sender, instance)
  File "/usr/local/lib/python3.12/site-packages/nautobot/extras/signals.py", line 137, in _cache_obj_data_in_change_context
    change = instance.to_objectchange(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/nautobot/extras/models/change_logging.py", line 44, in to_objectchange
    object_data=serialize_object(self, extra=object_data_extra, exclude=object_data_exclude),
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/nautobot/core/models/utils.py", line 106, in serialize_object
    json_str = serialize("json", [obj])
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/serializers/__init__.py", line 134, in serialize
    s.serialize(queryset, **options)
  File "/usr/local/lib/python3.12/site-packages/django/core/serializers/base.py", line 144, in serialize
    self.handle_m2m_field(obj, field)
  File "/usr/local/lib/python3.12/site-packages/django/core/serializers/python.py", line 95, in handle_m2m_field
    queryset_iterator(obj, field),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/serializers/python.py", line 89, in queryset_iterator
    query_set = getattr(obj, field.name).select_related(None).only("pk")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/nautobot/dcim/models/device_components.py", line 304, in select_related
    return super().select_related(*self._translate_select_related_fields(fields))
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/nautobot/dcim/models/device_components.py", line 287, in _translate_select_related_fields
    elif field.startswith("cable__"):
         ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'startswith'
```
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
