### PR TITLE
Fixed cable terminations API schema

### DIFF
--- a/changes/9174.fixed
+++ b/changes/9174.fixed
@@ -1,0 +1,1 @@
+Fixed the OpenAPI schema for the Cable `terminations` field.

--- a/nautobot/dcim/api/serializers.py
+++ b/nautobot/dcim/api/serializers.py
@@ -866,8 +866,8 @@ class CableSerializer(TaggedModelSerializerMixin, NautobotModelSerializer):
     # `SerializerMethodField` (rather than a declared nested field) so the per-request `?depth=N`
     # context drives the brief-vs-nested rendering of each slot. Writes are handled separately by
     # peeking at `self.initial_data` in `validate()` and applying via `_apply_terminations()`; see
-    # those methods below. The on-wire shape is a `{"a": {<connector>: ...}, "b": {...}}` dict
-    # keyed by cable side then connector index, mirroring the physical structure of the cable.
+    # those methods below. The on-wire shape is a flat dict keyed by side plus 1-indexed connector
+    # number (e.g. "a1", "b1"), one key per physical connector on the cable.
     terminations = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
@@ -898,32 +898,19 @@ class CableSerializer(TaggedModelSerializerMixin, NautobotModelSerializer):
         {
             "type": "object",
             "description": (
-                "Terminations on this cable, keyed by side ('a'/'b') then 1-indexed connector "
-                "number (as string). Each slot value is a brief representation (default depth) "
-                "or the full nested serializer (`?depth>=1`) of the termination at that connector "
-                "— polymorphic across Interface / CircuitTermination / ConsolePort / FrontPort / "
-                "RearPort / PowerPort / PowerOutlet / PowerFeed. Uncabled connectors on breakout "
-                "cables are represented as `null`."
+                "Terminations on this cable, keyed by side ('a'/'b') plus 1-indexed connector "
+                "number. A standard cable has one connector per side ('a1', 'b1'); higher "
+                "connector numbers ('a2', 'b2', ...) appear only on breakout cables with "
+                "multiple connectors per side. Each value is a brief representation (default "
+                "depth) or the full nested serializer (`?depth>=1`) of the termination at that "
+                "connector; polymorphic across Interface / CircuitTermination / ConsolePort / "
+                "FrontPort / RearPort / PowerPort / PowerOutlet / PowerFeed. Uncabled connectors "
+                "on breakout cables are represented as `null`."
             ),
-            "properties": {
-                "a": {
-                    "type": "object",
-                    "description": "A-side connector slots, keyed by 1-indexed connector number as string.",
-                    "additionalProperties": {
-                        "allOf": [{"$ref": "#/components/schemas/CableTermination"}],
-                        "nullable": True,
-                    },
-                },
-                "b": {
-                    "type": "object",
-                    "description": "B-side connector slots, keyed by 1-indexed connector number as string.",
-                    "additionalProperties": {
-                        "allOf": [{"$ref": "#/components/schemas/CableTermination"}],
-                        "nullable": True,
-                    },
-                },
+            "additionalProperties": {
+                "allOf": [{"$ref": "#/components/schemas/CableTermination"}],
+                "nullable": True,
             },
-            "required": ["a", "b"],
         }
     )
     def get_terminations(self, obj):
@@ -1017,7 +1004,7 @@ class CableSerializer(TaggedModelSerializerMixin, NautobotModelSerializer):
         """Translate the dict-shape `terminations` input into internal `_apply_terminations` entries.
 
         Input shape:
-            {"a1": {"<connector>": null | {"object_type": "<app.model>", "id": "<uuid>"}}, "b1": {...}}
+            {"a1": null | {"object_type": "<app.model>", "id": "<uuid>"}, "b1": ...}
 
         Output: list of {"cable_end": "A"/"B", "connector": int, <fk>: id?} dicts. A slot whose
         value is `null` (or an empty dict) yields an entry with no FK set, signaling delete to
@@ -1157,55 +1144,51 @@ class CableSerializer(TaggedModelSerializerMixin, NautobotModelSerializer):
         return cable
 
 
+@extend_schema_field(
+    {
+        "type": "object",
+        "description": (
+            "Terminations to apply, keyed by side ('a'/'b') plus 1-indexed connector number. "
+            "A standard cable has one connector per side ('a1', 'b1'); higher connector numbers "
+            "('a2', 'b2', ...) apply only to breakout cables with multiple connectors per side. "
+            "Each value is either `null` (delete the existing termination at this connector) or "
+            'an `{"object_type": "<app.model>", "id": "<uuid>"}` reference to the termination '
+            "to plug in. Connectors omitted from the payload are left untouched (PATCH-style "
+            "merge semantics)."
+        ),
+        "additionalProperties": {
+            "nullable": True,
+            "type": "object",
+            "properties": {
+                "object_type": {"type": "string", "example": "dcim.interface"},
+                "id": {"type": "string", "format": "uuid"},
+            },
+            "required": ["object_type", "id"],
+        },
+    }
+)
+class CableTerminationsPayloadField(serializers.JSONField):
+    """JSONField carrying the OpenAPI schema for the writable Cable `terminations` payload.
+
+    The `extend_schema_field` annotation must live on this class rather than on a field instance:
+    DRF's `Field.__deepcopy__` re-instantiates declared fields from their original constructor
+    arguments when a serializer binds its fields, discarding instance attributes such as the
+    schema override (which would leave the field typed as a bare untyped object in the schema).
+    """
+
+
 class WritableCableSerializer(CableSerializer):
     """Schema-only variant of `CableSerializer` advertising the writable `terminations` payload.
 
     The runtime `CableSerializer.terminations` field is a `SerializerMethodField` (for depth-aware
-    reads) — so drf-spectacular marks it `readOnly: true` by default. This subclass overrides the
-    field with a writable `JSONField` purely so the OpenAPI request body schema for POST/PATCH on
-    `/api/dcim/cables/` advertises `terminations` as writable, and documents its accepted shape.
+    reads), so drf-spectacular marks it `readOnly: true` by default. This subclass overrides the
+    field with a writable JSON field purely so the OpenAPI request body schema for POST/PUT/PATCH
+    on `/api/dcim/cables/` advertises `terminations` as writable, and documents its accepted shape.
 
     Not used at runtime; referenced only from `@extend_schema_view` on `CableViewSet`.
     """
 
-    terminations = extend_schema_field(
-        {
-            "type": "object",
-            "description": (
-                "Terminations to apply, keyed by side ('a'/'b') then 1-indexed connector number. "
-                "Each slot value is either `null` (delete the existing row at this connector) or "
-                'an `{"object_type": "<app.model>", "id": "<uuid>"}` reference to the '
-                "termination to plug in. Sides and connectors omitted from the payload are left "
-                "untouched (PATCH-style merge semantics)."
-            ),
-            "properties": {
-                "a": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "nullable": True,
-                        "type": "object",
-                        "properties": {
-                            "object_type": {"type": "string", "example": "dcim.interface"},
-                            "id": {"type": "string", "format": "uuid"},
-                        },
-                        "required": ["object_type", "id"],
-                    },
-                },
-                "b": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "nullable": True,
-                        "type": "object",
-                        "properties": {
-                            "object_type": {"type": "string", "example": "dcim.interface"},
-                            "id": {"type": "string", "format": "uuid"},
-                        },
-                        "required": ["object_type", "id"],
-                    },
-                },
-            },
-        }
-    )(serializers.JSONField(required=False))
+    terminations = CableTerminationsPayloadField(required=False)
 
 
 class TracedCableSerializer(serializers.ModelSerializer):

--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -750,7 +750,7 @@ class CableTypeViewSet(NautobotModelViewSet):
 # depth support, but the endpoint accepts a writable `terminations` payload via custom
 # `validate()` / `_apply_terminations()` logic. Advertise that writability to OpenAPI clients by
 # pointing the request schema at `WritableCableSerializer`, which differs only in declaring
-# `terminations` as a writable nested serializer field.
+# `terminations` as a writable JSON field.
 @extend_schema_view(
     create=extend_schema(request=serializers.WritableCableSerializer),
     update=extend_schema(request=serializers.WritableCableSerializer),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #DNE
# What's Changed

This PR updates the API schema for the Cable terminations field to 1) properly display for the POST call and 2) update the description and properties after #9174.

# Screenshots

|Type|Before|After|
|-|-|-|
|GET|<img width="1005" height="219" alt="Screenshot 2026-07-23 at 4 23 04 PM" src="https://github.com/user-attachments/assets/2106dbf2-fdc1-4c07-ad98-b87b98080c3d" />|<img width="1001" height="473" alt="Screenshot 2026-07-23 at 4 20 14 PM" src="https://github.com/user-attachments/assets/22944979-061c-4947-9178-8e7931191511" />
|POST|<img width="216" height="62" alt="Screenshot 2026-07-23 at 4 22 31 PM" src="https://github.com/user-attachments/assets/86c49110-50f6-4bde-bc10-5676f7a93e19" />|<img width="750" height="321" alt="Screenshot 2026-07-23 at 4 19 32 PM" src="https://github.com/user-attachments/assets/a01458a6-4bd8-465d-b948-144c48f7fd02" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [N/A] Unit, Integration Tests
- [N/A] Documentation Updates (when adding/changing features)
- [N/A] Example App Updates (when adding/changing features)
- [N/A] Outline Remaining Work, Constraints from Design
