### PR TITLE
Fixed lingering git processes

### DIFF
--- a/changes/8287.fixed
+++ b/changes/8287.fixed
@@ -1,0 +1,1 @@
+Fixed Git repository synchronization to not leave lingering `git` subprocesses.

--- a/nautobot/core/utils/git.py
+++ b/nautobot/core/utils/git.py
@@ -32,6 +32,14 @@ GIT_ENVIRONMENT = {
     "GIT_TERMINAL_PROMPT": "0",  # never prompt for user input such as credentials - important to avoid hangs!
 }
 
+# Local git config to set on every repository we manage, as (section, option): value.
+GIT_LOCAL_CONFIG = {
+    # Run git's automatic housekeeping (`gc`) synchronously instead of as a detached background process.
+    # A detached `git gc` re-parents to PID 1, and in container deployments whose PID 1 does not reap
+    # children it lingers as a zombie (`[git] <defunct>`) after every fetch. Issue #8287.
+    ("gc", "autoDetach"): "false",
+}
+
 
 def swap_status_initials(data):
     """Swap Git status initials with its equivalent."""
@@ -134,6 +142,25 @@ class GitRepo:
 
         if url not in self.repo.remotes.origin.urls:
             self.repo.remotes.origin.set_url(url)
+
+        # Inject our local git config into the repository.
+        with self.repo.config_writer() as config:
+            for (section, option), value in GIT_LOCAL_CONFIG.items():
+                config.set_value(section, option, value)
+
+    def close(self):
+        """Release the underlying Git subprocess resources.
+
+        GitPython keeps persistent `git cat-file` subprocesses alive for the lifetime of the `Repo`
+        object; closing it interrupts them so they don't accumulate across repeated repository syncs.
+        """
+        self.repo.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
 
     @property
     def head(self):

--- a/nautobot/extras/datasources/git.py
+++ b/nautobot/extras/datasources/git.py
@@ -161,15 +161,15 @@ def ensure_git_repository(repository_record, logger=None, head=None):  # pylint:
     if head is not None:
         # If the repo exists and has HEAD already checked out, the repo is present and has the correct branch selected.
         with suppress(InvalidGitRepositoryError):
-            if Path(repository_record.filesystem_path).exists() and str(
-                Repo(repository_record.filesystem_path).rev_parse("HEAD")
-            ) == str(head):
-                return False
+            if Path(repository_record.filesystem_path).exists():
+                with Repo(repository_record.filesystem_path) as repo:
+                    if str(repo.rev_parse("HEAD")) == str(head):
+                        return False
 
     from_url, to_path, from_branch = get_repo_from_url_to_path_and_from_branch(repository_record)
     try:
-        repo_helper = GitRepo(to_path, from_url)
-        head, changed = repo_helper.checkout(from_branch, head)
+        with GitRepo(to_path, from_url) as repo_helper:
+            head, changed = repo_helper.checkout(from_branch, head)
         if repository_record.current_head != head:
             repository_record.current_head = head
             repository_record.save()
@@ -205,9 +205,9 @@ def git_repository_dry_run(repository_record, logger):  # pylint: disable=redefi
     from_url, to_path, from_branch = get_repo_from_url_to_path_and_from_branch(repository_record)
 
     try:
-        repo_helper = GitRepo(to_path, from_url, clone_initially=False)
-        logger.info("Fetching from origin")
-        modified_files = repo_helper.diff_remote(from_branch)
+        with GitRepo(to_path, from_url, clone_initially=False) as repo_helper:
+            logger.info("Fetching from origin")
+            modified_files = repo_helper.diff_remote(from_branch)
         if modified_files:
             # Log each modified files
             for item in modified_files:

--- a/nautobot/extras/models/datasources.py
+++ b/nautobot/extras/models/datasources.py
@@ -272,9 +272,9 @@ class GitRepository(PrimaryModel):
 
         try:
             remote_url = get_repo_access_url(self)
-            repo_helper = GitRepo(path_name, remote_url, depth=depth, branch=branch)
-            if head:
-                repo_helper.checkout(branch, head)
+            with GitRepo(path_name, remote_url, depth=depth, branch=branch) as repo_helper:
+                if head:
+                    repo_helper.checkout(branch, head)
         except Exception as e:
             logger.error(f"Failed to clone repository {self.name} to {path_name}: {e}")
             raise e

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import RequestFactory
+from git import Repo
 import yaml
 
 from nautobot.core.jobs import GitRepositoryDryRun, GitRepositorySync
@@ -17,6 +18,7 @@ from nautobot.core.testing import (
     run_job_for_testing,
     TransactionTestCase,
 )
+from nautobot.core.utils.git import GitRepo
 from nautobot.dcim.models import Device, DeviceType, Location, LocationType, Manufacturer
 from nautobot.extras.choices import (
     JobResultStatusChoices,
@@ -24,6 +26,7 @@ from nautobot.extras.choices import (
     SecretsGroupAccessTypeChoices,
     SecretsGroupSecretTypeChoices,
 )
+from nautobot.extras.datasources.git import ensure_git_repository
 from nautobot.extras.datasources.registry import get_datasource_contents
 from nautobot.extras.models import (
     ConfigContext,
@@ -258,7 +261,7 @@ class GitTest(TransactionTestCase):
         """
         with tempfile.TemporaryDirectory() as tempdir:
             with self.settings(GIT_ROOT=tempdir):
-                MockGitRepo.return_value.checkout.return_value = ("0123456789abcdef", True)
+                MockGitRepo.return_value.__enter__.return_value.checkout.return_value = ("0123456789abcdef", True)
                 with open(os.path.join(tempdir, "username.txt"), "wt") as handle:
                     handle.write("núñez")
 
@@ -808,3 +811,84 @@ class GitTest(TransactionTestCase):
             self.assertEqual(from_url, "http://n%C3%BA%C3%B1ez:1%3A3%40%2F%3F%3Dab%40@localhost/git.git")
             self.assertEqual(kwargs["depth"], 0)
             self.assertEqual(kwargs["branch"], "main")
+
+    def assert_no_leaked_git_subprocess(self, repos):
+        # Issue #8287: Git repository syncing must not leave lingering `git` subprocesses.
+        # GitPython spawns a persistent `git cat-file --batch-check` subprocess the first time object data
+        # is read and keeps it running until the underlying `Repo` is closed. This test reproduces the
+        # leak by holding a reference to each repo object the code under test creates, then asserting that
+        # no such subprocess is still running.
+        self.assertTrue(repos, "expected a Git repo object to have been created")
+        for repo in repos:
+            # `repo` may be a GitRepo wrapper or a raw git.Repo; reach the underlying Git command object.
+            git_cmd = getattr(repo, "repo", repo).git
+            for cmd in (git_cmd.cat_file_header, git_cmd.cat_file_all):
+                self.assertTrue(
+                    cmd is None or cmd.proc is None or cmd.proc.poll() is not None,
+                    "a persistent `git cat-file` subprocess is still running (leaked)",
+                )
+
+    def _track_git_repo_instances(self):
+        """Patch GitRepo.__init__ to record every instance created; returns (patcher, instances)."""
+        instances = []
+        original_init = GitRepo.__init__
+
+        def tracking_init(repo_self, *args, **kwargs):
+            original_init(repo_self, *args, **kwargs)
+            instances.append(repo_self)
+
+        return mock.patch.object(GitRepo, "__init__", tracking_init), instances
+
+    def test_ensure_git_repository_does_not_leak_subprocess(self):
+        with tempfile.TemporaryDirectory() as tempdir, self.settings(GIT_ROOT=tempdir):
+            patcher, created = self._track_git_repo_instances()
+            with patcher:
+                ensure_git_repository(self.repo)
+            self.assert_no_leaked_git_subprocess(created)
+
+    def test_ensure_git_repository_head_match_does_not_leak_subprocess(self):
+        with tempfile.TemporaryDirectory() as tempdir, self.settings(GIT_ROOT=tempdir):
+            # First sync to clone the repo and record its current head.
+            ensure_git_repository(self.repo)
+            self.repo.refresh_from_db()
+            head = self.repo.current_head
+
+            created = []
+
+            class TrackingRepo(Repo):
+                def __init__(self, *args, **kwargs):
+                    super().__init__(*args, **kwargs)
+                    created.append(self)
+
+            with mock.patch("nautobot.extras.datasources.git.Repo", TrackingRepo):
+                # Repo is already at `head`, so this hits the early-return Repo(...).rev_parse("HEAD") branch.
+                changed = ensure_git_repository(self.repo, head=head)
+            self.assertFalse(changed)
+            self.assert_no_leaked_git_subprocess(created)
+
+    def test_ensure_git_repository_closes_repo_on_failure(self):
+        with tempfile.TemporaryDirectory() as tempdir, self.settings(GIT_ROOT=tempdir):
+            patcher, created = self._track_git_repo_instances()
+
+            def exploding_checkout(repo_self, *args, **kwargs):
+                # Read head first so the persistent `git cat-file` subprocess is spawned, then fail.
+                _ = repo_self.head
+                raise RuntimeError("simulated checkout failure")
+
+            with patcher, mock.patch.object(GitRepo, "checkout", exploding_checkout):
+                with self.assertRaises(RuntimeError):
+                    ensure_git_repository(self.repo)
+            self.assert_no_leaked_git_subprocess(created)
+
+    def test_clone_to_directory_does_not_leak_subprocess(self):
+        with tempfile.TemporaryDirectory() as tempdir, self.settings(GIT_ROOT=tempdir):
+            # Establish the current head so we can request a checkout (which reads object data).
+            ensure_git_repository(self.repo)
+            self.repo.refresh_from_db()
+            head = self.repo.current_head
+
+            patcher, created = self._track_git_repo_instances()
+            with patcher:
+                # Clones into a subdirectory of `tempdir`, so the TemporaryDirectory cleans it up.
+                self.repo.clone_to_directory(path=tempdir, head=head)
+            self.assert_no_leaked_git_subprocess(created)

--- a/nautobot/extras/tests/test_datasources.py
+++ b/nautobot/extras/tests/test_datasources.py
@@ -821,7 +821,8 @@ class GitTest(TransactionTestCase):
         self.assertTrue(repos, "expected a Git repo object to have been created")
         for repo in repos:
             # `repo` may be a GitRepo wrapper or a raw git.Repo; reach the underlying Git command object.
-            git_cmd = getattr(repo, "repo", repo).git
+            git_repo = repo.repo if isinstance(repo, GitRepo) else repo
+            git_cmd = git_repo.git
             for cmd in (git_cmd.cat_file_header, git_cmd.cat_file_all):
                 self.assertTrue(
                     cmd is None or cmd.proc is None or cmd.proc.poll() is not None,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8287
# What's Changed
There are currently two problems with Git sync. This PR addresses them both.

## Repo remaining open

After performing a git operation (e.g., repo sync), a lingering `git cat-file --batch-check` could be observed with `ps aux`. This is because we are not calling `repo_helper.repo.close()` in many cases.

This PR adds the plumbing to the `GitRepo` class so it can now be used as a context manager for automatic closing. I have converted all of our instances to a context manager now. This will still need to be replicated downstream to any apps for them to benefit.

## Async garbage collection

In container environments (docker, k8s), just running a git fetch can cause lingering defunct git processes:

```bash
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs# ps aux | grep git
root        34  0.0  0.0   3232  1420 pts/1    S+   16:10   0:00 grep git
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs# git fetch
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs# git fetch
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs# git fetch
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs# ps aux | grep git
root        41  0.0  0.0      0     0 ?        Zs   16:10   0:00 [git] <defunct>
root        48  0.0  0.0      0     0 ?        Zs   16:10   0:00 [git] <defunct>
root        55  0.0  0.0      0     0 ?        Zs   16:10   0:00 [git] <defunct>
root        57  0.0  0.0   3232  1408 pts/1    S+   16:10   0:00 grep git
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs#
```

This PR adds a config setting to tell git to run garbage collection synchronously instead.

```bash
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs# ps aux | grep git
root       341  0.0  0.0   3232  1412 pts/1    S+   18:26   0:00 grep git
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs# git fetch
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs# git fetch
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs# git fetch
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs# ps aux | grep git
root       361  0.0  0.0   3232  1420 pts/1    S+   18:26   0:00 grep git
root@d9e8fe5607fe:/opt/nautobot/git/test_jobs#
```

# Screenshots

|Before|After|
|-|-|
|<img width="839" height="329" alt="Screenshot 2026-06-30 at 1 28 24 PM" src="https://github.com/user-attachments/assets/8e798cc6-3287-4c7e-be76-0d7281a68b9a" />|<img width="675" height="156" alt="Screenshot 2026-06-30 at 1 28 35 PM" src="https://github.com/user-attachments/assets/749547f0-e018-4542-82c4-7cfbd7e7990b" />|


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
