### PR TITLE
Update data compliance rules documentation

### DIFF
--- a/changes/9201.documentation
+++ b/changes/9201.documentation
@@ -1,0 +1,1 @@
+Added documentation clarifying that `__init__.py` files are required in both the Git repository root and the `custom_validators/` folder for Data Compliance Rules to be discovered from a remote Git repository.

--- a/nautobot/docs/user-guide/feature-guides/data-compliance.md
+++ b/nautobot/docs/user-guide/feature-guides/data-compliance.md
@@ -48,7 +48,7 @@ There are two options for where to include these data compliance rule classes:
 
 #### Writing Data Compliance Rules in a Remote Git Repository
 
-A Git repository can be configured to add the `data compliance rules` context to store `DataComplianceRule` classes in source control. During the Git Repository Sync job, Nautobot looks for a folder in your repo called `custom_validators`, and any Python files within that folder containing classes that implement `DataComplianceRule` will be imported, as long as `custom_validators` contains a `__init.py__`. Another `__init.py__` must be included in the Git root folder as well, otherwise the sync job will not be able to import the data validation classes.
+A Git repository can be configured to add the `data compliance rules` context to store `DataComplianceRule` classes in source control. During the Git Repository Sync job, Nautobot looks for a folder in your repo called `custom_validators`, and any Python files within that folder containing classes that implement `DataComplianceRule` will be imported, as long as `custom_validators` contains a `__init__.py`. Another `__init__.py` must be included in the Git root folder as well, otherwise the sync job will not be able to import the data validation classes.
 
 Hence the correct/discoverable repo structure looks like this:
 

--- a/nautobot/docs/user-guide/feature-guides/data-compliance.md
+++ b/nautobot/docs/user-guide/feature-guides/data-compliance.md
@@ -48,7 +48,17 @@ There are two options for where to include these data compliance rule classes:
 
 #### Writing Data Compliance Rules in a Remote Git Repository
 
-A Git repository can be configured to add the `data compliance rules` context to store `DataComplianceRule` classes in source control. The app looks for a folder in your repo called `custom_validators`, and any Python files within that folder containing classes that implement `DataComplianceRule` will be imported. No code within the app itself needs to be added, changed, or modified.
+A Git repository can be configured to add the `data compliance rules` context to store `DataComplianceRule` classes in source control. During the Git Repository Sync job, Nautobot looks for a folder in your repo called `custom_validators`, and any Python files within that folder containing classes that implement `DataComplianceRule` will be imported, as long as `custom_validators` contains a `__init.py__`. Another `__init.py__` must be included in the Git root folder as well, otherwise the sync job will not be able to import the data validation classes.
+
+Hence the correct/discoverable repo structure looks like this:
+
+```shell
+.
+├── __init__.py
+├── custom_validators
+│   ├── __init__.py
+│   ├── my_data_compliance_rules.py
+```
 
 Below is a template data compliance rule class that would be stored in `custom_validators/my_data_compliance_rules.py` in a remote Git repository:
 


### PR DESCRIPTION
# Pull request overview

This PR introduces a small but important clarification in the documentation for [writing data compliance rules in a remote git repository](https://docs.nautobot.com/projects/core/en/stable/user-guide/feature-guides/data-compliance/?h=datacompliancerule#writing-data-compliance-rules-in-a-remote-git-repository).

The point the current documentation is not explaining properly is that the `custom_validators` folder containing the data compliance rules in the git repo needs the presence of `__init__.py` to be discoverable by the Git Repository Sync job. The same goes for the git root repo folder. Basically `__init__.py` must be present along the full path, i.e. in every subfolder until `custom_validators` is reached.

This has already proven to be a problem in NTC-6262.

## History

This change has been introduced in https://github.com/nautobot/nautobot/pull/7074 (2025-04-04), which had been shipped in Nautobot `v3.0.0`.  PR https://github.com/nautobot/nautobot/pull/7074, in turn, was a follow-up from https://github.com/nautobot/nautobot/pull/6866 whose goal was merging the data validation logic into core. 

Before https://github.com/nautobot/nautobot/pull/7074, it was still possible to import data validation rule classes without adding `__init__.py` all the way down to the `custom_validators` folder.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
