### PR TITLE
Added nested lookups to LinkedCountColumn

### DIFF
--- a/changes/6614.added
+++ b/changes/6614.added
@@ -1,0 +1,1 @@
+Added nested lookup support to LinkedCountColumn, allowing it to display a single related object rather than a count when a single object is present.

--- a/changes/6614.changed
+++ b/changes/6614.changed
@@ -1,0 +1,2 @@
+Updated the IP address table to display the device or virtual machine names when an IP address is assigned to an interface on a single device/VM, rather than always showing a count.
+Updated the cloud network Circuits column to display the circuit ID when a cloud network is related to a single circuit, rather than always showing a count.

--- a/nautobot/cloud/tables.py
+++ b/nautobot/cloud/tables.py
@@ -55,9 +55,11 @@ class CloudNetworkTable(BaseTable):
     circuit_count = LinkedCountColumn(
         viewname="circuits:circuit_list",
         url_params={"cloud_network": "name"},
-        # lookup="circuit_terminations__circuit",  # TODO: not currently supported
+        lookup="circuit_terminations__circuit",
         verbose_name="Circuits",
         reverse_lookup="circuit_terminations__cloud_network",
+        distinct=True,
+        display_field="cid",
     )
     cloud_service_count = LinkedCountColumn(
         viewname="cloud:cloudservice_list",

--- a/nautobot/cloud/tests/test_tables.py
+++ b/nautobot/cloud/tests/test_tables.py
@@ -1,0 +1,120 @@
+from django.contrib.contenttypes.models import ContentType
+
+from nautobot.circuits.choices import CircuitTerminationSideChoices
+from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, Provider
+from nautobot.cloud.models import CloudAccount, CloudNetwork, CloudResourceType
+from nautobot.cloud.tables import CloudNetworkTable
+from nautobot.core.testing import AssertNoRepeatedQueries, TestCase
+from nautobot.extras.models import Status
+
+
+class CloudNetworkTableTestCase(TestCase):
+    """Assert the Circuits column renders the circuit ID for a single circuit and a count otherwise."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cloud_network_ct = ContentType.objects.get_for_model(CloudNetwork)
+        cloud_resource_type = CloudResourceType.objects.get_for_model(CloudNetwork).first()
+        cloud_resource_type.content_types.add(cloud_network_ct)
+        cloud_account = CloudAccount.objects.first()
+
+        def _make_network(name):
+            return CloudNetwork.objects.create(
+                name=name, cloud_resource_type=cloud_resource_type, cloud_account=cloud_account
+            )
+
+        cls.network_single = _make_network("CloudNetworkTable Network Single")
+        cls.network_multiple = _make_network("CloudNetworkTable Network Multiple")
+        cls.network_double_termination = _make_network("CloudNetworkTable Network Double Termination")
+        cls.network_empty = _make_network("CloudNetworkTable Network Empty")
+
+        provider = Provider.objects.first()
+        circuit_type = CircuitType.objects.first()
+        circuit_status = Status.objects.get_for_model(Circuit).first()
+
+        def _make_circuit(cid):
+            return Circuit.objects.create(cid=cid, provider=provider, circuit_type=circuit_type, status=circuit_status)
+
+        # One circuit terminating on the single network.
+        cls.circuit_1 = _make_circuit("CloudNetworkTable Circuit 1")
+        CircuitTermination.objects.create(
+            circuit=cls.circuit_1, term_side=CircuitTerminationSideChoices.SIDE_A, cloud_network=cls.network_single
+        )
+
+        # Two distinct circuits terminating on the multiple network.
+        cls.circuit_2 = _make_circuit("CloudNetworkTable Circuit 2")
+        cls.circuit_3 = _make_circuit("CloudNetworkTable Circuit 3")
+        CircuitTermination.objects.create(
+            circuit=cls.circuit_2, term_side=CircuitTerminationSideChoices.SIDE_A, cloud_network=cls.network_multiple
+        )
+        CircuitTermination.objects.create(
+            circuit=cls.circuit_3, term_side=CircuitTerminationSideChoices.SIDE_A, cloud_network=cls.network_multiple
+        )
+
+        # A single circuit with BOTH terminations on the same network: distinct=True keeps this at one circuit.
+        cls.circuit_4 = _make_circuit("CloudNetworkTable Circuit 4")
+        CircuitTermination.objects.create(
+            circuit=cls.circuit_4,
+            term_side=CircuitTerminationSideChoices.SIDE_A,
+            cloud_network=cls.network_double_termination,
+        )
+        CircuitTermination.objects.create(
+            circuit=cls.circuit_4,
+            term_side=CircuitTerminationSideChoices.SIDE_Z,
+            cloud_network=cls.network_double_termination,
+        )
+
+    def _render_cell(self, cloud_network, column_name):
+        table = CloudNetworkTable(CloudNetwork.objects.filter(pk=cloud_network.pk))
+        bound_row = table.rows[0]
+        return bound_row.get_cell(column_name)  # pylint: disable=no-member
+
+    def test_single_circuit_shows_cid(self):
+        cell = self._render_cell(self.network_single, "circuit_count")
+        self.assertIn(self.circuit_1.cid, cell)
+        self.assertNotIn("badge", cell)
+
+    def test_multiple_circuits_shows_count(self):
+        cell = self._render_cell(self.network_multiple, "circuit_count")
+        self.assertIn('class="badge bg-primary">2</a>', cell)
+
+    def test_single_circuit_with_two_terminations_shows_cid(self):
+        # distinct=True -> one distinct circuit -> render the circuit ID, not a "2" badge.
+        cell = self._render_cell(self.network_double_termination, "circuit_count")
+        self.assertIn(self.circuit_4.cid, cell)
+        self.assertNotIn("badge", cell)
+
+    def test_no_circuits_shows_placeholder(self):
+        cell = self._render_cell(self.network_empty, "circuit_count")
+        self.assertNotIn("badge", cell)
+        self.assertNotIn("/circuits/circuits/", cell)
+
+    def test_circuit_column_avoids_n_plus_one_queries(self):
+        """The Circuits column must render without per-row queries.
+
+        The single-circuit display relies on a prefetch whose queryset `select_related`s `circuit`. If that
+        select_related is ever dropped, accessing `.circuit` would fall back to one query per row. Render
+        enough single-circuit rows that such a regression would trip `AssertNoRepeatedQueries`.
+        """
+        # Add cloud networks, each with its own single circuit, so the table has well more rows than the
+        # N+1 threshold.
+        for i in range(15):
+            network = CloudNetwork.objects.create(
+                name=f"CloudNetworkTable Network Extra {i}",
+                cloud_resource_type=self.network_single.cloud_resource_type,
+                cloud_account=self.network_single.cloud_account,
+            )
+            circuit = Circuit.objects.create(
+                cid=f"CloudNetworkTable Extra Circuit {i}",
+                provider=self.circuit_1.provider,
+                circuit_type=self.circuit_1.circuit_type,
+                status=self.circuit_1.status,
+            )
+            CircuitTermination.objects.create(
+                circuit=circuit, term_side=CircuitTerminationSideChoices.SIDE_A, cloud_network=network
+            )
+
+        with AssertNoRepeatedQueries(self):
+            table = CloudNetworkTable(CloudNetwork.objects.filter(name__startswith="CloudNetworkTable Network"))
+            for row in table.rows:
+                row.get_cell("circuit_count")  # pylint: disable=no-member

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -27,6 +27,15 @@ from nautobot.extras import choices, models
 logger = logging.getLogger(__name__)
 
 
+def _linked_count_to_attr(lookup):
+    """Derive the `Prefetch(to_attr=...)` name used by `LinkedCountColumn` for a (possibly nested) lookup.
+
+    Django forbids `__` in a `to_attr`, so a nested lookup like `"interfaces__device"` becomes
+    `"interfaces_device_list"`. A non-nested lookup like `"interfaces"` becomes `"interfaces_list"`.
+    """
+    return lookup.replace("__", "_") + "_list"
+
+
 class BaseTable(django_tables2.Table):
     """
     Default table for object lists.
@@ -230,17 +239,27 @@ class BaseTable(django_tables2.Table):
                     count_fields.append((column.name, column_model, reverse_lookup, distinct))
                     try:
                         lookup = column.column.lookup or get_related_field_for_models(model, column_model).name
+                        # `lookup` may be a nested lookup like `"interfaces__device"`; only the first segment is a
+                        # field on `model`. The remainder is followed on the related model via select_related below.
+                        first_relation, _, remainder = lookup.partition("__")
                         # For some reason get_related_field_for_models(Tag, DynamicGroup) gives a M2M with the name
                         # `dynamicgroup`, which isn't actually a field on Tag. May be a django-taggit issue?
                         # Workaround for now: make sure the field actually exists on the model under this name:
-                        getattr(model, lookup)
-                    except AttributeError:
-                        lookup = None
-                    if lookup is not None:
-                        # Also attempt to prefetch the first matching record for display - see LinkedCountColumn
+                        intermediate_model = model._meta.get_field(first_relation).related_model
+                    except (AttributeError, FieldDoesNotExist):
+                        # Couldn't resolve the lookup field; skip the display prefetch (the count annotation
+                        # below still applies, so the column degrades to a count badge).
+                        pass
+                    else:
+                        # Also attempt to prefetch the first matching record for display - see LinkedCountColumn.
+                        # Use order_by() because we don't care about ordering here and it's potentially expensive.
+                        related_qs = intermediate_model.objects.order_by()
+                        if remainder:
+                            # Follow the trailing chain (e.g. `device`) via select_related so the render-time
+                            # attribute walk is free.
+                            related_qs = related_qs.select_related(remainder)
                         prefetch_fields.append(
-                            # Use order_by() because we don't care about ordering here and it's potentially expensive
-                            Prefetch(lookup, column_model.objects.order_by()[:1], to_attr=f"{lookup}_list")
+                            Prefetch(first_relation, related_qs[:1], to_attr=_linked_count_to_attr(lookup))
                         )
                     continue
 
@@ -644,7 +663,8 @@ class LinkedCountColumn(django_tables2.Column):
         lookup (str, optional): The field name on the base record that can be used to query the related objects.
             If not specified, `nautobot.core.utils.lookup.get_related_field_for_models()` will be called at render time
             to attempt to intelligently find the appropriate field.
-            TODO: this currently does *not* support nested lookups via `__`. That may be solvable in the future.
+            Nested lookups via `__` are supported (e.g. `"interfaces__device"`): the first segment is prefetched
+            and the remaining segments are followed on the related object via `select_related`.
         reverse_lookup (str, optional): The reverse lookup parameter to use to derive the count.
             If not specified, the first key in `url_params` will be implicitly used as the `reverse_lookup` value.
         distinct (bool, optional): Parameter passed through to `count_related()`.
@@ -672,13 +692,13 @@ class LinkedCountColumn(django_tables2.Column):
                 # Link for N related circuits will be reverse("circuits:circuit_list") + "?cloud_network=<record.name>"
                 viewname="circuits:circuit_list",
                 url_params={"cloud_network": "name"},
-                # We'd like to do the below but this module isn't currently smart enough to build the right Prefetch()
-                # for a nested lookup:
-                # lookup="circuit_terminations__circuit",
-                # For the count,
+                # `reverse_lookup` is rooted on Circuit (the count model); it drives
                 # .annotate(circuit_count=count_related(Circuit, "circuit_terminations__cloud_network", distinct=True))
                 reverse_lookup="circuit_terminations__cloud_network",
+                # `lookup` is the nested lookup rooted on CloudNetwork, used to display the single related circuit
+                lookup="circuit_terminations__circuit",
                 distinct=True,
+                display_field="cid",
                 verbose_name="Circuits",
             )
         ```
@@ -714,8 +734,16 @@ class LinkedCountColumn(django_tables2.Column):
         except AttributeError:
             lookup = None
         if lookup:
-            if related_records := getattr(record, f"{lookup}_list", None):
+            if related_records := getattr(record, _linked_count_to_attr(lookup), None):
                 related_record = related_records[0]
+                # For a nested lookup like `"interfaces__device"`, walk the trailing chain (`device`) on the
+                # prefetched record. select_related (see BaseTable) makes this free; a None mid-chain falls
+                # through to the count badge below rather than raising.
+                _, _, remainder = lookup.partition("__")
+                for part in filter(None, remainder.split("__")):
+                    related_record = getattr(related_record, part, None)
+                    if related_record is None:
+                        break
         url = reverse(self.viewname, kwargs=self.view_kwargs)
         if self.url_params:
             url += "?" + urlencode(

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -245,6 +245,7 @@ class BaseTable(django_tables2.Table):
                         # For some reason get_related_field_for_models(Tag, DynamicGroup) gives a M2M with the name
                         # `dynamicgroup`, which isn't actually a field on Tag. May be a django-taggit issue?
                         # Workaround for now: make sure the field actually exists on the model under this name:
+                        getattr(model, first_relation)
                         intermediate_model = model._meta.get_field(first_relation).related_model
                     except (AttributeError, FieldDoesNotExist):
                         # Couldn't resolve the lookup field; skip the display prefetch (the count annotation

--- a/nautobot/core/tests/test_tables.py
+++ b/nautobot/core/tests/test_tables.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from django.db import connection
 from django.db.models import IntegerField, Value
 from django.test import tag, TestCase
@@ -6,6 +8,7 @@ from django.test.utils import CaptureQueriesContext
 from nautobot.circuits.models import Circuit
 from nautobot.circuits.tables import CircuitTable
 from nautobot.core.models.querysets import count_related
+from nautobot.core.tables import LinkedCountColumn
 from nautobot.dcim.models import Device, InventoryItem, Location, LocationType, Rack, RackGroup
 from nautobot.dcim.tables import InventoryItemTable, LocationTable, LocationTypeTable, RackGroupTable
 from nautobot.extras.models import JobLogEntry
@@ -251,3 +254,19 @@ class BaseTableLinkedCountColumnTestCase(TestCase):
             self.assertNotIn("assigned_prefix_count", table.data.data.query.annotations)
         finally:
             del RIR.assigned_prefix_count
+
+
+class LinkedCountColumnRenderTestCase(TestCase):
+    def test_nested_lookup_with_none_mid_chain_falls_back_to_count(self):
+        """A None partway through a nested `lookup` chain breaks the walk and falls back to the count badge."""
+        column = LinkedCountColumn(
+            viewname="dcim:device_list",
+            url_params={"ip_addresses": "pk"},
+            lookup="interfaces__device__name",
+        )
+        record = SimpleNamespace(
+            pk="00000000-0000-0000-0000-000000000000",
+            interfaces_device_name_list=[SimpleNamespace(device=None)],
+        )
+        rendered = column.render(bound_column=None, record=record, value=1)
+        self.assertIn("badge", rendered)

--- a/nautobot/ipam/tables.py
+++ b/nautobot/ipam/tables.py
@@ -543,7 +543,9 @@ class IPAddressTable(StatusTableMixin, RoleTableMixin, BaseTable):
         viewname="dcim:device_list",
         url_params={"ip_addresses": "pk"},
         reverse_lookup="interfaces__ip_addresses",
+        lookup="interfaces__device",
         distinct=True,
+        display_field="name",
         verbose_name="Devices",
     )
     vm_interface_count = LinkedCountColumn(
@@ -553,7 +555,9 @@ class IPAddressTable(StatusTableMixin, RoleTableMixin, BaseTable):
         viewname="virtualization:virtualmachine_list",
         url_params={"ip_addresses": "pk"},
         reverse_lookup="interfaces__ip_addresses",
+        lookup="vm_interfaces__virtual_machine",
         distinct=True,
+        display_field="name",
         verbose_name="Virtual Machines",
     )
     actions = ButtonsColumn(IPAddress)

--- a/nautobot/ipam/tests/test_tables.py
+++ b/nautobot/ipam/tests/test_tables.py
@@ -1,8 +1,12 @@
 from nautobot.core.models.querysets import count_related
-from nautobot.core.testing import TestCase
-from nautobot.dcim.models.locations import Location
-from nautobot.ipam.models import Prefix
-from nautobot.ipam.tables import PrefixTable
+from nautobot.core.testing import AssertNoRepeatedQueries, TestCase
+from nautobot.dcim.models import Device, DeviceType, Interface, Manufacturer
+from nautobot.dcim.models.locations import Location, LocationType
+from nautobot.extras.models import Role, Status
+from nautobot.ipam.choices import IPAddressTypeChoices
+from nautobot.ipam.models import IPAddress, Namespace, Prefix
+from nautobot.ipam.tables import IPAddressTable, PrefixTable
+from nautobot.virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
 
 
 class PrefixTableTestCase(TestCase):
@@ -39,3 +43,147 @@ class PrefixTableTestCase(TestCase):
         location_count_queryset = queryset.annotate(location_count=count_related(Location, "prefixes")).all()
         self._validate_sorted_queryset_same_with_table_queryset(location_count_queryset, PrefixTable, "location_count")
         self._validate_sorted_queryset_same_with_table_queryset(location_count_queryset, PrefixTable, "-location_count")
+
+
+class IPAddressTableTestCase(TestCase):
+    """Assert the Devices/Interfaces/Virtual Machines/VM Interfaces columns render names vs counts (#6614)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        namespace = Namespace.objects.create(name="IPAddressTable Test Namespace")
+        prefix_status = Status.objects.get_for_model(Prefix).first()
+        ip_status = Status.objects.get_for_model(IPAddress).first()
+        prefix = Prefix.objects.create(prefix="10.99.0.0/24", namespace=namespace, status=prefix_status, type="network")
+
+        location = Location.objects.filter(location_type=LocationType.objects.get(name="Campus")).first()
+        manufacturer = Manufacturer.objects.first()
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="IPAddressTable Device Type")
+        device_role = Role.objects.get_for_model(Device).first()
+        device_status = Status.objects.get_for_model(Device).first()
+        cls.device_1 = Device.objects.create(
+            name="IPAddressTable Device 1",
+            location=location,
+            device_type=device_type,
+            role=device_role,
+            status=device_status,
+        )
+        cls.device_2 = Device.objects.create(
+            name="IPAddressTable Device 2",
+            location=location,
+            device_type=device_type,
+            role=device_role,
+            status=device_status,
+        )
+
+        intf_status = Status.objects.get_for_model(Interface).first()
+        cls.interface_1a = Interface.objects.create(device=cls.device_1, name="Eth1a", status=intf_status)
+        cls.interface_1b = Interface.objects.create(device=cls.device_1, name="Eth1b", status=intf_status)
+        cls.interface_2 = Interface.objects.create(device=cls.device_2, name="Eth2", status=intf_status)
+
+        cluster_type = ClusterType.objects.create(name="IPAddressTable Cluster Type")
+        cluster = Cluster.objects.create(name="IPAddressTable Cluster", cluster_type=cluster_type)
+        vm_status = Status.objects.get_for_model(VirtualMachine).first()
+        cls.virtual_machine = VirtualMachine.objects.create(
+            cluster=cluster, name="IPAddressTable VM 1", status=vm_status
+        )
+        vm_intf_status = Status.objects.get_for_model(VMInterface).first()
+        cls.vm_interface = VMInterface.objects.create(
+            virtual_machine=cls.virtual_machine, name="VM Eth1", status=vm_intf_status
+        )
+
+        def _make_ip(host):
+            return IPAddress.objects.create(
+                parent=prefix, address=host, status=ip_status, type=IPAddressTypeChoices.TYPE_HOST
+            )
+
+        # IP on a single interface of a single device.
+        cls.ip_single = _make_ip("10.99.0.1/24")
+        cls.interface_1a.add_ip_addresses(cls.ip_single)
+
+        # IP on two interfaces of the same device.
+        cls.ip_same_device = _make_ip("10.99.0.2/24")
+        cls.interface_1a.add_ip_addresses(cls.ip_same_device)
+        cls.interface_1b.add_ip_addresses(cls.ip_same_device)
+
+        # IP on interfaces across two different devices.
+        cls.ip_multi_device = _make_ip("10.99.0.3/24")
+        cls.interface_1a.add_ip_addresses(cls.ip_multi_device)
+        cls.interface_2.add_ip_addresses(cls.ip_multi_device)
+
+        # IP on a single VM interface.
+        cls.ip_vm = _make_ip("10.99.0.4/24")
+        cls.vm_interface.add_ip_addresses(cls.ip_vm)
+
+    def _render_cell(self, ip_address, column_name):
+        """Render a single IP address's cell for the given column, via the full BaseTable pipeline."""
+        table = IPAddressTable(IPAddress.objects.filter(pk=ip_address.pk))
+        bound_row = table.rows[0]
+        return bound_row.get_cell(column_name)  # pylint: disable=no-member  # BoundRows[0] is a BoundRow
+
+    def test_single_device_single_interface_shows_names(self):
+        device_cell = self._render_cell(self.ip_single, "interface_parent_count")
+        self.assertIn(self.device_1.name, device_cell)
+        self.assertNotIn("badge", device_cell)
+        interface_cell = self._render_cell(self.ip_single, "interface_count")
+        self.assertIn(self.interface_1a.name, interface_cell)
+        self.assertNotIn("badge", interface_cell)
+
+    def test_single_device_multiple_interfaces_shows_device_name_and_interface_count(self):
+        # One distinct device -> render the device name, not a count badge.
+        device_cell = self._render_cell(self.ip_same_device, "interface_parent_count")
+        self.assertIn(self.device_1.name, device_cell)
+        self.assertNotIn("badge", device_cell)
+        # Two interfaces -> render a count badge.
+        interface_cell = self._render_cell(self.ip_same_device, "interface_count")
+        self.assertIn('class="badge bg-primary">2</a>', interface_cell)
+
+    def test_multiple_devices_shows_counts(self):
+        device_cell = self._render_cell(self.ip_multi_device, "interface_parent_count")
+        self.assertIn('class="badge bg-primary">2</a>', device_cell)
+        interface_cell = self._render_cell(self.ip_multi_device, "interface_count")
+        self.assertIn('class="badge bg-primary">2</a>', interface_cell)
+
+    def test_single_vm_interface_shows_names(self):
+        vm_cell = self._render_cell(self.ip_vm, "vm_interface_parent_count")
+        self.assertIn(self.virtual_machine.name, vm_cell)
+        self.assertNotIn("badge", vm_cell)
+        vm_interface_cell = self._render_cell(self.ip_vm, "vm_interface_count")
+        self.assertIn(self.vm_interface.name, vm_interface_cell)
+        self.assertNotIn("badge", vm_interface_cell)
+
+    def test_dual_interfaces_prefetch_does_not_collide(self):
+        """Both the Interfaces and Devices columns prefetch `interfaces`; evaluating the table must not raise."""
+        table = IPAddressTable(IPAddress.objects.filter(parent__namespace__name="IPAddressTable Test Namespace"))
+        # Force queryset evaluation through the prefetch machinery; this raised ValueError before the
+        # distinct to_attr fix ("'interfaces' lookup was already seen with a different queryset").
+        self.assertEqual(len(list(table.rows)), 4)
+
+    def test_nested_lookup_columns_avoid_n_plus_one_queries(self):
+        """The Devices/Virtual Machines columns must render without per-row queries.
+
+        The single-object display relies on a prefetch whose queryset `select_related`s the trailing
+        relation (`device`/`virtual_machine`). If that select_related is ever dropped, accessing it would
+        fall back to one query per row. Render enough single-device rows that such a regression would trip
+        `AssertNoRepeatedQueries`.
+        """
+        # Add IPs (all on the same interface/device) so the table has well more rows than the N+1 threshold.
+        for i in range(15):
+            extra_ip = IPAddress.objects.create(
+                parent=self.ip_single.parent,
+                address=f"10.99.0.{100 + i}/24",
+                status=self.ip_single.status,
+                type=IPAddressTypeChoices.TYPE_HOST,
+            )
+            self.interface_1a.add_ip_addresses(extra_ip)
+
+        nested_columns = (
+            "interface_count",
+            "interface_parent_count",
+            "vm_interface_count",
+            "vm_interface_parent_count",
+        )
+        with AssertNoRepeatedQueries(self):
+            table = IPAddressTable(IPAddress.objects.filter(parent__namespace__name="IPAddressTable Test Namespace"))
+            for row in table.rows:
+                for column_name in nested_columns:
+                    row.get_cell(column_name)  # pylint: disable=no-member  # BoundRow has get_cell


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #6614
# What's Changed
This PR adds nested lookup support for LinkedCountColumn to enable showing a single related object when there is only one related object and reverts back to the count badge otherwise.
# Screenshots
|Table|Before|After|
|-|-|-|
|IP Addresses List View|<img width="692" height="267" alt="Screenshot 2026-06-25 at 1 47 37 PM" src="https://github.com/user-attachments/assets/59e2f664-1a7a-4d08-8f92-746aa72e0c67" />|<img width="830" height="261" alt="Screenshot 2026-06-25 at 1 47 15 PM" src="https://github.com/user-attachments/assets/d8ee6943-87ff-4c5e-8ccc-6066de14b4aa" />|
|Prefix > IP Addresses tab|<img width="630" height="325" alt="Screenshot 2026-06-25 at 10 44 45 AM" src="https://github.com/user-attachments/assets/62a69f08-6da0-432f-842d-f8306f80664e" />|<img width="754" height="325" alt="Screenshot 2026-06-25 at 10 30 54 AM" src="https://github.com/user-attachments/assets/002db8f3-ff29-45f7-8748-276cd285ed0e" />|
|Namespace > IP Addresses tab|<img width="616" height="253" alt="Screenshot 2026-06-25 at 11 10 46 AM" src="https://github.com/user-attachments/assets/f8086d35-aaf1-42f7-9a7c-d9832a05c282" />|<img width="738" height="260" alt="Screenshot 2026-06-25 at 11 02 00 AM" src="https://github.com/user-attachments/assets/a27cf79c-ece9-4229-9ce9-3d1ac56b644b" />|
|IP Address > Related IP Addresses|<img width="611" height="216" alt="Screenshot 2026-06-25 at 11 11 15 AM" src="https://github.com/user-attachments/assets/e10f8843-9de2-4e3d-a1b9-b966df8881f0" />|<img width="739" height="221" alt="Screenshot 2026-06-25 at 11 11 36 AM" src="https://github.com/user-attachments/assets/858b6de3-2e87-412b-8c89-0ca06a56af48" />|
|Cloud Networks List View|<img width="111" height="203" alt="Screenshot 2026-06-25 at 2 22 09 PM" src="https://github.com/user-attachments/assets/ba613216-69da-4d74-87ab-abed62dc6f39" />|<img width="156" height="210" alt="Screenshot 2026-06-25 at 2 11 23 PM" src="https://github.com/user-attachments/assets/1bc9545a-9a78-4bc9-8f6c-ebc585bf93c6" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
