### PR TITLE
[LTM Backport] Changed the REST API to automatically pre-fetch related items used in the natural_slug

### DIFF
--- a/changes/9250.changed
+++ b/changes/9250.changed
@@ -1,0 +1,1 @@
+Enhanced the REST API queryset optimizer to automatically pre-fetch the related objects traversed by a model's natural key to avoid N+1 queries.

--- a/changes/9250.fixed
+++ b/changes/9250.fixed
@@ -1,0 +1,1 @@
+Fixed an N+1 query when listing Interfaces via the REST API.

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -278,6 +278,21 @@ class ModelViewSetMixin:
                 if isinstance(model_field, ForeignKey):
                     select_fields.append(field_instance.source)
 
+        # Prefetch deeper relations needed for this object's natural key (e.g. for `natural_slug`) to avoid N+1 queries.
+        try:
+            natural_key_field_lookups = model.natural_key_field_lookups
+        except AttributeError:
+            natural_key_field_lookups = []
+        natural_key_prefetch_fields = set()
+        for lookup in natural_key_field_lookups:
+            if "__" in lookup:
+                prefix, _ = lookup.rsplit("__", 1)
+                # Single-level FKs are already covered by select_fields above.
+                if prefix not in select_fields:
+                    natural_key_prefetch_fields.add(prefix)
+        # Add to prefetch_fields rather than select_fields to prevent unnecessary query expansion.
+        prefetch_fields.extend(sorted(natural_key_prefetch_fields))
+
         if select_fields:
             queryset = maybe_select_related(queryset, select_fields)
 

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -528,6 +528,7 @@ class ModelViewSetMixinTest(testing.APITestCase):
         serializer_class = ipam_serializers.IPAddressSerializer
         filterset_class = ipam_filters.IPAddressFilterSet
 
+    @override_settings(ALLOWED_HOSTS=["*"])  # serializing hyperlinked fields builds absolute URLs
     def test_get_queryset_optimizations(self):
         """Test that the queryset is appropriately optimized based on request parameters."""
         self.user.is_superuser = True
@@ -543,7 +544,8 @@ class ModelViewSetMixinTest(testing.APITestCase):
         view.initial(request)
 
         queryset = view.get_queryset()
-        with self.assertNumQueries(5):  # IPAddress plus four prefetches
+        # IPAddress plus one natural-key prefetch (parent__namespace), plus four prefetches.
+        with self.assertNumQueries(6):
             instance = queryset.first()
         # FK related objects should have been auto-selected
         with self.assertNumQueries(0):
@@ -561,6 +563,19 @@ class ModelViewSetMixinTest(testing.APITestCase):
             list(instance.vm_interfaces.all())
             list(instance.tags.all())
 
+        # The `natural_slug` field calls `natural_key()`, which walks related-object natural keys (e.g.
+        # parent__namespace). Those relations were prefetched above, so computing it for every object must
+        # not issue an additional query per object (this was previously an N+1).
+        instances = list(view.get_queryset())
+        self.assertGreater(len(instances), 1, "need multiple objects for a meaningful N+1 assertion")
+        with self.assertNumQueries(0):
+            natural_slugs = [instance.natural_slug for instance in instances]
+        # Exercise the real serializer too: natural_slug should render for every object, matching the
+        # query-free traversal above. (Full serialization also issues a couple of constant, per-model
+        # custom-field metadata lookups, which is why the query-count assertion targets the traversal.)
+        data = view.get_serializer(instances, many=True).data
+        self.assertEqual([row["natural_slug"] for row in data], natural_slugs)
+
         # With exclude_m2m query parameter
         view = self.SimpleIPAddressViewSet()
         view.action_map = {"get": "list"}
@@ -573,7 +588,9 @@ class ModelViewSetMixinTest(testing.APITestCase):
         view.initial(request)
 
         queryset = view.get_queryset()
-        with self.assertNumQueries(1):  # IPAddress only, no prefetches
+        # IPAddress plus the natural-key prefetch (parent__namespace).
+        # exclude_m2m suppresses the additional M2M/reverse prefetches.
+        with self.assertNumQueries(2):
             instance = queryset.first()
         # FK related objects should still have been auto-selected
         with self.assertNumQueries(0):

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 
-from nautobot.core.testing import APITestCase, APIViewTestCases
+from nautobot.core.testing import APITestCase, APIViewTestCases, AssertNoRepeatedQueries
 from nautobot.core.testing.utils import generate_random_device_asset_tag_of_specified_size, get_deletable_objects
 from nautobot.dcim.choices import (
     ConsolePortTypeChoices,
@@ -2437,6 +2437,28 @@ class InterfaceTest(Mixins.ModularDeviceComponentMixin, Mixins.BasePortTestMixin
                 },
             ],
         ]
+
+    def test_interface_list_avoids_natural_key_n_plus_one(self):
+        """Serializing the interfaces list must not issue one dcim_location query per interface.
+
+        The always-present `natural_slug` field calls `natural_key()`, which traverses device -> location
+        because Device's natural key includes location by default (unless DEVICE_NAME_AS_NATURAL_KEY is set).
+        `device.location` is a second-level relation, so without prefetching it is a query per row (N+1).
+        """
+        self.add_permissions("dcim.view_interface")
+        interface_status = Status.objects.get_for_model(Interface).first()
+        for i in range(15):  # enough rows to exceed the default threshold when the N+1 is present
+            Interface.objects.create(
+                device=self.devices[0],
+                name=f"n-plus-one-{i}",
+                status=interface_status,
+                type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            )
+        url = reverse("dcim-api:interface-list")
+        with override_config(DEVICE_NAME_AS_NATURAL_KEY=False):  # keep location in Device's natural key
+            with AssertNoRepeatedQueries(self, threshold=10):
+                response = self.client.get(f"{url}?limit=0", **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
 
     def test_untagged_vlan_requires_mode(self):
         """Test that when an `untagged_vlan` is specified, `mode` is also required."""


### PR DESCRIPTION
# Closes #DNE
# What's Changed

This is a backport of #9250 for the LTM branch. The same fix has been applied as in develop, but I did have to tweak the tests a bit as we introduced the concept of `DEVICE_UNIQUENESS` in v3, but in 2.4 we only had the `DEVICE_NAME_AS_NATURAL_KEY` setting (which is defaulted to False).

# Screenshots
|Before|After|
|-|-|
|<img width="210" height="145" alt="Screenshot 2026-07-16 at 10 21 12 AM" src="https://github.com/user-attachments/assets/847f4b07-fe6a-4c79-9ceb-aba96c2d6c1e" />|<img width="216" height="150" alt="Screenshot 2026-07-16 at 10 19 57 AM" src="https://github.com/user-attachments/assets/39efc53b-8f35-4de8-8bb1-731fe5f16e15" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [N/A] Documentation Updates (when adding/changing features)
- [N/A] Example App Updates (when adding/changing features)
- [N/A] Outline Remaining Work, Constraints from Design

NTC-6296