### PR TITLE
Add support for SavedView to ObjectChange View

### DIFF
--- a/changes/9271.added
+++ b/changes/9271.added
@@ -1,0 +1,1 @@
+Added `SavedView` support to `ObjectChange` list view.

--- a/nautobot/extras/models/change_logging.py
+++ b/nautobot/extras/models/change_logging.py
@@ -110,6 +110,7 @@ class ObjectChange(BaseModel):
     documentation_static_path = "docs/user-guide/platform-functionality/change-logging.html"
     natural_key_field_names = ["pk"]
     hide_in_diff_view = True
+    is_saved_view_model = True
 
     class Meta:
         ordering = ["-time"]

--- a/nautobot/extras/models/change_logging.py
+++ b/nautobot/extras/models/change_logging.py
@@ -12,6 +12,7 @@ from nautobot.core.utils.data import shallow_compare_dict
 from nautobot.core.utils.lookup import get_route_for_model
 from nautobot.extras.choices import ObjectChangeActionChoices, ObjectChangeEventContextChoices
 from nautobot.extras.constants import CHANGELOG_MAX_CHANGE_CONTEXT_DETAIL, CHANGELOG_MAX_OBJECT_REPR
+from nautobot.extras.models.mixins import SavedViewMixin
 from nautobot.extras.utils import extras_features
 
 #
@@ -65,7 +66,7 @@ class ChangeLoggedModel(models.Model):
 
 
 @extras_features("graphql")
-class ObjectChange(BaseModel):
+class ObjectChange(SavedViewMixin, BaseModel):
     """
     Record a change to an object and the user account associated with that change. A change record may optionally
     indicate an object related to the one being changed. For example, a change to an interface may also indicate the
@@ -110,7 +111,6 @@ class ObjectChange(BaseModel):
     documentation_static_path = "docs/user-guide/platform-functionality/change-logging.html"
     natural_key_field_names = ["pk"]
     hide_in_diff_view = True
-    is_saved_view_model = True
 
     class Meta:
         ordering = ["-time"]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

Currently, ObjectChange records do not have support for SavedViews, this is due to ObjectChange model being a BaseModel.  This PR adds the SavedView functionality to ObjectChange. I validated the SavedViews do work for ObjectChange, once the fix is applied.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Before:
<img width="1448" height="168" alt="image" src="https://github.com/user-attachments/assets/da01e254-b913-4301-8abc-003151a0f954" />

After:
<img width="1448" height="122" alt="image" src="https://github.com/user-attachments/assets/d84e1f0c-80e2-4e54-b516-da9fb3ce9cea" />


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
