### PR TITLE
Fix corruption of multi-value filter params in PrefixFilterForm.

### DIFF
--- a/changes/xxxx.fixed
+++ b/changes/xxxx.fixed
@@ -1,0 +1,3 @@
+Fixed `prefix_length__lte` filter value being corrupted (e.g. `['16']`) when adding another filter in the Prefix list view.
+Fixed `within_include` filter field in `PrefixFilterForm` not supporting multiple values.
+Fixed `MultiValueCharField` splitting a bare string value into per-character choices.

--- a/nautobot/core/forms/fields.py
+++ b/nautobot/core/forms/fields.py
@@ -270,6 +270,8 @@ class MultiValueCharField(django_forms.CharField):
         widget = bound_field.field.widget
         # Save the selected choices in the widget even after the filterform is submitted
         if value is not None:
+            if isinstance(value, str):
+                value = [value]
             widget.choices = [(v, v) for v in value]
 
         return bound_field

--- a/nautobot/core/tests/test_forms.py
+++ b/nautobot/core/tests/test_forms.py
@@ -475,6 +475,19 @@ class MultiValueCharFieldTest(testing.TestCase):
             ["device-1", "device-2", "rack-1"],
         )
 
+    def test_get_bound_field_with_string_value(self):
+        """A bare string value must render as a single choice, not be iterated character by character."""
+
+        class TestForm(django_forms.Form):
+            test_field = forms.MultiValueCharField(required=False)
+
+        form = TestForm(data={"test_field": "192.168.0.0/16"})
+        bound_field = form["test_field"]
+        self.assertEqual(
+            bound_field.field.widget.choices,
+            [("192.168.0.0/16", "192.168.0.0/16")],
+        )
+
 
 class NumericArrayFieldTest(testing.TestCase):
     def setUp(self):

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -10,6 +10,8 @@ from nautobot.core.forms import (
     DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,
     ExpandableIPAddressField,
+    MultiValueCharField,
+    MultiValueCharInput,
     NumericArrayField,
     PrefixFieldMixin,
     ReturnURLForm,
@@ -449,11 +451,14 @@ class PrefixFilterForm(
         "tenant",
         "rir",
     ]
-    prefix_length__lte = forms.IntegerField(widget=forms.HiddenInput(), required=False)
-    q = forms.CharField(required=False, label="Search")
-    within_include = forms.CharField(
+    prefix_length__lte = MultiValueCharField(
+        widget=forms.MultipleHiddenInput,
         required=False,
-        widget=forms.TextInput(
+    )
+    q = forms.CharField(required=False, label="Search")
+    within_include = MultiValueCharField(
+        required=False,
+        widget=MultiValueCharInput(
             attrs={
                 "placeholder": "Prefix",
             }

--- a/nautobot/ipam/forms.py
+++ b/nautobot/ipam/forms.py
@@ -460,7 +460,7 @@ class PrefixFilterForm(
         required=False,
         widget=MultiValueCharInput(
             attrs={
-                "placeholder": "Prefix",
+                "data-placeholder": "Prefix",
             }
         ),
         label="Search within",

--- a/nautobot/ipam/tests/test_forms.py
+++ b/nautobot/ipam/tests/test_forms.py
@@ -1,6 +1,9 @@
 """Test IPAM forms."""
 
+import re
+
 from django.forms import Form
+from django.http import QueryDict
 
 from nautobot.core.testing import TestCase
 from nautobot.core.testing.forms import FormTestCases
@@ -79,6 +82,75 @@ class PrefixFormTest(NetworkFormTestCases.BaseNetworkFormTest, FormTestCases.Bas
             "type": "network",
             "rir": models.RIR.objects.first(),
         }
+
+
+class PrefixFilterFormTest(TestCase):
+    """Tests for PrefixFilterForm."""
+
+    form_class = forms.PrefixFilterForm
+
+    def test_all_fields_render_submitted_values(self):
+        """
+        Every field must render its submitted value back in the generated HTML:
+        input-based widgets via the value attribute, select-based widgets via a
+        selected option. Multi-value fields receive list values, as produced by
+        the list view's filter params processing.
+        """
+        namespace = Namespace.objects.first()
+        status = Status.objects.get_for_model(Prefix).first()
+
+        # field name -> submitted data; input widgets checked via value attribute
+        input_cases = {
+            "prefix_length__lte": ["16"],
+            "q": "192.168",
+            "within_include": "192.168.0.0/16",
+            "max_depth": "2",
+        }
+        # field name -> (submitted data, expected selected option value)
+        select_cases = {
+            "ip_version": ("4", "4"),
+            "prefix_length": ("24", "24"),
+            "type": (["container"], "container"),
+            "namespace": ([namespace.name], namespace.name),
+            "status": ([status.name], status.name),
+        }
+
+        for field_name, value in input_cases.items():
+            with self.subTest(field=field_name):
+                form = self.form_class(data={field_name: value})
+                html = str(form[field_name])
+                rendered_value = value[0] if isinstance(value, list) else value
+                self.assertIn(f'value="{rendered_value}"', html)
+
+        for field_name, (value, expected) in select_cases.items():
+            with self.subTest(field=field_name):
+                form = self.form_class(data={field_name: value})
+                html = str(form[field_name])
+                self.assertRegex(html, rf'<option value="{re.escape(expected)}"\s+selected')
+
+    def test_form_valid_with_combined_filters_from_querydict(self):
+        """A realistic multi-filter query string must validate and clean without corruption."""
+        namespace = Namespace.objects.first()
+        query = f"prefix_length__lte=16&type=container&type=network&namespace={namespace.name}&ip_version=4&q=192.168"
+        form = self.form_class(data=QueryDict(query))
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["prefix_length__lte"], ["16"])
+        self.assertEqual(form.cleaned_data["type"], ["container", "network"])
+        self.assertEqual(form.cleaned_data["q"], "192.168")
+
+    def test_within_include_handles_list_values(self):
+        """
+        `within_include` is backed by a MultiValueCharFilter, so the form field must
+        accept a list value (as produced by the list view's filter params processing),
+        render it back without corruption, and clean it to a list of values.
+        """
+        form = self.form_class(data={"within_include": ["192.168.0.0/16"]})
+
+        html = str(form["within_include"])
+        self.assertIn('value="192.168.0.0/16"', html)
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["within_include"], ["192.168.0.0/16"])
 
 
 class IPAddressFormTest(NetworkFormTestCases.BaseNetworkFormTest):


### PR DESCRIPTION
Tracking: NAUTOBOT-1224
# What's Changed
- Changed `PrefixFilterForm.prefix_length__lte`: `IntegerField` + `HiddenInput` to  `MultiValueCharField` + `MultipleHiddenInput`
- Changed `PrefixFilterForm.within_include`: `CharField` to `MultiValueCharField`. The backing filter (`MultiValueCharFilter`) already supported multiple values, now the UI does too
- Fixed `MultiValueCharField.get_bound_field`: a bare string value was iterated character by character when populating widget choice. It is now wrapped in a list first
- Added `PrefixFilterFormTest` (ipam) and a regression test in `MultiValueCharFieldTest` (core)
- 
# Screenshots
**BEFORE**

<img width="1771" height="496" alt="image-20260706-092136" src="https://github.com/user-attachments/assets/61907dac-3c80-4e0e-b955-460f00899746" />

**AFTER**

<img width="1781" height="1002" alt="image" src="https://github.com/user-attachments/assets/66a65594-3261-45c4-89ad-807c67a7a5f3" />


**within_include BEFORE**
1. Add within_include filter alone -> url and filter work
2. Add `type=contrainer` -> url and filter broken
<img width="1755" height="423" alt="image" src="https://github.com/user-attachments/assets/57100754-ea80-4e56-b759-a9a5a0485498" />


**within_include AFTER**
1. Add within_include filter alone -> url and filter work
2. Add `type=contrainer` -> url and filter work
<img width="1773" height="463" alt="image" src="https://github.com/user-attachments/assets/7923f744-5e6f-46db-8b0b-8b817d0b7f98" />



# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
