### PR TITLE
Closes #9120: Fix negation filtering of multi-select custom fields

### DIFF
--- a/changes/9120.fixed
+++ b/changes/9120.fixed
@@ -1,0 +1,1 @@
+Fixed negation (`__n`) filtering of multi-select custom fields, which previously matched all records instead of excluding records containing the specified value.

--- a/nautobot/core/constants.py
+++ b/nautobot/core/constants.py
@@ -34,6 +34,10 @@ FILTER_NUMERIC_BASED_LOOKUP_MAP = {
 
 FILTER_NEGATION_LOOKUP_MAP = {"n": "exact"}
 
+# For filters against JSON list values (multi-select custom fields), where negation must invert a `contains`
+# lookup rather than an `exact` comparison against the whole list.
+FILTER_CONTAINS_NEGATION_LOOKUP_MAP = {"n": "contains"}
+
 #
 # User input sanitization
 #

--- a/nautobot/docs/user-guide/platform-functionality/rest-api/filtering.md
+++ b/nautobot/docs/user-guide/platform-functionality/rest-api/filtering.md
@@ -82,7 +82,7 @@ Custom fields can be mixed with built-in fields to further narrow results. When 
 
 ## Lookup Expressions
 
-Certain model fields (including, in Nautobot 1.4.0 and later, custom fields of type `text`, `url`, `select`, `integer`, and `date`) also support filtering using additional lookup expressions. This allows for negation and other context-specific filtering.
+Certain model fields (including custom fields of type `text`, `url`, `select`, `multiselect`, `integer`, `date`, and `datetime`) also support filtering using additional lookup expressions. This allows for negation and other context-specific filtering.
 
 These lookup expressions can be applied by adding a suffix to the desired field's name, e.g. `mac_address__n`. In this case, the filter expression is for negation and it is separated by two underscores. Below are the lookup expressions that are supported across different field types.
 

--- a/nautobot/extras/filter_mixins.py
+++ b/nautobot/extras/filter_mixins.py
@@ -8,7 +8,7 @@ from django_filters.utils import verbose_lookup_expr
 
 from nautobot.core.constants import (
     FILTER_CHAR_BASED_LOOKUP_MAP,
-    FILTER_NEGATION_LOOKUP_MAP,
+    FILTER_CONTAINS_NEGATION_LOOKUP_MAP,
     FILTER_NUMERIC_BASED_LOOKUP_MAP,
 )
 from nautobot.core.filters import (
@@ -108,7 +108,9 @@ class CustomFieldModelFilterSetMixin(django_filters.FilterSet):
         ):
             return FILTER_NUMERIC_BASED_LOOKUP_MAP
         elif issubclass(filter_type, CustomFieldMultiSelectFilter):
-            return FILTER_NEGATION_LOOKUP_MAP
+            # Multi-select values are JSON lists; negation must invert the `contains` lookup used by the base
+            # filter, as excluding on `exact` compares the whole list against a single value and matches nothing.
+            return FILTER_CONTAINS_NEGATION_LOOKUP_MAP
         else:
             return FILTER_CHAR_BASED_LOOKUP_MAP
 

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -2370,6 +2370,23 @@ class CustomFieldFilterTest(TestCase):
             self.filterset({"cf_cf9": str(self.multiselect_choices[0].pk)}, self.queryset).qs,
             self.queryset.filter(_custom_field_data__cf9__contains=self.multiselect_choices[0].value),
         )
+        # Negation excludes records containing the value (https://github.com/nautobot/nautobot/issues/9120)
+        self.assertQuerySetEqualAndNotEmpty(
+            self.filterset({"cf_cf9__n": ["Foo"]}, self.queryset).qs,
+            self.queryset.exclude(_custom_field_data__cf9__contains="Foo")
+            | self.queryset.filter(_custom_field_data__cf9__isnull=True),
+        )
+        self.assertQuerySetEqualAndNotEmpty(
+            self.filterset({"cf_cf9__n": ["Bar"]}, self.queryset).qs,
+            self.queryset.exclude(_custom_field_data__cf9__contains="Bar")
+            | self.queryset.filter(_custom_field_data__cf9__isnull=True),
+        )
+        # Negation by choice PK, mirroring the positive-filter case above
+        self.assertQuerySetEqualAndNotEmpty(
+            self.filterset({"cf_cf9__n": [str(self.multiselect_choices[0].pk)]}, self.queryset).qs,
+            self.queryset.exclude(_custom_field_data__cf9__contains=self.multiselect_choices[0].value)
+            | self.queryset.filter(_custom_field_data__cf9__isnull=True),
+        )
 
 
 @tag("example_app")


### PR DESCRIPTION
# Closes #9120

# What's Changed

Fixed negation (`__n`) filtering of multi-select custom fields, which previously matched **all** records instead of excluding anything.

**Root cause:** the generated `cf_<key>__n` filter for `TYPE_MULTISELECT` custom fields was built from `FILTER_NEGATION_LOOKUP_MAP` (`{"n": "exact"}`), passing `lookup_expr="exact"` explicitly — which bypasses `CustomFieldMultiSelectFilter`'s own `setdefault("lookup_expr", "contains")`. Excluding on `__exact` compares the stored JSON list (e.g. `["WLAN_Manager"]`) against a single scalar, which never matches, so the `exclude()` removed nothing and the null/missing-key union in `CustomFieldFilterMixin.filter` returned the entire queryset.

**Fix:** introduce `FILTER_CONTAINS_NEGATION_LOOKUP_MAP` (`{"n": "contains"}`) in `nautobot.core.constants` and use it for the multi-select branch, so the negation filter inverts the same `contains` lookup the positive filter uses. The result is the exact complement of the positive filter: records not containing the value, plus records where the field is null or unset. `DynamicGroup` negation self-heals as well, since `generate_query` derives from `self.lookup_expr`, and filtering by choice PK continues to work through `CustomFieldSelectFilter.get_filter_predicate`.

Regression assertions were added to the existing `CustomFieldFilterTest.test_filter_multi_select` (whose fixture already covers empty-list, single-value, multi-value, and missing-key records), including the negation-by-choice-PK path. Also updated the REST API filtering docs to include `multiselect` and `datetime` in the list of custom field types supporting lookup expressions, resolving the code/docs discrepancy noted in the issue.

**Note:** this changes `cf_<key>__n` on multi-select fields from a silent no-op to actually excluding — the documented and intended behavior of `__n`; anyone relying on the previous behavior was receiving unfiltered results.

# Screenshots

N/A — filter behavior fix covered by the added tests. Example: `GET /api/dcim/locations/?cf_managed_by__n=WLAN_Manager` now excludes locations whose `managed_by` multi-select contains `WLAN_Manager` (previously returned all locations).

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example — payload example above
- [x] Unit, Integration Tests — extended `test_filter_multi_select` with negation assertions
- [x] Documentation Updates — lookup-expression type list corrected
- [ ] Example App Updates — N/A
- [x] Outline Remaining Work, Constraints from Design — none
