### PR TITLE
Closes #7319: Document extras.view_fileproxy permission for downloading job output

### DIFF
--- a/changes/7319.documentation
+++ b/changes/7319.documentation
@@ -1,0 +1,1 @@
+Added documentation clarifying that the `extras.view_fileproxy` permission is required to download a job's output files.

--- a/nautobot/docs/user-guide/administration/guides/permissions.md
+++ b/nautobot/docs/user-guide/administration/guides/permissions.md
@@ -133,5 +133,12 @@ Create a Permission to allow users to view the results of Export jobs they ran:
 - Users/Groups: Any user or restrict as needed
 - Constraints: `[{"user": "$user", "task_name": "nautobot.core.jobs.ExportObjectList"}]`
 
+Create a Permission to allow users to download a job's output file(s), such as the result file produced by an Export job:
+
+- Permission Name: `Download Job output files`
+- Object type: `Extras > File proxy`
+- Action: `View`
+- Users/Groups: Any user or restrict as needed
+
 !!! info
     Export jobs run with the permissions of the user that start the job.

--- a/nautobot/docs/user-guide/platform-functionality/jobs/managing-jobs.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/managing-jobs.md
@@ -138,3 +138,4 @@ When a Job is submitted for execution or scheduling, Nautobot checks for any rel
 | Approve scheduled Job      | `extras.change_approvalworkflowstage` + `extras.view_approvalworkflowstage` + `extras.change_scheduledjob`|
 | View Job Log Entries       | `extras.view_joblogentry`                                |
 | View Job Console Output    | `extras.view_jobconsoleentry`                            |
+| Download Job output file(s)| `extras.view_fileproxy`                                  |


### PR DESCRIPTION
# Closes #7319

# What's Changed

Documented that downloading a job's output file(s) requires the `extras.view_fileproxy` permission — previously undocumented, leaving users to discover it via Slack (per the issue discussion and the +1 comment).

- `user-guide/platform-functionality/jobs/managing-jobs.md` — added a **Download Job output file(s)** row to the Permissions checklist (the location the issue explicitly suggested).
- `user-guide/administration/guides/permissions.md` — added a permission recipe under **Export Job** for downloading a job's output file(s) (the location the +1 commenter had looked for it).

The requirement is enforced by the file-download view `get_file_with_authorization` (`nautobot/core/views/__init__.py`), which applies `@permission_required(get_permission_for_model(FileProxy, "view"))` and object-level `FileProxy.objects.restrict(request.user, "view")` — i.e. `extras.view_fileproxy`.

# Screenshots

N/A — documentation only.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [x] Documentation Updates
- [ ] Attached Screenshots, Payload Example — N/A
- [ ] Unit, Integration Tests — N/A (docs only)
- [ ] Example App Updates — N/A
- [x] Outline Remaining Work, Constraints from Design — none
