### PR TITLE
fix generic bulk delete test

### DIFF
--- a/changes/9163.housekeeping
+++ b/changes/9163.housekeeping
@@ -1,0 +1,1 @@
+Fixed some incorrect logic in the generic bulk delete view test.

--- a/nautobot/core/testing/views.py
+++ b/nautobot/core/testing/views.py
@@ -32,7 +32,7 @@ from nautobot.core.forms import (
     NumericArrayField,
     TagFilterField,
 )
-from nautobot.core.jobs.bulk_actions import BulkEditObjects
+from nautobot.core.jobs.bulk_actions import BulkDeleteObjects, BulkEditObjects
 from nautobot.core.models.generics import PrimaryModel
 from nautobot.core.models.tree_queries import TreeModel
 from nautobot.core.templatetags import buttons, helpers
@@ -1788,10 +1788,10 @@ class ViewTestCases:
             self.assertIn("<strong>Warning:</strong> The following operation will delete 2 ", response_body)
             self.assertInHTML('<input type="hidden" name="_all" value="true" />', response_body)
 
+        @mock.patch.object(JobResult, "enqueue_job")
         @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
-        def test_bulk_delete_objects_with_constrained_permission(self):
-            pk_list = self.get_deletable_object_pks()
-            initial_count = self._get_queryset().count()
+        def test_bulk_delete_objects_with_constrained_permission(self, mock_enqueue_job):
+            pk_list = list(self.get_deletable_object_pks())
             data = {
                 "pk": pk_list,
                 "confirm": True,
@@ -1808,9 +1808,17 @@ class ViewTestCases:
             obj_perm.users.add(self.user)
             obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
 
-            # Attempt to bulk delete non-permitted objects
+            job_model = BulkDeleteObjects().job_model
+            job_result = JobResult.objects.create(
+                name=job_model.name,
+                job_model=job_model,
+                user=self.user,
+            )
+            mock_enqueue_job.return_value = job_result
+
+            # Attempt to bulk delete non-permitted objects; the constraint denies all, so nothing is deleted.
             self.assertHttpStatus(self.client.post(self._get_url("bulk_delete"), data), 302)
-            self.assertEqual(self._get_queryset().count(), initial_count)
+            mock_enqueue_job.assert_not_called()
 
             # Update permission constraints
             obj_perm.constraints = {"pk__isnull": False}  # Match a non-existent pk (i.e., allow all)
@@ -1819,8 +1827,10 @@ class ViewTestCases:
             # User would be redirected to Job Result therefore user needs to have permission to view Job Result
             self.add_permissions("extras.view_jobresult")
             response = self.client.post(self._get_url("bulk_delete"), data)
-            job_result = JobResult.objects.filter(name="Bulk Delete Objects").first()
-            self.assertIsNotNone(job_result)
+            mock_enqueue_job.assert_called_once()
+            job_kwargs = mock_enqueue_job.call_args.kwargs
+            self.assertEqual(job_kwargs.get("pk_list", []), [str(pk) for pk in pk_list])
+
             self.assertRedirects(
                 response,
                 reverse("extras:jobresult", args=[job_result.pk]),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes DNE
# What's Changed

It looks like this may have gotten mixed up when we transitioned the bulk delete view to a job. I altered the generic test to look directly at the function call to `JobResult.enqueue_job` instead of trying to do a full integration test of the view.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
