### PR TITLE
Added `obj` context variable to data validation regex rule

### DIFF
--- a/changes/7946.added
+++ b/changes/7946.added
@@ -1,0 +1,1 @@
+Added the `obj` Jinja2 variable to data validation regex rules to align with Nautobot's conventions.

--- a/changes/7946.deprecated
+++ b/changes/7946.deprecated
@@ -1,0 +1,1 @@
+Deprecated the `object` Jinja2 variable in data validation regex rules in favor of `obj`; `object` will be removed in Nautobot 4.0.

--- a/nautobot/data_validation/custom_validators.py
+++ b/nautobot/data_validation/custom_validators.py
@@ -48,7 +48,7 @@ class BaseValidator(CustomValidator):
 
     def clean(self, exclude_disabled_rules=True):  # pylint: disable=too-many-branches
         """The clean method executes the actual rule enforcement logic for each model."""
-        obj = self.context["object"]
+        obj = self.context["obj"]
 
         method_name = "get_enabled_for_model" if exclude_disabled_rules else "get_for_model"
 
@@ -61,6 +61,9 @@ class BaseValidator(CustomValidator):
                 field_value = ""
 
             if rule.context_processing:
+                self.context.warn_about_deprecated_template_variables(
+                    rule.regular_expression, source=f"Data validation rule '{rule}'"
+                )
                 # Render the regular_expression as a jinja2 string and ensure it is valid
                 try:
                     regular_expression = render_jinja2(rule.regular_expression, self.context)
@@ -155,11 +158,11 @@ class BaseValidator(CustomValidator):
         for repo in GitRepository.objects.get_for_provided_contents("data_validation.data_compliance_rule"):
             for compliance_class in get_data_compliance_classes_from_git_repo(repo):
                 if (
-                    f"{self.context['object']._meta.app_label}.{self.context['object']._meta.model_name}"
+                    f"{self.context['obj']._meta.app_label}.{self.context['obj']._meta.model_name}"
                     != compliance_class.model
                 ):
                     continue
-                compliance_class(self.context["object"]).clean()
+                compliance_class(self.context["obj"]).clean()
 
     def get_compliance_result(self, message=None, instance=None, attribute=None, valid=True):
         """Generate a DataCompliance object based on the given parameters."""
@@ -253,7 +256,7 @@ class DataComplianceRule(CustomValidator):
         We pass in any attributes that had ComplianceErrors raised so that we end up with the list of attributes that should now be valid.
         This doesn't create DataCompliance objects for any fields that have always been valid or not referenced in the DataComplianceRule.
         """
-        instance = self.context["object"]
+        instance = self.context["obj"]
         if not exclude_attributes:
             exclude_attributes = []
         attributes = (
@@ -273,7 +276,7 @@ class DataComplianceRule(CustomValidator):
         try:
             self.audit()
             self.mark_existing_attributes_as_valid()
-            self.compliance_result(message=f"All {self.name} class rules for {self.context['object']} are valid.")
+            self.compliance_result(message=f"All {self.name} class rules for {self.context['obj']} are valid.")
         except ComplianceError as ex:
             # Create a list of attributes that had ComplianceErrors raised to exclude from later function call
             exclude_attributes = []
@@ -290,7 +293,7 @@ class DataComplianceRule(CustomValidator):
             finally:
                 self.mark_existing_attributes_as_valid(exclude_attributes=exclude_attributes)
                 self.compliance_result(
-                    message=f"One or more {self.name} class rules for {self.context['object']} are not valid.",
+                    message=f"One or more {self.name} class rules for {self.context['obj']} are not valid.",
                     valid=False,
                 )
             if self.enforce:
@@ -303,7 +306,7 @@ class DataComplianceRule(CustomValidator):
 
     def compliance_result(self, message, attribute=None, valid=True):
         """Generate a DataCompliance object based on the given parameters."""
-        instance = self.context["object"]
+        instance = self.context["obj"]
         attribute_value = None
         if attribute:
             attribute_value = getattr(instance, attribute)

--- a/nautobot/data_validation/models.py
+++ b/nautobot/data_validation/models.py
@@ -112,7 +112,7 @@ class RegularExpressionValidationRule(ValidationRuleModelMixin, PrimaryModel):
     regular_expression = models.TextField()
     context_processing = models.BooleanField(
         default=False,
-        help_text="When enabled, the regular expression value is first processed as a Jinja2 template with access to the context of the data being validated in a variable named <code>object</code>.",
+        help_text="When enabled, the regular expression value is first processed as a Jinja2 template with access to the object being validated in a variable named <code>obj</code>.",
     )
 
     clone_fields = ["enabled", "content_type", "regular_expression", "error_message"]

--- a/nautobot/data_validation/tests/test_custom_validators.py
+++ b/nautobot/data_validation/tests/test_custom_validators.py
@@ -84,7 +84,7 @@ class RegularExpressionValidationRuleCustomValidatorTestCase(CustomValidatorTest
             name="Regex rule 1",
             content_type=ContentType.objects.get_for_model(Location),
             field="description",
-            regular_expression="{{ object.name[0:3] }}.*",
+            regular_expression="{{ obj.name[0:3] }}.*",
             context_processing=True,
         )
 
@@ -105,7 +105,7 @@ class RegularExpressionValidationRuleCustomValidatorTestCase(CustomValidatorTest
             name="Regex rule 1",
             content_type=ContentType.objects.get_for_model(Location),
             field="description",
-            regular_expression="{{ object.name[0:3] }}.*",
+            regular_expression="{{ obj.name[0:3] }}.*",
             context_processing=True,
         )
 
@@ -124,7 +124,7 @@ class RegularExpressionValidationRuleCustomValidatorTestCase(CustomValidatorTest
             name="Regex rule 1",
             content_type=ContentType.objects.get_for_model(Location),
             field="description",
-            regular_expression="[{{ object.name[0:3] }}.*",  # once processed, this is an invalid regex
+            regular_expression="[{{ obj.name[0:3] }}.*",  # once processed, this is an invalid regex
             context_processing=True,
         )
 
@@ -135,6 +135,31 @@ class RegularExpressionValidationRuleCustomValidatorTestCase(CustomValidatorTest
             "There was an error rendering the regular expression in the data validation rule 'Regex rule 1'. Either fix the validation rule or disable it in order to save this data.",
         ):
             location.clean()
+
+    def test_context_processing_deprecated_object_variable_still_works_and_warns(self):
+        # TODO: 4.0 remove this test along with support for the legacy `object` variable.
+        RegularExpressionValidationRule.objects.create(
+            name="Regex rule 1",
+            content_type=ContentType.objects.get_for_model(Location),
+            field="description",
+            regular_expression="{{ object.name[0:3] }}.*",  # legacy variable name
+            context_processing=True,
+        )
+
+        location = Location(
+            name="AMS-195",
+            location_type=self.location_type,
+            status=self.status,
+            description="AMS-195 is really cool",  # This should match `AMS.*`
+        )
+
+        # The legacy `object` variable is still rendered (backward compatible) but logs a deprecation warning.
+        with self.assertLogs("nautobot.extras.plugins", level="WARNING") as logs:
+            try:
+                location.clean()
+            except ValidationError as e:
+                self.fail(f"rule.clean() failed validation: {e}")
+        self.assertTrue(any("deprecated Jinja2 variable `object`" in message for message in logs.output))
 
 
 class MinMaxValidationRuleCustomValidatorTestCase(CustomValidatorTestCases.CustomValidatorTestCase):

--- a/nautobot/docs/user-guide/platform-functionality/data-validation.md
+++ b/nautobot/docs/user-guide/platform-functionality/data-validation.md
@@ -68,7 +68,10 @@ In this example, a device hostname validation rule has been created and prevents
 ![Regex Rules Enforcement](../../media/data-validation-engine/ss_regex-rules-enforcement_dark.png#only-dark){ .on-glb }
 [//]: # "`https://next.demo.nautobot.com/dcim/devices/add/`"
 
-Regex rules may also support complex Jinja2 rendering called context processing which allows for the regular expression itself to by dynamically generated based on the context of the data it is validating.
+Regex rules may also support complex Jinja2 rendering called context processing which allows for the regular expression itself to by dynamically generated based on the context of the data it is validating. The object being validated is available in the template as the `obj` variable (e.g. `{{ obj.name }}`).
+
+!!! note
+    The `obj` variable was previously named `object`. The `object` variable is still available but is deprecated and will be removed in Nautobot 4.0.
 
 In this example the name of a device must start with the first three characters of the name of the location to which the device belongs. The dynamic nature of the Jinja2 rendering means that the location name can be anything, the enforcement action is simply that the given device name matches its assigned location.
 

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -7,8 +7,10 @@ from logging import getLogger
 from django.conf import settings
 from django.conf.urls import include
 from django.core.exceptions import ValidationError
+from django.template import engines
 from django.template.loader import get_template
 from django.urls import clear_url_caches, get_resolver, path, URLPattern
+from jinja2 import meta
 from packaging import version
 
 from nautobot.core.apps import (
@@ -715,6 +717,11 @@ def register_plugin_menu_items(section_name, menu_items):
 
 
 class CustomValidatorContext(dict):
+    # Mapping of deprecated context variable names to a (replacement, removal_version) tuple. Used to warn
+    # authors who still reference an old variable name in a Jinja2 template rendered with this context.
+    # TODO: 4.0 remove the `object` entry (and the legacy `object` key set in __init__).
+    DEPRECATED_VARIABLES = {"object": ("obj", "4.0")}
+
     def __init__(self, obj):
         """
         If there is an active change context, meaning we are in a web request context,
@@ -736,7 +743,41 @@ class CustomValidatorContext(dict):
         if user is None:
             user = AnonymousUser()
 
-        super().__init__(object=obj, user=user)
+        # TODO: 4.0 remove the legacy `object` key; `obj` is the supported name.
+        super().__init__(obj=obj, object=obj, user=user)
+
+    @classmethod
+    def warn_about_deprecated_template_variables(cls, template_code, source=None):
+        """Log a warning for each deprecated context variable referenced in a Jinja2 template.
+
+        Any feature that renders a user-provided Jinja2 template against this context can call this to nudge
+        authors toward the supported variable names defined in `DEPRECATED_VARIABLES`.
+
+        Args:
+            template_code (str): The Jinja2 template source to inspect.
+            source (str, optional): Human-readable identifier for the template (e.g. a rule name) used in the log message.
+        """
+        if not cls.DEPRECATED_VARIABLES:
+            return
+        try:
+            parsed = engines["jinja"].env.parse(template_code)
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Don't let our desire to warn about deprecated variables break the app if the template is invalid.
+            # Syntax errors will be surfaced when the template is rendered.
+            return
+        referenced_variables = meta.find_undeclared_variables(parsed)
+        prefix = f"{source} " if source else ""
+        for deprecated, (replacement, removal_version) in cls.DEPRECATED_VARIABLES.items():
+            if deprecated in referenced_variables:
+                logger.warning(
+                    "%suses the deprecated Jinja2 variable `%s`; use `%s` instead. "
+                    "Support for `%s` will be removed in Nautobot %s.",
+                    prefix,
+                    deprecated,
+                    replacement,
+                    deprecated,
+                    removal_version,
+                )
 
 
 class CustomValidator:
@@ -765,7 +806,8 @@ class CustomValidator:
     def clean(self):
         """
         Implement custom model validation in the standard Django clean method pattern. The model instance is accessed
-        with the `object` key within `self.context`, e.g. `self.context['object']`. ValidationError must be raised to
+        with the `obj` key within `self.context`, e.g. `self.context['obj']`. (The legacy `object` key is also
+        available but is deprecated and will be removed in Nautobot 4.0.) ValidationError must be raised to
         prevent saving model instance changes, and propagate messages to the user. For convenience,
         `self.validation_error(<message>)` may be called to raise a ValidationError.
         """

--- a/nautobot/extras/plugins/__init__.py
+++ b/nautobot/extras/plugins/__init__.py
@@ -766,11 +766,11 @@ class CustomValidatorContext(dict):
             # Syntax errors will be surfaced when the template is rendered.
             return
         referenced_variables = meta.find_undeclared_variables(parsed)
-        prefix = f"{source} " if source else ""
+        prefix = f"{source} uses the" if source else "Encountered the"
         for deprecated, (replacement, removal_version) in cls.DEPRECATED_VARIABLES.items():
             if deprecated in referenced_variables:
                 logger.warning(
-                    "%suses the deprecated Jinja2 variable `%s`; use `%s` instead. "
+                    "%s deprecated Jinja2 variable `%s`; use `%s` instead. "
                     "Support for `%s` will be removed in Nautobot %s.",
                     prefix,
                     deprecated,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #7946
# What's Changed
When the Data Validation app was folded into Nautobot core, we intentionally didn't make many changes so it would be forwards compatible. The DV app used the inconsistent context variable `object` instead of the standard `obj`. This PR adds our typical `obj` variable to the context to bring it inline with the rest of Nautobot core and deprecates the `object` variable. It still remains as an alias for now until we remove it.
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
