### PR TITLE
Fixed interface VRF validations

### DIFF
--- a/changes/9149.changed
+++ b/changes/9149.changed
@@ -1,0 +1,2 @@
+Changed removing a VRF from a Device or VirtualMachine to raise an error if that VRF is still attached to one of the interfaces.
+Changed attaching a VRF to a VM interface via API/ORM to raise an error if the parent Virtual Machine does not have that VRF assigned.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -18,11 +18,11 @@ from nautobot.core.models.fields import JSONArrayField, PositiveRangeNumberTextF
 from nautobot.core.models.generics import OrganizationalModel, PrimaryModel
 from nautobot.core.models.utils import array_to_string
 from nautobot.core.utils.data import UtilizationData
-from nautobot.dcim.models import Interface
+from nautobot.dcim.models import Device, Interface
 from nautobot.extras.models import RoleField, StatusField
 from nautobot.extras.utils import extras_features
 from nautobot.ipam import choices, constants
-from nautobot.virtualization.models import VMInterface
+from nautobot.virtualization.models import VirtualMachine, VMInterface
 
 from .fields import VarbinaryIPField
 from .querysets import IPAddressQuerySet, PrefixQuerySet, RIRQuerySet, VLANQuerySet
@@ -354,6 +354,16 @@ class VRF(PrimaryModel):
     remove_prefix.alters_data = True
 
 
+def interfaces_assigned_to_vrf(vrf, parent):
+    """Return the interfaces on `parent` (Device or VirtualMachine) that still reference `vrf`."""
+    if isinstance(parent, Device):
+        return parent.all_interfaces.filter(vrf=vrf)
+    if isinstance(parent, VirtualMachine):
+        return parent.interfaces.filter(vrf=vrf)
+    # TODO: account for VirtualDeviceContext interfaces as well.
+    return Interface.objects.none()
+
+
 @extras_features("graphql")
 class VRFDeviceAssignment(BaseModel):
     vrf = models.ForeignKey("ipam.VRF", on_delete=models.CASCADE, related_name="device_assignments")
@@ -426,6 +436,21 @@ class VRFDeviceAssignment(BaseModel):
             )
 
     clean.alters_data = True
+
+    def delete(self, *args, **kwargs):
+        """Prevent removing this VRF from its Device or VirtualMachine while its interfaces still reference the VRF."""
+        # TODO: account for VirtualDeviceContext interfaces as well.
+        parent = self.device or self.virtual_machine
+        interfaces = interfaces_assigned_to_vrf(self.vrf, parent)
+        if interfaces.exists():
+            raise models.ProtectedError(
+                msg=(
+                    f"Cannot remove VRF {self.vrf} from {parent} because it is still assigned to one or more "
+                    "of its interfaces. Remove the VRF from those interfaces first."
+                ),
+                protected_objects=set(interfaces),
+            )
+        return super().delete(*args, **kwargs)
 
 
 @extras_features("graphql")

--- a/nautobot/ipam/signals.py
+++ b/nautobot/ipam/signals.py
@@ -6,6 +6,7 @@ from django.dispatch import receiver
 
 from nautobot.dcim.models import Device, VirtualDeviceContext
 from nautobot.ipam.models import (
+    interfaces_assigned_to_vrf,
     IPAddress,
     IPAddressToInterface,
     Prefix,
@@ -110,6 +111,25 @@ def vrf_device_associated(sender, instance, action, reverse, model, pk_set, **kw
             else:
                 return
             _validate_device_vrf_assignments(sender, instance, pk_set, device_field)
+
+
+@receiver(m2m_changed, sender=VRFDeviceAssignment)
+def vrf_device_disassociated(sender, instance, action, reverse, model, pk_set, **kwargs):
+    """Prevent removing a VRF from a parent object while its interfaces still reference that VRF."""
+    if action != "pre_remove" or not pk_set:
+        return
+    if isinstance(instance, VRF):
+        pairs = [(instance, parent) for parent in model.objects.filter(pk__in=pk_set)]
+    else:
+        pairs = [(vrf, instance) for vrf in VRF.objects.filter(pk__in=pk_set)]
+    for vrf, parent in pairs:
+        interfaces = interfaces_assigned_to_vrf(vrf, parent)
+        if interfaces.exists():
+            raise ValidationError(
+                f"Cannot remove VRF {vrf} from {parent} because it is still assigned to the following "
+                f"interface(s): {', '.join(str(interface) for interface in interfaces)}. "
+                "Remove the VRF from those interfaces first."
+            )
 
 
 @receiver(pre_delete, sender=IPAddressToInterface)

--- a/nautobot/ipam/tests/test_models.py
+++ b/nautobot/ipam/tests/test_models.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.db import connection, IntegrityError
+from django.db import connection, IntegrityError, transaction
 from django.db.models import ProtectedError
 import netaddr
 
@@ -2407,6 +2407,90 @@ class VRFDeviceAssignmentSignalTest(TestCase):
                 pk_set={self.vrf1.pk},
             )
             mock_validated_save.assert_not_called()
+
+    def _device_interface_with_vrf(self, device, vrf):
+        """Assign `vrf` to `device` and create an interface on `device` using that VRF."""
+        device.vrfs.add(vrf)
+        return Interface.objects.create(
+            device=device,
+            name="GigabitEthernet0/0",
+            status=Status.objects.get_for_model(Interface).first(),
+            type=dcim_choices.InterfaceTypeChoices.TYPE_1GE_FIXED,
+            vrf=vrf,
+        )
+
+    def _vm_interface_with_vrf(self, virtual_machine, vrf):
+        """Assign `vrf` to `virtual_machine` and create a VM interface using that VRF."""
+        virtual_machine.vrfs.add(vrf)
+        return VMInterface.objects.create(
+            virtual_machine=virtual_machine,
+            name="eth0",
+            status=Status.objects.get_for_model(VMInterface).first(),
+            vrf=vrf,
+        )
+
+    def test_cannot_remove_vrf_from_device_with_interface(self):
+        """Removing a VRF from a device is blocked while one of its interfaces still uses the VRF."""
+        self._device_interface_with_vrf(self.device1, self.vrf1)
+        with self.assertRaises(ValidationError), transaction.atomic():
+            self.device1.vrfs.remove(self.vrf1)
+        self.assertTrue(self.device1.vrf_assignments.filter(vrf=self.vrf1).exists())
+
+    def test_cannot_clear_vrfs_from_device_with_interface(self):
+        """Clearing a device's VRFs via set([]) is blocked while one of its interfaces still uses a VRF."""
+        self._device_interface_with_vrf(self.device1, self.vrf1)
+        with self.assertRaises(ValidationError), transaction.atomic():
+            self.device1.vrfs.set([])
+        self.assertTrue(self.device1.vrf_assignments.filter(vrf=self.vrf1).exists())
+
+    def test_cannot_remove_vrf_from_device_forward_direction(self):
+        """The block also applies when removing from the VRF side (vrf.devices.remove)."""
+        self._device_interface_with_vrf(self.device1, self.vrf1)
+        with self.assertRaises(ValidationError), transaction.atomic():
+            self.vrf1.devices.remove(self.device1)
+        self.assertTrue(self.device1.vrf_assignments.filter(vrf=self.vrf1).exists())
+
+    def test_cannot_remove_vrf_from_vm_with_interface(self):
+        """Removing a VRF from a virtual machine is blocked while one of its interfaces still uses the VRF."""
+        self._vm_interface_with_vrf(self.vm1, self.vrf1)
+        with self.assertRaises(ValidationError), transaction.atomic():
+            self.vm1.vrfs.remove(self.vrf1)
+        self.assertTrue(self.vm1.vrf_assignments.filter(vrf=self.vrf1).exists())
+
+    def test_remove_device_helper_raises_protected_error(self):
+        """The programmatic VRF.remove_device() helper is also blocked via a ProtectedError."""
+        self._device_interface_with_vrf(self.device1, self.vrf1)
+        with self.assertRaises(ProtectedError), transaction.atomic():
+            self.vrf1.remove_device(self.device1)
+        self.assertTrue(self.device1.vrf_assignments.filter(vrf=self.vrf1).exists())
+
+    def test_can_remove_vrf_from_device_after_clearing_interface(self):
+        """Removal from a device succeeds once the VRF is cleared from the interface."""
+        interface = self._device_interface_with_vrf(self.device1, self.vrf1)
+        interface.vrf = None
+        interface.save()
+        self.device1.vrfs.remove(self.vrf1)
+        self.assertFalse(self.device1.vrf_assignments.filter(vrf=self.vrf1).exists())
+
+    def test_can_remove_vrf_from_vm_after_clearing_interface(self):
+        """Removal from a virtual machine succeeds once the VRF is cleared from the interface."""
+        interface = self._vm_interface_with_vrf(self.vm1, self.vrf1)
+        interface.vrf = None
+        interface.save()
+        self.vm1.vrfs.remove(self.vrf1)
+        self.assertFalse(self.vm1.vrf_assignments.filter(vrf=self.vrf1).exists())
+
+    def test_deleting_device_not_blocked_by_interface_vrf(self):
+        """Cascade deletion of the parent Device is not blocked, even when an interface uses the VRF."""
+        self._device_interface_with_vrf(self.device2, self.vrf1)
+        self.device2.delete()
+        self.assertFalse(Device.objects.filter(pk=self.device2.pk).exists())
+
+    def test_deleting_vrf_not_blocked_by_interface_vrf(self):
+        """Cascade deletion of the VRF itself is not blocked, even when an interface uses it."""
+        self._device_interface_with_vrf(self.device1, self.vrf1)
+        self.vrf1.delete()
+        self.assertFalse(VRF.objects.filter(pk=self.vrf1.pk).exists())
 
 
 class TestVRF(ModelTestCases.BaseModelTestCase):

--- a/nautobot/virtualization/models.py
+++ b/nautobot/virtualization/models.py
@@ -386,6 +386,13 @@ class VMInterface(PrimaryModel, BaseInterface):
     def parent(self):
         return self.virtual_machine
 
+    def clean(self):
+        super().clean()
+
+        # VRF validation
+        if self.vrf and self.parent and self.vrf not in self.parent.vrfs.all():
+            raise ValidationError({"vrf": "VRF must be assigned to same Virtual Machine."})
+
     @property
     def ip_address_count(self):
         return self.ip_addresses.count()

--- a/nautobot/virtualization/tests/test_models.py
+++ b/nautobot/virtualization/tests/test_models.py
@@ -5,7 +5,7 @@ from nautobot.core.testing import TestCase
 from nautobot.dcim.models import Device, Location, LocationType
 from nautobot.extras.models import Role, Status
 from nautobot.ipam.factory import VLANGroupFactory
-from nautobot.ipam.models import IPAddress, IPAddressToInterface, VLAN
+from nautobot.ipam.models import IPAddress, IPAddressToInterface, VLAN, VRF
 from nautobot.tenancy.models import Tenant
 from nautobot.virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
 
@@ -138,6 +138,18 @@ class VMInterfaceTestCase(TestCase):  # TODO: change to BaseModelTestCase
         self.assertEqual(
             err.exception.message_dict["tagged_vlans"][0], "Mode must be set to tagged when specifying tagged_vlans"
         )
+
+    def test_vrf_must_be_assigned_to_parent_virtual_machine(self):
+        """A VM interface may only reference a VRF that is assigned to its parent virtual machine."""
+        vrf = VRF.objects.create(name="VM Interface VRF Test")
+        interface = VMInterface(virtual_machine=self.virtualmachine, name="Int VRF", status=self.int_status, vrf=vrf)
+        with self.assertRaises(ValidationError):
+            interface.validated_save()
+
+        # Assigning the VRF to the parent virtual machine makes the interface valid.
+        self.virtualmachine.vrfs.add(vrf)
+        interface.validated_save()
+        self.assertEqual(interface.vrf, vrf)
 
     def test_add_ip_addresses(self):
         """Test the `add_ip_addresses` helper method on `VMInterface`"""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #9149
# What's Changed

It is currently possible to remove a VRF from a Device or Virtual Machine regardless if that VRF is attached to any of the interfaces. This can cause bad data where an Interface cannot be saved any longer until you remove the VRF. In order to prevent this bad data from happening, this PR raises an error to prevent removing the VRF until it has been removed from all interfaces.

In addition, I noticed that although the UI did not allow selecting a VRF to a VM Interface if that VRF is not attached to the parent VM, there was not a similar validation for attaching it via API or ORM. This PR also adds this to be consistent with both the UI and how Device Interfaces work.

# Screenshots

## Attempting to remove a VRF from a Device

<img width="593" height="102" alt="Screenshot 2026-07-07 at 1 18 51 PM" src="https://github.com/user-attachments/assets/e954aa41-ac9f-4f9b-ae86-64e1a4d5d293" />

## Attempting to add a VRF to a VM Interface

```python
In [8]: interface.save()
---------------------------------------------------------------------------
RequestError                              Traceback (most recent call last)
Cell In[8], line 1
----> 1 interface.save()

File ~/pynautobot/pynautobot/core/response.py:461, in Record.save(self)
    452         serialized = self.serialize()
    453         req = Request(
    454             key=self.id,
    455             base=self.endpoint.url,
   (...)    459             filters=self.api.default_filters,
    460         )
--> 461         if req.patch({i: serialized[i] for i in diff}):
    462             return True
    464 return False

File ~/pynautobot/pynautobot/core/query.py:442, in Request.patch(self, data)
    428 def patch(self, data: dict) -> dict:
    429     """Makes a PATCH request to the Nautobot API.
    430
    431     Args:
   (...)    440         dict: The deserialized JSON response from the Nautobot API.
    441     """
--> 442     return self._make_call(verb="patch", data=data)

File ~/pynautobot/pynautobot/core/query.py:304, in Request._make_call(self, verb, url_override, add_params, data)
    302         raise ContentError(req) from exc
    303 else:
--> 304     raise RequestError(req)

RequestError: The request failed with code 400 Bad Request: {'vrf': ['VRF must be assigned to same Virtual Machine.']}
```

# Out of scope

In addition to this work, I noticed that we currently are lacking some validations for Virtual Device Contexts with regards to VRFs as well. I initially was going to roll those changes into this PR, but the logic was getting rather complex and I decided to shelve that work for now.

I believe we still need to document the expected limitations regarding VRFs when it comes to VDCs and their assigned interfaces so we can dictate exactly what we want to allow or block.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [N/A] Documentation Updates (when adding/changing features)
- [N/A] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
