### PR TITLE
Fix computed field interleaved table

### DIFF
--- a/changes/xxxx.fixed
+++ b/changes/xxxx.fixed
@@ -1,0 +1,1 @@
+Fixed `ComputedFieldColumn` rendering its fallback value on non-matching row types in interleaved tables (e.g. Prefix > IP Addresses). Such cells now render a placeholder.

--- a/nautobot/core/tables.py
+++ b/nautobot/core/tables.py
@@ -833,6 +833,11 @@ class ComputedFieldColumn(django_tables2.Column):
         super().__init__(*args, **kwargs)
 
     def render(self, *, record):  # pylint: disable=arguments-differ  # tables2 varies its kwargs
+        model = self.computedfield.content_type.model_class()
+        if not isinstance(record, model):
+            # Interleaved tables (e.g. Prefix > IP Addresses) can contain rows of other types that this computed
+            # field doesn't apply to. Render a placeholder instead of evaluating the template.
+            return helpers.placeholder(None)
         value = self.computedfield.render({"obj": record})
         if self.computedfield.output_type == choices.ComputedFieldTypeChoices.TYPE_MARKDOWN:
             return helpers.render_markdown(value)

--- a/nautobot/core/tests/test_tables.py
+++ b/nautobot/core/tests/test_tables.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.db.models import IntegerField, Value
 from django.test import tag, TestCase
@@ -8,10 +9,12 @@ from django.test.utils import CaptureQueriesContext
 from nautobot.circuits.models import Circuit
 from nautobot.circuits.tables import CircuitTable
 from nautobot.core.models.querysets import count_related
-from nautobot.core.tables import ButtonsColumn, LinkedCountColumn
+from nautobot.core.tables import ButtonsColumn, ComputedFieldColumn, LinkedCountColumn
+from nautobot.core.templatetags import helpers
 from nautobot.dcim.models import Device, InventoryItem, Location, LocationType, Rack, RackGroup
 from nautobot.dcim.tables import InventoryItemTable, LocationTable, LocationTypeTable, RackGroupTable
-from nautobot.extras.models import JobLogEntry
+from nautobot.extras.choices import ComputedFieldTypeChoices
+from nautobot.extras.models import ComputedField, JobLogEntry
 from nautobot.extras.tables import JobLogEntryTable
 from nautobot.ipam.models import RIR
 from nautobot.ipam.tables import RIRTable
@@ -299,3 +302,51 @@ class ButtonsColumnTestCase(TestCase):
         """An explicit non-empty subset is passed through unchanged."""
         column = ButtonsColumn(RIR, buttons=("delete",))
         self.assertEqual(column.extra_context["buttons"], ("delete",))
+
+
+class ComputedFieldColumnRenderTestCase(TestCase):
+    """Covers the content-type guard in `ComputedFieldColumn.render`."""
+
+    @classmethod
+    def setUpTestData(cls):
+        location_ct = ContentType.objects.get_for_model(Location)
+        cls.text_field = ComputedField.objects.create(
+            key="cf_render_text",
+            label="Computed Field Text",
+            template="{{ obj.name }}",
+            fallback_value="error",
+            content_type=location_ct,
+        )
+        cls.markdown_field = ComputedField.objects.create(
+            key="cf_render_markdown",
+            label="Computed Field Markdown",
+            template="**{{ obj.name }}**",
+            fallback_value="error",
+            content_type=location_ct,
+        )
+
+    def test_render_evaluates_template_for_matching_row_type(self):
+        """A record matching the computed field's content type is rendered via the template."""
+        column = ComputedFieldColumn(self.text_field)
+        record = Location(name="Matching Location")
+        self.assertEqual(column.render(record=record), "Matching Location")
+
+    def test_render_returns_placeholder_for_foreign_row_type(self):
+        """A foreign model instance yields the placeholder, not the template output or fallback."""
+        column = ComputedFieldColumn(self.text_field)
+        # If the guard were missing, the template would render this name instead of a placeholder.
+        record = LocationType(name="Should Not Render")
+        self.assertEqual(column.render(record=record), helpers.placeholder(None))
+
+    def test_render_returns_placeholder_for_non_model_row(self):
+        """`available`-style rows (not model instances at all) also skip template evaluation."""
+        column = ComputedFieldColumn(self.text_field)
+        record = SimpleNamespace(name="Should Not Render")
+        self.assertEqual(column.render(record=record), helpers.placeholder(None))
+
+    def test_render_applies_markdown_output_type_for_matching_row(self):
+        """Markdown computed fields still pass through the markdown renderer for matching rows."""
+        self.markdown_field.output_type = ComputedFieldTypeChoices.TYPE_MARKDOWN
+        column = ComputedFieldColumn(self.markdown_field)
+        record = Location(name="Bold")
+        self.assertEqual(column.render(record=record), helpers.render_markdown("**Bold**"))


### PR DESCRIPTION
Tracking: NAUTOBOT-1449
# What's Changed
Fixed `ComputedFieldColumn` rendering its fallback value on non-matching row types in interleaved tables (e.g. Prefix > IP Addresses). Such cells now render a placeholder.

# Screenshots
Computed Field
<img width="1175" height="721" alt="image" src="https://github.com/user-attachments/assets/988e7f80-5d32-48fb-8431-a702e9741491" />

## BEFORE
<img width="1666" height="417" alt="image" src="https://github.com/user-attachments/assets/c908451a-c920-48e9-bbdb-2fc7bad60c1f" />

## AFTER
<img width="1656" height="420" alt="image" src="https://github.com/user-attachments/assets/c1f37e07-3746-4c4e-8dea-20ab34ff0675" />

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
