### PR TITLE
Fix dropdown fields not hiding on bulk-edit "Set null"

### DIFF
--- a/changes/8981.fixed
+++ b/changes/8981.fixed
@@ -1,0 +1,1 @@
+Fixed dropdown (Select2) fields not hiding when their "Set null" checkbox is checked on bulk-edit forms.

--- a/nautobot/dcim/tests/integration/test_device_bulk_operations.py
+++ b/nautobot/dcim/tests/integration/test_device_bulk_operations.py
@@ -95,3 +95,69 @@ class DeviceBulkUrlParamTestCase(SeleniumTestCase):
                 )
             )
         )
+
+
+class DeviceBulkEditNullifyTestCase(SeleniumTestCase):
+    """
+    Dropdown (Select2) fields must hide when their "Set null" checkbox is checked on the
+    bulk-edit form.
+
+    Regression test for https://github.com/nautobot/nautobot/issues/8981.
+    """
+
+    PLATFORM_SELECT2_XPATH = (
+        '//select[@id="id_platform"]/following-sibling::span[contains(@class, "select2-container")]'
+    )
+
+    def setUp(self):
+        super().setUp()
+        self.user.is_superuser = True
+        self.user.save()
+        self.login(self.user.username, self.password)
+
+        self.device1 = create_test_device("Device 1")
+
+    def tearDown(self):
+        self.logout()
+        super().tearDown()
+
+    def _open_device_bulk_edit_form(self):
+        """Select the test device on the list view and open the bulk-edit form."""
+
+        self.browser.visit(
+            self.live_server_url + reverse("dcim:device_list") + f"?device_type={self.device1.device_type.pk}"
+        )
+
+        pk = str(self.device1.pk)
+        cb_xpath = f'//input[@type="checkbox" and @name="pk" and @value="{pk}"]'
+        checkbox = WebDriverWait(self.browser.driver, 2).until(
+            expected_conditions.element_to_be_clickable((By.XPATH, cb_xpath))
+        )
+        self.browser.driver.execute_script("arguments[0].click();", checkbox)
+
+        # The bulk-edit button submits via formaction.
+        bulk_url = reverse("dcim:device_bulk_edit")
+        btn_xpath = f'//button[@type="submit" and starts-with(@formaction, "{bulk_url}")]'
+        bulk_btn = WebDriverWait(self.browser.driver, 2).until(
+            expected_conditions.element_to_be_clickable((By.XPATH, btn_xpath))
+        )
+        bulk_btn.click()
+
+    def test_set_null_hides_dropdown_field(self):
+        """Checking a dropdown field's "Set null" checkbox hides its Select2 widget."""
+        self._open_device_bulk_edit_form()
+
+        # platform is a nullable dropdown, rendered as a Select2 widget and visible initially.
+        select2_widget = WebDriverWait(self.browser.driver, 2).until(
+            expected_conditions.visibility_of_element_located((By.XPATH, self.PLATFORM_SELECT2_XPATH))
+        )
+        self.assertTrue(select2_widget.is_displayed())
+
+        nullify_checkbox = self.browser.driver.find_element(By.ID, "id_platform_nullify")
+        self.browser.driver.execute_script("arguments[0].click();", nullify_checkbox)
+
+        # Checking "Set null" should hide the Select2 widget.
+        WebDriverWait(self.browser.driver, 2).until(
+            expected_conditions.invisibility_of_element_located((By.XPATH, self.PLATFORM_SELECT2_XPATH))
+        )
+        self.assertFalse(select2_widget.is_displayed())

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -150,8 +150,11 @@ function initializeBulkEditNullification(context){
             return; // no UI change; _nullify still submitted
         }
 
-        // Existing behavior for other fields
-        $('#id_' + this.value).toggle('disabled');
+        // Select2 hides the original <select> and shows a sibling `.select2-container`,
+        // so toggle that widget when present; otherwise toggle the original control.
+        var $select2 = $field.siblings('.select2-container');
+        var $target = $select2.length ? $select2 : $field;
+        $target.toggle('disabled');
     });
 }
 

--- a/nautobot/project-static/js/forms.js
+++ b/nautobot/project-static/js/forms.js
@@ -154,7 +154,7 @@ function initializeBulkEditNullification(context){
         // so toggle that widget when present; otherwise toggle the original control.
         var $select2 = $field.siblings('.select2-container');
         var $target = $select2.length ? $select2 : $field;
-        $target.toggle('disabled');
+        $target.toggle(!this.checked);
     });
 }
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #8981

# What's Changed
Fixed dropdown (Select2) fields not hiding when their "Set null" checkbox is checked on bulk-edit forms. The handler now toggles the rendered Select2 widget instead of the original hidden `<select>`.

# Screenshots
Before:
<img width="623" height="374" alt="image" src="https://github.com/user-attachments/assets/2a3b52c6-1f78-41d7-86ea-badd3028b407" />
After:
<img width="591" height="257" alt="image" src="https://github.com/user-attachments/assets/64311975-5671-40a7-8bfc-c39a82e8e4bb" />

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
