### PR TITLE
Render CustomField description as Markdown on the detail view

### DIFF
--- a/changes/9144.fixed
+++ b/changes/9144.fixed
@@ -1,0 +1,1 @@
+Fixed the CustomField `description` field no longer being rendered as Markdown on the Custom Field detail view.

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -2153,6 +2153,18 @@ class CustomFieldTestCase(
             "remove_content_types": [device_ct.pk],
         }
 
+    def test_customfield_description_rendered_as_markdown(self):
+        """The description field is rendered as Markdown on the CustomField detail view."""
+        self.add_permissions("extras.view_customfield")
+        custom_field = CustomField.objects.create(
+            key="markdown_description_cf",
+            label="Markdown Description CF",
+            type=CustomFieldTypeChoices.TYPE_TEXT,
+            description="**bold description**",
+        )
+        response = self.client.get(custom_field.get_absolute_url())
+        self.assertBodyContains(response, "<strong>bold description</strong>", html=True)
+
     def test_create_object_without_permission(self):
         # Can't have two CustomFields with the same "key"
         self.form_data = self.form_data.copy()

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -1380,6 +1380,7 @@ class CustomFieldUIViewSet(NautobotUIViewSet):
                 section=SectionChoices.LEFT_HALF,
                 fields="__all__",
                 exclude_fields=["content_types", "validation_minimum", "validation_maximum", "validation_regex"],
+                value_transforms={"description": [helpers.render_markdown, helpers.placeholder]},
             ),
             object_detail.DataTablePanel(
                 weight=200,


### PR DESCRIPTION
# What's Changed

Restores Markdown rendering for the `description` field on the **Custom Field** detail view, which regressed when the CustomField UI was migrated to the UI Component Framework (#7315 / #7689).

The removed legacy template rendered `{{ object.description | render_markdown | placeholder }}`, but the replacement `CustomFieldObjectFieldsPanel.render_value` only applies Markdown to the `default` field — so `description` falls through to plain-text rendering.

This adds `value_transforms={"description": [helpers.render_markdown, helpers.placeholder]}` to that panel (the custom `render_value` defers non-`default` keys to `super()`, which applies the transforms). It is the same, XSS-sanitized fix pattern approved for the analogous Provider regression in #8677 (fixed in #9142), and is consistent with the `value_transforms` already used by other panels in this same view. A regression test is included.

Verified on a dev instance: before this change, `**bold**` in a Custom Field's Description renders as literal text; after, it renders as `<strong>bold</strong>`.

> Note: this is a self-reported regression with no separate tracking issue (it is the same class as #8677). Happy to open a dedicated issue if maintainers prefer that workflow.

# Screenshots

N/A — behavioral fix covered by the added test.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example — N/A
- [x] Unit, Integration Tests — added `test_customfield_description_rendered_as_markdown`
- [ ] Documentation Updates — N/A
- [ ] Example App Updates — N/A
- [x] Outline Remaining Work, Constraints from Design — none
