### PR TITLE
Fixes broken tab name for saved views

### DIFF
--- a/changes/8807.fixed
+++ b/changes/8807.fixed
@@ -1,0 +1,1 @@
+Fixed the browser tab title on saved view list pages showing the saved view name twice, and displaying raw HTML tags when there were unsaved changes.

--- a/nautobot/core/templates/generic/object_list.html
+++ b/nautobot/core/templates/generic/object_list.html
@@ -14,8 +14,6 @@
     {% include "inc/header_messages.html" with messages=None %}
 {% endblock header_messages %}
 
-{% block title %}{{ block.super }}{% saved_view_title %}{% endblock %}
-
 {% block breadcrumbs_wrapper %}
     {% captureas default_breadcrumbs %}
         {% if list_url %}

--- a/nautobot/core/templates/inc/page_title.html
+++ b/nautobot/core/templates/inc/page_title.html
@@ -18,6 +18,6 @@
             </button>
         </span>
     {% else %}
-        {{ title }}
+        {{ title }}{% saved_view_title %}
     {% endif %}
 </h1>

--- a/nautobot/core/tests/test_title_persistence.py
+++ b/nautobot/core/tests/test_title_persistence.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from django.template import engines, TemplateSyntaxError
+from django.template import TemplateSyntaxError
 from django.template.loader import get_template
 from django.template.utils import get_app_template_dirs
 from django.test import override_settings, SimpleTestCase
@@ -10,95 +10,13 @@ from django.urls import reverse
 from nautobot.core.testing import TestCase as NautobotTestCase
 from nautobot.extras.models import SavedView, Status
 
-# A minimal stand-in for the real `base.html`/`base_django.html` chain, isolated from
-# Nautobot's actual nav menu/request/permission requirements.
-SYNTHETIC_TEMPLATES = {
-    "base.html": "<title>{% block title %}Default Title{% endblock %}</title>",
-    "middle.html": "{% extends 'base.html' %}",
-}
-
-
-@override_settings(
-    TEMPLATES=[
-        {
-            "BACKEND": "django.template.backends.django.DjangoTemplates",
-            "DIRS": [],
-            "APP_DIRS": False,
-            "OPTIONS": {
-                "loaders": [("django.template.loaders.locmem.Loader", SYNTHETIC_TEMPLATES)],
-            },
-        }
-    ]
-)
-class TestDjangoTemplateBlockChanges(SimpleTestCase):
-    def render_child(self, title_block_body, parent="base.html"):
-        template_string = f"{{% extends '{parent}' %}}" + title_block_body
-        return engines["django"].from_string(template_string).render({})
-
-    def test_block_renders(self):
-        rendered = self.render_child("""{% block title %}My Override{% endblock %}""")
-        self.assertEqual(rendered, "<title>My Override</title>")
-
-    def test_title_block_override_scenarios(self):
-        """
-        Almost any content can be dropped into `{% block title %}`, and in most cases
-        the template will render without raising.
-        """
-        cases = [
-            ("empty override", "{% block title %}{% endblock %}", "<title></title>"),
-            (
-                "plain text",
-                "{% block title %}Single Source of Truth{% endblock %}",
-                "<title>Single Source of Truth</title>",
-            ),
-            (
-                "extends parent default via block.super",
-                "{% block title %}{{ block.super }} - Extra{% endblock %}",
-                "<title>Default Title - Extra</title>",
-            ),
-            (
-                "No override",
-                "",
-                "<title>Default Title</title>",
-            ),
-        ]
-        for label, title_block_body, expected in cases:
-            with self.subTest(label):
-                rendered = self.render_child(title_block_body)
-                self.assertEqual(rendered, expected)
-
-    def test_title_block_override_through_intermediate_template_without_override(self):
-        """
-        Checks triple-nested block title. Extends a middle.html, which does not implement block title,
-        but inherits it from one level above.
-        """
-        rendered = self.render_child("{% block title %}Single Source of Truth{% endblock %}", parent="middle.html")
-        self.assertEqual(rendered, "<title>Single Source of Truth</title>")
-
-    def test_title_block_super_through_intermediate_template_without_override(self):
-        """Tests the {{ block.super }} falling back to what is defined at the top level."""
-        rendered = self.render_child("{% block title %}{{ block.super }} - Extra{% endblock %}", parent="middle.html")
-        self.assertEqual(rendered, "<title>Default Title - Extra</title>")
-
-    def test_no_override_anywhere_falls_back_to_grandparent_default(self):
-        """Tests the title falling back to what is defined at the top level."""
-        rendered = self.render_child("", parent="middle.html")
-        self.assertEqual(rendered, "<title>Default Title</title>")
-
 
 @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
 class TestSavedViewTitleFix(NautobotTestCase):
     """
-    End-to-end regression tests, exercising the
-    `generic/object_list.html` / `base_django.html` templates through an actual view
-    request rather than synthetic templates.
-
-    Before the fix, `generic/object_list.html` defined both:
-        {% block title %}{{ block.super }}{% saved_view_title %}{% endblock %}
-    and `{% block document_title_extra %}{% saved_view_title "plain" %}{% endblock %}`.
-    The first used the default "html" mode of `saved_view_title`, so the saved view
-    name was appended twice to the browser tab title, and once as raw `<i>` markup
-    that a browser can't render inside `<title>`.
+    Tests the SavedView page, ensuring the browser title contains only one
+    non-italicised SavedView title and that the html body contains
+    italicised `Pending changes not saved`.
     """
 
     @staticmethod
@@ -117,20 +35,23 @@ class TestSavedViewTitleFix(NautobotTestCase):
 
         browser_title = self.get_browser_title(response)
         self.assertEqual(browser_title.count(saved_view.name), 1)
-        self.assertNotIn("<i", browser_title)
+        self.assertNotIn('<i title="Pending changes not saved">', browser_title)
         self.assertBodyContains(response, '— <i title="Pending changes not saved">')
 
     def test_other_view_for_errors(self):
         """A different object_list-based list view (no saved view) still renders after the fix."""
-        response = self.client.get(reverse("dcim:location_list"))
-        self.assertHttpStatus(response, 200)
+        location_response = self.client.get(reverse("dcim:location_list"))
+        self.assertHttpStatus(location_response, 200)
+        device_response = self.client.get(reverse("dcim:device_list"))
+        self.assertHttpStatus(device_response, 200)
+        prefix_response = self.client.get(reverse("ipam:prefix_list"))
+        self.assertHttpStatus(prefix_response, 200)
 
 
 class ObjectListChildrenCompileTest(SimpleTestCase):
     """
-    Discover every installed template that extends `generic/object_list.html` and confirm each one
-    COMPILES. This catches the structural break class — a missing `{% load %}`, a syntax error, or a
-    broken parent chain — for ALL children at once, without needing each view's render context.
+    Test every installed template that extends `generic/object_list.html` and confirm each one
+    COMPILES.
 
     Scope/limits:
     - Only sees templates from INSTALLED apps.

--- a/nautobot/core/tests/test_title_persistence.py
+++ b/nautobot/core/tests/test_title_persistence.py
@@ -1,0 +1,168 @@
+import os
+import re
+
+from django.template import engines, TemplateSyntaxError
+from django.template.loader import get_template
+from django.template.utils import get_app_template_dirs
+from django.test import override_settings, SimpleTestCase
+from django.urls import reverse
+
+from nautobot.core.testing import TestCase as NautobotTestCase
+from nautobot.extras.models import SavedView, Status
+
+# A minimal stand-in for the real `base.html`/`base_django.html` chain, isolated from
+# Nautobot's actual nav menu/request/permission requirements.
+SYNTHETIC_TEMPLATES = {
+    "base.html": "<title>{% block title %}Default Title{% endblock %}</title>",
+    "middle.html": "{% extends 'base.html' %}",
+}
+
+
+@override_settings(
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": [],
+            "APP_DIRS": False,
+            "OPTIONS": {
+                "loaders": [("django.template.loaders.locmem.Loader", SYNTHETIC_TEMPLATES)],
+            },
+        }
+    ]
+)
+class TestDjangoTemplateBlockChanges(SimpleTestCase):
+    def render_child(self, title_block_body, parent="base.html"):
+        template_string = f"{{% extends '{parent}' %}}" + title_block_body
+        return engines["django"].from_string(template_string).render({})
+
+    def test_block_renders(self):
+        rendered = self.render_child("""{% block title %}My Override{% endblock %}""")
+        self.assertEqual(rendered, "<title>My Override</title>")
+
+    def test_title_block_override_scenarios(self):
+        """
+        Almost any content can be dropped into `{% block title %}`, and in most cases
+        the template will render without raising.
+        """
+        cases = [
+            ("empty override", "{% block title %}{% endblock %}", "<title></title>"),
+            (
+                "plain text",
+                "{% block title %}Single Source of Truth{% endblock %}",
+                "<title>Single Source of Truth</title>",
+            ),
+            (
+                "extends parent default via block.super",
+                "{% block title %}{{ block.super }} - Extra{% endblock %}",
+                "<title>Default Title - Extra</title>",
+            ),
+            (
+                "No override",
+                "",
+                "<title>Default Title</title>",
+            ),
+        ]
+        for label, title_block_body, expected in cases:
+            with self.subTest(label):
+                rendered = self.render_child(title_block_body)
+                self.assertEqual(rendered, expected)
+
+    def test_title_block_override_through_intermediate_template_without_override(self):
+        """
+        Checks triple-nested block title. Extends a middle.html, which does not implement block title,
+        but inherits it from one level above.
+        """
+        rendered = self.render_child("{% block title %}Single Source of Truth{% endblock %}", parent="middle.html")
+        self.assertEqual(rendered, "<title>Single Source of Truth</title>")
+
+    def test_title_block_super_through_intermediate_template_without_override(self):
+        """Tests the {{ block.super }} falling back to what is defined at the top level."""
+        rendered = self.render_child("{% block title %}{{ block.super }} - Extra{% endblock %}", parent="middle.html")
+        self.assertEqual(rendered, "<title>Default Title - Extra</title>")
+
+    def test_no_override_anywhere_falls_back_to_grandparent_default(self):
+        """Tests the title falling back to what is defined at the top level."""
+        rendered = self.render_child("", parent="middle.html")
+        self.assertEqual(rendered, "<title>Default Title</title>")
+
+
+@override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+class TestSavedViewTitleFix(NautobotTestCase):
+    """
+    End-to-end regression tests, exercising the
+    `generic/object_list.html` / `base_django.html` templates through an actual view
+    request rather than synthetic templates.
+
+    Before the fix, `generic/object_list.html` defined both:
+        {% block title %}{{ block.super }}{% saved_view_title %}{% endblock %}
+    and `{% block document_title_extra %}{% saved_view_title "plain" %}{% endblock %}`.
+    The first used the default "html" mode of `saved_view_title`, so the saved view
+    name was appended twice to the browser tab title, and once as raw `<i>` markup
+    that a browser can't render inside `<title>`.
+    """
+
+    @staticmethod
+    def get_browser_title(response):
+        return re.findall(r"<title>(.*?)</title>", response.content.decode())[0]
+
+    def test_saved_view_name_appears_once_in_browser_title_without_html_tags(self):
+        saved_view = SavedView.objects.create(
+            name="My Statuses",
+            owner=self.user,
+            view=f"{Status._meta.app_label}:{Status._meta.model_name}_list",
+        )
+        url = reverse(saved_view.view) + f"?saved_view={saved_view.pk}&table_changes_pending=true"
+        response = self.client.get(url)
+        self.assertHttpStatus(response, 200)
+
+        browser_title = self.get_browser_title(response)
+        self.assertEqual(browser_title.count(saved_view.name), 1)
+        self.assertNotIn("<i", browser_title)
+        self.assertBodyContains(response, '— <i title="Pending changes not saved">')
+
+    def test_other_view_for_errors(self):
+        """A different object_list-based list view (no saved view) still renders after the fix."""
+        response = self.client.get(reverse("dcim:location_list"))
+        self.assertHttpStatus(response, 200)
+
+
+class ObjectListChildrenCompileTest(SimpleTestCase):
+    """
+    Discover every installed template that extends `generic/object_list.html` and confirm each one
+    COMPILES. This catches the structural break class — a missing `{% load %}`, a syntax error, or a
+    broken parent chain — for ALL children at once, without needing each view's render context.
+
+    Scope/limits:
+    - Only sees templates from INSTALLED apps.
+    - Compile != render: `{% url %}` / missing-context errors are render-time and are covered by the
+      per-view render suites (each list view's test GETs the page and asserts 200).
+    """
+
+    _EXTENDS_OBJECT_LIST = re.compile(r"""{%\s*extends\s+['"]generic/object_list\.html['"]\s*%}""")
+
+    @classmethod
+    def _object_list_children(cls):
+        """Return the template names of every installed .html that extends generic/object_list.html."""
+        template_dirs = [*get_app_template_dirs("templates")]
+        names = set()
+        for directory in template_dirs:
+            for root, _dirs, files in os.walk(directory):
+                for filename in files:
+                    if not filename.endswith(".html"):
+                        continue
+                    path = os.path.join(root, filename)
+                    with open(path, encoding="utf-8") as handle:
+                        if cls._EXTENDS_OBJECT_LIST.search(handle.read()):
+                            names.add(os.path.relpath(path, directory).replace(os.sep, "/"))
+        return sorted(names)
+
+    def test_all_object_list_children_compile(self):
+        children = self._object_list_children()
+        errors = {}
+        if len(children) > 0:
+            for name in children:
+                try:
+                    get_template(name)
+                except TemplateSyntaxError as exc:
+                    errors[name] = str(exc)
+        self.assertEqual(errors, {}, f"object_list children failed to compile: {errors}")


### PR DESCRIPTION
# Closes #8807
# What's Changed
This fixes the browser tab title on saved-view list pages showing the saved view's name twice, and displayed raw HTML tags in the tab whenever there were unsaved changes. 
### The root cause:
The saved-view name was being added to the page title in two different places, both ending up in the name of the tab. This change removes the duplicate source so the tab now shows the saved view name only once, in plain text. Removing title override is mitigated by adding `{% saved_view_title %}` in the `page_title.html`, which works with other views due to `saved_view_title` returns `""` if the page is not a saved view. 
# Screenshots
### Initially reported bug, edited/filtered saved view tab name:
| Before | After |
|-------|-------|
| <img width="449" height="33" alt="Screenshot 2026-07-13 at 8 39 45 PM" src="https://github.com/user-attachments/assets/4939b1b3-ecd8-4ec7-b824-98099be66b75" /> | <img width="434" height="241" alt="Screenshot 2026-07-14 at 7 37 58 AM" src="https://github.com/user-attachments/assets/587590ea-55ce-4bf5-9978-31038b0a86fc" /> |


### The tab name was broken for unedited saved views as well:
| Before | After |
|-----|-----|
| <img width="435" height="65" alt="Screenshot 2026-07-13 at 8 13 32 PM" src="https://github.com/user-attachments/assets/9f4045e4-e167-4a54-a391-b7b9b53989a4" /> | <img width="437" height="256" alt="Screenshot 2026-07-14 at 7 47 30 AM" src="https://github.com/user-attachments/assets/d84fe383-4923-4d00-aa63-47a20345edd0" /> |
