### PR TITLE
Closes #4502: Remove unused PasswordInputWithPlaceholder form widget

### DIFF
--- a/changes/4502.housekeeping
+++ b/changes/4502.housekeeping
@@ -1,0 +1,1 @@
+Removed the unused `PasswordInputWithPlaceholder` form widget, which had been orphaned since support for storing Git repository credentials in the database was removed.

--- a/nautobot/extras/forms/forms.py
+++ b/nautobot/extras/forms/forms.py
@@ -212,7 +212,6 @@ __all__ = (
     "ObjectMetadataCreateForm",
     "ObjectMetadataFilterForm",
     "ObjectMetadataForm",
-    "PasswordInputWithPlaceholder",
     "RelationshipAssociationFilterForm",
     "RelationshipBulkEditForm",
     "RelationshipFilterForm",
@@ -1289,21 +1288,6 @@ class ExternalIntegrationFilterForm(NautobotFilterForm):
 
 def get_git_datasource_content_choices():
     return get_datasource_content_choices("extras.gitrepository")
-
-
-class PasswordInputWithPlaceholder(forms.PasswordInput):
-    """PasswordInput that is populated with a placeholder value if any existing value is present."""
-
-    def __init__(self, attrs=None, placeholder="", render_value=False):
-        if placeholder:
-            render_value = True
-        self._placeholder = placeholder
-        super().__init__(attrs=attrs, render_value=render_value)
-
-    def get_context(self, name, value, attrs):
-        if value:
-            value = self._placeholder
-        return super().get_context(name, value, attrs)
 
 
 class GitRepositoryForm(NautobotModelForm):


### PR DESCRIPTION
# Closes #4502

# What's Changed

Removed the unused `PasswordInputWithPlaceholder` form widget from `nautobot/extras/forms/forms.py` (and its entry in the module's `__all__`).

The widget was a small `forms.PasswordInput` subclass used only by the Git repository form's token/password field. That field was removed when support for storing Git repository credentials in the database was dropped (#3451), leaving the widget orphaned with no remaining references anywhere in the codebase. This is the cleanup requested in #4502.

# Screenshots

N/A — internal dead-code removal; no user-facing or behavioral change.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example — N/A
- [ ] Unit, Integration Tests — N/A (removal of unused code; existing `nautobot.extras.tests.test_forms` pass unchanged)
- [ ] Documentation Updates — N/A
- [ ] Example App Updates — N/A
- [x] Outline Remaining Work, Constraints from Design — none; single dead-code removal
