### PR TITLE
Fix DynamicGroup members tab action return URL (#9117)

### DIFF
--- a/changes/9117.fixed
+++ b/changes/9117.fixed
@@ -1,0 +1,1 @@
+Fixed edit/delete actions on a Dynamic Group's Members tab returning the user to the group's detail page instead of the Members tab.

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2718,6 +2718,26 @@ class DynamicGroupTestCase(
         self.assertIn("You can bulk-add and bulk-remove members of this group from the", members_body)
         self.assertNotIn("Dynamic group membership is cached for performance reasons", members_body)
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_members_tab_action_return_url(self):
+        """Edit/delete actions on the Members tab return to the Members tab, not the group's detail page (#9117)."""
+        static_group = DynamicGroup.objects.create(
+            name="DG Members Return URL",
+            content_type=ContentType.objects.get_for_model(Location),
+            group_type=DynamicGroupTypeChoices.TYPE_STATIC,
+        )
+        static_group.add_members(Location.objects.all()[:2])
+        self.add_permissions("dcim.change_location", "dcim.delete_location")
+
+        group_url = static_group.get_absolute_url()
+        members_url = reverse("extras:dynamicgroup_members", kwargs={"pk": static_group.pk})
+        response = self.client.get(members_url)
+        self.assertHttpStatus(response, 200)
+        body = extract_page_body(response.content.decode(response.charset))
+
+        self.assertIn(f"return_url={group_url}members/", body)
+        self.assertNotIn(f'return_url={group_url}"', body)
+
     @override_settings(PAGINATE_COUNT=1)
     def test_get_object_dynamic_set_descendants_view_more(self):
         _, dynamic_set, _ = self.create_dynamic_group()

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2735,7 +2735,7 @@ class DynamicGroupTestCase(
         self.assertHttpStatus(response, 200)
         body = extract_page_body(response.content.decode(response.charset))
 
-        self.assertIn(f"return_url={group_url}members/", body)
+        self.assertIn(f"return_url={members_url}", body)
         self.assertNotIn(f'return_url={group_url}"', body)
 
     @override_settings(PAGINATE_COUNT=1)

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2735,7 +2735,8 @@ class DynamicGroupTestCase(
         self.assertHttpStatus(response, 200)
         body = extract_page_body(response.content.decode(response.charset))
 
-        self.assertIn(f"return_url={members_url}", body)
+        self.assertIn(f"/edit/?return_url={members_url}", body)
+        self.assertIn(f"/delete/?return_url={members_url}", body)
         self.assertNotIn(f'return_url={group_url}"', body)
 
     @override_settings(PAGINATE_COUNT=1)

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1769,9 +1769,7 @@ class DynamicGroupUIViewSet(NautobotUIViewSet):
                 RequestConfig(request, paginate).configure(members_table)
 
                 if "actions" in members_table.columns:
-                    members_table.columns["actions"].column.extra_context["return_url_extra"] = (
-                        self.members.url_path + "/"
-                    )
+                    members_table.columns["actions"].column.extra_context["return_url"] = ""
 
                 if instance.group_type != DynamicGroupTypeChoices.TYPE_STATIC:
                     context["members_list_url"] = None

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1768,6 +1768,11 @@ class DynamicGroupUIViewSet(NautobotUIViewSet):
                 }
                 RequestConfig(request, paginate).configure(members_table)
 
+                if "actions" in members_table.columns:
+                    members_table.columns["actions"].column.extra_context["return_url_extra"] = (
+                        self.members.url_path + "/"
+                    )
+
                 if instance.group_type != DynamicGroupTypeChoices.TYPE_STATIC:
                     context["members_list_url"] = None
                 else:


### PR DESCRIPTION
# Closes #9117

# What's Changed

Edit and delete actions in a Dynamic Group's **Members** tab built their return URL from the group's detail page, so canceling or completing the action returned the user to the group detail view (`/extras/dynamic-groups/{id}/`) instead of the Members tab they came from (`/extras/dynamic-groups/{id}/members/`).

Unlike the path-based component tabs fixed in #9116, the Members tab does **not** render through `ObjectsTablePanel` — it builds its members table by hand in `DynamicGroupUIViewSet.get_extra_context()`, so it never picked up any tab-aware return URL (not even the legacy `?tab=` form). This sets the members table's `actions` column return URL to the Members tab path.

## Out of scope / follow-up
The cleaner long-term convergence would be to migrate the Members tab to `ObjectsTablePanel` so it inherits the framework's tab-aware return-URL behavior for free (the same code path #9116 hardens), rather than building the table by hand. That's a larger refactor with its own risk, so it's intentionally left out of this bug fix.

# Screenshots

Behavior-only fix — the change is the `return_url` carried on each row's edit/delete action link. Before/after for the rendered action-link `href` on the Members tab:

**Before** (returns to the group detail page):
```html
<a href="/dcim/locations/{member_id}/delete/?return_url=/extras/dynamic-groups/{id}/" ...>
```

**After** (returns to the Members tab):
```html
<a href="/dcim/locations/{member_id}/delete/?return_url=/extras/dynamic-groups/{id}/members/" ...>
```

Covered by a regression test (`DynamicGroupTestCase.test_members_tab_action_return_url`) asserting the `members/` suffix is present on the action links.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
