### PR TITLE
Closes #8497: Validate parent bay location/rack in the Device REST API

### DIFF
--- a/changes/8497.fixed
+++ b/changes/8497.fixed
@@ -1,0 +1,1 @@
+Added REST API validation that a device being installed in a device bay must be assigned to the same location and rack as the parent device, matching the existing UI behavior.

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -565,6 +565,27 @@ class DeviceSerializer(TaggedModelSerializerMixin, NautobotModelSerializer):
                     }
                 )
 
+            # Child devices must be assigned to the same location/rack as the parent device (mirrors the
+            # PopulateDeviceBayForm queryset used by the UI).
+            if "location" in attrs or self.instance is None:
+                device_location = attrs.get("location")
+            else:
+                device_location = self.instance.location
+            if "rack" in attrs or self.instance is None:
+                device_rack = attrs.get("rack")
+            else:
+                device_rack = self.instance.rack
+            if device_location != parent_bay.device.location or device_rack != parent_bay.device.rack:
+                raise ValidationError(
+                    {
+                        "parent_bay": (
+                            "Cannot install device; child devices must first be assigned to the location/rack "
+                            f"of the parent device (location: {parent_bay.device.location}, "
+                            f"rack: {parent_bay.device.rack})"
+                        )
+                    }
+                )
+
             if self.instance:
                 parent_bay.installed_device = self.instance
                 parent_bay.full_clean()

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -2260,6 +2260,74 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
         child_device.refresh_from_db()
         self.assertEqual(child_device.parent_bay.pk, device_bay_1.pk)
 
+    def test_parent_bay_location_and_rack_must_match_parent_device(self):
+        """Installing a device in a device bay requires matching the parent's location/rack (#8497)."""
+        parent_device, device_bay_1, device_bay_2, device_type_child = self._parent_device_test_data()
+        rack = Rack.objects.create(
+            name="Parent bay test rack",
+            location=parent_device.location,
+            status=Status.objects.get_for_model(Rack).first(),
+        )
+        parent_device.rack = rack
+        parent_device.save()
+
+        self.add_permissions(
+            "dcim.add_device",
+            "dcim.change_device",
+            "dcim.view_device",
+            "dcim.view_devicetype",
+            "extras.view_role",
+            "extras.view_status",
+            "dcim.view_location",
+            "dcim.view_rack",
+            "dcim.view_devicebay",
+        )
+        url = reverse("dcim-api:device-list")
+
+        # An unracked child cannot be installed in a bay of a racked parent device
+        data = {
+            "device_type": device_type_child.pk,
+            "role": parent_device.role.pk,
+            "location": parent_device.location.pk,
+            "name": "Device parent bay test #7",
+            "status": parent_device.status.pk,
+            "parent_bay": device_bay_1.pk,
+        }
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            "must first be assigned to the location/rack of the parent device",
+            response.content.decode(response.charset),
+        )
+        device_bay_1.refresh_from_db()
+        self.assertIsNone(device_bay_1.installed_device)
+
+        # A child assigned to the parent's location and rack installs successfully
+        data["rack"] = rack.pk
+        response = self.client.post(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_201_CREATED)
+        created_device = Device.objects.get(name="Device parent bay test #7")
+        self.assertEqual(created_device.parent_bay.pk, device_bay_1.pk)
+
+        # An existing child in a different location cannot be installed via PATCH
+        other_location = (
+            Location.objects.filter(location_type=LocationType.objects.get(name="Campus"))
+            .exclude(pk=parent_device.location.pk)
+            .first()
+        )
+        child_device = Device.objects.create(
+            device_type=device_type_child,
+            role=parent_device.role,
+            location=other_location,
+            name="Device parent bay test #8",
+            status=parent_device.status,
+        )
+        patch_data = {"parent_bay": device_bay_2.pk}
+        response = self.client.patch(self._get_detail_url(child_device), patch_data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        device_bay_2.refresh_from_db()
+        self.assertIsNone(device_bay_2.installed_device)
+
 
 class ModuleTestCase(APIViewTestCases.APIViewTestCase):
     model = Module


### PR DESCRIPTION
# Closes #8497

# What's Changed

Added REST API validation that a device being installed in a device bay must be assigned to the same location and rack as the parent device.

The UI has always enforced this (`PopulateDeviceBayForm` limits eligible child devices to `location=parent.location, rack=parent.rack`), but the REST API allowed installing a child whose location/rack didn't match — e.g. an unracked child into a bay of a racked parent. Per @glennmatthews's assessment in #8497, the missing API-side check was an oversight in the original `parent_bay` API support (#6898), with `DeviceSerializer.validate` as the appropriate place for the fix — which is what this PR implements. The check uses the request's `location`/`rack` values, falling back to the instance's current values on partial update.

Regression tests cover: rejecting an unracked child against a racked parent on create; rejecting a child in a different location on update; the matching location+rack success path; and the existing unracked-parent tests continue to pass unchanged (exact-match semantics, same as the UI).

**Notes for reviewers:**

- @nrnvgh's alternative (auto-assigning the parent's rack to the child on install) was left as-is since it wasn't picked up by maintainers; happy to pivot or follow up if that direction is preferred.
- The DeviceBay API's `installed_device` field (the reverse path) still performs no location/rack validation — kept out of scope here to match the endorsed fix location, but I'm happy to extend the same check to `DeviceBaySerializer` in this PR or a follow-up if desired.

# Screenshots

N/A — API validation change covered by the added tests. Example rejected request now returns:

```
400 {"parent_bay": ["Cannot install device; child devices must first be assigned to the location/rack of the parent device (location: <location>, rack: <rack>)"]}
```

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example — payload example above
- [x] Unit, Integration Tests — added `test_parent_bay_location_and_rack_must_match_parent_device`
- [ ] Documentation Updates — N/A (restores documented/UI-consistent behavior)
- [ ] Example App Updates — N/A
- [x] Outline Remaining Work, Constraints from Design — DeviceBay-side validation noted above as possible follow-up
