### PR TITLE
Add release-overview note about change to device-component ordering

### DIFF
--- a/nautobot/docs/release-notes/version-3.2.md
+++ b/nautobot/docs/release-notes/version-3.2.md
@@ -101,7 +101,7 @@ A [`Cable`](../user-guide/core-data-model/dcim/cable.md) is no longer required t
 
 The [`Cable`](../user-guide/core-data-model/dcim/cable.md) REST API serializer adds a single `terminations` field keyed by side (`a`/`b`) and then by 1-indexed connector number, mirroring the physical structure of the cable. This field is writable on POST and PATCH, and uncabled connectors on breakout cables are surfaced as explicit `null` slots. The legacy `termination_a` / `termination_b` (and `*_type` / `*_id`) fields remain for backward compatibility and refer to connector 1 on each side. The nested `terminations` field is omitted from CSV exports; use the [`CableToCableTermination`](../user-guide/core-data-model/dcim/cabletocabletermination.md) endpoint for per-connector CSV detail.
 
-### Device Component Default Ordering
+#### Device Component Default Ordering
 
 The default sort ordering of device-component models (Interface, Front Port, Rear Port, Console Port, etc.) has been changed to group and sort records by their associated `device_id` (UUID) rather than by the associated device's `name`, as the prior behavior (requiring a join across database tables) performed poorly at high data scale. This change affects the default behavior of the following:
 

--- a/nautobot/docs/release-notes/version-3.2.md
+++ b/nautobot/docs/release-notes/version-3.2.md
@@ -101,6 +101,16 @@ A [`Cable`](../user-guide/core-data-model/dcim/cable.md) is no longer required t
 
 The [`Cable`](../user-guide/core-data-model/dcim/cable.md) REST API serializer adds a single `terminations` field keyed by side (`a`/`b`) and then by 1-indexed connector number, mirroring the physical structure of the cable. This field is writable on POST and PATCH, and uncabled connectors on breakout cables are surfaced as explicit `null` slots. The legacy `termination_a` / `termination_b` (and `*_type` / `*_id`) fields remain for backward compatibility and refer to connector 1 on each side. The nested `terminations` field is omitted from CSV exports; use the [`CableToCableTermination`](../user-guide/core-data-model/dcim/cabletocabletermination.md) endpoint for per-connector CSV detail.
 
+### Device Component Default Ordering
+
+The default sort ordering of device-component models (Interface, Front Port, Rear Port, Console Port, etc.) has been changed to group and sort records by their associated `device_id` (UUID) rather than by the associated device's `name`, as the prior behavior (requiring a join across database tables) performed poorly at high data scale. This change affects the default behavior of the following:
+
+* `/dcim/interfaces/` UI list view (and `/dcim/front-ports/`, `/dcim/rear-ports/`, etc.)
+* `/api/dcim/interfaces/` REST API list view (and `/api/dcim/front-ports/`, `/api/dcim/rear-ports/`, etc.)
+* GraphQL query responses that invole listing any of these models
+
+For the UI and REST API list views, if ordering by device name is desired, the prior behavior may be achieved by explicitly specifying a `?sort=device` query parameter when requesting these views, but users are encouraged to be aware of the performance implications of doing so.
+
 ### Dependencies
 
 TODO


### PR DESCRIPTION
Add a release-overview note about #9159 since it's a significant user-visible change in behavior.