### PR TITLE
Closes #3146: Add bulk action buttons to the VM detail Interfaces panel

### DIFF
--- a/changes/3146.fixed
+++ b/changes/3146.fixed
@@ -1,0 +1,1 @@
+Added bulk rename/edit/delete buttons to the Interfaces panel on the Virtual Machine detail view, matching the Device detail view behavior.

--- a/nautobot/virtualization/tests/test_views.py
+++ b/nautobot/virtualization/tests/test_views.py
@@ -1,5 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
+from django.urls import reverse
 from netaddr import EUI
 
 from nautobot.core.testing import post_data, ViewTestCases
@@ -187,6 +188,33 @@ class VirtualMachineTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "comments": "New comments",
             "software_version": software_versions[0].pk,
         }
+
+    def test_interfaces_panel_has_bulk_action_buttons(self):
+        """The Interfaces panel on the detail view exposes bulk rename/edit/delete buttons (#3146)."""
+        virtual_machine = VirtualMachine.objects.get(name="Virtual Machine 1")
+        VMInterface.objects.create(
+            virtual_machine=virtual_machine,
+            name="Interface 1",
+            status=Status.objects.get_for_model(VMInterface).first(),
+        )
+        bulk_urls = [
+            reverse("virtualization:vminterface_bulk_rename"),
+            reverse("virtualization:vminterface_bulk_edit"),
+            reverse("virtualization:vminterface_bulk_delete"),
+        ]
+
+        # With only view permissions, the bulk-selection checkbox column is not rendered
+        self.add_permissions("virtualization.view_virtualmachine", "virtualization.view_vminterface")
+        response = self.client.get(virtual_machine.get_absolute_url())
+        self.assertHttpStatus(response, 200)
+        self.assertNotIn('title="Toggle all"', response.content.decode(response.charset))
+
+        # With change/delete permissions, the selection checkboxes and bulk action buttons appear
+        self.add_permissions("virtualization.change_vminterface", "virtualization.delete_vminterface")
+        response = self.client.get(virtual_machine.get_absolute_url())
+        self.assertBodyContains(response, 'title="Toggle all"')
+        for url in bulk_urls:
+            self.assertBodyContains(response, url)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_local_config_context_schema_validation_pass(self):

--- a/nautobot/virtualization/views.py
+++ b/nautobot/virtualization/views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from nautobot.core.choices import ButtonActionColorChoices
 from nautobot.core.templatetags.helpers import HTML_NONE
 from nautobot.core.ui import object_detail
+from nautobot.core.ui.bulk_buttons import BulkDeleteButton, BulkEditButton, BulkRenameButton
 from nautobot.core.ui.choices import SectionChoices
 from nautobot.core.views import generic
 from nautobot.core.views.utils import common_detail_view_context
@@ -235,6 +236,13 @@ class VirtualMachineUIViewSet(NautobotUIViewSet):
                 table_title="Interfaces",
                 table_class=tables.VirtualMachineVMInterfaceTable,
                 table_filter="virtual_machine",
+                enable_bulk_actions=True,
+                form_id="vminterfaces-form",
+                footer_buttons=[
+                    BulkRenameButton(form_id="vminterfaces-form", model=VMInterface),
+                    BulkEditButton(form_id="vminterfaces-form", model=VMInterface),
+                    BulkDeleteButton(form_id="vminterfaces-form", model=VMInterface),
+                ],
                 header_extra_content_template_path="virtualization/inc/virtualmachine_vminterface_filter.html",
             ),
         ),


### PR DESCRIPTION
# Closes #3146

# What's Changed

Added bulk rename/edit/delete buttons (and row-selection checkboxes) to the **Interfaces** panel on the Virtual Machine detail view.

The VM detail view's Interfaces table had no bulk operations, unlike the Device detail view's Interfaces tab. All the pieces already existed — the `vminterface_bulk_rename`/`_bulk_edit`/`_bulk_delete` routes, views, and forms, plus the UI framework's `ObjectsTablePanel` bulk-actions support — so this wires them together on the existing panel (`enable_bulk_actions`, `form_id`, and the standard `BulkRenameButton`/`BulkEditButton`/`BulkDeleteButton` footer buttons), following the same pattern used by the Device detail view and DeviceType component tabs.

Behavior matches the framework's existing permission handling: the selection-checkbox column only renders for users with change or delete permission on VMInterface.

A view test asserts the checkbox column is absent for view-only users and that the checkboxes and all three bulk-action buttons render once change/delete permissions are granted.

# Screenshots

The Interfaces panel on a VM detail page now shows row checkboxes and Rename / Edit / Delete footer buttons, identical in style to the Device Interfaces tab.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example — can add before/after screenshots on request
- [x] Unit, Integration Tests — added `test_interfaces_panel_has_bulk_action_buttons`
- [ ] Documentation Updates — N/A
- [ ] Example App Updates — N/A
- [x] Outline Remaining Work, Constraints from Design — kept to the in-panel fix as filed; a Device-style separate Interfaces tab would be a larger redesign out of scope here
