### PR TITLE
Moved the charset declaration to the first tag in <head>.

### DIFF
--- a/changes/9132.fixed
+++ b/changes/9132.fixed
@@ -1,1 +1,1 @@
-Moved the charset declaration to the first tag in <head>.
+Moved the charset declaration to be the first tag in `<head>`.

--- a/changes/9132.fixed
+++ b/changes/9132.fixed
@@ -1,0 +1,1 @@
+Moved the charset declaration to the first tag in <head>.

--- a/nautobot/core/templates/admin/base.html
+++ b/nautobot/core/templates/admin/base.html
@@ -7,6 +7,7 @@
 <!DOCTYPE html>
 <html lang="en"{% if request.COOKIES|get_item:"theme" == 'dark' %} data-theme="dark"{% endif %}>
     <head>
+        <meta charset="UTF-8">
         <title>{% block title %}Admin Home{% endblock %} - Nautobot</title>
         {% include 'inc/media.html' %}
         {% block extrahead %}{% endblock %}

--- a/nautobot/core/templates/base_django.html
+++ b/nautobot/core/templates/base_django.html
@@ -10,6 +10,11 @@
 <!DOCTYPE html>
 <html lang="en"{% with cookie_theme=request.COOKIES|get_item:'theme' %}{% if cookie_theme == 'dark' or cookie_theme == 'light' %} data-theme="{{cookie_theme}}" data-bs-theme="{{cookie_theme}}"{% endif %}{% endwith %}>
     <head>
+        {% comment %}
+        charset must be declared in the first 1024 bytes of the document so
+        we declare it before anything else in <head>
+        {% endcomment %}
+        <meta charset="UTF-8">
         <title>{{ title_block_content }}{% block document_title_extra %}{% endblock %} - {{ settings.BRANDING_TITLE }}</title>
         {% include 'inc/media.html' %}
         {% block extra_styles %}{% endblock %}

--- a/nautobot/core/templates/graphene/graphiql.html
+++ b/nautobot/core/templates/graphene/graphiql.html
@@ -12,6 +12,7 @@ add "&raw" to the end of the URL within a browser.
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="UTF-8">
         {% include 'inc/media.html' %}
         {% block extra_styles %}{% endblock %}
         <!-- Nautobot template requirements -->

--- a/nautobot/core/templates/inc/media.html
+++ b/nautobot/core/templates/inc/media.html
@@ -35,7 +35,6 @@
 <link rel="shortcut icon" href="{% custom_branding_or_static 'favicon' 'img/favicon.ico' %}">
 <meta name="msapplication-TileColor" content="#2d89ef">
 <meta name="theme-color" content="#ffffff">
-<meta charset="UTF-8">
 <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width">
 {% if settings.PUBLISH_ROBOTS_TXT %}
     <meta name="robots" content="noindex, nofollow">


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes DNE
# What's Changed

- Moved the `<meta charset="UTF-8">` tag to the first tag in `<head>` in `base_django.html` instead of below a large block of JS in `inc/media.html`

The charset declaration must be within the first 1024 bytes of the document: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta#charset

This is one of potentially multiple angles to solve the `materialdesignicons.css` encoding being set incorrectly causing the icons to render as unicode characters.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
