### PR TITLE
fix: change celery liveness probes to piggybag consumer

### DIFF
--- a/changes/9273.fixed
+++ b/changes/9273.fixed
@@ -1,1 +1,1 @@
-Fixed the Worker's livenss probe files to be updated based on consumer's connection.
+Fixed the worker liveness probe file to be updated based on the consumer's connection.

--- a/changes/9273.fixed
+++ b/changes/9273.fixed
@@ -1,0 +1,1 @@
+Fixed the Worker's livenss probe files to be updated based on consumer's connection.

--- a/nautobot/core/celery/__init__.py
+++ b/nautobot/core/celery/__init__.py
@@ -288,7 +288,7 @@ def worker_shutdown(**_):
 
 
 class LivenessProbe(bootsteps.StartStopStep):
-    requires = {"celery.worker.components:Timer"}
+    requires = {"celery.worker.consumer.connection:Connection"}
 
     def __init__(self, parent, **kwargs):
         self.requests = []
@@ -313,4 +313,4 @@ class LivenessProbe(bootsteps.StartStopStep):
         self.WORKER_HEARTBEAT_FILE.touch(exist_ok=True)
 
 
-app.steps["worker"].add(LivenessProbe)
+app.steps["consumer"].add(LivenessProbe)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #9273 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->
Changed the creation of health file of celery workers to be added into the celery consumer and not the worker. That way, when connection to redis is lost but re-established the worker's are not restarted for no reason, because the file's edit time is stuck when connection lost. 
More info can be found [here ](https://github.com/celery/celery/issues/3955).

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
