### PR TITLE
Update homepage object counts to display with commas

### DIFF
--- a/changes/9210.changed
+++ b/changes/9210.changed
@@ -1,0 +1,1 @@
+Object counts on the home page are now displayed with thousands separators (e.g., `1,009,518`).

--- a/nautobot/core/settings.py
+++ b/nautobot/core/settings.py
@@ -719,6 +719,11 @@ AUTHENTICATION_BACKENDS = [
 LANGUAGE_CODE = "en-us"
 USE_I18N = True
 USE_TZ = True
+# Group numbers into thousands (e.g. 1,009,518) for filters that force grouping such as `intcomma`.
+# Because our FORMAT_MODULE_PATH stub proxies format lookups to settings, this would otherwise fall
+# back to Django's default of 0, which disables grouping. USE_THOUSAND_SEPARATOR remains False, so
+# general number rendering is unaffected.
+NUMBER_GROUPING = 3
 
 # WSGI
 WSGI_APPLICATION = "nautobot.core.wsgi.application"

--- a/nautobot/core/templates/home.html
+++ b/nautobot/core/templates/home.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load helpers %}
+{% load humanize %}
 {% load registry %}
 
 {# TODO: Figure out better solution: this is a quick hack to remove "chevrons" from homepage because in this commit I'm adding the chevrons in base_django.html #}
@@ -91,7 +92,7 @@
                                 {% if request.user|has_one_or_more_perms:item_details.permissions %}
                                     <li class="list-group-item" data-item-weight="{{ item_details.weight }}">
                                         {% if request.user|has_perms:item_details.permissions %}
-                                            <span class="badge bg-primary float-end my-1">{{ item_details.count }}</span>
+                                            <span class="badge bg-primary float-end my-1">{{ item_details.count|intcomma }}</span>
                                             <h4 class="fw-normal lh-base">
                                                     {% comment %}
                                                         Use 'url xxx as variable' so that an invalid
@@ -122,7 +123,7 @@
                                                         {{ group_item_details.rendered_html }}
                                                     {% endautoescape %}
                                                 {% else %}
-                                                    <span class="badge bg-primary float-end mt-4">{{ group_item_details.count }}</span>
+                                                    <span class="badge bg-primary float-end mt-4">{{ group_item_details.count|intcomma }}</span>
                                                     <p class="mb-0 mt-4 ps-20">
                                                             {% comment %}
                                                                 Use 'url xxx as variable' so that an invalid

--- a/nautobot/core/tests/test_settings_schema.py
+++ b/nautobot/core/tests/test_settings_schema.py
@@ -150,6 +150,7 @@ class SettingsJSONSchemaTestCase(TestCase):
             "MESSAGE_STORAGE",
             "MESSAGE_TAGS",
             "MIDDLEWARE",
+            "NUMBER_GROUPING",
             "PROMETHEUS_EXPORT_MIGRATIONS",
             "REST_FRAMEWORK",
             "REST_FRAMEWORK_ALLOWED_VERSIONS",


### PR DESCRIPTION
# Closes #9210

# What's Changed

Object counts displayed next to items on the home page are now formatted with thousands separators for readability. A count that previously rendered as `1009518` now renders as `1,009,518`.

This is achieved by loading Django's built-in `humanize` template tags in `home.html` and applying the `intcomma` filter to the count badges (both the top-level item counts and the grouped sub-item counts, so every badge on the page is consistent). `django.contrib.humanize` is already present in `INSTALLED_APPS`.

On its own, `intcomma` returned the number unchanged in Nautobot: because Nautobot sets a custom `FORMAT_MODULE_PATH`, the active locale leaves `NUMBER_GROUPING` at Django's default of `0`, which disables digit grouping even for filters that force it. Rather than working around this per-call, the fix sets `NUMBER_GROUPING = 3` in `nautobot/core/settings.py` so `intcomma` (and any other caller that forces grouping) works at the source. Because `USE_THOUSAND_SEPARATOR` remains `False`, general number rendering across the app is unaffected — only callers that explicitly force grouping are impacted.

This is effectively a **display-only** change — the count values themselves are unchanged, and the only non-template change is enabling digit grouping in settings.

# Screenshots

**Before:** _Location count showing `10000`_

<img width="762" height="461" alt="image" src="https://github.com/user-attachments/assets/931ee27d-9ef4-4c64-90bc-a142b7306487" />

**After:** _Location count showing `10,000`_
<img width="653" height="442" alt="image" src="https://github.com/user-attachments/assets/e49f5b66-ee43-4122-8c27-64ac9437cc28" />

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests — _N/A; display-only change (see note below)_
- [x] Documentation Updates — _N/A; no feature added or changed_
- [x] Example App Updates — _N/A_
- [x] Outline Remaining Work, Constraints from Design

> **Note on testing:** This is a purely presentational change (applying the `intcomma` template filter, plus enabling `NUMBER_GROUPING`). Asserting the comma formatting in a test would require a model with ≥1,000 objects or mocking the homepage registry counts, since `intcomma` leaves values under 1,000 unchanged. Given there is no logic branching, no automated test was added.
