### PR TITLE
IP Address Range - improvements performance

### DIFF
--- a/changes/9277.changed
+++ b/changes/9277.changed
@@ -1,0 +1,1 @@
+Changed `Prefix.get_available_ips()` to exclude only exclusive IP Address Ranges, aligning availability with IPAddress validation. The `/available-ips/` API endpoint now lists and allocates addresses inside non-exclusive ranges. Removed the unused `exclude_child_ips` parameter.

--- a/changes/9277.fixed
+++ b/changes/9277.fixed
@@ -1,0 +1,1 @@
+Improved performance of "ip address ranges" feature.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -1501,6 +1501,18 @@ class Prefix(PrimaryModel):
         streamed from the DB in ascending order and merged lazily; the scan
         stops at the first gap.
 
+        All contained IPAddressRanges are treated as blockers, regardless of
+        their `count_as_utilized` or `is_exclusive` flags:
+
+        - When pre-filling a new IPAddressRange (exclude_child_ips=False), any
+        overlap with an existing range is rejected by validation
+        (`IPAddressRange._validate_no_range_overlap`), so every existing range
+        must be skipped no matter its flags.
+        - The flags have narrower, unrelated roles: `count_as_utilized` only
+        affects utilization statistics, and `is_exclusive` only affects
+        validation of creating individual IPAddresses inside the range.
+        Neither defines availability in the sense of this method.
+
         Returns:
             netaddr.IPAddress or None
         """
@@ -1541,7 +1553,7 @@ class Prefix(PrimaryModel):
             blockers = range_intervals()
 
         for start, end in blockers:
-            if start > candidate:
+            if candidate < start:
                 # Found a gap before this blocker.
                 break
             # This blocker starts at/before the candidate; skip past it if it covers it.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -1,4 +1,5 @@
 import contextvars
+import heapq
 import logging
 import operator
 from typing import Optional
@@ -1378,10 +1379,14 @@ class Prefix(PrimaryModel):
             child_ips = netaddr.IPSet([ip.address.ip for ip in self.get_all_ips()])
             available_ips -= child_ips
 
-        for ip_range in self.get_all_ip_address_ranges():
-            start = netaddr.IPAddress(ip_range.start_address)
-            end = netaddr.IPAddress(ip_range.end_address)
-            available_ips -= netaddr.IPSet(netaddr.IPRange(start, end))
+        # Collect every range's CIDRs into a single IPSet and subtract once;
+        # subtracting per-range in a loop rebuilds the set N times and is the
+        # dominant cost when there are thousands of ranges.
+        range_cidrs = []
+        for start_host, end_host in self.get_all_ip_address_ranges().values_list("start_host", "end_host"):
+            range_cidrs.extend(netaddr.IPRange(start_host, end_host).cidrs())
+        if range_cidrs:
+            available_ips -= netaddr.IPSet(range_cidrs)
 
         # IPv6, pool, or IPv4 /31-32 sets are fully usable
         if any(
@@ -1469,10 +1474,10 @@ class Prefix(PrimaryModel):
         """
         Return the first available IP within the prefix (or None).
         """
-        available_ips = self.get_available_ips()
-        if not available_ips:
+        first = self._first_available_host(exclude_child_ips=True)
+        if first is None:
             return None
-        return f"{next(available_ips.__iter__())}/{self.prefix_length}"
+        return f"{first}/{self.prefix_length}"
 
     def get_first_available_ip_for_range(self):
         """
@@ -1482,10 +1487,71 @@ class Prefix(PrimaryModel):
         Unlike get_first_available_ip(), this ignores existing IP Addresses,
         since a non-exclusive Range may contain them.
         """
-        available_ips = self.get_available_ips(exclude_child_ips=False)
-        if not available_ips:
+        first = self._first_available_host(exclude_child_ips=False)
+        if first is None:
             return None
-        return str(next(available_ips.__iter__()))
+        return str(first)
+
+    def _first_available_host(self, exclude_child_ips=True):
+        """
+        Find the first host address in this prefix not covered by any blocker,
+        without materializing the full availability set.
+
+        Blockers are contained IPAddressRanges and (optionally) IPAddresses,
+        streamed from the DB in ascending order and merged lazily; the scan
+        stops at the first gap.
+
+        Returns:
+            netaddr.IPAddress or None
+        """
+        fully_usable = any(
+            [
+                self.ip_version == choices.IPAddressVersionChoices.VERSION_6,
+                self.type == choices.PrefixTypeChoices.TYPE_POOL,
+                self.ip_version == choices.IPAddressVersionChoices.VERSION_4 and self.prefix_length >= 31,
+            ]
+        )
+        candidate = self.prefix.first
+        last_usable = self.prefix.last
+        if not fully_usable:
+            # Omit the prefix's own network and broadcast addresses.
+            candidate += 1
+            last_usable -= 1
+        if candidate > last_usable:
+            return None
+
+        def range_intervals():
+            qs = self.get_all_ip_address_ranges().order_by("start_host").values_list("start_host", "end_host")
+            for start_host, end_host in qs.iterator(chunk_size=1000):
+                yield (int(netaddr.IPAddress(start_host)), int(netaddr.IPAddress(end_host)))
+
+        def ip_intervals():
+            qs = self.get_all_ips().order_by("host").values_list("host", flat=True)
+            for host in qs.iterator(chunk_size=1000):
+                value = int(netaddr.IPAddress(host))
+                yield (value, value)
+
+        if exclude_child_ips:
+            # Both streams are sorted ascending by their first element (VarbinaryIPField
+            # byte ordering == numeric ordering within a single ip_version, and both
+            # querysets are already filtered to self.ip_version). heapq.merge keeps the
+            # combined stream sorted while consuming both lazily.
+            blockers = heapq.merge(range_intervals(), ip_intervals())
+        else:
+            blockers = range_intervals()
+
+        for start, end in blockers:
+            if start > candidate:
+                # Found a gap before this blocker.
+                break
+            # This blocker starts at/before the candidate; skip past it if it covers it.
+            # (end may be < candidate for stale/overtaken blockers - just ignore those.)
+            if end >= candidate:
+                candidate = end + 1
+                if candidate > last_usable:
+                    return None
+
+        return netaddr.IPAddress(candidate, version=self.ip_version)
 
     def get_utilization(self):
         """Return the utilization of this prefix as a UtilizationData object.

--- a/nautobot/ipam/models.py
+++ b/nautobot/ipam/models.py
@@ -1365,25 +1365,23 @@ class Prefix(PrimaryModel):
 
         return available_prefixes
 
-    def get_available_ips(self, exclude_child_ips=True):
+    def get_available_ips(self):
         """
         Return all available IPs within this prefix as an IPSet.
 
-        exclude_child_ips: when False, existing IP Addresses are NOT removed from
-        the set. Used when pre-filling a new (non-exclusive) IP Address Range,
-        which may legitimately overlap already-assigned IPs.
+        Addresses inside exclusive IP Address Ranges are excluded (IPAddress
+        creation there is forbidden); non-exclusive ranges are NOT excluded,
+        consistent with IPAddress validation.
         """
         available_ips = netaddr.IPSet(self.prefix)
+        child_ips = netaddr.IPSet([ip.address.ip for ip in self.get_all_ips()])
+        available_ips -= child_ips
 
-        if exclude_child_ips:
-            child_ips = netaddr.IPSet([ip.address.ip for ip in self.get_all_ips()])
-            available_ips -= child_ips
-
-        # Collect every range's CIDRs into a single IPSet and subtract once;
-        # subtracting per-range in a loop rebuilds the set N times and is the
-        # dominant cost when there are thousands of ranges.
+        # Subtract all exclusive ranges as a single IPSet operation; per-range
+        # subtraction in a loop rebuilds the set on every iteration.
         range_cidrs = []
-        for start_host, end_host in self.get_all_ip_address_ranges().values_list("start_host", "end_host"):
+        qs = self.get_all_ip_address_ranges().filter(is_exclusive=True)
+        for start_host, end_host in qs.values_list("start_host", "end_host"):
             range_cidrs.extend(netaddr.IPRange(start_host, end_host).cidrs())
         if range_cidrs:
             available_ips -= netaddr.IPSet(range_cidrs)

--- a/nautobot/ipam/views.py
+++ b/nautobot/ipam/views.py
@@ -857,7 +857,6 @@ class PrefixUIViewSet(NautobotUIViewSet):
 
         return Response(
             {
-                "first_available_ip": instance.get_first_available_ip(),
                 "first_available_ip_for_range": instance.get_first_available_ip_for_range(),
                 "ipaddressrange_table": ip_address_range_table,
                 "permissions": permissions,


### PR DESCRIPTION
Tracking: NAUTOBOT-1478

# What's Changed
Improve performance of IP Address and IP Address Ranges tab by replaced the full-set computation with a merge-scan: blocking intervals (ranges, and IPs where applicable) are streamed from the DB in ascending order and merged lazily (heapq.merge). The scan advances a candidate address past each covering blocker and exits at the first gap. Typical cost is a handful of DB rows regardless of prefix size. `get_available_ips()` is kept for callers that need the full set, with per-range subtraction replaced by a single bulk subtraction.

# Screenshots
```
Created root 10.0.0.0/8 in namespace 'Perf Test'
[    0.6s] /16 1/8 done (prefixes=12, ranges=30, ips=20)
[    1.0s] /16 2/8 done (prefixes=23, ranges=60, ips=40)
[    1.4s] /16 3/8 done (prefixes=34, ranges=90, ips=60)
[    1.8s] /16 4/8 done (prefixes=45, ranges=120, ips=80)
[    2.2s] /16 5/8 done (prefixes=56, ranges=150, ips=100)
[    2.6s] /16 6/8 done (prefixes=67, ranges=180, ips=120)
[    3.0s] /16 7/8 done (prefixes=78, ranges=210, ips=140)
[    3.3s] /16 8/8 done (prefixes=89, ranges=240, ips=160)
Done in 3.3s: 89 prefixes, 240 ranges, 160 IPs.
```

## Results - method level
 
| Prefix | Method | Before | After | Speedup |
|---|---|---|---|---|
| /8 root | `get_first_available_ip` | 282.0 ms | 1.7 ms | ~165x |
| /8 root | `get_first_available_ip_for_range` | 159.8 ms | 0.9 ms | ~175x |
| /16 | `get_first_available_ip` | 7.0 ms | 1.0 ms | 7x |
| /16 | `get_first_available_ip_for_range` | 4.4 ms | 0.6 ms | 7x |
| /24 leaf | `get_first_available_ip` | 1.3 ms | 1.0 ms | — |
| /24 leaf | `get_first_available_ip_for_range` | 0.7 ms | 0.5 ms | — |
 
## Results - view level (/8 root detail tabs)
 
| View | Before | After |
|---|---|---|
| IP Addresses tab | 773.6 ms | 323.8 ms |
| IP Address Ranges tab | 710.5 ms | 295.7 ms |
| Descendant Prefixes tab | 540.7 ms | 581.7 ms |

## Edge cases
 
Two hand-crafted scenarios on top of the seeded data (245 ranges total):
- **first gap not at start** - a range `10.0.0.1–10.0.0.255` occupies the beginning of the /8, and leaf `10.0.1.0/24` is completely filled with ranges, so the scan must skip past blockers instead of returning immediately
- **fully packed (no gap)** - the filled /24 leaf has no available IP, so the scan must read every blocker before returning `None` (worst case for the new algorithm).

| Scenario | Prefix | Result (both branches) | Before | After |
|---|---|---|---|---|
| first gap not at start | /8 | `10.0.1.0/8` | 271.7 ms | 1.3 ms |
| fully packed (no gap) | /24 | `None` | 1.4 ms | 1.2 ms |

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
