### PR TITLE
Closes #8677: Render Provider noc_contact and admin_contact as Markdown

### DIFF
--- a/changes/8677.fixed
+++ b/changes/8677.fixed
@@ -1,0 +1,1 @@
+Fixed Provider `noc_contact` and `admin_contact` fields no longer being rendered as Markdown on the Provider detail view.

--- a/nautobot/circuits/tests/test_views.py
+++ b/nautobot/circuits/tests/test_views.py
@@ -43,6 +43,18 @@ class ProviderTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "comments": "New comments",
         }
 
+    def test_provider_contacts_rendered_as_markdown(self):
+        """The noc_contact and admin_contact fields are rendered as Markdown on the detail view (#8677)."""
+        self.add_permissions("circuits.view_provider")
+        provider = Provider.objects.create(
+            name="Markdown Provider",
+            noc_contact="**NOC bold**",
+            admin_contact="*Admin italic*",
+        )
+        response = self.client.get(provider.get_absolute_url())
+        self.assertBodyContains(response, "<strong>NOC bold</strong>", html=True)
+        self.assertBodyContains(response, "<em>Admin italic</em>", html=True)
+
 
 class CircuitTypeTestCase(ViewTestCases.OrganizationalObjectViewTestCase, ViewTestCases.BulkEditObjectsViewTestCase):
     model = CircuitType

--- a/nautobot/circuits/views.py
+++ b/nautobot/circuits/views.py
@@ -170,6 +170,10 @@ class ProviderUIViewSet(NautobotUIViewSet):
                 section=SectionChoices.LEFT_HALF,
                 weight=100,
                 fields="__all__",
+                value_transforms={
+                    "noc_contact": [helpers.render_markdown, helpers.placeholder],
+                    "admin_contact": [helpers.render_markdown, helpers.placeholder],
+                },
             ),
             ObjectsTablePanel(
                 weight=200,


### PR DESCRIPTION
# Closes #8677

# What's Changed

Restores Markdown rendering for the Provider detail view's `noc_contact` and `admin_contact` fields, which regressed in v2.4.0.

When the Provider detail view was migrated to the UI Component Framework (#6306, commit `cbd8aed`), the deleted `provider_retrieve.html` template had rendered these fields with `|render_markdown|placeholder`. The replacement `ObjectFieldsPanel` (`fields="__all__"`) carried no `value_transforms` for them, so they fell through to plain-text rendering.

This adds `value_transforms` applying `helpers.render_markdown` (XSS-sanitized via `clean_html`) and `helpers.placeholder` to both fields — restoring the pre-2.4.0 behavior and matching the existing `value_transforms` idiom already used in this file (e.g. `commit_rate`).

A regression test (`ProviderTestCase.test_provider_contacts_rendered_as_markdown`) is added, asserting the fields render to HTML on the detail page (fails before this change, passes after).

Implements the fix proposed by @seaburger in #8677, approved by @glennmatthews.

# Screenshots

N/A — behavioral fix covered by the added test. `**bold**` / `*italic*` entered in NOC/Admin Contact now render as HTML on the Provider detail page instead of literal text.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example — N/A
- [x] Unit, Integration Tests — added `test_provider_contacts_rendered_as_markdown`
- [ ] Documentation Updates — N/A
- [ ] Example App Updates — N/A
- [x] Outline Remaining Work, Constraints from Design — scoped to Provider per the issue; a sibling regression in `CustomField.description` from the same class of migration is addressed separately in #9144.
