### PR TITLE
Fix contains filter

### DIFF
--- a/changes/xxxx.fixed
+++ b/changes/xxxx.fixed
@@ -1,0 +1,1 @@
+Fixed `contains` filter on IP Address Ranges matching ranges of the wrong IP family due to raw byte comparison without IP version scoping.

--- a/nautobot/ipam/filters.py
+++ b/nautobot/ipam/filters.py
@@ -740,8 +740,9 @@ class IPAddressRangeFilterSet(
         """Find ranges whose span (start_host..end_host) includes the given address(es)."""
         query = Q()
         for val in value:
-            host = bytes(netaddr.IPNetwork(val).ip)
-            query |= Q(start_host__lte=host, end_host__gte=host)
+            ip = netaddr.IPNetwork(val)
+            host = bytes(ip.ip)
+            query |= Q(start_host__lte=host, end_host__gte=host, ip_version=ip.version)
         return query
 
     def filter_contains(self, queryset, name, value):

--- a/nautobot/ipam/tests/test_filters.py
+++ b/nautobot/ipam/tests/test_filters.py
@@ -1210,6 +1210,10 @@ class IPAddressRangeTestCase(FilterTestCases.FilterTestCase, FilterTestCases.Ten
         cls.prefix4 = Prefix.objects.create(prefix="10.0.0.0/8", namespace=cls.namespace, status=prefix_status)
         cls.prefix6 = Prefix.objects.create(prefix="2001:db8::/64", namespace=cls.namespace, status=prefix_status)
 
+        # cross-family byte-match
+        cls.prefix6_low = Prefix.objects.create(prefix="0800::/5", namespace=cls.namespace, status=prefix_status)
+        cls.prefix4_high = Prefix.objects.create(prefix="32.0.0.0/4", namespace=cls.namespace, status=prefix_status)
+
         # Ranges are intentionally disjoint (no overlaps allowed within a parent).
         cls.ip_address_range1_v4 = IPAddressRange.objects.create(
             name="IP Range Alpha",
@@ -1263,6 +1267,26 @@ class IPAddressRangeTestCase(FilterTestCases.FilterTestCase, FilterTestCases.Ten
             status=cls.status_a,
             count_as_utilized=False,
             is_exclusive=True,
+        )
+
+        # cross-family byte-match
+        cls.ip_address_range_v6_cross_family = IPAddressRange.objects.create(
+            name="IP Range Foxtrot",
+            start_address="0800::1",
+            end_address="0fff::1",
+            namespace=cls.namespace,
+            status=cls.status_a,
+            count_as_utilized=False,
+            is_exclusive=False,
+        )
+        cls.ip_address_range_v4_cross_family = IPAddressRange.objects.create(
+            name="IP Range Golf",
+            start_address="32.0.0.1",
+            end_address="40.0.0.1",
+            namespace=cls.namespace,
+            status=cls.status_a,
+            count_as_utilized=False,
+            is_exclusive=False,
         )
 
     def test_search(self):
@@ -1410,6 +1434,18 @@ class IPAddressRangeTestCase(FilterTestCases.FilterTestCase, FilterTestCases.Ten
                 fs.filter_contains(self.queryset, "contains", []),
                 self.queryset.none(),
             )
+
+        with self.subTest("v4 query must not match byte-overlapping v6 range"):
+            params = {"contains": ["10.0.0.15"], "namespace": [self.namespace.id]}
+            qs = self.filterset(params, self.queryset).qs
+            self.assertIn(self.ip_address_range1_v4, qs)
+            self.assertNotIn(self.ip_address_range_v6_cross_family, qs)
+
+        with self.subTest("v6 query must not match byte-overlapping v4 range"):
+            params = {"contains": ["2001:db8::150"], "namespace": [self.namespace.id]}
+            qs = self.filterset(params, self.queryset).qs
+            self.assertIn(self.ip_address_range2_v6, qs)
+            self.assertNotIn(self.ip_address_range_v4_cross_family, qs)
 
 
 class VRFDeviceAssignmentTestCase(FilterTestCases.FilterTestCase):


### PR DESCRIPTION
Tracking: NAUTOBOT-1463

# What's Changed
Fixed `contains` filter on IP Address Ranges matching ranges of the wrong IP family due to raw byte comparison without IP version scoping.

# Screenshots
## BEFORE
v4 contains
<img width="1652" height="427" alt="image" src="https://github.com/user-attachments/assets/5b9e8146-bf0d-4518-a692-b75f7add5631" />

v6 contains
<img width="1650" height="399" alt="image" src="https://github.com/user-attachments/assets/1c25327b-9bac-4be5-9743-7bf7bcdb5484" />


## AFTER
v4 contains
<img width="1652" height="424" alt="image" src="https://github.com/user-attachments/assets/b21a70d7-66ef-4832-90b0-4a71362d8bc3" />

v6 contains
<img width="1663" height="403" alt="image" src="https://github.com/user-attachments/assets/d084669c-a108-4c69-bb87-445edba38a8f" />


# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- n/a Outline Remaining Work, Constraints from Design
