### PR TITLE
Fix Operational Compliance link in marketplace_manifest (#9161)

### DIFF
--- a/changes/9161.fixed
+++ b/changes/9161.fixed
@@ -1,0 +1,1 @@
+Fixed the broken Operational Compliance documentation link in the Application Marketplace, which returned a 404 due to a trailing quotation mark in the URL.

--- a/nautobot/extras/plugins/marketplace_manifest.yml
+++ b/nautobot/extras/plugins/marketplace_manifest.yml
@@ -416,7 +416,7 @@
   - "Compliance"
   - "Security"
   "requires": []
-  "docs": "https://docs.nautobot.com/projects/operational-compliance/en/stable/\""
+  "docs": "https://docs.nautobot.com/projects/operational-compliance/en/stable/"
   "headline": "Perform pre- and post-change validation with defined validation rules before and after every change."
   "description": >-
     Validate network changes on-demand with Operational Compliance by capturing and comparing device state before


### PR DESCRIPTION
# Closes #9161

# What's Changed

The **Operational Compliance** entry in the Application Marketplace had a malformed `docs` link: the URL in `nautobot/extras/plugins/marketplace_manifest.yml` ended with an extra escaped quotation mark (`\"`), so the rendered "docs" link pointed to `.../operational-compliance/en/stable/"` and returned a **404**.

Removed the stray trailing quotation mark so the link resolves correctly. This was the only app entry with a malformed `docs` value; all others were already well-formed.

```diff
- "docs": "https://docs.nautobot.com/projects/operational-compliance/en/stable/\""
+ "docs": "https://docs.nautobot.com/projects/operational-compliance/en/stable/"
```

# Screenshots

Payload before/after (the rendered `docs` link target for the Operational Compliance app):

- **Before:** `https://docs.nautobot.com/projects/operational-compliance/en/stable/"` → 404 Not Found

<img width="799" height="429" alt="image" src="https://github.com/user-attachments/assets/c375ced3-eeeb-485e-8e5b-081a5aa8fff9" />

- **After:** `https://docs.nautobot.com/projects/operational-compliance/en/stable/` → loads the documentation page

<img width="797" height="423" alt="image" src="https://github.com/user-attachments/assets/0b35349d-bcfc-4785-baeb-93d09e755ae7" />


# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example <!-- URL before/after shown above; the change is a one-character data correction -->
- [x] Unit, Integration Tests <!-- N/A: static data (YAML) correction, no code logic to test -->
- [x] Documentation Updates (when adding/changing features) <!-- N/A: no feature change -->
- [x] Example App Updates (when adding/changing features) <!-- N/A -->
- [x] Outline Remaining Work, Constraints from Design <!-- None. Optionally, a meta-test validating all marketplace_manifest docs URLs could be added in a follow-up. -->
