### PR TITLE
Fix firewall HA pair and firewall cluster config template examples

### DIFF
--- a/nautobot/docs/user-guide/core-data-model/dcim/deviceredundancygroup.md
+++ b/nautobot/docs/user-guide/core-data-model/dcim/deviceredundancygroup.md
@@ -395,7 +395,7 @@ The following [Design Builder](https://docs.nautobot.com/projects/design-builder
 The following query retrieves a device redundancy group by name, without needing to know any of the member hostnames up front. It is built to answer the "Questions to ask of the data model" below in a single call.
 
 !!! note
-    The `failover_links: interfaces(name__ie: "failover-link")` is a convention, this would work in a scenario where you defined your interface to be named `failover-link`. You can choose other methods (such as a tag or role) and would need ot update accordingly.
+    The `failover_links: interfaces(name__ie: "failover-link")` is a convention, this would work in a scenario where you defined your interface to be named `failover-link`. You can choose other methods (such as a tag or role) and would need to update accordingly.
 
 ```graphql
 query ($redundancy_group: [String]) {
@@ -635,29 +635,27 @@ Given the data model, what questions would a user ask?
 
 === "Firewall HA pair"
 
-    Operating systems and technologies include Palo Alto, Fortinet, and Cisco ASA
+    Operating systems and technologies include Palo Alto, Fortinet, and Cisco ASA. Cisco ASA is shown as the representative example; the same data model drives the equivalent Palo Alto (`high-availability`) and Fortinet (`config system ha`) stanzas.
 
     ```jinja2
     {% set group = data.device_redundancy_groups[0] %}
     {% set ordered = group.devices | sort(attribute="device_redundancy_group_priority", reverse=true) %}
     {% set primary = ordered | first %}
+    {% set secondary = ordered | last %}
     {% for device in ordered %}
-    {% set peer = group.devices | rejectattr("name", "equalto", device.name) | first %}
     # ~~~~~ {{ device.name }} ({{ "Primary/Active" if device.name == primary.name else "Secondary/Standby" }}) ~~~~~
 
     ## Failover Config
 
-    failover
     failover lan unit {{ "primary" if device.name == primary.name else "secondary" }}
-    {% for link in device.failover_links %}
-    failover lan interface FAILOVER {{ link.name }}
-    failover interface ip FAILOVER {{ link.ip_addresses[0].host }} {{ link.ip_addresses[0].mask_length | netmask }} standby {{ peer.failover_links[0].ip_addresses[0].host }}
-    {% endfor %}
+    failover lan interface FAILOVER {{ device.failover_links[0].name }}
+    failover interface ip FAILOVER {{ primary.failover_links[0].ip_addresses[0].host }} {{ primary.failover_links[0].ip_addresses[0].mask_length | netmask }} standby {{ secondary.failover_links[0].ip_addresses[0].host }}
+    failover
     {% endfor %}
     ```
 
     !!! note
-        The secondary unit receives the full running config from the primary after the failover link is established; interface IPs need not be set manually
+        The `failover interface ip` command is identical on both units — the active IP is always the primary's, and `standby` is always the secondary's. Only `failover lan unit` differs per device. Once the failover link is established, the secondary receives the full running config from the primary, so interface IPs need not be set manually.
 
 === "HA pairs"
 

--- a/nautobot/docs/user-guide/core-data-model/dcim/virtualchassis.md
+++ b/nautobot/docs/user-guide/core-data-model/dcim/virtualchassis.md
@@ -755,67 +755,51 @@ Given the data model, what questions would a user ask?
 
 === "Firewall Cluster"
 
-    Firewall Cluster Cisco FTD / SRX
+    Operating systems and technologies include Cisco Secure Firewall (FTD) and Juniper SRX. Cisco FTD inter-chassis clustering is shown as the representative example; the configuration is applied per chassis through the FXOS CLI (Firepower 4100/9300), which bootstraps the clustered FTD logical device. The same data model drives the equivalent Juniper SRX chassis cluster stanzas.
 
-    TODO: Is it FXOS or FTD??
-
-    A config template driven entirely by the GraphQL response above. The chassis `domain` becomes the cluster group id, the lowest-numbered member takes the `control` role, and each LAG becomes a CCL port channel built from its member interfaces.
+    A config template driven entirely by the GraphQL response above. Each member renders as its own chassis: its cluster control link (CCL) port channel is built from the member's own ports that reference the LAG, and the cluster bootstrap assigns `chassis-id` from `vc_position` with the chassis `domain` as the cluster group name.
 
     ```jinja2
     {% set vc = data.virtual_chassis[0] %}
-    ## Physical Interface Configuration
+    {% for member in vc.members %}
+    # ~~~~~ {{ member.name }} (chassis {{ member.vc_position }}) ~~~~~
 
+    ## Cluster Control Link (CCL) Port Channel Configuration
+
+    {% for lag_name in member.interfaces | selectattr("lag") | map(attribute="lag.name") | unique %}
     scope eth-uplink
       scope fabric a
-    {% for member in vc.members %}
-    {% for port in member.interfaces if port.lag %}
-        scope interface {{ port.name }}
+        create port-channel {{ lag_name | replace("Port-Channel", "") }}
           set port-type cluster
-          enable
-          exit
-    {% endfor %}
-    {% endfor %}
-        exit
-      exit
-    !
-    ## CCL Port Channel Configuration
-
-    {% for member in vc.members %}
-    {% for lag in member.interfaces if lag.type == "LAG" %}
-    scope eth-uplink
-      scope fabric a
-        create port-channel {{ lag.name | replace("Port-Channel", "") }}
           set port-channel-mode active
-    {% for m in vc.members %}
-    {% for port in m.interfaces if port.lag and port.lag.name == lag.name %}
+    {% for port in member.interfaces if port.lag and port.lag.name == lag_name %}
           create member-port {{ port.name }}
-    {% endfor %}
+            exit
     {% endfor %}
           exit
         exit
       exit
     {% endfor %}
-    {% endfor %}
-    !
+
     ## Logical Device (Cluster Bootstrap) Configuration
 
     scope ssa
-    {% for member in vc.members %}
-      scope slot {{ member.vc_position }}
-        scope app-instance ftd {{ vc.name }}
-          set cluster-group-id {{ vc.domain }}
-          set cluster-role {{ "control" if member.name == vc.master.name else "data" }}
+      enter logical-device {{ vc.name }} ftd 1 clustered
+        enter cluster-bootstrap
+          set chassis-id {{ member.vc_position }}
+          set cluster-group name {{ vc.domain }}
+          set mode spanned-etherchannel
           exit
         exit
-    {% endfor %}
       exit
+    {% endfor %}
     ```
 
-    > Note: `cluster-role` is set to `control` on the primary chassis slot and `data` on all others; `cluster-group-id` must match across all members
+    > Note: `set chassis-id` is unique per chassis (from `vc_position`); the cluster group name and the CCL port-channel ID must match on all chassis. Use dedicated high-bandwidth interfaces for the CCL.
 
-    > Note: The CCL port channel ID must match on both chassis; use dedicated high-bandwidth interfaces
+    > Note: The control/data role is not configured — the cluster elects the control unit when it forms. The Nautobot `master` field records which member is expected to hold the control role.
 
-The script below renders the templates against GrpahQL query. Paste the GraphQL query from the [GraphQL](#graphql) section into a variable called `GRAPHQL_QUERY`, and one of the three templates above into `CLI_CONFIG_TEMPLATE`. This script is a continuation of the prior script above and assumes the variables `nb`, `NAUTOBOT_URL`, and `NAUTOBOT_TOKEN` are already set.
+The script below renders the templates against GraphQL query. Paste the GraphQL query from the [GraphQL](#graphql) section into a variable called `GRAPHQL_QUERY`, and one of the three templates above into `CLI_CONFIG_TEMPLATE`. This script is a continuation of the prior script above and assumes the variables `nb`, `NAUTOBOT_URL`, and `NAUTOBOT_TOKEN` are already set.
 
 ??? example "Config Generation Script"
 


### PR DESCRIPTION
## What's Changed

Fixes correctness issues in the firewall example config templates on the device redundancy best-practices docs, verified by rendering each template against the sample GraphQL data in the docs.

### Firewall HA pair (ASA) — `deviceredundancygroup.md`

- The `failover interface ip` command now renders identically on both units — the active IP is always the primary's and `standby` is always the secondary's. Previously the secondary unit rendered the command inverted (its own IP as active), which would misconfigure a real failover pair.
- The `failover` enable command now renders last in the stanza; it must come after the LAN unit/interface/IP bootstrap.
- Intro now calls out Cisco ASA as the representative example for Palo Alto / Fortinet / ASA.
- Updated the note to explain the IP-symmetry rule and config sync behavior.

### Firewall Cluster (FTD/FXOS) — `virtualchassis.md`

- Resolved the `TODO: Is it FXOS or FTD??` — the example is the FXOS CLI (Firepower 4100/9300) bootstrapping a clustered FTD logical device; the intro now says so, keeping SRX in the technology list with FTD as the representative example.
- The template now renders per-chassis stanzas (each chassis is its own FXOS instance). Previously the CCL port channel mixed both chassis' physical ports into a single port-channel.
- Each chassis's CCL port channel is derived from its own ports' LAG references, so it renders correctly even though the LAG interface object lives on only one VC member in the sample data.
- `set port-type cluster` moved from the physical member interfaces to the port channel itself, matching FXOS behavior.
- Replaced the invalid `scope slot` / `set cluster-group-id` / `set cluster-role` bootstrap with a real `cluster-bootstrap` block (`set chassis-id` from `vc_position`, shared cluster group name, spanned-etherchannel mode). Notes now explain that the control role is elected, not configured.

### Typos

- `GrpahQL` → `GraphQL` (virtualchassis.md), `ot` → `to` (deviceredundancygroup.md).