### PR TITLE
Reading termination_X_type back before save

### DIFF
--- a/nautobot/dcim/models/cables.py
+++ b/nautobot/dcim/models/cables.py
@@ -646,8 +646,15 @@ class Cable(PrimaryModel):
 
     @property
     def termination_a_type(self):
-        """ContentType of the A-side termination on connector 1 (backward compat)."""
-        return self._get_termination_attr("A", "termination_type", "_initial_termination_a_type")
+        """ContentType of the A-side termination on connector 1 (backward compat).
+
+        On an unsaved assignment, resolves from either the `termination_a_type` or the
+        `termination_a_type_id` setter, mirroring Django's usual FK field/attname pairing.
+        """
+        ct = self._get_termination_attr("A", "termination_type", "_initial_termination_a_type")
+        if ct is None:
+            ct = self._resolve_initial_termination_type("a")
+        return ct
 
     @termination_a_type.setter
     def termination_a_type(self, value):
@@ -676,8 +683,15 @@ class Cable(PrimaryModel):
 
     @property
     def termination_b_type(self):
-        """ContentType of the B-side termination on connector 1 (backward compat)."""
-        return self._get_termination_attr("B", "termination_type", "_initial_termination_b_type")
+        """ContentType of the B-side termination on connector 1 (backward compat).
+
+        On an unsaved assignment, resolves from either the `termination_b_type` or the
+        `termination_b_type_id` setter, mirroring Django's usual FK field/attname pairing.
+        """
+        ct = self._get_termination_attr("B", "termination_type", "_initial_termination_b_type")
+        if ct is None:
+            ct = self._resolve_initial_termination_type("b")
+        return ct
 
     @termination_b_type.setter
     def termination_b_type(self, value):

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -3459,10 +3459,13 @@ class CableTestCase(ModelTestCases.BaseModelTestCase):
             termination_b_id=self.rear_port1.pk,
             status=self.status,
         )
-        # The `*_type_id` getter reports the PK, and `*_type` stays None until save resolves the join rows.
+        # The `*_type_id` getter reports the PK, and the `*_type` getter resolves the ContentType
+        # from it pre-save, mirroring Django's usual FK field/attname pairing.
         self.assertEqual(via_type_pk.termination_a_type_id, interface_ct.pk)
+        self.assertEqual(via_type_pk.termination_a_type, interface_ct)
         self.assertEqual(via_type_pk.termination_a_id, self.interface3.pk)
         self.assertEqual(via_type_pk.termination_b_type_id, rear_port_ct.pk)
+        self.assertEqual(via_type_pk.termination_b_type, rear_port_ct)
         self.assertEqual(via_type_pk.termination_b_id, self.rear_port1.pk)
         assert_round_trip(via_type_pk)
 
@@ -3473,7 +3476,9 @@ class CableTestCase(ModelTestCases.BaseModelTestCase):
         via_type_pk_setters.termination_b_type_id = rear_port_ct.pk
         via_type_pk_setters.termination_b_id = self.rear_port1.pk
         self.assertEqual(via_type_pk_setters.termination_a_type_id, interface_ct.pk)
+        self.assertEqual(via_type_pk_setters.termination_a_type, interface_ct)
         self.assertEqual(via_type_pk_setters.termination_b_type_id, rear_port_ct.pk)
+        self.assertEqual(via_type_pk_setters.termination_b_type, rear_port_ct)
         assert_round_trip(via_type_pk_setters)
 
     def test_termination_backward_compat_queryset_lookups(self):


### PR DESCRIPTION
Was talking with the Ole AI for any optimizations for backward compat, and this is the only one that seems sane. Here is a example from the AI.


Reading `termination_a_type` back before save
---------------------------------------------

The trigger is **construct with `*_type_id`, then read `*_type` before `save()`** --- and the read usually happens in code the author doesn't control: validation and logging layers that run pre-save. Concretely, Design Builder (the motivating consumer for the branch) and similar factory-style code do:

```
cable = Cable(
    termination_a_type_id=interface_ct.pk,   # attname form, PKs from resolved lookups
    termination_a_id=intf.pk,
    termination_b_type_id=rear_port_ct.pk,
    termination_b_id=rp.pk,
    status=status,
)
cable.full_clean()      # ← custom validators, clean() logic run BEFORE save
cable.validated_save()

```

Anything running in that pre-save window that inspects the type --- a custom validator with `if cable.termination_a_type.model == "interface": ...`, a `clean()` compatibility check, or even a log line like `f"connecting {cable.termination_a_type}"` --- got `None` under the branch as it stood, because only the `_type_id` slot was populated. On Nautobot 2.x this Just Worked: `termination_a_type` was a real FK, and Django's descriptor lazily resolved the instance from the stored `termination_a_type_id`. So the failure mode was a pre-save `AttributeError: 'NoneType' object has no attribute 'model'` (or a silently wrong branch taken on `None`) in validator code that was correct for years. Fix 2 restores the lazy resolution, so the getter returns the `ContentType` whichever form the caller assigned.

The two fixes also compose: with fix 2, assigning a *dangling* `type_id` and then reading `termination_a_type` raises `ContentType.DoesNotExist` at the attribute access --- which mirrors what Django's own FK descriptor does for a broken FK id, so that edge stays faithful too.

The common thread --- and why I flagged these two as "worth fixing before merge" --- is that both are hit by *callers who never see the shim*: replayed data and pre-save validation hooks. 