### PR TITLE
Fix SSO SAML documentation and add SAML support to SSO group sync

### DIFF
--- a/changes/6834.documentation
+++ b/changes/6834.documentation
@@ -1,0 +1,1 @@
+Fixed the Okta SAML documentation example to set `requestedAuthnContext` via `SOCIAL_AUTH_SAML_SECURITY_CONFIG` instead of the unsupported per-IdP `requested_authn_context`, `force_authn`, and `allow_unsolicited` keys.

--- a/changes/6887.fixed
+++ b/changes/6887.fixed
@@ -1,0 +1,1 @@
+Fixed SSO group syncing to also read group attributes from SAML responses.

--- a/changes/978.documentation
+++ b/changes/978.documentation
@@ -1,0 +1,1 @@
+Added a warning to the SSO documentation that only a single SAML identity provider is supported at a time.

--- a/nautobot/docs/user-guide/administration/configuration/authentication/sso.md
+++ b/nautobot/docs/user-guide/administration/configuration/authentication/sso.md
@@ -193,7 +193,7 @@ AUTHENTICATION_BACKENDS = [
 SOCIAL_AUTH_SAML_SP_ENTITY_ID = "https://nautobot.example.com/"
 
 # X.509 cert/key pair used for host verification are not used for this example because
-# Nautobot is directly authenticating itself to Google. Set them to empty strings.
+# Nautobot is directly authenticating itself to Okta. Set them to empty strings.
 SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = ""
 SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = ""
 
@@ -232,14 +232,11 @@ OKTA_CERTIFICATE = "<Signing Certificate from Okta>"
 # for each provider that you app wants to support.
 SOCIAL_AUTH_SAML_ENABLED_IDPS = {
     "okta": {
-        'force_authn': "true",
-        'allow_unsolicited': "true",
-        'requested_authn_context': "false",
         "entity_id": OKTA_ENTITY_ID,
         "url": OKTA_SSO_URL,
         "x509cert": OKTA_CERTIFICATE,
-        # These are used to map to User object fields in Nautobot using Google
-        # attribute fields we configured in step 8 of "Setup SAML in Google".
+        # These are used to map to User object fields in Nautobot using the Okta
+        # attribute statements we configured in step 5 of "Setup SAML in Okta".
         "attr_user_permanent_id": "emailAddress",
         "attr_first_name": "firstName",
         "attr_last_name": "lastName",
@@ -248,17 +245,30 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS = {
     }
 }
 
+# Optional: SAML security settings, applied to all SAML requests. For example, setting
+# "requestedAuthnContext" to False lets the IdP decide how to authenticate the user,
+# so users with an active IdP session are not prompted for credentials again.
+SOCIAL_AUTH_SAML_SECURITY_CONFIG = {
+    "requestedAuthnContext": False,
+}
+
 # Required for correctly redirecting when behind SSL proxy (NGINX). You may or may not need
 # these depending on your production deployment. They are provided here just in case.
 SECURE_SSL_REDIRECT = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 ```
 
+!!! warning
+    Nautobot currently supports only a single SAML identity provider at a time. Only the first key defined in `SOCIAL_AUTH_SAML_ENABLED_IDPS` is used when building the login URL.
+
+!!! note
+    SAML security options (such as `requestedAuthnContext`) are configured in `SOCIAL_AUTH_SAML_SECURITY_CONFIG` and apply to all configured identity providers. These settings are passed through to the underlying [`python3-saml`](https://github.com/SAML-Toolkits/python3-saml) library; the full list of available options is documented under the `security` key in the [python3-saml settings documentation](https://github.com/SAML-Toolkits/python3-saml#settings).
+
 #### Login with Okta SAML
 
 Note the provider entry we configured in SOCIAL_AUTH_SAML_ENABLED_IDPS as okta. This will be used to login and will be referenced in the query parameter using idp=okta. For example /login/saml/?idp=okta.
 
-This should be the URL that is mapped to the "Log in" button on the top right of the index page when you navigate to Nautobot in your browser. Clicking this link should automatically redirect you to Google, ask you to "Choose an account", log you in and redirect you back to the Nautobot home page. Your email address will also be your username.
+This should be the URL that is mapped to the "Log in" button on the top right of the index page when you navigate to Nautobot in your browser. Clicking this link should automatically redirect you to Okta, log you in and redirect you back to the Nautobot home page. Your email address will also be your username.
 
 Be sure to configure EXTERNAL_AUTH_DEFAULT_GROUPS and EXTERNAL_AUTH_DEFAULT_PERMISSIONS next.
 
@@ -438,6 +448,9 @@ SECURE_SSL_REDIRECT = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 ```
 
+!!! warning
+    Nautobot currently supports only a single SAML identity provider at a time. Only the first key defined in `SOCIAL_AUTH_SAML_ENABLED_IDPS` is used when building the login URL.
+
 ##### Enable SAML in Google
 
 Now that you've configured both Google and Nautobot for SAML, you still need to enable SAML for your users in your Google domain.
@@ -553,6 +566,10 @@ A group syncing function is provided and but needs to be configured. See [Group 
     You may need to set `UWSGI_BUFFER_SIZE` to something bigger than the default 4096 bytes in the UWSGI config if you are seeing errors like `invalid request block size` in your application logs (see [here](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#buffer-size) for more information)
 
 ## Group Syncing
+
+Nautobot can synchronize a user's group memberships from the SSO response each time they log in, and optionally flag members of specific groups as staff or superusers. This works with OAuth2/OIDC providers, where the group claim appears at the top level of the response, as well as with SAML providers, where the group attribute is nested under the SAML assertion's attributes.
+
++++ 3.1.8 "SAML support"
 
 To do so `nautobot.extras.group_sync.group_sync` must be part of `SOCIAL_AUTH_PIPELINE` which can be achieved
 by setting the environment variable `NAUTOBOT_SSO_ENABLE_GROUP_SYNC` to `true`. Or by setting

--- a/nautobot/docs/user-guide/administration/configuration/authentication/sso.md
+++ b/nautobot/docs/user-guide/administration/configuration/authentication/sso.md
@@ -569,7 +569,7 @@ A group syncing function is provided and but needs to be configured. See [Group 
 
 Nautobot can synchronize a user's group memberships from the SSO response each time they log in, and optionally flag members of specific groups as staff or superusers. This works with OAuth2/OIDC providers, where the group claim appears at the top level of the response, as well as with SAML providers, where the group attribute is nested under the SAML assertion's attributes.
 
-+++ 3.1.8 "SAML support"
++++ 3.2.2 "SAML support"
 
 To do so `nautobot.extras.group_sync.group_sync` must be part of `SOCIAL_AUTH_PIPELINE` which can be achieved
 by setting the environment variable `NAUTOBOT_SSO_ENABLE_GROUP_SYNC` to `true`. Or by setting

--- a/nautobot/extras/group_sync.py
+++ b/nautobot/extras/group_sync.py
@@ -1,4 +1,4 @@
-"""Additional functions to process an OAuth2/OIDC user."""
+"""Additional functions to process an SSO (OAuth2/OIDC/SAML) user."""
 
 import logging
 
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 CLAIMS_GROUP_NAME = getattr(settings, "SSO_CLAIMS_GROUP", "groups")
-""" Which claim to look at in the OAuth2/OIDC response
+""" Which claim to look at in the SSO response
 
     For Okta you can look at `Okta -> Authorization Servers -> Claims`. And a reasonable
     default is "groups". For Azure a reasonable default is "roles".
@@ -20,9 +20,15 @@ STAFF_GROUPS = getattr(settings, "SSO_STAFF_GROUPS", [])
 
 
 def group_sync(uid, user=None, response=None, *args, **kwargs):
-    """Sync the users groups from OAuth2/OIDC auth and set staff/superuser as appropriate."""
-    if user and response and CLAIMS_GROUP_NAME and response.get(CLAIMS_GROUP_NAME, False):
+    """Sync the users groups from SSO (OAuth2/OIDC/SAML) auth and set staff/superuser as appropriate."""
+    group_memberships = None
+    if user and response and CLAIMS_GROUP_NAME:
+        # OAuth2/OIDC responses carry group claims at the top level of the response
         group_memberships = response.get(CLAIMS_GROUP_NAME)
+        if not group_memberships and isinstance(response.get("attributes"), dict):
+            # SAML responses nest the assertion attributes under the "attributes" key
+            group_memberships = response["attributes"].get(CLAIMS_GROUP_NAME)
+    if group_memberships:
         is_staff = False
         is_superuser = False
         logger.debug(f"User {uid} is a member of {', '.join(group_memberships)}")
@@ -39,4 +45,4 @@ def group_sync(uid, user=None, response=None, *args, **kwargs):
         user.is_staff = is_staff
         user.save()
     else:
-        logger.debug(f"Did not receive groups from OAuth2/OIDC, response: {response}")
+        logger.debug(f"Did not receive groups from SSO, response: {response}")

--- a/nautobot/extras/tests/test_group_sync.py
+++ b/nautobot/extras/tests/test_group_sync.py
@@ -1,0 +1,74 @@
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import TestCase
+
+from nautobot.extras.group_sync import group_sync
+
+User = get_user_model()
+
+
+@mock.patch("nautobot.extras.group_sync.SUPERUSER_GROUPS", ["nautobot_admin"])
+@mock.patch("nautobot.extras.group_sync.STAFF_GROUPS", ["nautobot_admin", "nautobot_staff"])
+class GroupSyncTestCase(TestCase):
+    """Tests for the SSO group_sync pipeline function."""
+
+    def setUp(self):
+        self.user = User.objects.create(username="ssouser")
+
+    def test_oauth2_oidc_response(self):
+        """Group claims at the top level of the response (OAuth2/OIDC) are synced."""
+        response = {"groups": ["ops", "nautobot_admin"]}
+
+        group_sync("ssouser", user=self.user, response=response)
+
+        self.user.refresh_from_db()
+        self.assertEqual(
+            sorted(self.user.groups.values_list("name", flat=True)),
+            ["nautobot_admin", "ops"],
+        )
+        self.assertTrue(self.user.is_superuser)
+        self.assertTrue(self.user.is_staff)
+
+    def test_saml_response(self):
+        """Group attributes nested under "attributes" (SAML) are synced. Regression test for #6887."""
+        response = {"attributes": {"groups": ["ops", "nautobot_staff"]}}
+
+        group_sync("ssouser", user=self.user, response=response)
+
+        self.user.refresh_from_db()
+        self.assertEqual(
+            sorted(self.user.groups.values_list("name", flat=True)),
+            ["nautobot_staff", "ops"],
+        )
+        self.assertFalse(self.user.is_superuser)
+        self.assertTrue(self.user.is_staff)
+
+    def test_top_level_claim_preferred_over_saml_attributes(self):
+        """When both shapes are present, the top-level claim wins."""
+        response = {"groups": ["ops"], "attributes": {"groups": ["nautobot_admin"]}}
+
+        group_sync("ssouser", user=self.user, response=response)
+
+        self.user.refresh_from_db()
+        self.assertEqual(list(self.user.groups.values_list("name", flat=True)), ["ops"])
+        self.assertFalse(self.user.is_superuser)
+
+    def test_response_without_groups(self):
+        """A response without any group claims leaves the user unchanged."""
+        self.user.groups.add(Group.objects.create(name="existing"))
+
+        group_sync("ssouser", user=self.user, response={"attributes": {"other": "value"}})
+
+        self.user.refresh_from_db()
+        self.assertEqual(list(self.user.groups.values_list("name", flat=True)), ["existing"])
+        self.assertFalse(self.user.is_superuser)
+        self.assertFalse(self.user.is_staff)
+
+    def test_no_response(self):
+        """A missing response does not raise and leaves the user unchanged."""
+        group_sync("ssouser", user=self.user, response=None)
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.groups.count(), 0)


### PR DESCRIPTION
# Closes #978, #6834, and #6887

# What's Changed

- Documented that only a single SAML identity provider is supported at a time. (#978)
- Fixed the Okta SAML example to set `requestedAuthnContext` via `SOCIAL_AUTH_SAML_SECURITY_CONFIG` instead of unsupported per-IdP keys, and cleaned up copy-paste artifacts from the Google example. (#6834)
- Fixed SSO group syncing to also read group attributes from SAML responses, which nest them under the `attributes` key, and added unit tests for `group_sync()` including a regression test. (#6887)

# Screenshots

N/A: documentation and pipeline function changes, no UI changes.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design