### PR TITLE
Add Job source_version and Log on Run

### DIFF
--- a/changes/7494.added
+++ b/changes/7494.added
@@ -1,0 +1,3 @@
+Added `source_version` property to the `Job` model, exposing the version of the source code providing the job — the Nautobot version for system Jobs, the App version for App-provided Jobs, or the `current_head` commit hash for Jobs provided by a Git repository.
+Added a debug-level log entry recording the Job's source version at the start of each Job run.
+Added display of the Job source version to the Job detail view and as an optional column on the Jobs list view.

--- a/changes/7494.added
+++ b/changes/7494.added
@@ -1,3 +1,3 @@
 Added `source_version` property to the `Job` model, exposing the version of the source code providing the job — the Nautobot version for system Jobs, the App version for App-provided Jobs, or the `current_head` commit hash for Jobs provided by a Git repository.
-Added a debug-level log entry recording the Job's source version at the start of each Job run.
+Added the Job's source version to the "Running job" log entry recorded at the start of each Job run.
 Added display of the Job source version to the Job detail view and as an optional column on the Jobs list view.

--- a/nautobot/docs/user-guide/platform-functionality/jobs/models.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/models.md
@@ -14,6 +14,7 @@ For any given Job record, most of its fields are populated initially from data d
 Records of this type store the following data as read-only (not modifiable via the UI or REST API):
 
 * The source of the job (local installation, Git repository, App)
+* The version of the source code providing the job (`source_version`) — the Nautobot version for system Jobs, the App version for App-provided Jobs, or the Git commit hash for Jobs provided by a Git repository
 * The name of the module containing the Job class
 * The name of the Job class
 * Whether the job class is installed presently

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1324,9 +1324,8 @@ def _prepare_job(job_class_path, request, kwargs) -> tuple[Job, dict]:
     if not job.job_model.has_sensitive_variables:
         event_payload["job_kwargs"] = kwargs
     publish_event(topic="nautobot.jobs.job.started", payload=event_payload)
-    job.logger.info("Running job", extra={"grouping": "initialization", "object": job.job_model})
-    job.logger.debug(
-        "Job source version: %s",
+    job.logger.info(
+        "Running job (source version: %s)",
         job.job_model.source_version or "unknown",
         extra={"grouping": "initialization", "object": job.job_model},
     )

--- a/nautobot/extras/jobs.py
+++ b/nautobot/extras/jobs.py
@@ -1325,6 +1325,11 @@ def _prepare_job(job_class_path, request, kwargs) -> tuple[Job, dict]:
         event_payload["job_kwargs"] = kwargs
     publish_event(topic="nautobot.jobs.job.started", payload=event_payload)
     job.logger.info("Running job", extra={"grouping": "initialization", "object": job.job_model})
+    job.logger.debug(
+        "Job source version: %s",
+        job.job_model.source_version or "unknown",
+        extra={"grouping": "initialization", "object": job.job_model},
+    )
 
     # Return the job, ready to run
     return job, event_payload

--- a/nautobot/extras/models/jobs.py
+++ b/nautobot/extras/models/jobs.py
@@ -10,6 +10,7 @@ from typing import Optional, TYPE_CHECKING, Union
 from billiard.exceptions import SoftTimeLimitExceeded
 from celery.exceptions import NotRegistered
 from celery.utils.log import get_logger, LoggingProxy
+from django.apps import apps
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
@@ -337,6 +338,29 @@ class Job(PrimaryModel):
             return GitRepository.objects.get(slug=self.module_name.split(".")[0])
         except GitRepository.DoesNotExist:
             return None
+
+    @property
+    def source_version(self) -> str:
+        """
+        Version of the source code that provides this Job, derived from the Job's source.
+
+        - System Jobs (`module_name` in the `nautobot.` namespace): the Nautobot version (`settings.VERSION`).
+        - App-provided Jobs (top-level module in `settings.PLUGINS`): the App's declared `version`, if any.
+        - Git-repository-provided Jobs: the owning GitRepository's `current_head` commit hash
+          (empty string if the repository has never been synced).
+        - `JOBS_ROOT` Jobs: an empty string, as no version information is available.
+
+        Sources are checked in the same order of precedence as `nautobot.extras.jobs.get_job()`:
+        system, then App, then Git repository.
+        """
+        if self.module_name.startswith("nautobot."):
+            return settings.VERSION
+        module_root = self.module_name.split(".")[0]
+        if module_root in settings.PLUGINS:
+            return apps.get_app_config(module_root).version or ""
+        if self.git_repository is not None:
+            return self.git_repository.current_head
+        return ""
 
     @property
     def job_task(self):

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from textwrap import dedent
 
 from django.contrib.contenttypes.models import ContentType
@@ -1126,12 +1127,12 @@ def log_entry_color_css(record):
 
 class JobTable(BaseTable):
     pk = ToggleColumn()
-    source = tables.Column()
     # grouping is used to, well, group the Jobs, so it isn't a column of its own.
     name = tables.Column(
         attrs={"a": {"class": "job_run", "title": "Run/Schedule"}},
         linkify=("extras:job_run", {"pk": tables.A("pk")}),
     )
+    source_version = tables.Column(orderable=False)
     installed = BooleanColumn()
     enabled = BooleanColumn()
     has_sensitive_variables = BooleanColumn()
@@ -1175,13 +1176,19 @@ class JobTable(BaseTable):
             value,
         )
 
+    def render_source_version(self, value):
+        """Abbreviate Git commit hashes to their familiar short form, with the full hash as hover text."""
+        if re.fullmatch(r"[0-9a-fA-F]{20,}", value):
+            return format_html('<span title="{}">{}</span>', value, value[:7])
+        return value
+
     class Meta(BaseTable.Meta):
         model = JobModel
         orderable = False
         fields = (
             "pk",
-            "source",
             "name",
+            "source_version",
             "installed",
             "enabled",
             "has_sensitive_variables",

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -693,6 +693,19 @@ class JobTransactionTest(TransactionTestCase):
             ).exists()
         )
 
+        # With a resolvable source version (e.g. a Git-repository-provided job), the version itself is logged
+        with mock.patch.object(models.Job, "source_version", new_callable=mock.PropertyMock) as mock_source_version:
+            mock_source_version.return_value = "0123456789abcdef0123456789abcdef01234567"
+            job_result = create_job_result_and_run_job(module, name)
+        self.assertTrue(
+            models.JobLogEntry.objects.filter(
+                job_result=job_result,
+                log_level=LogLevelChoices.LOG_INFO,
+                grouping="initialization",
+                message="Running job (source version: 0123456789abcdef0123456789abcdef01234567)",
+            ).exists()
+        )
+
     def test_job_pass(self):
         """
         Job test with pass result.

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -679,16 +679,19 @@ class JobTransactionTest(TransactionTestCase):
         )
 
     def test_job_run_logs_source_version(self):
-        """Every job run records a debug-level log entry with the job's source version."""
+        """The "Running job" log entry at the start of each job run includes the job's source version."""
         module = "pass_job"
         name = "TestPassJob"
         job_result = create_job_result_and_run_job(module, name)
-        log_debug = models.JobLogEntry.objects.filter(
-            job_result=job_result, log_level=LogLevelChoices.LOG_DEBUG, grouping="initialization"
-        ).first()
-        self.assertIsNotNone(log_debug)
-        # pass_job is a JOBS_ROOT-style job, so no version information is available
-        self.assertEqual(log_debug.message, "Job source version: unknown")
+        self.assertTrue(
+            models.JobLogEntry.objects.filter(
+                job_result=job_result,
+                log_level=LogLevelChoices.LOG_INFO,
+                grouping="initialization",
+                # pass_job is a JOBS_ROOT-style job, so no version information is available
+                message="Running job (source version: unknown)",
+            ).exists()
+        )
 
     def test_job_pass(self):
         """
@@ -802,9 +805,8 @@ class JobTransactionTest(TransactionTestCase):
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job log messages were saved
         job_logs = models.JobLogEntry.objects.filter(job_result=job_result).values_list("message", flat=True)
-        self.assertEqual(len(job_logs), 4)
-        self.assertIn("Running job", job_logs)
-        self.assertIn("Job source version: unknown", job_logs)
+        self.assertEqual(len(job_logs), 3)
+        self.assertIn("Running job (source version: unknown)", job_logs)
         self.assertIn("Job succeeded.", job_logs)
         self.assertIn("Job completed", job_logs)
         self.assertNotIn("Job failed, all database changes have been rolled back.", job_logs)
@@ -821,9 +823,8 @@ class JobTransactionTest(TransactionTestCase):
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job console text were saved
         job_console_logs = models.JobConsoleEntry.objects.filter(job_result=job_result).values_list("text", flat=True)
-        self.assertEqual(len(job_console_logs), 4)
-        self.assertIn("Running job", job_console_logs)
-        self.assertIn("Job source version: unknown", job_console_logs)
+        self.assertEqual(len(job_console_logs), 3)
+        self.assertIn("Running job (source version: unknown)", job_console_logs)
         self.assertIn("Job succeeded.", job_console_logs)
         self.assertIn("Job completed", job_console_logs)
         self.assertNotIn("Job failed, all database changes have been rolled back.", job_console_logs)
@@ -840,9 +841,8 @@ class JobTransactionTest(TransactionTestCase):
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job log messages were saved
         job_logs = models.JobLogEntry.objects.filter(job_result=job_result).values_list("message", flat=True)
-        self.assertEqual(len(job_logs), 4)
-        self.assertIn("Running job", job_logs)
-        self.assertIn("Job source version: unknown", job_logs)
+        self.assertEqual(len(job_logs), 3)
+        self.assertIn("Running job (source version: unknown)", job_logs)
         self.assertIn("Job succeeded.", job_logs)
         self.assertIn("Job completed", job_logs)
         self.assertNotIn("Job failed, all database changes have been rolled back.", job_logs)
@@ -859,9 +859,8 @@ class JobTransactionTest(TransactionTestCase):
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job console text were saved
         job_console_logs = models.JobConsoleEntry.objects.filter(job_result=job_result).values_list("text", flat=True)
-        self.assertEqual(len(job_console_logs), 4)
-        self.assertIn("Running job", job_console_logs)
-        self.assertIn("Job source version: unknown", job_console_logs)
+        self.assertEqual(len(job_console_logs), 3)
+        self.assertIn("Running job (source version: unknown)", job_console_logs)
         self.assertIn("Job succeeded.", job_console_logs)
         self.assertIn("Job completed", job_console_logs)
         self.assertNotIn("Job failed, all database changes have been rolled back.", job_console_logs)
@@ -878,9 +877,8 @@ class JobTransactionTest(TransactionTestCase):
         self.assertFalse(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job log messages were saved
         job_logs = models.JobLogEntry.objects.filter(job_result=job_result).values_list("message", flat=True)
-        self.assertEqual(len(job_logs), 3)
-        self.assertIn("Running job", job_logs)
-        self.assertIn("Job source version: unknown", job_logs)
+        self.assertEqual(len(job_logs), 2)
+        self.assertIn("Running job (source version: unknown)", job_logs)
         self.assertIn("Job failed, all database changes have been rolled back.", job_logs)
         self.assertNotIn("Job succeeded.", job_logs)
 
@@ -896,9 +894,8 @@ class JobTransactionTest(TransactionTestCase):
         self.assertFalse(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job console text were saved
         job_console_logs = models.JobConsoleEntry.objects.filter(job_result=job_result).values_list("text", flat=True)
-        self.assertEqual(len(job_console_logs), 3)
-        self.assertIn("Running job", job_console_logs)
-        self.assertIn("Job source version: unknown", job_console_logs)
+        self.assertEqual(len(job_console_logs), 2)
+        self.assertIn("Running job (source version: unknown)", job_console_logs)
         self.assertIn("Job failed, all database changes have been rolled back.", job_console_logs)
         self.assertNotIn("Job succeeded.", job_console_logs)
 
@@ -914,9 +911,8 @@ class JobTransactionTest(TransactionTestCase):
         self.assertFalse(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job log messages were saved
         job_logs = models.JobLogEntry.objects.filter(job_result=job_result).values_list("message", flat=True)
-        self.assertEqual(len(job_logs), 3)
-        self.assertIn("Running job", job_logs)
-        self.assertIn("Job source version: unknown", job_logs)
+        self.assertEqual(len(job_logs), 2)
+        self.assertIn("Running job (source version: unknown)", job_logs)
         self.assertIn("Job failed, all database changes have been rolled back.", job_logs)
         self.assertNotIn("Job succeeded.", job_logs)
 
@@ -932,9 +928,8 @@ class JobTransactionTest(TransactionTestCase):
         self.assertFalse(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job console text were saved
         job_console_logs = models.JobConsoleEntry.objects.filter(job_result=job_result).values_list("text", flat=True)
-        self.assertEqual(len(job_console_logs), 3)
-        self.assertIn("Running job", job_console_logs)
-        self.assertIn("Job source version: unknown", job_console_logs)
+        self.assertEqual(len(job_console_logs), 2)
+        self.assertIn("Running job (source version: unknown)", job_console_logs)
         self.assertIn("Job failed, all database changes have been rolled back.", job_console_logs)
         self.assertNotIn("Job succeeded.", job_console_logs)
 
@@ -1035,8 +1030,7 @@ class JobTransactionTest(TransactionTestCase):
 
         self.assertGreater(job_result.job_log_entries.count(), 0)
         self.assertIsNotNone(job_result.debug_log_count)
-        # 1 = the "Job source version" entry logged at the start of every job run
-        self.assertEqual(job_result.debug_log_count, 1)
+        self.assertEqual(job_result.debug_log_count, 0)
         self.assertIsNotNone(job_result.success_log_count)
         self.assertEqual(job_result.success_log_count, 1)
         self.assertIsNotNone(job_result.info_log_count)
@@ -1684,8 +1678,7 @@ class JobHookTransactionTest(TransactionTestCase):  # TODO: BaseModelTestCase mi
         job_result = models.JobResult.objects.filter(job_model=self.job_model).first()
         self.assertIsNotNone(job_result)
         expected_log_messages = [
-            ("info", "Running job"),
-            ("debug", "Job source version: unknown"),
+            ("info", "Running job (source version: unknown)"),
             ("info", f"change: DCIM | location Test Job Hook Location 1 created by {self.user.username}"),
             ("info", "action: create"),
             ("info", f"jobresult.user: {self.user.username}"),
@@ -1711,8 +1704,7 @@ class JobHookTransactionTest(TransactionTestCase):  # TODO: BaseModelTestCase mi
         job_result = models.JobResult.objects.filter(job_model=self.job_model).first()
         self.assertIsNotNone(job_result)
         expected_log_messages = [
-            ("info", "Running job"),
-            ("debug", "Job source version: unknown"),
+            ("info", "Running job (source version: unknown)"),
             ("info", f"change: DCIM | location Test Job Hook Location 1 updated by {self.user.username}"),
             ("info", "action: update"),
             ("info", f"jobresult.user: {self.user.username}"),
@@ -1920,7 +1912,7 @@ class RunConsoleLogJobTestCase(CelerySubprocessTestCase):
             "text", flat=True
         )
         expected_logs = [
-            "Running job",  # from _prepare_job
+            "Running job (source version: unknown)",  # from _prepare_job
             "before_start() was called as expected",  # from TestPassJob
             "Success",  # from TestPassJob
             "on_success() was called as expected",  # from TestPassJob
@@ -1949,7 +1941,7 @@ class RunConsoleLogJobTestCase(CelerySubprocessTestCase):
         )
 
         expected_logs = [
-            "Running job",  # from _prepare_job
+            "Running job (source version: unknown)",  # from _prepare_job
             "before_start() was called as expected",  # from TestFailJob
             "I'm a test job that fails!",  # from TestFailJob
             "on_failure() was called as expected",  # from TestFailJob

--- a/nautobot/extras/tests/test_jobs.py
+++ b/nautobot/extras/tests/test_jobs.py
@@ -678,6 +678,18 @@ class JobTransactionTest(TransactionTestCase):
             "This job will fail silently after 5.0 seconds.",
         )
 
+    def test_job_run_logs_source_version(self):
+        """Every job run records a debug-level log entry with the job's source version."""
+        module = "pass_job"
+        name = "TestPassJob"
+        job_result = create_job_result_and_run_job(module, name)
+        log_debug = models.JobLogEntry.objects.filter(
+            job_result=job_result, log_level=LogLevelChoices.LOG_DEBUG, grouping="initialization"
+        ).first()
+        self.assertIsNotNone(log_debug)
+        # pass_job is a JOBS_ROOT-style job, so no version information is available
+        self.assertEqual(log_debug.message, "Job source version: unknown")
+
     def test_job_pass(self):
         """
         Job test with pass result.
@@ -790,8 +802,9 @@ class JobTransactionTest(TransactionTestCase):
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job log messages were saved
         job_logs = models.JobLogEntry.objects.filter(job_result=job_result).values_list("message", flat=True)
-        self.assertEqual(len(job_logs), 3)
+        self.assertEqual(len(job_logs), 4)
         self.assertIn("Running job", job_logs)
+        self.assertIn("Job source version: unknown", job_logs)
         self.assertIn("Job succeeded.", job_logs)
         self.assertIn("Job completed", job_logs)
         self.assertNotIn("Job failed, all database changes have been rolled back.", job_logs)
@@ -808,8 +821,9 @@ class JobTransactionTest(TransactionTestCase):
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job console text were saved
         job_console_logs = models.JobConsoleEntry.objects.filter(job_result=job_result).values_list("text", flat=True)
-        self.assertEqual(len(job_console_logs), 3)
+        self.assertEqual(len(job_console_logs), 4)
         self.assertIn("Running job", job_console_logs)
+        self.assertIn("Job source version: unknown", job_console_logs)
         self.assertIn("Job succeeded.", job_console_logs)
         self.assertIn("Job completed", job_console_logs)
         self.assertNotIn("Job failed, all database changes have been rolled back.", job_console_logs)
@@ -826,8 +840,9 @@ class JobTransactionTest(TransactionTestCase):
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job log messages were saved
         job_logs = models.JobLogEntry.objects.filter(job_result=job_result).values_list("message", flat=True)
-        self.assertEqual(len(job_logs), 3)
+        self.assertEqual(len(job_logs), 4)
         self.assertIn("Running job", job_logs)
+        self.assertIn("Job source version: unknown", job_logs)
         self.assertIn("Job succeeded.", job_logs)
         self.assertIn("Job completed", job_logs)
         self.assertNotIn("Job failed, all database changes have been rolled back.", job_logs)
@@ -844,8 +859,9 @@ class JobTransactionTest(TransactionTestCase):
         self.assertTrue(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job console text were saved
         job_console_logs = models.JobConsoleEntry.objects.filter(job_result=job_result).values_list("text", flat=True)
-        self.assertEqual(len(job_console_logs), 3)
+        self.assertEqual(len(job_console_logs), 4)
         self.assertIn("Running job", job_console_logs)
+        self.assertIn("Job source version: unknown", job_console_logs)
         self.assertIn("Job succeeded.", job_console_logs)
         self.assertIn("Job completed", job_console_logs)
         self.assertNotIn("Job failed, all database changes have been rolled back.", job_console_logs)
@@ -862,8 +878,9 @@ class JobTransactionTest(TransactionTestCase):
         self.assertFalse(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job log messages were saved
         job_logs = models.JobLogEntry.objects.filter(job_result=job_result).values_list("message", flat=True)
-        self.assertEqual(len(job_logs), 2)
+        self.assertEqual(len(job_logs), 3)
         self.assertIn("Running job", job_logs)
+        self.assertIn("Job source version: unknown", job_logs)
         self.assertIn("Job failed, all database changes have been rolled back.", job_logs)
         self.assertNotIn("Job succeeded.", job_logs)
 
@@ -879,8 +896,9 @@ class JobTransactionTest(TransactionTestCase):
         self.assertFalse(models.Status.objects.filter(name="Test database atomic rollback 1").exists())
         # Ensure the correct job console text were saved
         job_console_logs = models.JobConsoleEntry.objects.filter(job_result=job_result).values_list("text", flat=True)
-        self.assertEqual(len(job_console_logs), 2)
+        self.assertEqual(len(job_console_logs), 3)
         self.assertIn("Running job", job_console_logs)
+        self.assertIn("Job source version: unknown", job_console_logs)
         self.assertIn("Job failed, all database changes have been rolled back.", job_console_logs)
         self.assertNotIn("Job succeeded.", job_console_logs)
 
@@ -896,8 +914,9 @@ class JobTransactionTest(TransactionTestCase):
         self.assertFalse(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job log messages were saved
         job_logs = models.JobLogEntry.objects.filter(job_result=job_result).values_list("message", flat=True)
-        self.assertEqual(len(job_logs), 2)
+        self.assertEqual(len(job_logs), 3)
         self.assertIn("Running job", job_logs)
+        self.assertIn("Job source version: unknown", job_logs)
         self.assertIn("Job failed, all database changes have been rolled back.", job_logs)
         self.assertNotIn("Job succeeded.", job_logs)
 
@@ -913,8 +932,9 @@ class JobTransactionTest(TransactionTestCase):
         self.assertFalse(models.Status.objects.filter(name="Test database atomic rollback 2").exists())
         # Ensure the correct job console text were saved
         job_console_logs = models.JobConsoleEntry.objects.filter(job_result=job_result).values_list("text", flat=True)
-        self.assertEqual(len(job_console_logs), 2)
+        self.assertEqual(len(job_console_logs), 3)
         self.assertIn("Running job", job_console_logs)
+        self.assertIn("Job source version: unknown", job_console_logs)
         self.assertIn("Job failed, all database changes have been rolled back.", job_console_logs)
         self.assertNotIn("Job succeeded.", job_console_logs)
 
@@ -1015,7 +1035,8 @@ class JobTransactionTest(TransactionTestCase):
 
         self.assertGreater(job_result.job_log_entries.count(), 0)
         self.assertIsNotNone(job_result.debug_log_count)
-        self.assertEqual(job_result.debug_log_count, 0)
+        # 1 = the "Job source version" entry logged at the start of every job run
+        self.assertEqual(job_result.debug_log_count, 1)
         self.assertIsNotNone(job_result.success_log_count)
         self.assertEqual(job_result.success_log_count, 1)
         self.assertIsNotNone(job_result.info_log_count)
@@ -1664,6 +1685,7 @@ class JobHookTransactionTest(TransactionTestCase):  # TODO: BaseModelTestCase mi
         self.assertIsNotNone(job_result)
         expected_log_messages = [
             ("info", "Running job"),
+            ("debug", "Job source version: unknown"),
             ("info", f"change: DCIM | location Test Job Hook Location 1 created by {self.user.username}"),
             ("info", "action: create"),
             ("info", f"jobresult.user: {self.user.username}"),
@@ -1690,6 +1712,7 @@ class JobHookTransactionTest(TransactionTestCase):  # TODO: BaseModelTestCase mi
         self.assertIsNotNone(job_result)
         expected_log_messages = [
             ("info", "Running job"),
+            ("debug", "Job source version: unknown"),
             ("info", f"change: DCIM | location Test Job Hook Location 1 updated by {self.user.username}"),
             ("info", "action: update"),
             ("info", f"jobresult.user: {self.user.username}"),

--- a/nautobot/extras/tests/test_models.py
+++ b/nautobot/extras/tests/test_models.py
@@ -7,6 +7,7 @@ import uuid
 from zoneinfo import ZoneInfo
 
 from django import forms as django_forms
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -2205,6 +2206,46 @@ class JobModelTest(ModelTestCases.BaseModelTestCase):
         self.assertEqual(self.app_job.class_path, "example_app.jobs.ExampleJob")
         self.assertEqual(self.app_job.class_path, self.app_job.job_class.class_path)
 
+    def test_source_version_system_job(self):
+        system_job = JobModel.objects.get(job_class_name="ExportObjectList")
+        self.assertEqual(system_job.source_version, settings.VERSION)
+
+    def test_source_version_app_job(self):
+        expected = apps.get_app_config("example_app").version
+        # Guard against a vacuous pass if example_app ever stops declaring a version
+        self.assertNotEqual(expected, "")
+        self.assertEqual(self.app_job.source_version, expected)
+
+    def test_source_version_jobs_root_job(self):
+        self.assertEqual(self.local_job.source_version, "")
+
+    def test_source_version_git_job(self):
+        repo = GitRepository(
+            name="Source Version Test Repo",
+            slug="source_version_test_repo",
+            remote_url="http://localhost/git.git",
+            current_head="0123456789abcdef0123456789abcdef01234567",
+        )
+        repo.validated_save()
+        # A fresh instance so that the git_repository cached_property hasn't been populated yet;
+        # module_name is only changed in memory as source_version reads nothing else from the record.
+        job = JobModel.objects.get(pk=self.local_job.pk)
+        job.module_name = f"{repo.slug}.jobs.my_job"
+        self.assertEqual(job.source_version, repo.current_head)
+
+    def test_source_version_app_precedence_over_git_repository(self):
+        # A GitRepository slug shadowing an installed module is rejected by clean()
+        # (see GitRepositoryTest.test_no_module_clobbering), so bypass validation with save()
+        # to simulate legacy data and prove that the App source takes precedence.
+        repo = GitRepository(
+            name="Shadowing Repo",
+            slug="example_app",
+            remote_url="http://localhost/git.git",
+            current_head="0123456789abcdef0123456789abcdef01234567",
+        )
+        repo.save()
+        self.assertEqual(self.app_job.source_version, apps.get_app_config("example_app").version)
+
     def test_latest_result(self):
         self.assertEqual(self.local_job.latest_result, self.local_job.job_results.only("status").first())
         self.assertEqual(self.app_job.latest_result, self.app_job.job_results.only("status").first())
@@ -2416,7 +2457,6 @@ class MetadataTypeTest(ModelTestCases.BaseModelTestCase):
         self.assertNotIsInstance(mt.to_form_field(), django_forms.Field)
 
     def test_to_form_field_integer_returns_integer_field(self):
-
         mt = MetadataType.objects.create(name="MT int", data_type=MetadataTypeDataTypeChoices.TYPE_INTEGER)
         field = mt.to_form_field(initial=42)
         self.assertIs(type(field), django_forms.IntegerField)
@@ -2424,14 +2464,12 @@ class MetadataTypeTest(ModelTestCases.BaseModelTestCase):
         self.assertFalse(field.required)
 
     def test_to_form_field_float_returns_float_field(self):
-
         mt = MetadataType.objects.create(name="MT float", data_type=MetadataTypeDataTypeChoices.TYPE_FLOAT)
         field = mt.to_form_field(initial=1.5)
         self.assertIs(type(field), django_forms.FloatField)
         self.assertEqual(field.initial, 1.5)
 
     def test_to_form_field_boolean_returns_nullboolean_field(self):
-
         mt = MetadataType.objects.create(name="MT bool", data_type=MetadataTypeDataTypeChoices.TYPE_BOOLEAN)
         field = mt.to_form_field(initial=False)
         self.assertIs(type(field), django_forms.NullBooleanField)
@@ -2441,19 +2479,16 @@ class MetadataTypeTest(ModelTestCases.BaseModelTestCase):
         self.assertIn(False, widget_choices)
 
     def test_to_form_field_date_returns_nullable_date_field(self):
-
         mt = MetadataType.objects.create(name="MT date", data_type=MetadataTypeDataTypeChoices.TYPE_DATE)
         field = mt.to_form_field()
         self.assertIs(type(field), NullableDateField)
 
     def test_to_form_field_datetime_returns_datetime_field(self):
-
         mt = MetadataType.objects.create(name="MT datetime", data_type=MetadataTypeDataTypeChoices.TYPE_DATETIME)
         field = mt.to_form_field()
         self.assertIs(type(field), django_forms.DateTimeField)
 
     def test_to_form_field_url_returns_lax_url_field(self):
-
         mt = MetadataType.objects.create(name="MT url", data_type=MetadataTypeDataTypeChoices.TYPE_URL)
         field = mt.to_form_field()
         self.assertIs(type(field), LaxURLField)
@@ -2466,13 +2501,11 @@ class MetadataTypeTest(ModelTestCases.BaseModelTestCase):
         self.assertEqual(field.initial, "hello")
 
     def test_to_form_field_markdown_returns_comment_field(self):
-
         mt = MetadataType.objects.create(name="MT md", data_type=MetadataTypeDataTypeChoices.TYPE_MARKDOWN)
         field = mt.to_form_field()
         self.assertIs(type(field), CommentField)
 
     def test_to_form_field_select_returns_choice_field_with_choices(self):
-
         mt = MetadataType.objects.create(name="MT select", data_type=MetadataTypeDataTypeChoices.TYPE_SELECT)
         MetadataChoice.objects.create(metadata_type=mt, value="alpha")
         MetadataChoice.objects.create(metadata_type=mt, value="beta")
@@ -2484,7 +2517,6 @@ class MetadataTypeTest(ModelTestCases.BaseModelTestCase):
         self.assertIn("beta", choice_values)
 
     def test_to_form_field_multiselect_returns_multiple_choice_field(self):
-
         mt = MetadataType.objects.create(name="MT multiselect", data_type=MetadataTypeDataTypeChoices.TYPE_MULTISELECT)
         MetadataChoice.objects.create(metadata_type=mt, value="x")
         MetadataChoice.objects.create(metadata_type=mt, value="y")
@@ -2495,7 +2527,6 @@ class MetadataTypeTest(ModelTestCases.BaseModelTestCase):
         self.assertEqual(set(choice_values), {"x", "y"})
 
     def test_to_form_field_json_falls_back_to_jsonformfield(self):
-
         mt = MetadataType.objects.create(name="MT json", data_type=MetadataTypeDataTypeChoices.TYPE_JSON)
         field = mt.to_form_field()
         self.assertIs(type(field), JSONFormField)

--- a/nautobot/extras/tests/test_tables.py
+++ b/nautobot/extras/tests/test_tables.py
@@ -1,9 +1,10 @@
+from django.apps import apps
 from django.utils.html import escape
 from jsonschema import Draft7Validator
 
 from nautobot.core.testing import TestCase
-from nautobot.extras.models import ConfigContext, ConfigContextSchema, JobResult
-from nautobot.extras.tables import ConfigContextSchemaValidationStateColumn, JobResultTable
+from nautobot.extras.models import ConfigContext, ConfigContextSchema, GitRepository, Job, JobResult
+from nautobot.extras.tables import ConfigContextSchemaValidationStateColumn, JobResultTable, JobTable
 
 
 class ConfigContextSchemaValidationStateColumnTestCase(TestCase):
@@ -39,6 +40,44 @@ class ConfigContextSchemaValidationStateColumnTestCase(TestCase):
         self.assertIn("mdi-close-thick", rendered)
         self.assertIn("text-danger", rendered)
         self.assertIn("No schema available", rendered)
+
+
+class JobTableTestCase(TestCase):
+    def test_source_version_column_abbreviates_commit_hash(self):
+        """Git commit hashes render abbreviated to 7 characters with the full hash as hover text."""
+        repo = GitRepository(
+            name="Source Version Table Test Repo",
+            slug="source_version_table_test_repo",
+            remote_url="http://localhost/git.git",
+            current_head="0123456789abcdef0123456789abcdef01234567",
+        )
+        repo.validated_save()
+        job = Job.objects.get(job_class_name="TestPassJob")
+        job.module_name = f"{repo.slug}.jobs.my_job"
+        job.save()
+        table = JobTable(Job.objects.filter(pk=job.pk))
+
+        cell = next(iter(table.rows)).get_cell("source_version")
+
+        self.assertEqual(cell, '<span title="0123456789abcdef0123456789abcdef01234567">0123456</span>')
+
+    def test_source_version_column_renders_app_version_unmodified(self):
+        """Non-hash version strings (e.g. App versions) render as-is."""
+        job = Job.objects.get(job_class_name="ExampleJob")
+        table = JobTable(Job.objects.filter(pk=job.pk))
+
+        cell = next(iter(table.rows)).get_cell("source_version")
+
+        self.assertEqual(cell, apps.get_app_config("example_app").version)
+
+    def test_source_version_column_renders_placeholder_when_unknown(self):
+        """JOBS_ROOT jobs have no version information and render the empty placeholder."""
+        job = Job.objects.get(job_class_name="TestPassJob")
+        table = JobTable(Job.objects.filter(pk=job.pk))
+
+        cell = next(iter(table.rows)).get_cell("source_version")
+
+        self.assertEqual(cell, table.default)
 
 
 class JobResultTableTestCase(TestCase):

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -5,6 +5,7 @@ from unittest import mock
 import urllib.parse
 import uuid
 
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -5584,6 +5585,13 @@ class JobTestCase(
         """
         queryset = self._get_queryset().exclude(module_name__startswith="nautobot.")
         return get_deletable_objects(self.model, queryset).values_list("pk", flat=True)[:3]
+
+    def test_job_detail_source_version(self):
+        """The Job detail view renders the Job's source_version in the Source Code panel."""
+        self.add_permissions("extras.view_job")
+        instance = Job.objects.get(job_class_name="ExampleJob")
+        response = self.client.get(instance.get_absolute_url())
+        self.assertBodyContains(response, apps.get_app_config("example_app").version)
 
     def test_delete_system_jobs_fail(self):
         instance = self._get_queryset().filter(module_name__startswith="nautobot.").first()

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2425,6 +2425,7 @@ class JobUIViewSet(NautobotUIViewSet):
                     "module_name",
                     "job_class_name",
                     "class_path",
+                    "source_version",
                     "installed",
                     "is_job_hook_receiver",
                     "is_job_button_receiver",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #7494
# What's Changed

- Added `source_version` property on Job which resolves the current loaded version of a Job
    - System & App Jobs load their package version
    - Git-repo Jobs load the commit hash
    - JOBS_ROOT Jobs are excluded as they aren't "versioned"
- Show `source_version` on Job list view optionally
- Cleanup stale `source` field
- Log at debug level the `source_version` of Job when it's run

# Screenshots

<img width="1495" height="820" alt="Screenshot 2026-07-10 at 13 06 04" src="https://github.com/user-attachments/assets/472fb25b-6fe0-4c7f-a774-9e26b079b906" />

<img width="2990" height="1474" alt="image" src="https://github.com/user-attachments/assets/254d298c-deb6-41c0-ae96-21b5a1f9cd93" />

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [NA] Example App Updates (when adding/changing features)
- [NA] Outline Remaining Work, Constraints from Design
