### PR TITLE
Closes #7475: Document that Git DatasourceContent callbacks are always called

### DIFF
--- a/changes/7475.documentation
+++ b/changes/7475.documentation
@@ -1,0 +1,1 @@
+Added documentation noting that app-provided `DatasourceContent` callbacks are always called when a Git repository is synced and should always check `repository_record.provided_contents` before taking action.

--- a/nautobot/docs/development/apps/api/platform-features/git-repository-content.md
+++ b/nautobot/docs/development/apps/api/platform-features/git-repository-content.md
@@ -60,3 +60,6 @@ datasource_contents = [
 ```
 
 With this code, once your app is installed, the Git repository creation/editing UI will now include "Animals" as an option for the type(s) of data that a given repository may provide. If this option is selected for a given Git repository, your `refresh_git_animals` function will be automatically called when the repository is synced.
+
+!!! warning
+    When your app provides a `DatasourceContent` callback function, that function *will always be called* whenever a Git repository is synced, even if that given repository is not marked as providing your specific content type. This is by design, as in some cases an app may want to take action when given a repository that *doesn't* (but perhaps previously did) provide that type of content. Your callback function should **always** check `repository_record.provided_contents` (as in the example above) before taking any action.


### PR DESCRIPTION
# Closes #7475

# What's Changed

Added a warning admonition to the "Loading Data from a Git Repository" developer documentation clarifying that an app-provided `DatasourceContent` callback is **always** invoked whenever a Git repository is synced — even when the repository is not marked as providing the app's content type — and that callbacks must therefore always check `repository_record.provided_contents` before taking action.

This documents existing, intentional behavior rather than changing core: per @glennmatthews's feedback on #7475, the callback is called unconditionally so that an app can handle the removal/deletion case (acting when a repository no longer — but perhaps previously did — provide that content type). The wording follows the admonition proposed in the issue discussion.

# Screenshots

N/A — documentation-only change. Renders as a standard MkDocs `!!! warning` admonition immediately after the `datasource_contents` example.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [x] Documentation Updates
- [ ] Attached Screenshots, Payload Example — N/A (docs only)
- [ ] Unit, Integration Tests — N/A (docs only)
- [ ] Example App Updates — N/A
- [x] Outline Remaining Work, Constraints from Design — none; single-file doc clarification
