### PR TITLE
Fixed bulk edit/delete to honor `alter_queryset` scoping

### DIFF
--- a/changes/9264.fixed
+++ b/changes/9264.fixed
@@ -1,0 +1,1 @@
+Fixed bulk "Select All" delete and edit operations ignoring a view's implicit `alter_queryset()` scoping.

--- a/examples/example_app/example_app/homepage.py
+++ b/examples/example_app/example_app/homepage.py
@@ -10,6 +10,10 @@ def get_example_data(request):
             ExampleModel.objects.create(name="Example 1", number=100),
             ExampleModel.objects.create(name="Example 2", number=200),
             ExampleModel.objects.create(name="Example 3", number=300),
+            # "Archived" records (negative number) hidden from the default list view by
+            # ExampleModelUIViewSet.alter_queryset(), to demonstrate implicit view scoping.
+            ExampleModel.objects.create(name="Example 4 (Archived)", number=-100),
+            ExampleModel.objects.create(name="Example 5 (Archived)", number=-200),
         )
     return examples
 

--- a/examples/example_app/example_app/templates/example_app/examplemodel_list.html
+++ b/examples/example_app/example_app/templates/example_app/examplemodel_list.html
@@ -1,0 +1,8 @@
+{% extends 'generic/object_list.html' %}
+{% load helpers %}
+
+{% block buttons %}
+    <a class="btn btn-primary" href="{% url 'plugins:example_app:examplemodel_list' %}?number__lt=0" id="archived-objects-button">
+        <span aria-hidden="true" class="mdi mdi-archive"></span> Archived Objects (Number < 0)
+    </a>
+{% endblock buttons %}

--- a/examples/example_app/example_app/views.py
+++ b/examples/example_app/example_app/views.py
@@ -255,6 +255,20 @@ class ExampleModelUIViewSet(views.NautobotUIViewSet):
         ),
     )
 
+    def alter_queryset(self, request):
+        """Hide "archived" records (negative `number`) from the default list view.
+
+        If the user explicitly filters on `number` (e.g., `number` or `number__lt`),
+        return the queryset as is.
+        """
+        queryset = super().alter_queryset(request)
+        filter_params = self.get_filter_params(request)
+        # This is fragile and can create a false positive if we add another filter
+        # that starts with "number", but it's just an example.
+        if not any(param.startswith("number") for param in filter_params):
+            queryset = queryset.exclude(number__lt=0)
+        return queryset
+
     def get_extra_context(self, request, instance):
         context = super().get_extra_context(request, instance)
         if self.action == "retrieve":

--- a/nautobot/core/tests/test_views_utils.py
+++ b/nautobot/core/tests/test_views_utils.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import urllib.parse
 
 from django.contrib.auth.models import AnonymousUser
@@ -552,3 +553,64 @@ class GetBulkQuerysetFromViewScopingTestCase(TestCase):
             action="delete",
         )
         self.assertQuerySetEqual(qs, self.archived, ordered=False)
+
+    def test_pk_list_honored_when_no_filterset(self):
+        """A PK-list bulk op targets only the selected PKs even when no filterset is available.
+
+        Regression test: the "no filterset" short-circuit must not preempt the explicit pk_list handling,
+        which would otherwise cause the operation to fall through and target all (scoped) objects.
+        """
+        from example_app.models import ExampleModel
+
+        class FakeViewNoFilterset:  # UIViewSet-like, but no filterset_class declared
+            queryset = ExampleModel.objects.all()
+
+            def alter_queryset(self, request):
+                return self.queryset.all()
+
+        with (
+            mock.patch("nautobot.core.views.utils.get_view_for_model", return_value=FakeViewNoFilterset),
+            mock.patch("nautobot.core.views.utils.get_filterset_for_model", return_value=None),
+        ):
+            qs = get_bulk_queryset_from_view(
+                user=self.user,
+                content_type=self.content_type,
+                delete_all=False,
+                filter_query_params={},
+                pk_list=[self.visible[0].pk, self.visible[1].pk],
+                saved_view_id=None,
+                action="delete",
+            )
+        self.assertQuerySetEqual(qs, [self.visible[0], self.visible[1]], ordered=False)
+
+    def test_legacy_bulk_view_falls_back_to_list_view_scoping(self):
+        """When the resolved bulk view lacks alter_queryset (legacy views), the list view's scoping is used.
+
+        Legacy `BulkDeleteView`/`BulkEditView` don't define alter_queryset(); the scoping lives on the
+        separate `ObjectListView`. get_bulk_queryset_from_view should look that up and honor it.
+        """
+        from example_app.models import ExampleModel
+
+        class FakeLegacyBulkDeleteView:  # no alter_queryset(), mirrors legacy BulkDeleteView
+            queryset = ExampleModel.objects.all()
+
+        class FakeLegacyListView:  # scopes rows the way a legacy ObjectListView.alter_queryset() would
+            queryset = ExampleModel.objects.all()
+
+            def alter_queryset(self, request):
+                return self.queryset.exclude(number__lt=0)
+
+        def fake_get_view_for_model(_model, view_type=""):
+            return FakeLegacyListView if view_type == "List" else FakeLegacyBulkDeleteView
+
+        with mock.patch("nautobot.core.views.utils.get_view_for_model", side_effect=fake_get_view_for_model):
+            qs = get_bulk_queryset_from_view(
+                user=self.user,
+                content_type=self.content_type,
+                delete_all=True,
+                filter_query_params={},
+                pk_list=[],
+                saved_view_id=None,
+                action="delete",
+            )
+        self.assertQuerySetEqual(qs, self.visible, ordered=False)

--- a/nautobot/core/tests/test_views_utils.py
+++ b/nautobot/core/tests/test_views_utils.py
@@ -3,6 +3,7 @@ import urllib.parse
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.db import ProgrammingError
+from django.test import tag
 
 from nautobot.core.models.querysets import count_related
 from nautobot.core.testing import TestCase
@@ -470,3 +471,84 @@ class GetBulkQuerysetFromViewTestCase(TestCase):
             action="change",
         )
         self.assertQuerySetEqual(qs, VRF.objects.none(), ordered=False)
+
+
+@tag("example_app")
+class GetBulkQuerysetFromViewScopingTestCase(TestCase):
+    """Test that get_bulk_queryset_from_view respects a view's implicit `alter_queryset()` scoping.
+
+    ExampleModelUIViewSet overrides `alter_queryset()` to hide "archived" records
+    (negative `number`) from its default list view unless the user explicitly filters on `number`.
+    Bulk operations ("Select All") must apply that same scoping rather than targeting records the
+    user cannot see (NTC-6326).
+    """
+
+    def setUp(self):
+        super().setUp()
+        from example_app.models import ExampleModel
+
+        self.model = ExampleModel
+        self.user = User.objects.create_user(username="scopinguser", is_superuser=True)
+        self.content_type = ContentType.objects.get_for_model(ExampleModel)
+        self.visible = [ExampleModel.objects.create(name=f"visible-{i}", number=100) for i in range(5)]
+        self.archived = [ExampleModel.objects.create(name=f"archived-{i}", number=-1) for i in range(3)]
+
+    def test_bulk_delete_respects_alter_queryset(self):
+        """delete_all should target only the visible (non-archived) records the list view shows."""
+        qs = get_bulk_queryset_from_view(
+            user=self.user,
+            content_type=self.content_type,
+            delete_all=True,
+            filter_query_params={},
+            pk_list=[],
+            saved_view_id=None,
+            action="delete",
+        )
+        self.assertQuerySetEqual(qs, self.visible, ordered=False)
+
+    def test_bulk_edit_respects_alter_queryset(self):
+        """edit_all should likewise exclude records hidden by the view's alter_queryset()."""
+        qs = get_bulk_queryset_from_view(
+            user=self.user,
+            content_type=self.content_type,
+            edit_all=True,
+            filter_query_params={},
+            pk_list=[],
+            saved_view_id=None,
+            action="change",
+        )
+        self.assertQuerySetEqual(qs, self.visible, ordered=False)
+
+    def test_explicit_filter_relaxes_scoping(self):
+        """Filtering explicitly on `number` relaxes the implicit scoping and applies the view's filterset.
+
+        This exercises the synthetic request's GET reaching alter_queryset()/get_filter_params() and
+        confirms the view's own filterset_class is used for the bulk queryset.
+        """
+        qs = get_bulk_queryset_from_view(
+            user=self.user,
+            content_type=self.content_type,
+            delete_all=True,
+            filter_query_params={"number": ["-1"]},
+            pk_list=[],
+            saved_view_id=None,
+            action="delete",
+        )
+        self.assertQuerySetEqual(qs, self.archived, ordered=False)
+
+    def test_explicit_filter_lookup_expression_relaxes_scoping(self):
+        """A `number` lookup expression (e.g. number__lt) also relaxes the implicit scoping.
+
+        The view's alter_queryset() must recognize any `number` lookup, not just the exact `number` key,
+        so that filtering on the scoped field surfaces the otherwise-hidden records.
+        """
+        qs = get_bulk_queryset_from_view(
+            user=self.user,
+            content_type=self.content_type,
+            delete_all=True,
+            filter_query_params={"number__lt": ["0"]},
+            pk_list=[],
+            saved_view_id=None,
+            action="delete",
+        )
+        self.assertQuerySetEqual(qs, self.archived, ordered=False)

--- a/nautobot/core/views/utils.py
+++ b/nautobot/core/views/utils.py
@@ -646,9 +646,7 @@ def get_bulk_queryset_from_view(
         log.debug("Filtering by None, as no PKs provided for bulk operation, returning empty queryset")
         return queryset.none()
 
-    # Prefer the view's own filterset_class (a class attribute, so still job-safe), falling back to the
-    # model-level lookup. This honors views that declare a narrower/custom filterset than the model default.
-    filterset_class = getattr(view_class, "filterset_class", None) or get_filterset_for_model(model)
+    filterset_class = get_filterset_for_model(model)
 
     if not filterset_class:
         log.debug(f"No filterset_class found for model {model}, returning all objects")

--- a/nautobot/core/views/utils.py
+++ b/nautobot/core/views/utils.py
@@ -612,30 +612,28 @@ def get_bulk_queryset_from_view(
     synthetic_request.GET = get_params
     synthetic_request.user = user
 
-    view = view_class()
-    view.request = synthetic_request
-    # Map to the permission-bearing UI action so the view's get_action()/restrict() line up with `action`.
-    view.action = "bulk_destroy" if action == "delete" else "bulk_update"
-    view.kwargs = {}
+    def scoped_queryset(scoping_view_class):
+        """Instantiate the given view and return its alter_queryset() result using the synthetic request."""
+        scoping_view = scoping_view_class()
+        scoping_view.request = synthetic_request
+        # Map to the permission-bearing UI action so the view's get_action()/restrict() line up with `action`.
+        scoping_view.action = "bulk_destroy" if action == "delete" else "bulk_update"
+        scoping_view.kwargs = {}
+        return scoping_view.alter_queryset(synthetic_request)
 
-    # Apply the view's alter_queryset() so implicit list-view scoping is honored. The default implementation
-    # returns the base queryset unchanged, so views that don't override it behave exactly as before. The
-    # trailing restrict() covers legacy generic views whose alter_queryset() does not restrict by permission.
-    if hasattr(view, "alter_queryset"):
-        queryset = view.alter_queryset(synthetic_request).restrict(user, action)
+    if hasattr(view_class, "alter_queryset"):
+        # Case: NautobotUIViewSet
+        queryset = scoped_queryset(view_class)
     else:
-        queryset = view_class.queryset.restrict(user, action)
-
-    # Prefer the view's own filterset_class (a class attribute, so still job-safe), falling back to the
-    # model-level lookup. This honors views that declare a narrower/custom filterset than the model default.
-    filterset_class = getattr(view_class, "filterset_class", None) or get_filterset_for_model(model)
-
-    if not filterset_class:
-        log.debug(f"No filterset_class found for model {model}, returning all objects")
-        return queryset
-
-    filter_query_params = normalize_querydict(filter_query_params, filterset=filterset_class())
-    log.debug(f"Normalized filter_query_params: {filter_query_params}")
+        # Case: Legacy bulk views (BulkDeleteView/BulkEditView)
+        list_view_class = get_view_for_model(model, view_type="List")
+        if list_view_class is not None and hasattr(list_view_class, "alter_queryset"):
+            # Case: Legacy list view (ObjectListView) with alter_queryset
+            queryset = scoped_queryset(list_view_class)
+        else:
+            # Case: Legacy list view (ObjectListView) without alter_queryset
+            queryset = view_class.queryset
+    queryset = queryset.restrict(user, action)
 
     # The form actually sends the pks and the "all" parameter, so seeing pk_list by itself is not
     # sufficient to determine if we are filtering by pk_list or by all. We need to see is_all=False.
@@ -647,6 +645,17 @@ def get_bulk_queryset_from_view(
     if not is_all and not pk_list:
         log.debug("Filtering by None, as no PKs provided for bulk operation, returning empty queryset")
         return queryset.none()
+
+    # Prefer the view's own filterset_class (a class attribute, so still job-safe), falling back to the
+    # model-level lookup. This honors views that declare a narrower/custom filterset than the model default.
+    filterset_class = getattr(view_class, "filterset_class", None) or get_filterset_for_model(model)
+
+    if not filterset_class:
+        log.debug(f"No filterset_class found for model {model}, returning all objects")
+        return queryset
+
+    filter_query_params = normalize_querydict(filter_query_params, filterset=filterset_class())
+    log.debug(f"Normalized filter_query_params: {filter_query_params}")
 
     # The query params when you manually delete filters from the UI include on the saved view filter
     # set the flag all_filters_removed to true. If that is the case, we ignore the saved view below, by setting it

--- a/nautobot/core/views/utils.py
+++ b/nautobot/core/views/utils.py
@@ -8,6 +8,8 @@ from django.contrib import messages
 from django.core.cache import cache
 from django.core.exceptions import FieldError, ValidationError
 from django.db.models import ForeignKey
+from django.http import QueryDict
+from django.test.client import RequestFactory
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django_tables2 import RequestConfig
@@ -18,7 +20,6 @@ from rest_framework import exceptions, serializers
 from nautobot.core.api.fields import ChoiceField, ContentTypeField, TimeZoneSerializerField
 from nautobot.core.api.parsers import NautobotCSVParser
 from nautobot.core.models.utils import is_taggable
-from nautobot.core.utils import lookup
 from nautobot.core.utils.data import is_uuid
 from nautobot.core.utils.filtering import get_filter_field_label
 from nautobot.core.utils.lookup import (
@@ -549,12 +550,14 @@ def get_bulk_queryset_from_view(
 
     Args:
         user: The user performing the bulk operation.
-        model: The model class on which the bulk operation is being performed.
-        delete_all: Boolean indicating whether the operation applies to pk_list or not.
-        edit_all: Boolean indicating whether the operation applies to pk_list or not.
+        content_type: The ContentType of the model on which the bulk operation is being performed.
         filter_query_params: A dictionary of filter parameters to apply to the queryset as produced by convert_querydict_to_dict(request.GET).
         pk_list: A list of primary keys to include, when not using a filter.
         saved_view_id: (Optional) UUID of a saved view to apply additional filters from.
+        action: The action being performed, either "delete" or "change".
+        delete_all: Boolean indicating whether a "delete" action applies to all (filtered) objects rather than pk_list.
+        edit_all: Boolean indicating whether a "change" action applies to all (filtered) objects rather than pk_list.
+        log: (Optional) Logger to use; defaults to this module's logger.
 
     Returns:
         A Django queryset representing the objects to be affected by the bulk operation.
@@ -597,23 +600,42 @@ def get_bulk_queryset_from_view(
     if not view_class:
         raise RuntimeError(f"No view found for model {model} to determine base queryset.")
 
-    queryset = view_class.queryset.restrict(user, action)
+    # Reconstruct a job-safe synthetic request from the (already serializable) params so that the view's
+    # alter_queryset() runs identically whether we're called from a UI view (request exists) or from a
+    # background system Job (no request/view instance exists). This ensures implicit view scoping applied
+    # by alter_queryset() is respected during bulk operations rather than silently dropped.
+    get_params = QueryDict(mutable=True)
+    for key, values in (filter_query_params or {}).items():
+        values = values if isinstance(values, (list, tuple)) else [values]
+        get_params.setlist(key, [str(value) for value in values])
+    synthetic_request = RequestFactory().get("/")
+    synthetic_request.GET = get_params
+    synthetic_request.user = user
 
-    # The filterset_class is determined from model on purpose versus getting it from the view itself. This is
-    # because the filterset_class on the view as a param, will not work with a job. It is better to be consistent
-    # with each with sending the same params that will always be available from to the confirmation page and to the job.
-    filterset_class = get_filterset_for_model(model)
+    view = view_class()
+    view.request = synthetic_request
+    # Map to the permission-bearing UI action so the view's get_action()/restrict() line up with `action`.
+    view.action = "bulk_destroy" if action == "delete" else "bulk_update"
+    view.kwargs = {}
+
+    # Apply the view's alter_queryset() so implicit list-view scoping is honored. The default implementation
+    # returns the base queryset unchanged, so views that don't override it behave exactly as before. The
+    # trailing restrict() covers legacy generic views whose alter_queryset() does not restrict by permission.
+    if hasattr(view, "alter_queryset"):
+        queryset = view.alter_queryset(synthetic_request).restrict(user, action)
+    else:
+        queryset = view_class.queryset.restrict(user, action)
+
+    # Prefer the view's own filterset_class (a class attribute, so still job-safe), falling back to the
+    # model-level lookup. This honors views that declare a narrower/custom filterset than the model default.
+    filterset_class = getattr(view_class, "filterset_class", None) or get_filterset_for_model(model)
 
     if not filterset_class:
         log.debug(f"No filterset_class found for model {model}, returning all objects")
         return queryset
 
-    filterset_class = lookup.get_filterset_for_model(model)
-    if filterset_class:
-        filter_query_params = normalize_querydict(filter_query_params, filterset=filterset_class())
-        log.debug(f"Normalized filter_query_params: {filter_query_params}")
-    else:
-        filter_query_params = {}
+    filter_query_params = normalize_querydict(filter_query_params, filterset=filterset_class())
+    log.debug(f"Normalized filter_query_params: {filter_query_params}")
 
     # The form actually sends the pks and the "all" parameter, so seeing pk_list by itself is not
     # sufficient to determine if we are filtering by pk_list or by all. We need to see is_all=False.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #9264
# What's Changed

Some Views use `alter_queryset` to scope the default list view. Currently, when selecting all multi-paginated objects (via the "Select all N {model name} matching query" checkbox), we default to using the unaltered queryset for this bulk operation. This can cause a bad UX as we edit or delete objects that were not visible from the default scoped list view.

This PR changes `get_bulk_queryset_from_view` to detect and resolve the `alter_queryset` method from the underlying View so that we start with the same base queryset that the list view would have presented as well.

# Screenshots

Case: Bulk deleting all `ExampleModel` objects when 2 are hidden by default. You can see the "Select all" checkbox lists 3 objects:

<img width="364" height="171" alt="Screenshot 2026-07-20 at 12 44 22 PM" src="https://github.com/user-attachments/assets/1d61e576-ba46-41cc-a96e-6f07ab5f8fb8" />

You can see after selecting to delete all objects, before the fix it changes from 3 objects to 5. After the fix, it properly scopes to the original 3.

|Before|After|
|-|-|
|<img width="453" height="118" alt="Screenshot 2026-07-20 at 12 45 50 PM" src="https://github.com/user-attachments/assets/7b4cee34-13c0-46f9-8637-b53ac9f800e4" />|<img width="458" height="122" alt="Screenshot 2026-07-20 at 12 44 31 PM" src="https://github.com/user-attachments/assets/47505abc-6fdc-4d48-8a8b-8b6f1831ea8a" />|

# TODO

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [N/A] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [N/A] Outline Remaining Work, Constraints from Design

NTC-6326