### PR TITLE
Fix Remove "None" option from Prefix form Locations field

### DIFF
--- a/changes/8605.fixed
+++ b/changes/8605.fixed
@@ -1,0 +1,1 @@
+Fixed the Prefix form's Locations field offering a "None" option that raised `"null" is not a valid UUID.` when selected.

--- a/nautobot/core/forms/fields.py
+++ b/nautobot/core/forms/fields.py
@@ -651,6 +651,15 @@ class DynamicModelMultipleChoiceField(DynamicModelChoiceMixin, django_forms.Mode
     filter = django_filters.ModelMultipleChoiceFilter
     widget = widgets.APISelectMultiple
 
+    def clean(self, value):
+        """
+        When null option is enabled and "None" is selected, it is submitted as the string 'null'. Drop any
+        such values so they don't reach the model lookup and fail.
+        """
+        if self.null_option is not None and isinstance(value, (list, tuple)):
+            value = [v for v in value if v != settings.FILTERS_NULL_CHOICE_VALUE]
+        return super().clean(value)
+
 
 class LaxURLField(django_forms.URLField):
     """

--- a/nautobot/core/tests/test_forms.py
+++ b/nautobot/core/tests/test_forms.py
@@ -442,6 +442,22 @@ class DynamicModelMultipleChoiceFieldTest(testing.TestCase):
             [address_1.address, address_2.address],
         )
 
+    def test_clean_null_option(self):
+        """Selecting the "None" null option (submitted as the string "null") should be dropped gracefully."""
+        field = forms.DynamicModelMultipleChoiceField(
+            queryset=ipam_models.IPAddress.objects.all(), null_option="None", required=False
+        )
+        # "null" on its own clears the selection rather than raising `"null" is not a valid UUID.`
+        self.assertEqual(list(field.clean(["null"])), [])
+
+        # "null" mixed with a real selection keeps only the real object
+        ipaddr_status = extras_models.Status.objects.get_for_model(ipam_models.IPAddress).first()
+        prefix_status = extras_models.Status.objects.get_for_model(ipam_models.Prefix).first()
+        namespace = ipam_models.Namespace.objects.first()
+        ipam_models.Prefix.objects.create(prefix="10.1.1.0/24", namespace=namespace, status=prefix_status)
+        address = ipam_models.IPAddress.objects.create(address="10.1.1.1/24", namespace=namespace, status=ipaddr_status)
+        self.assertEqual(list(field.clean(["null", str(address.pk)])), [address])
+
 
 class MultiValueCharFieldTest(testing.TestCase):
     def setUp(self):

--- a/nautobot/core/tests/test_forms.py
+++ b/nautobot/core/tests/test_forms.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from django import forms as django_forms
 from django.apps import apps as django_apps
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.http import QueryDict
 from django.test import tag
@@ -447,16 +448,17 @@ class DynamicModelMultipleChoiceFieldTest(testing.TestCase):
         field = forms.DynamicModelMultipleChoiceField(
             queryset=ipam_models.IPAddress.objects.all(), null_option="None", required=False
         )
-        # "null" on its own clears the selection rather than raising `"null" is not a valid UUID.`
-        self.assertEqual(list(field.clean(["null"])), [])
+        null_value = settings.FILTERS_NULL_CHOICE_VALUE
+        # The null value on its own clears the selection rather than raising `"null" is not a valid UUID.`
+        self.assertEqual(list(field.clean([null_value])), [])
 
-        # "null" mixed with a real selection keeps only the real object
+        # The null value mixed with a real selection keeps only the real object
         ipaddr_status = extras_models.Status.objects.get_for_model(ipam_models.IPAddress).first()
         prefix_status = extras_models.Status.objects.get_for_model(ipam_models.Prefix).first()
         namespace = ipam_models.Namespace.objects.first()
         ipam_models.Prefix.objects.create(prefix="10.1.1.0/24", namespace=namespace, status=prefix_status)
         address = ipam_models.IPAddress.objects.create(address="10.1.1.1/24", namespace=namespace, status=ipaddr_status)
-        self.assertEqual(list(field.clean(["null", str(address.pk)])), [address])
+        self.assertEqual(list(field.clean([null_value, str(address.pk)])), [address])
 
 
 class MultiValueCharFieldTest(testing.TestCase):

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -291,7 +291,6 @@ class PrefixForm(NautobotModelForm, TenancyForm, PrefixFieldMixin):
         queryset=Location.objects.all(),
         required=False,
         label="Locations",
-        null_option="None",
         query_params={"content_type": Prefix._meta.label_lower},
     )
     vlan_group = DynamicModelChoiceField(


### PR DESCRIPTION
# Closes #8605

# What's Changed
- Removed the `None` option from the Prefix form's Locations field.
- Updated `DynamicModelMultipleChoiceField.clean()` to drop the `"null"` sentinel values.

# Screenshots
Before:
<img width="964" height="199" alt="image" src="https://github.com/user-attachments/assets/d59b49dc-daac-4184-9b6b-cfb6d67f86d9" />

After:
<img width="977" height="216" alt="image" src="https://github.com/user-attachments/assets/01acb1ed-fbd7-45d0-9807-a0001155ea7b" />

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
