### PR TITLE
Build each detail-view ObjectsTablePanel table only once per request …

### DIFF
--- a/changes/9234.fixed
+++ b/changes/9234.fixed
@@ -1,0 +1,1 @@
+Fixed `ObjectsTablePanel` building each detail-view table (and running its pagination query) twice per request.

--- a/nautobot/core/tests/test_ui.py
+++ b/nautobot/core/tests/test_ui.py
@@ -385,6 +385,58 @@ class ObjectsTablePanelTest(TestCase):
 
         self.assertIn("non-existent column `non_existent_column`", str(context.exception))
 
+    def test_get_extra_context_is_cached_per_request(self):
+        """The table should be built only once per request even though `get_extra_context` is called twice.
+
+        A detail-view render calls `get_extra_context` once via the `render_table_config_forms` templatetag
+        and again when the panel body is rendered; the result must be cached so the table (and its pagination
+        query) is not built twice. Regression test for #9234.
+        """
+        panel = ObjectsTablePanel(
+            weight=100,
+            table_class=DeviceTable,
+            table_attribute="devices_sorted",
+            related_field_name="device_redundancy_group",
+        )
+        redundancy_group = DeviceRedundancyGroup.objects.first()
+        context = {"request": self.request, "object": redundancy_group}
+
+        build_count = 0
+        original_build = ObjectsTablePanel._build_extra_context
+
+        def counting_build(inner_self, inner_context):
+            nonlocal build_count
+            build_count += 1
+            return original_build(inner_self, inner_context)
+
+        with patch.object(ObjectsTablePanel, "_build_extra_context", counting_build):
+            first = panel.get_extra_context(context)
+            second = panel.get_extra_context(context)
+
+        self.assertEqual(build_count, 1)
+        self.assertIs(first, second)
+        self.assertIs(first["body_content_table"], second["body_content_table"])
+
+    def test_get_extra_context_not_cached_across_requests(self):
+        """A subsequent request must rebuild the table rather than reusing another request's cached context."""
+        panel = ObjectsTablePanel(
+            weight=100,
+            table_class=DeviceTable,
+            table_attribute="devices_sorted",
+            related_field_name="device_redundancy_group",
+        )
+        redundancy_group = DeviceRedundancyGroup.objects.first()
+
+        first_request = self.factory.get("/")
+        first_request.user = self.user
+        second_request = self.factory.get("/")
+        second_request.user = self.user
+
+        first = panel.get_extra_context({"request": first_request, "object": redundancy_group})
+        second = panel.get_extra_context({"request": second_request, "object": redundancy_group})
+
+        self.assertIsNot(first["body_content_table"], second["body_content_table"])
+
 
 class EChartsBaseTests(TestCase):
     def setUp(self):

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -1232,9 +1232,9 @@ class ObjectsTablePanel(Panel):
         if context_cache is None:
             context_cache = {}
             request._objects_table_panel_extra_context = context_cache
-        if id(self) not in context_cache:
-            context_cache[id(self)] = self._build_extra_context(context)
-        return context_cache[id(self)]
+        if self.component_id not in context_cache:
+            context_cache[self.component_id] = self._build_extra_context(context)
+        return context_cache[self.component_id]
 
     def _build_extra_context(self, context: Context):
         """Build the render context for this table panel. See `get_extra_context()` for caching details."""

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -1221,11 +1221,9 @@ class ObjectsTablePanel(Panel):
         for listing and adding objects. It also handles field inclusion/exclusion and
         displays the appropriate table title if provided.
 
-        The result is cached per-request because this method is called twice for each panel during a
-        single detail-view render -- once by the `render_table_config_forms` templatetag and once when the
-        panel body is rendered -- and rebuilding the table (including its pagination count query) both
-        times is wasteful. The cache is stored on the request rather than on the panel because panels are
-        defined as view-class attributes and are therefore shared across all requests.
+        There are two callers in a single web request -- the `render_table_config_forms` templatetag and
+        the detail-view template itself -- so we cache the result on the request: build and store it on the
+        first call, then return the cached value on the second instead of rebuilding the table.
         """
         request = context["request"]
         context_cache = getattr(request, "_objects_table_panel_extra_context", None)

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -1220,7 +1220,24 @@ class ObjectsTablePanel(Panel):
         This method processes the table data, configures pagination, and generates URLs
         for listing and adding objects. It also handles field inclusion/exclusion and
         displays the appropriate table title if provided.
+
+        The result is cached per-request because this method is called twice for each panel during a
+        single detail-view render -- once by the `render_table_config_forms` templatetag and once when the
+        panel body is rendered -- and rebuilding the table (including its pagination count query) both
+        times is wasteful. The cache is stored on the request rather than on the panel because panels are
+        defined as view-class attributes and are therefore shared across all requests.
         """
+        request = context["request"]
+        context_cache = getattr(request, "_objects_table_panel_extra_context", None)
+        if context_cache is None:
+            context_cache = {}
+            request._objects_table_panel_extra_context = context_cache
+        if id(self) not in context_cache:
+            context_cache[id(self)] = self._build_extra_context(context)
+        return context_cache[id(self)]
+
+    def _build_extra_context(self, context: Context):
+        """Build the render context for this table panel. See `get_extra_context()` for caching details."""
         request = context["request"]
         if self.context_table_key:
             body_content_table = context.get(self.context_table_key)


### PR DESCRIPTION
# Closes #9234

# What's Changed

`ObjectsTablePanel.get_extra_context()` — which instantiates the panel's table and runs its pagination `count()` query — was being called **twice per request** for every table panel on an object detail view:

1. Once by the `render_table_config_forms` templatetag (via `get_table_config_form_context()`), which collects the table-config forms.
2. Again when the panel body is rendered (via `Panel.render()`).

Because the result was not cached, each configurable detail-view table (and its associated database queries) was built twice on every page load.

## Fix

- Split `ObjectsTablePanel.get_extra_context()` into a thin caching entry point plus `_build_extra_context()`, which holds the original table-building logic.
- The built context is now **memoized on the request** (keyed by panel instance), so the table is built only once per request regardless of how many times `get_extra_context()` is called.
- The cache is stored on the `request` rather than on the panel because panels are defined as view-class attributes and are therefore shared across all requests; a request-scoped cache avoids leaking one request's table/user/data into the next.

Panels that don't render a table-config button (e.g. non-configurable tables) were already built only once and are unaffected.

# Screenshots

This is a non-visual performance fix, so there is no UI change to show. Instead, here is the reproduction (counting actual table builds during a single detail-view request against a live instance):

**Before** — each configurable panel builds its table twice:

```
Target: dcim.Location
LocationSiblingsTablePanel: 2
ObjectsTablePanel:          2
ObjectsTablePanel:          2
LocationImageAttachmentsTablePanel: 1   # no config button -> already once
```

**After** — every panel builds its table exactly once:

```
Target: dcim.Location
LocationSiblingsTablePanel: 1
ObjectsTablePanel:          1
ObjectsTablePanel:          1
LocationImageAttachmentsTablePanel: 1
```

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example <!-- N/A: non-visual fix; before/after reproduction included above -->
- [x] Unit, Integration Tests <!-- Added regression tests: table built once per request, and rebuilt on a new request -->
- [x] Documentation Updates (when adding/changing features) <!-- N/A: no feature or behavior change -->
- [x] Example App Updates (when adding/changing features) <!-- N/A -->
- [x] Outline Remaining Work, Constraints from Design <!-- None -->
