### PR TITLE
Fixed M2M API change logging

### DIFF
--- a/changes/9204.changed
+++ b/changes/9204.changed
@@ -1,0 +1,1 @@
+Changed change logging of many-to-many associations declared with an explicit `through` model so that both associated objects now receive a change log entry.

--- a/changes/9204.fixed
+++ b/changes/9204.fixed
@@ -1,0 +1,1 @@
+Fixed missing change log entries, webhooks, job hooks, and events when creating or deleting many-to-many association records via the REST API.

--- a/changes/9270.fixed
+++ b/changes/9270.fixed
@@ -1,0 +1,1 @@
+Fixed missing change log entries, webhooks, job hooks, and events when creating or deleting many-to-many association records via the REST API.

--- a/nautobot/core/testing/api.py
+++ b/nautobot/core/testing/api.py
@@ -135,9 +135,9 @@ class APITestCase(views.ModelTestCase):
         depth_fields = [field_name for field_name in depth_fields if field_name in serializer.fields]
         return depth_fields
 
-    def get_m2m_side_objects(self, instance):
+    def get_change_logged_m2m_side_objects(self, instance):
         """If self.model is an explicit M2M through model, return the non-null, change-logged objects it associates."""
-        side_field_names = extras_utils.get_explicit_m2m_through_side_field_names().get(self.model, ())
+        side_field_names = extras_utils.get_change_logged_m2m_through_side_field_names().get(self.model, ())
         side_objects = []
         for field_name in side_field_names:
             side_object = getattr(instance, field_name, None)
@@ -934,9 +934,10 @@ class APIViewTestCases:
                     # Verify that at least one ObjectChange record is for this instance
                     self.assertTrue(any(oc.changed_object == instance for oc in objectchanges))
 
-                # Creating a record of an explicit M2M through model must record an ObjectChange
-                # against both of the objects it associates
-                self.assert_m2m_side_objects_change_logged(self.get_m2m_side_objects(instance))
+                if changed_m2m_side_objects := self.get_change_logged_m2m_side_objects(instance):
+                    # This is an explicit M2M through model; creating this record must record
+                    # an ObjectChange against both of the objects it associates between
+                    self.assert_m2m_side_objects_change_logged(changed_m2m_side_objects)
 
         # TODO: The override_settings here is a temporary workaround for not breaking any app tests
         # long term fix should be using appropriate object permissions instead of the blanket override
@@ -1328,7 +1329,7 @@ class APIViewTestCases:
             instance = self.get_deletable_object()
             url = self._get_detail_url(instance)
             # Capture the side objects of an explicit M2M through model before the record is deleted
-            m2m_side_objects = self.get_m2m_side_objects(instance)
+            m2m_side_objects = self.get_change_logged_m2m_side_objects(instance)
 
             # Add object-level permission
             self.add_permissions(f"{self.model._meta.app_label}.delete_{self.model._meta.model_name}")
@@ -1356,7 +1357,7 @@ class APIViewTestCases:
             m2m_side_objects = [
                 side_object
                 for record in self._get_queryset().filter(pk__in=id_list)
-                for side_object in self.get_m2m_side_objects(record)
+                for side_object in self.get_change_logged_m2m_side_objects(record)
             ]
             # Add object-level permission
             self.add_permissions(f"{self.model._meta.app_label}.delete_{self.model._meta.model_name}")

--- a/nautobot/core/testing/api.py
+++ b/nautobot/core/testing/api.py
@@ -24,7 +24,7 @@ from nautobot.core.models.tree_queries import TreeModel
 from nautobot.core.testing import mixins, utils, views
 from nautobot.core.utils import lookup
 from nautobot.core.utils.data import is_uuid
-from nautobot.extras import choices as extras_choices, models as extras_models, registry
+from nautobot.extras import choices as extras_choices, models as extras_models, registry, utils as extras_utils
 from nautobot.users import models as users_models
 
 __all__ = (
@@ -134,6 +134,28 @@ class APITestCase(views.ModelTestCase):
         serializer = serializer_class()
         depth_fields = [field_name for field_name in depth_fields if field_name in serializer.fields]
         return depth_fields
+
+    def get_m2m_side_objects(self, instance):
+        """If self.model is an explicit M2M through model, return the non-null, change-logged objects it associates."""
+        side_field_names = extras_utils.get_explicit_m2m_through_side_field_names().get(self.model, ())
+        side_objects = []
+        for field_name in side_field_names:
+            side_object = getattr(instance, field_name, None)
+            if side_object is not None and hasattr(side_object, "to_objectchange"):
+                side_objects.append(side_object)
+        return side_objects
+
+    def assert_m2m_side_objects_change_logged(self, side_objects):
+        """Assert that an ACTION_UPDATE ObjectChange exists for each of the given M2M through-model side objects."""
+        for side_object in side_objects:
+            objectchanges = lookup.get_changes_for_model(side_object).filter(
+                action=extras_choices.ObjectChangeActionChoices.ACTION_UPDATE
+            )
+            self.assertTrue(
+                objectchanges.exists(),
+                f"No update ObjectChange was recorded for {side_object._meta.label} {side_object} "
+                f"as a side of a {self.model._meta.label} change",
+            )
 
     @staticmethod
     def add_query_params_to_url(url: str, query_dict: dict) -> str:
@@ -912,6 +934,10 @@ class APIViewTestCases:
                     # Verify that at least one ObjectChange record is for this instance
                     self.assertTrue(any(oc.changed_object == instance for oc in objectchanges))
 
+                # Creating a record of an explicit M2M through model must record an ObjectChange
+                # against both of the objects it associates
+                self.assert_m2m_side_objects_change_logged(self.get_m2m_side_objects(instance))
+
         # TODO: The override_settings here is a temporary workaround for not breaking any app tests
         # long term fix should be using appropriate object permissions instead of the blanket override
         @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
@@ -1301,6 +1327,8 @@ class APIViewTestCases:
             """
             instance = self.get_deletable_object()
             url = self._get_detail_url(instance)
+            # Capture the side objects of an explicit M2M through model before the record is deleted
+            m2m_side_objects = self.get_m2m_side_objects(instance)
 
             # Add object-level permission
             self.add_permissions(f"{self.model._meta.app_label}.delete_{self.model._meta.model_name}")
@@ -1314,11 +1342,22 @@ class APIViewTestCases:
                 objectchanges = lookup.get_changes_for_model(instance)
                 self.assertEqual(objectchanges[0].action, extras_choices.ObjectChangeActionChoices.ACTION_DELETE)
 
+            # Deleting a record of an explicit M2M through model must record an ObjectChange
+            # against both of the objects it associated
+            self.assert_m2m_side_objects_change_logged(m2m_side_objects)
+
         def test_bulk_delete_objects(self):
             """
             DELETE a set of objects in a single request.
             """
-            id_list = self.get_deletable_object_pks()
+            # Materialized to a list because MySQL doesn't support a LIMIT-ed queryset inside a `pk__in` filter
+            id_list = list(self.get_deletable_object_pks())
+            # Capture the side objects of an explicit M2M through model before the records are deleted
+            m2m_side_objects = [
+                side_object
+                for record in self._get_queryset().filter(pk__in=id_list)
+                for side_object in self.get_m2m_side_objects(record)
+            ]
             # Add object-level permission
             self.add_permissions(f"{self.model._meta.app_label}.delete_{self.model._meta.model_name}")
 
@@ -1328,6 +1367,10 @@ class APIViewTestCases:
             response = self.client.delete(self._get_list_url(), data, format="json", **self.header)
             self.assertHttpStatus(response, status.HTTP_204_NO_CONTENT)
             self.assertEqual(self._get_queryset().count(), initial_count - len(id_list))
+
+            # Deleting records of an explicit M2M through model must record ObjectChanges
+            # against the objects they associated
+            self.assert_m2m_side_objects_change_logged(m2m_side_objects)
 
     class NotesURLViewTestCase(APITestCase):
         """Validate Notes URL on objects that have the Note model Mixin."""

--- a/nautobot/core/tests/test_authentication.py
+++ b/nautobot/core/tests/test_authentication.py
@@ -634,15 +634,20 @@ class ObjectPermissionAPIViewTestCase(TestCase):
         self.assertTrue(self.user.has_perms(["extras.view_objectchange", "extras.list_objectchange"]))
         self.assertTrue(obj_user2.has_perms(["extras.view_objectchange", "extras.list_objectchange"]))
 
+        # Each user's request created two change records;
+        # the constraint must limit each user to only their own records.
+
         # Check against 1st user's response
         self.assertEqual(response_user1.status_code, 200)
-        self.assertEqual(response_user1.data["count"], 1)
-        self.assertEqual(response_user1.data["results"][0]["user"]["id"], self.user.pk)
+        self.assertEqual(response_user1.data["count"], 2)
+        for result in response_user1.data["results"]:
+            self.assertEqual(result["user"]["id"], self.user.pk)
 
         # Check against 2nd user's response
         self.assertEqual(response_user2.status_code, 200)
-        self.assertEqual(response_user2.data["count"], 1)
-        self.assertEqual(response_user2.data["results"][0]["user"]["id"], obj_user2.pk)
+        self.assertEqual(response_user2.data["count"], 2)
+        for result in response_user2.data["results"]:
+            self.assertEqual(result["user"]["id"], obj_user2.pk)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
     def test_user_token_list_constraints(self):

--- a/nautobot/docs/user-guide/platform-functionality/change-logging.md
+++ b/nautobot/docs/user-guide/platform-functionality/change-logging.md
@@ -31,3 +31,21 @@ Change records can also be accessed via the read-only GraphQL endpoint `/api/gra
   }
 }
 ```
+
+## Many-to-Many Association Changes
+
++++ 3.2.1
+
+Some many-to-many relationships in Nautobot are implemented with an explicit "through" model that is exposed through its own REST API endpoint, for example `IPAddressToInterface` (`/api/ipam/ip-address-to-interface/`, associating IP addresses with interfaces) or `VRFPrefixAssignment` (`/api/ipam/vrf-prefix-assignments/`, associating VRFs with prefixes).
+
+Creating or deleting such an association record - whether through its REST API endpoint, the UI, or ORM many-to-many operations such as `interface.ip_addresses.add(...)`, `.remove(...)`, `.set(...)`, or `.clear()` - records an "update" change against *both* of the objects it associates. These change records appear in both objects' change logs and drive any [webhooks](webhook.md), [job hooks](jobs/jobhook.md), and [events](events.md) configured for those objects.
+
+!!! note
+    As with all change logging, ORM operations are only recorded when performed within a change-logging context: this is automatic for web requests and Jobs, while shell or script usage must be wrapped in `web_request_context`. See [Change Logging and Webhooks](../administration/tools/nautobot-shell.md#change-logging-and-webhooks) for details.
+
+Please note the following behavioral details:
+
+- Deleting an object that *cascades* to its association records (for example, deleting a Device that has VRF assignments) records a "delete" change for the deleted object only; the surviving objects on the other side of its associations (the VRFs) do not receive a change record, and their webhooks and job hooks do not fire. This is a deliberate trade-off: a single delete may cascade to association records for many thousands of surviving objects (consider deleting a Location to which thousands of Prefixes are assigned), and recording a change for each would require serializing every one of those objects and dispatching a webhook, job hook, and event for each within that one request. Note that the deleted object's own "delete" change record includes its final serialized data, so removed associations remain discoverable from that record where the object's REST API representation includes them (for example, a deleted Prefix's record includes its location assignments).
+- Updating additional fields on an association record itself (for example, `VRFDeviceAssignment.rd`) does not record a change against the associated objects, as their own data is unaffected.
+- Because the serialized data of the associated objects may not include the association itself, the "difference" display of such a change record may be empty even though the change record is meaningful and still drives webhooks, job hooks, and events.
+- App-defined models automatically receive the same behavior for any many-to-many relationship declared with an explicit `through` model. An App can opt an association model out of this behavior by setting the class attribute `is_m2m_change_logged = False` on the through model, as Nautobot itself does for user-specific preference data such as `UserSavedViewAssociation`.

--- a/nautobot/docs/user-guide/platform-functionality/change-logging.md
+++ b/nautobot/docs/user-guide/platform-functionality/change-logging.md
@@ -34,7 +34,7 @@ Change records can also be accessed via the read-only GraphQL endpoint `/api/gra
 
 ## Many-to-Many Association Changes
 
-+++ 3.2.1
++++ 3.2.2
 
 Some many-to-many relationships in Nautobot are implemented with an explicit "through" model that is exposed through its own REST API endpoint, for example `IPAddressToInterface` (`/api/ipam/ip-address-to-interface/`, associating IP addresses with interfaces) or `VRFPrefixAssignment` (`/api/ipam/vrf-prefix-assignments/`, associating VRFs with prefixes).
 

--- a/nautobot/extras/models/models.py
+++ b/nautobot/extras/models/models.py
@@ -952,6 +952,8 @@ class UserSavedViewAssociation(BaseModel):
     view_name = models.CharField(max_length=CHARFIELD_MAX_LENGTH)
     is_metadata_associable_model = False
     is_data_compliance_model = False
+    # A user pinning a personal default view is preference data, not shared data; don't change-log the SavedView.
+    is_m2m_change_logged = False
 
     class Meta:
         unique_together = [["user", "view_name"]]

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -54,7 +54,11 @@ from nautobot.extras.models.approvals import (
     ApprovalWorkflowStageDefinition,
 )
 from nautobot.extras.querysets import NotesQuerySet
-from nautobot.extras.utils import get_explicit_m2m_through_side_field_names, refresh_job_model_from_job_class
+from nautobot.extras.utils import (
+    get_change_logged_m2m_through_side_field_names,
+    get_explicit_m2m_through_side_field_names,
+    refresh_job_model_from_job_class,
+)
 
 # thread safe change context state variable
 change_context_state = contextvars.ContextVar("change_context_state", default=None)
@@ -319,7 +323,7 @@ def _handle_changed_object(sender, instance, raw=False, **kwargs):
         # A new record of an explicit M2M through model (created directly, e.g. via its REST API endpoint,
         # rather than through an M2M manager, which bulk-creates and so never fires post_save) is an update
         # to both of the objects it associates. m2m_changed additions are handled separately below.
-        side_field_names = get_explicit_m2m_through_side_field_names().get(sender)
+        side_field_names = get_change_logged_m2m_through_side_field_names().get(sender)
         if side_field_names:
             _record_m2m_side_object_changes(change_context, instance, side_field_names)
     elif kwargs.get("action") == "post_add" and kwargs["pk_set"] and not sender._meta.auto_created:
@@ -329,7 +333,7 @@ def _handle_changed_object(sender, instance, raw=False, **kwargs):
         # a time (Nautobot's global pre_delete receiver rules out Django's fast-delete path), so
         # _handle_deleted_m2m_through_object records the other side exactly once per object.
         other_model = kwargs["model"]
-        if sender in get_explicit_m2m_through_side_field_names() and hasattr(other_model, "to_objectchange"):
+        if sender in get_change_logged_m2m_through_side_field_names() and hasattr(other_model, "to_objectchange"):
             for other_instance in other_model.objects.filter(pk__in=kwargs["pk_set"]).iterator():
                 _create_or_update_object_change(change_context, other_instance, ObjectChangeActionChoices.ACTION_UPDATE)
 
@@ -530,7 +534,7 @@ def _handle_deleted_m2m_through_object(sender, instance, origin=None, **kwargs):
     if change_context is None:
         return
 
-    side_field_names = get_explicit_m2m_through_side_field_names().get(sender)
+    side_field_names = get_change_logged_m2m_through_side_field_names().get(sender)
     if not side_field_names:
         return
 
@@ -560,6 +564,7 @@ def _handle_deleted_m2m_through_object(sender, instance, origin=None, **kwargs):
 def post_migrate_clear_content_type_caches(sender, app_config, signal, **kwargs):
     """Clear various content-type caches after a migration."""
     get_explicit_m2m_through_side_field_names.cache_clear()
+    get_change_logged_m2m_through_side_field_names.cache_clear()
     with contextlib.suppress(redis.exceptions.ConnectionError):
         cache.delete("nautobot.extras.utils.change_logged_models_queryset")
         cache.delete_pattern("nautobot.extras.utils.FeatureQuery.*")

--- a/nautobot/extras/signals.py
+++ b/nautobot/extras/signals.py
@@ -54,7 +54,7 @@ from nautobot.extras.models.approvals import (
     ApprovalWorkflowStageDefinition,
 )
 from nautobot.extras.querysets import NotesQuerySet
-from nautobot.extras.utils import refresh_job_model_from_job_class
+from nautobot.extras.utils import get_explicit_m2m_through_side_field_names, refresh_job_model_from_job_class
 
 # thread safe change context state variable
 change_context_state = contextvars.ContextVar("change_context_state", default=None)
@@ -313,69 +313,111 @@ def _handle_changed_object(sender, instance, raw=False, **kwargs):
 
     # Record an ObjectChange if applicable
     if hasattr(instance, "to_objectchange"):
-        branch_name = _object_change_branch_name(instance)
-        user = change_context.get_user(instance)
+        _create_or_update_object_change(change_context, instance, action)
 
-        with BranchContext(branch_name=branch_name, user=user, autocommit=False):
-            # save a copy of this instance's field cache so it can be restored after serialization
-            # to prevent unexpected behavior when chaining multiple signal handlers
-            original_cache = instance._state.fields_cache.copy()
-
-            changed_object_type = ContentType.objects.get_for_model(instance)
-            changed_object_id = instance.id
-
-            # Generate a unique identifier for this change to stash in the change context
-            # This is used for deferred change logging and for looking up related changes without querying the database
-            unique_object_change_id = None
-            if user is not None:
-                unique_object_change_id = f"{changed_object_type.pk}__{changed_object_id}__{user.pk}"
-            else:
-                unique_object_change_id = f"{changed_object_type.pk}__{changed_object_id}"
-
-            # If a change already exists for this change_id, user, and object, update it instead of creating a new one.
-            # If the object was deleted then recreated with the same pk (don't do this), change the action to update.
-            if unique_object_change_id in change_context.deferred_object_changes:
-                related_changes = ObjectChange.objects.filter(
-                    changed_object_type=changed_object_type,
-                    changed_object_id=changed_object_id,
-                    user=user,
-                    request_id=change_context.change_id,
-                )
-
-                # Skip the database check when deferring object changes
-                if not change_context.defer_object_changes and related_changes.exists():
-                    objectchange = instance.to_objectchange(action)
-                    if objectchange is not None:
-                        most_recent_change = related_changes.order_by("-time").first()
-                        if most_recent_change.action == ObjectChangeActionChoices.ACTION_DELETE:
-                            most_recent_change.action = ObjectChangeActionChoices.ACTION_UPDATE
-                        most_recent_change.object_data = objectchange.object_data
-                        most_recent_change.object_data_v2 = objectchange.object_data_v2
-                        most_recent_change.save()
-
-            else:
-                change_context.deferred_object_changes[unique_object_change_id] = [
-                    {"action": action, "instance": instance, "user": user}
-                ]
-                if not change_context.defer_object_changes:
-                    objectchange = instance.to_objectchange(action)
-                    if objectchange is not None:
-                        objectchange.user = user
-                        objectchange.request_id = change_context.change_id
-                        objectchange.change_context = change_context.context
-                        objectchange.change_context_detail = change_context.context_detail[
-                            :CHANGELOG_MAX_CHANGE_CONTEXT_DETAIL
-                        ]
-                        objectchange.save()
-
-            # restore field cache
-            instance._state.fields_cache = original_cache
+    if kwargs.get("created"):
+        # A new record of an explicit M2M through model (created directly, e.g. via its REST API endpoint,
+        # rather than through an M2M manager, which bulk-creates and so never fires post_save) is an update
+        # to both of the objects it associates. m2m_changed additions are handled separately below.
+        side_field_names = get_explicit_m2m_through_side_field_names().get(sender)
+        if side_field_names:
+            _record_m2m_side_object_changes(change_context, instance, side_field_names)
+    elif kwargs.get("action") == "post_add" and kwargs["pk_set"] and not sender._meta.auto_created:
+        # An M2M manager addition (`.add()`/`.set()`) on a relation with an explicit through model changed
+        # the objects on the *other* side of the relation too; `instance` itself was logged above.
+        # Removals are deliberately not handled here: `.remove()`/`.clear()` delete the through rows one at
+        # a time (Nautobot's global pre_delete receiver rules out Django's fast-delete path), so
+        # _handle_deleted_m2m_through_object records the other side exactly once per object.
+        other_model = kwargs["model"]
+        if sender in get_explicit_m2m_through_side_field_names() and hasattr(other_model, "to_objectchange"):
+            for other_instance in other_model.objects.filter(pk__in=kwargs["pk_set"]).iterator():
+                _create_or_update_object_change(change_context, other_instance, ObjectChangeActionChoices.ACTION_UPDATE)
 
     # Increment metric counters
     if action == ObjectChangeActionChoices.ACTION_CREATE:
         model_inserts.labels(instance._meta.model_name).inc()
     elif action == ObjectChangeActionChoices.ACTION_UPDATE:
         model_updates.labels(instance._meta.model_name).inc()
+
+
+def _create_or_update_object_change(change_context, instance, action):
+    """
+    Record an ObjectChange of the given action for `instance`, respecting the change context's dedup and
+    deferral semantics: if a change was already recorded for this (object, user, request), the existing
+    ObjectChange is updated in place rather than creating a second entry.
+
+    The caller is responsible for verifying that `instance` has a `to_objectchange` method.
+    """
+    branch_name = _object_change_branch_name(instance)
+    user = change_context.get_user(instance)
+
+    with BranchContext(branch_name=branch_name, user=user, autocommit=False):
+        # save a copy of this instance's field cache so it can be restored after serialization
+        # to prevent unexpected behavior when chaining multiple signal handlers
+        original_cache = instance._state.fields_cache.copy()
+
+        changed_object_type = ContentType.objects.get_for_model(instance)
+        changed_object_id = instance.id
+
+        # Generate a unique identifier for this change to stash in the change context
+        # This is used for deferred change logging and for looking up related changes without querying the database
+        unique_object_change_id = None
+        if user is not None:
+            unique_object_change_id = f"{changed_object_type.pk}__{changed_object_id}__{user.pk}"
+        else:
+            unique_object_change_id = f"{changed_object_type.pk}__{changed_object_id}"
+
+        # If a change already exists for this change_id, user, and object, update it instead of creating a new one.
+        # If the object was deleted then recreated with the same pk (don't do this), change the action to update.
+        if unique_object_change_id in change_context.deferred_object_changes:
+            related_changes = ObjectChange.objects.filter(
+                changed_object_type=changed_object_type,
+                changed_object_id=changed_object_id,
+                user=user,
+                request_id=change_context.change_id,
+            )
+
+            # Skip the database check when deferring object changes
+            if not change_context.defer_object_changes and related_changes.exists():
+                objectchange = instance.to_objectchange(action)
+                if objectchange is not None:
+                    most_recent_change = related_changes.order_by("-time").first()
+                    if most_recent_change.action == ObjectChangeActionChoices.ACTION_DELETE:
+                        most_recent_change.action = ObjectChangeActionChoices.ACTION_UPDATE
+                    most_recent_change.object_data = objectchange.object_data
+                    most_recent_change.object_data_v2 = objectchange.object_data_v2
+                    most_recent_change.save()
+
+        else:
+            change_context.deferred_object_changes[unique_object_change_id] = [
+                {"action": action, "instance": instance, "user": user}
+            ]
+            if not change_context.defer_object_changes:
+                objectchange = instance.to_objectchange(action)
+                if objectchange is not None:
+                    objectchange.user = user
+                    objectchange.request_id = change_context.change_id
+                    objectchange.change_context = change_context.context
+                    objectchange.change_context_detail = change_context.context_detail[
+                        :CHANGELOG_MAX_CHANGE_CONTEXT_DETAIL
+                    ]
+                    objectchange.save()
+
+        # restore field cache
+        instance._state.fields_cache = original_cache
+
+
+def _record_m2m_side_object_changes(change_context, through_instance, side_field_names):
+    """
+    Record an ACTION_UPDATE ObjectChange for each non-null, change-logged M2M "side" of an explicit
+    through-model record, so that association changes appear in (and fire hooks for) both related
+    objects' change logs regardless of which side, or which API endpoint, initiated the change.
+    """
+    for field_name in side_field_names:
+        side_object = getattr(through_instance, field_name, None)
+        if side_object is None or not hasattr(side_object, "to_objectchange"):
+            continue
+        _create_or_update_object_change(change_context, side_object, ObjectChangeActionChoices.ACTION_UPDATE)
 
 
 @receiver(pre_delete)
@@ -472,6 +514,43 @@ def _handle_deleted_object(sender, instance, **kwargs):
     model_deletes.labels(instance._meta.model_name).inc()
 
 
+@receiver(post_delete)
+def _handle_deleted_m2m_through_object(sender, instance, origin=None, **kwargs):
+    """
+    Fires after any object is deleted; when the object is a record of an explicit M2M through model, record
+    an update to both of the objects it associated.
+
+    post_delete (rather than pre_delete) is required for snapshot correctness: the side objects' serialized
+    data includes their M2M memberships, which must reflect the association's removal. The side objects
+    themselves still exist at this point because cascade deletes are excluded below, and the through
+    record's foreign key values remain readable on the in-memory `instance`.
+    """
+    change_context = change_context_state.get()
+
+    if change_context is None:
+        return
+
+    side_field_names = get_explicit_m2m_through_side_field_names().get(sender)
+    if not side_field_names:
+        return
+
+    # Only record the side objects when the deletion originated at the through record(s) themselves:
+    # either a single record delete (REST API destroy, ORM `record.delete()`) or a queryset delete of
+    # through records (M2M manager `.remove()`/`.clear()`, job code). Cascades originating from the
+    # deletion of some other object (e.g. a Device deletion cascading to its VRFDeviceAssignments) are
+    # deliberately skipped, meaning the surviving side objects (the VRFs) get no change record and
+    # their webhooks/job hooks do not fire. This is a conscious trade-off: a single delete can cascade
+    # to association records for many thousands of surviving objects (e.g. every Prefix assigned to a
+    # deleted Location), each of which would require full serialization plus webhook/job hook/event
+    # dispatch within that one request. It also matches long-standing behavior, as the m2m_changed
+    # signal never fires for cascades either; the deleted object's own DELETE change record still
+    # captures its association memberships where its REST API representation includes them.
+    if not (origin is instance or getattr(origin, "model", None) is sender):
+        return
+
+    _record_m2m_side_object_changes(change_context, instance, side_field_names)
+
+
 #
 # Content types
 #
@@ -480,6 +559,7 @@ def _handle_deleted_object(sender, instance, **kwargs):
 @receiver(post_migrate)
 def post_migrate_clear_content_type_caches(sender, app_config, signal, **kwargs):
     """Clear various content-type caches after a migration."""
+    get_explicit_m2m_through_side_field_names.cache_clear()
     with contextlib.suppress(redis.exceptions.ConnectionError):
         cache.delete("nautobot.extras.utils.change_logged_models_queryset")
         cache.delete_pattern("nautobot.extras.utils.FeatureQuery.*")

--- a/nautobot/extras/tests/test_changelog.py
+++ b/nautobot/extras/tests/test_changelog.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings, tag
 from django.urls import reverse
@@ -11,17 +12,44 @@ from nautobot.core.testing import APITestCase, TestCase
 from nautobot.core.testing.utils import post_data
 from nautobot.core.testing.views import ModelViewTestCase
 from nautobot.core.utils.lookup import get_changes_for_model
-from nautobot.dcim.choices import InterfaceModeChoices
-from nautobot.dcim.models import Location, LocationType
+from nautobot.dcim.choices import InterfaceModeChoices, InterfaceTypeChoices
+from nautobot.dcim.models import (
+    Device,
+    DeviceType,
+    DeviceTypeToSoftwareImageFile,
+    Interface,
+    Location,
+    LocationType,
+    SoftwareImageFile,
+)
 from nautobot.extras import context_managers
 from nautobot.extras.choices import (
     CustomFieldTypeChoices,
+    DynamicGroupOperatorChoices,
     DynamicGroupTypeChoices,
     ObjectChangeActionChoices,
     ObjectChangeEventContextChoices,
 )
-from nautobot.extras.models import CustomField, CustomFieldChoice, DynamicGroup, ObjectChange, Status, Tag
-from nautobot.ipam.models import VLAN, VLANGroup
+from nautobot.extras.models import (
+    CustomField,
+    CustomFieldChoice,
+    DynamicGroup,
+    DynamicGroupMembership,
+    ObjectChange,
+    Role,
+    Status,
+    Tag,
+)
+from nautobot.ipam.models import (
+    IPAddress,
+    IPAddressToInterface,
+    Prefix,
+    PrefixLocationAssignment,
+    RouteTarget,
+    VLAN,
+    VLANGroup,
+    VRF,
+)
 from nautobot.virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
 
 
@@ -647,3 +675,286 @@ class ObjectChangeModelTest(TestCase):  # TODO: change to BaseModelTestCase once
             self.assertIsNone(snapshots["postchange"])
             self.assertEqual(snapshots["differences"]["removed"], oc_with_object_data_v2.object_data_v2)
             self.assertIsNone(snapshots["differences"]["added"])
+
+
+class ChangeLogM2MThroughTest(APITestCase):
+    """
+    Test automatic change logging of both side objects of explicit M2M through models,
+    whether written via their REST API endpoints or via M2M manager methods.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.prefix_location_ct = ContentType.objects.get_for_model(Prefix)
+        self.locations = Location.objects.filter(location_type__content_types=self.prefix_location_ct)
+        # Materialized to a list because MySQL doesn't support a LIMIT-ed queryset inside an `__in` filter
+        self.prefix = Prefix.objects.exclude(locations__in=list(self.locations[:2])).first()
+
+        location = Location.objects.get_for_model(Device).first()
+        devicetype = DeviceType.objects.first()
+        devicerole = Role.objects.get_for_model(Device).first()
+        devicestatus = Status.objects.get_for_model(Device).first()
+        self.device = Device.objects.create(
+            name="Change Log M2M Test Device",
+            location=location,
+            device_type=devicetype,
+            role=devicerole,
+            status=devicestatus,
+        )
+        int_status = Status.objects.get_for_model(Interface).first()
+        self.interface = Interface.objects.create(
+            device=self.device, name="eth0", status=int_status, type=InterfaceTypeChoices.TYPE_1GE_FIXED
+        )
+        clustertype = ClusterType.objects.create(name="Change Log M2M Test Cluster Type")
+        cluster = Cluster.objects.create(cluster_type=clustertype, name="Change Log M2M Test Cluster")
+        vm_status = Status.objects.get_for_model(VirtualMachine).first()
+        virtual_machine = VirtualMachine.objects.create(
+            name="Change Log M2M Test VM", cluster=cluster, status=vm_status
+        )
+        vm_int_status = Status.objects.get_for_model(VMInterface).first()
+        self.vm_interface = VMInterface.objects.create(
+            virtual_machine=virtual_machine, name="veth0", status=vm_int_status
+        )
+        self.ip_addresses = list(IPAddress.objects.all()[:6])
+
+    def assert_single_update_change(self, instance, request_id):
+        """Assert exactly one ACTION_UPDATE ObjectChange was recorded for `instance` in the given request."""
+        changes = ObjectChange.objects.filter(
+            changed_object_type=ContentType.objects.get_for_model(instance),
+            changed_object_id=instance.pk,
+            request_id=request_id,
+        )
+        self.assertEqual(changes.count(), 1)
+        self.assertEqual(changes.first().action, ObjectChangeActionChoices.ACTION_UPDATE)
+        return changes.first()
+
+    def test_api_create_logs_both_sides(self):
+        self.add_permissions("ipam.add_prefixlocationassignment", "ipam.view_prefix", "dcim.view_location")
+        location = self.locations[0]
+
+        url = reverse("ipam-api:prefixlocationassignment-list")
+        response = self.client.post(
+            url, {"prefix": self.prefix.pk, "location": location.pk}, format="json", **self.header
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        prefix_change = get_changes_for_model(self.prefix).first()
+        self.assertIsNotNone(prefix_change)
+        location_change = self.assert_single_update_change(location, prefix_change.request_id)
+        self.assertEqual(prefix_change.action, ObjectChangeActionChoices.ACTION_UPDATE)
+        self.assertEqual(prefix_change.user_id, self.user.pk)
+        self.assertEqual(location_change.user_id, self.user.pk)
+
+    def test_api_create_with_null_side_logs_non_null_sides(self):
+        self.add_permissions("ipam.add_ipaddresstointerface", "ipam.view_ipaddress", "virtualization.view_vminterface")
+        ip_address = self.ip_addresses[0]
+
+        url = reverse("ipam-api:ipaddresstointerface-list")
+        response = self.client.post(
+            url,
+            {"ip_address": ip_address.pk, "interface": None, "vm_interface": self.vm_interface.pk},
+            format="json",
+            **self.header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        ip_change = get_changes_for_model(ip_address).first()
+        self.assertIsNotNone(ip_change)
+        self.assert_single_update_change(self.vm_interface, ip_change.request_id)
+        self.assertEqual(ip_change.action, ObjectChangeActionChoices.ACTION_UPDATE)
+
+    def test_api_delete_logs_both_sides(self):
+        self.add_permissions("ipam.delete_ipaddresstointerface")
+        ip_address = self.ip_addresses[1]
+        assignment = IPAddressToInterface.objects.create(ip_address=ip_address, interface=self.interface)
+
+        url = reverse("ipam-api:ipaddresstointerface-detail", kwargs={"pk": assignment.pk})
+        response = self.client.delete(url, **self.header)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        interface_change = get_changes_for_model(self.interface).first()
+        self.assertIsNotNone(interface_change)
+        self.assert_single_update_change(ip_address, interface_change.request_id)
+        self.assertEqual(interface_change.action, ObjectChangeActionChoices.ACTION_UPDATE)
+        # post_delete timing: the recorded snapshot must reflect the association's removal
+        self.assertNotIn(str(ip_address.pk), str(interface_change.object_data_v2.get("ip_addresses", "")))
+
+    def test_orm_add_logs_both_sides_once_each(self):
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            self.interface.ip_addresses.add(self.ip_addresses[2], self.ip_addresses[3])
+
+        self.assert_single_update_change(self.interface, change_id)
+        self.assert_single_update_change(self.ip_addresses[2], change_id)
+        self.assert_single_update_change(self.ip_addresses[3], change_id)
+
+    def test_orm_reverse_manager_add_logs_both_sides(self):
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            self.ip_addresses[4].interfaces.add(self.interface)
+
+        self.assert_single_update_change(self.ip_addresses[4], change_id)
+        self.assert_single_update_change(self.interface, change_id)
+
+    def test_orm_set_remove_clear_log_both_sides_once_each(self):
+        locations = list(self.locations[:2])
+
+        with self.subTest("set() with additions"):
+            change_id = uuid.uuid4()
+            with context_managers.web_request_context(self.user, change_id=change_id):
+                self.prefix.locations.set(locations)
+            self.assert_single_update_change(self.prefix, change_id)
+            self.assert_single_update_change(locations[0], change_id)
+            self.assert_single_update_change(locations[1], change_id)
+
+        with self.subTest("remove() does not double-log despite firing both delete and m2m signals"):
+            change_id = uuid.uuid4()
+            with context_managers.web_request_context(self.user, change_id=change_id):
+                self.prefix.locations.remove(locations[0])
+            self.assert_single_update_change(self.prefix, change_id)
+            self.assert_single_update_change(locations[0], change_id)
+            self.assertFalse(
+                ObjectChange.objects.filter(changed_object_id=locations[1].pk, request_id=change_id).exists()
+            )
+
+        with self.subTest("clear() logs both sides via the through record deletions"):
+            change_id = uuid.uuid4()
+            with context_managers.web_request_context(self.user, change_id=change_id):
+                self.prefix.locations.clear()
+            self.assert_single_update_change(self.prefix, change_id)
+            self.assert_single_update_change(locations[1], change_id)
+
+    def test_orm_auto_created_m2m_remains_one_sided(self):
+        route_target = RouteTarget.objects.create(name="65000:99999")
+        vrf = VRF.objects.create(name="Change Log M2M Test VRF", namespace=self.prefix.namespace)
+
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            vrf.import_targets.add(route_target)
+
+        self.assert_single_update_change(vrf, change_id)
+        self.assertFalse(ObjectChange.objects.filter(changed_object_id=route_target.pk, request_id=change_id).exists())
+
+    def test_parent_created_in_same_request_stays_create(self):
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            vrf = VRF.objects.create(name="Change Log M2M Test VRF 2", namespace=self.prefix.namespace)
+            vrf.prefixes.add(self.prefix)
+
+        vrf_changes = ObjectChange.objects.filter(changed_object_id=vrf.pk, request_id=change_id)
+        self.assertEqual(vrf_changes.count(), 1)
+        self.assertEqual(vrf_changes.first().action, ObjectChangeActionChoices.ACTION_CREATE)
+        self.assert_single_update_change(self.prefix, change_id)
+
+    def test_cascade_delete_does_not_log_surviving_side(self):
+        vrf = VRF.objects.create(name="Change Log M2M Test VRF 3", namespace=self.prefix.namespace)
+        with context_managers.web_request_context(self.user):
+            vrf.prefixes.add(self.prefix)
+
+        vrf_pk = vrf.pk
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            vrf.delete()
+
+        vrf_changes = ObjectChange.objects.filter(changed_object_id=vrf_pk, request_id=change_id)
+        self.assertEqual(vrf_changes.count(), 1)
+        self.assertEqual(vrf_changes.first().action, ObjectChangeActionChoices.ACTION_DELETE)
+        self.assertFalse(ObjectChange.objects.filter(changed_object_id=self.prefix.pk, request_id=change_id).exists())
+
+    def test_queryset_delete_of_through_records_logs_both_sides(self):
+        ip_address = self.ip_addresses[5]
+        assignment = IPAddressToInterface.objects.create(ip_address=ip_address, interface=self.interface)
+
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            IPAddressToInterface.objects.filter(pk=assignment.pk).delete()
+
+        self.assert_single_update_change(self.interface, change_id)
+        self.assert_single_update_change(ip_address, change_id)
+
+    def test_deferred_change_logging_logs_both_sides(self):
+        location = self.locations[0]
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            with context_managers.deferred_change_logging_for_bulk_operation():
+                PrefixLocationAssignment.objects.create(prefix=self.prefix, location=location)
+
+        self.assert_single_update_change(self.prefix, change_id)
+        self.assert_single_update_change(location, change_id)
+
+    def test_tags_remain_unlogged(self):
+        location_tag = Tag.objects.get_for_model(Location).first()
+        location = self.locations[0]
+
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            location.tags.set([location_tag])
+
+        self.assertTrue(ObjectChange.objects.filter(changed_object_id=location.pk, request_id=change_id).exists())
+        self.assertFalse(ObjectChange.objects.filter(changed_object_id=location_tag.pk, request_id=change_id).exists())
+
+    def test_anonymous_user_does_not_error(self):
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(AnonymousUser(), change_id=change_id):
+            self.interface.ip_addresses.add(self.ip_addresses[2])
+
+        changes = ObjectChange.objects.filter(changed_object_id=self.ip_addresses[2].pk, request_id=change_id)
+        self.assertEqual(changes.count(), 1)
+        self.assertIsNone(changes.first().user)
+
+    def test_self_referential_through_model_logs_both_sides(self):
+        device_ct = ContentType.objects.get_for_model(Device)
+        parent_group = DynamicGroup.objects.create(
+            name="Change Log M2M Test Parent Group",
+            content_type=device_ct,
+            group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_SET,
+        )
+        child_group = DynamicGroup.objects.create(
+            name="Change Log M2M Test Child Group",
+            content_type=device_ct,
+            group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_FILTER,
+        )
+
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            DynamicGroupMembership.objects.create(
+                parent_group=parent_group,
+                group=child_group,
+                operator=DynamicGroupOperatorChoices.OPERATOR_UNION,
+                weight=10,
+            )
+
+        self.assert_single_update_change(parent_group, change_id)
+        self.assert_single_update_change(child_group, change_id)
+
+    def test_change_logged_through_model_logs_itself_and_both_sides(self):
+        software_image_file = SoftwareImageFile.objects.first()
+        device_type = DeviceType.objects.exclude(software_image_files=software_image_file).first()
+
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            assignment = DeviceTypeToSoftwareImageFile.objects.create(
+                device_type=device_type, software_image_file=software_image_file
+            )
+
+        assignment_changes = ObjectChange.objects.filter(changed_object_id=assignment.pk, request_id=change_id)
+        self.assertEqual(assignment_changes.count(), 1)
+        self.assertEqual(assignment_changes.first().action, ObjectChangeActionChoices.ACTION_CREATE)
+        self.assert_single_update_change(device_type, change_id)
+        self.assert_single_update_change(software_image_file, change_id)
+
+    def test_primary_ip_nullification_on_assignment_delete(self):
+        ip_address = IPAddress.objects.filter(ip_version=4).first()
+        assignment = IPAddressToInterface.objects.create(ip_address=ip_address, interface=self.interface)
+        self.device.primary_ip4 = ip_address
+        self.device.save()
+
+        change_id = uuid.uuid4()
+        with context_managers.web_request_context(self.user, change_id=change_id):
+            assignment.delete()
+
+        self.device.refresh_from_db()
+        self.assertIsNone(self.device.primary_ip4)
+        self.assert_single_update_change(self.interface, change_id)
+        self.assert_single_update_change(ip_address, change_id)

--- a/nautobot/extras/tests/test_changelog.py
+++ b/nautobot/extras/tests/test_changelog.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import uuid
 
 from django.contrib.auth.models import AnonymousUser
@@ -958,3 +959,31 @@ class ChangeLogM2MThroughTest(APITestCase):
         self.assertIsNone(self.device.primary_ip4)
         self.assert_single_update_change(self.interface, change_id)
         self.assert_single_update_change(ip_address, change_id)
+
+    @mock.patch("nautobot.extras.context_managers.publish_event")
+    @mock.patch("nautobot.extras.jobs.enqueue_job_hooks", return_value=(False, None))
+    @mock.patch("nautobot.extras.context_managers.enqueue_webhooks", return_value=None)
+    def test_hooks_and_events_dispatched_for_both_sides(
+        self, mock_enqueue_webhooks, mock_enqueue_job_hooks, mock_publish_event
+    ):
+        """Creating a through record dispatches job hooks, webhooks, and events for both side objects (#9270)."""
+        ip_address = self.ip_addresses[0]
+        with context_managers.web_request_context(self.user):
+            IPAddressToInterface.objects.create(ip_address=ip_address, interface=self.interface)
+
+        expected_changed_objects = {
+            (ContentType.objects.get_for_model(Interface), self.interface.pk),
+            (ContentType.objects.get_for_model(IPAddress), ip_address.pk),
+        }
+        webhook_changed_objects = {
+            (call.args[0].changed_object_type, call.args[0].changed_object_id)
+            for call in mock_enqueue_webhooks.call_args_list
+        }
+        self.assertEqual(webhook_changed_objects, expected_changed_objects)
+        jobhook_changed_objects = {
+            (call.args[0].changed_object_type, call.args[0].changed_object_id)
+            for call in mock_enqueue_job_hooks.call_args_list
+        }
+        self.assertEqual(jobhook_changed_objects, expected_changed_objects)
+        event_topics = {call.kwargs["topic"] for call in mock_publish_event.call_args_list}
+        self.assertEqual(event_topics, {"nautobot.update.dcim.interface", "nautobot.update.ipam.ipaddress"})

--- a/nautobot/extras/tests/test_utils.py
+++ b/nautobot/extras/tests/test_utils.py
@@ -13,17 +13,58 @@ from nautobot.core.testing import TestCase
 from nautobot.dcim.models import Cable, Device, PowerPort
 from nautobot.extras.choices import JobQueueTypeChoices
 from nautobot.extras.exceptions import KubernetesJobManifestError
-from nautobot.extras.models import JobQueue, JobResult
+from nautobot.extras.models import DynamicGroupMembership, JobQueue, JobResult, TaggedItem
+from nautobot.extras.models.models import UserSavedViewAssociation
 from nautobot.extras.registry import registry
 from nautobot.extras.utils import (
     get_base_template,
     get_celery_queues,
+    get_explicit_m2m_through_side_field_names,
     get_kubernetes_job_manifest,
     get_worker_count,
     populate_model_features_registry,
     run_kubernetes_job_and_return_job_result,
 )
+from nautobot.ipam.models import IPAddressToInterface, VRF, VRFDeviceAssignment, VRFPrefixAssignment
 from nautobot.users.models import Token
+from nautobot.wireless.models import ControllerManagedDeviceGroupWirelessNetworkAssignment
+
+
+class GetExplicitM2MThroughSideFieldNamesTest(TestCase):
+    """Tests for the registry of explicit M2M through models used for automatic association change logging."""
+
+    def test_side_field_names(self):
+        mapping = get_explicit_m2m_through_side_field_names()
+
+        with self.subTest("through model with multiple M2M relations and nullable sides"):
+            self.assertEqual(mapping[IPAddressToInterface], ("interface", "ip_address", "vm_interface"))
+            self.assertEqual(
+                mapping[VRFDeviceAssignment], ("device", "virtual_device_context", "virtual_machine", "vrf")
+            )
+
+        with self.subTest("simple two-sided through model"):
+            self.assertEqual(mapping[VRFPrefixAssignment], ("prefix", "vrf"))
+
+        with self.subTest("extra foreign keys that are not M2M sides are excluded"):
+            self.assertEqual(
+                mapping[ControllerManagedDeviceGroupWirelessNetworkAssignment],
+                ("controller_managed_device_group", "wireless_network"),
+            )
+
+        with self.subTest("self-referential M2M with through_fields"):
+            self.assertEqual(mapping[DynamicGroupMembership], ("group", "parent_group"))
+
+    def test_excluded_models(self):
+        mapping = get_explicit_m2m_through_side_field_names()
+
+        with self.subTest("taggit through model (GenericForeignKey-based) is excluded"):
+            self.assertNotIn(TaggedItem, mapping)
+
+        with self.subTest("auto-created through models are excluded"):
+            self.assertNotIn(VRF.import_targets.through, mapping)
+
+        with self.subTest("through models with is_m2m_change_logged = False are excluded"):
+            self.assertNotIn(UserSavedViewAssociation, mapping)
 
 
 class UtilsTestCase(TestCase):

--- a/nautobot/extras/tests/test_utils.py
+++ b/nautobot/extras/tests/test_utils.py
@@ -19,6 +19,7 @@ from nautobot.extras.registry import registry
 from nautobot.extras.utils import (
     get_base_template,
     get_celery_queues,
+    get_change_logged_m2m_through_side_field_names,
     get_explicit_m2m_through_side_field_names,
     get_kubernetes_job_manifest,
     get_worker_count,
@@ -63,8 +64,18 @@ class GetExplicitM2MThroughSideFieldNamesTest(TestCase):
         with self.subTest("auto-created through models are excluded"):
             self.assertNotIn(VRF.import_targets.through, mapping)
 
-        with self.subTest("through models with is_m2m_change_logged = False are excluded"):
-            self.assertNotIn(UserSavedViewAssociation, mapping)
+    def test_change_logged_variant_respects_opt_out(self):
+        base_mapping = get_explicit_m2m_through_side_field_names()
+        change_logged_mapping = get_change_logged_m2m_through_side_field_names()
+
+        with self.subTest("is_m2m_change_logged = False models are introspected but not change-logged"):
+            self.assertIn(UserSavedViewAssociation, base_mapping)
+            self.assertNotIn(UserSavedViewAssociation, change_logged_mapping)
+
+        with self.subTest("all other through models are unaffected by the filtering"):
+            expected = dict(base_mapping)
+            del expected[UserSavedViewAssociation]
+            self.assertEqual(change_logged_mapping, expected)
 
 
 class UtilsTestCase(TestCase):

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -1,6 +1,7 @@
 import collections
 import contextlib
 import copy
+import functools
 import hashlib
 import hmac
 import json
@@ -17,7 +18,7 @@ from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.core.validators import ValidationError
 from django.db import transaction
-from django.db.models import Model, Q
+from django.db.models import ForeignKey, ManyToManyField, Model, Q
 from django.db.models.deletion import Collector
 from django.template.loader import get_template, TemplateDoesNotExist
 from django.utils.deconstruct import deconstructible
@@ -155,6 +156,47 @@ def change_logged_models_queryset():
             # cache is explicitly invalidated by nautobot.extras.signals.post_migrate_clear_content_type_caches
             cache.set(cache_key, queryset, timeout=None)
     return queryset
+
+
+@functools.cache
+def get_explicit_m2m_through_side_field_names():
+    """Map each explicitly-declared M2M "through" model class to the names of its "side" foreign key fields.
+
+    A "side" field is a foreign key on the through model that constitutes one end of the many-to-many
+    relation(s) the through model implements. Extra foreign keys on the through model that are not declared
+    as a side of any `ManyToManyField` (e.g. `ControllerManagedDeviceGroupWirelessNetworkAssignment.vlan`)
+    are not included. A through model may implement several M2M relations (e.g. `VRFDeviceAssignment` serves
+    `VRF.devices`, `VRF.virtual_machines`, and `VRF.virtual_device_contexts`), in which case the union of all
+    of their side field names is returned; sides not participating in a given row are simply null.
+
+    Through models may opt out of the automatic change logging of their side objects by setting the class
+    attribute `is_m2m_change_logged = False` (e.g. `UserSavedViewAssociation`, which records per-user
+    preferences rather than shared data).
+
+    Cache is cleared by the post_migrate signal (nautobot.extras.signals.post_migrate_clear_content_type_caches).
+
+    Returns:
+        dict: `{through_model_class: (side_field_name, ...)}`
+    """
+    mapping = {}
+    for model in apps.get_models():
+        for field in model._meta.local_many_to_many:
+            # TaggableManager (TagsField) also appears in local_many_to_many but is not a ManyToManyField;
+            # its taggit through model (TaggedItem) uses a GenericForeignKey and must not be included here.
+            if not isinstance(field, ManyToManyField):
+                continue
+            through = field.remote_field.through
+            if through is None or through._meta.auto_created:
+                continue
+            if not getattr(through, "is_m2m_change_logged", True):
+                continue
+            side_field_names = set()
+            for side_field_name in (field.m2m_field_name(), field.m2m_reverse_field_name()):
+                side_field = through._meta.get_field(side_field_name)
+                if isinstance(side_field, ForeignKey):
+                    side_field_names.add(side_field_name)
+            mapping.setdefault(through, set()).update(side_field_names)
+    return {through: tuple(sorted(sides)) for through, sides in mapping.items()}
 
 
 @deconstructible

--- a/nautobot/extras/utils.py
+++ b/nautobot/extras/utils.py
@@ -169,10 +169,6 @@ def get_explicit_m2m_through_side_field_names():
     `VRF.devices`, `VRF.virtual_machines`, and `VRF.virtual_device_contexts`), in which case the union of all
     of their side field names is returned; sides not participating in a given row are simply null.
 
-    Through models may opt out of the automatic change logging of their side objects by setting the class
-    attribute `is_m2m_change_logged = False` (e.g. `UserSavedViewAssociation`, which records per-user
-    preferences rather than shared data).
-
     Cache is cleared by the post_migrate signal (nautobot.extras.signals.post_migrate_clear_content_type_caches).
 
     Returns:
@@ -188,8 +184,6 @@ def get_explicit_m2m_through_side_field_names():
             through = field.remote_field.through
             if through is None or through._meta.auto_created:
                 continue
-            if not getattr(through, "is_m2m_change_logged", True):
-                continue
             side_field_names = set()
             for side_field_name in (field.m2m_field_name(), field.m2m_reverse_field_name()):
                 side_field = through._meta.get_field(side_field_name)
@@ -197,6 +191,26 @@ def get_explicit_m2m_through_side_field_names():
                     side_field_names.add(side_field_name)
             mapping.setdefault(through, set()).update(side_field_names)
     return {through: tuple(sorted(sides)) for through, sides in mapping.items()}
+
+
+@functools.cache
+def get_change_logged_m2m_through_side_field_names():
+    """Like `get_explicit_m2m_through_side_field_names`, but only through models subject to association change logging.
+
+    Through models may opt out of the automatic change logging of their side objects by setting the class
+    attribute `is_m2m_change_logged = False` (e.g. `UserSavedViewAssociation`, which records per-user
+    preferences rather than shared data).
+
+    Cache is cleared by the post_migrate signal (nautobot.extras.signals.post_migrate_clear_content_type_caches).
+
+    Returns:
+        dict: `{through_model_class: (side_field_name, ...)}`
+    """
+    return {
+        through: side_field_names
+        for through, side_field_names in get_explicit_m2m_through_side_field_names().items()
+        if getattr(through, "is_m2m_change_logged", True)
+    }
 
 
 @deconstructible


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #9204, Closes #9270
# What's Changed

Previously, creating, updating, or deleting M2M through-table records via their REST API endpoints produced no ObjectChange at all. This meant they also failed to fire any webhooks, job hooks, or events. In the UI, it only ever logged one side of the association - typically whichever object's M2M manager was used.

This PR fixes both problems holistically at the signal level, covering all existing explicit M2M through models in core as well as any App-defined through models automatically, instead of patching individual serializers and viewsets. This is an alternative approach and replacement to #9222.

Creating or deleting an explicit through-model record now records an `update` ObjectChange against **both** of the objects it associates, regardless of entry point (REST, UI, ORM w/ web request). Auto-created (plain) M2Ms keep their existing one-sided behavior, and tags are unaffected since taggit does not use `ManyToManyField`.

# Screenshots

|Type|Before|After|
|-|-|-|
|(UI) Add IP to Interface|<img width="868" height="116" alt="Screenshot 2026-07-24 at 9 35 21 AM" src="https://github.com/user-attachments/assets/32e01580-ae71-4468-b0c0-ec9a76bc90bc" />|<img width="867" height="181" alt="Screenshot 2026-07-24 at 9 27 28 AM" src="https://github.com/user-attachments/assets/6d1ec199-9baa-4bc8-a6b9-10fe61762436" />|
|(UI) Remove IP from Interface|<img width="868" height="119" alt="Screenshot 2026-07-24 at 9 35 53 AM" src="https://github.com/user-attachments/assets/1447d2af-ee84-4bc8-89b7-0610c8bcfa16" />|<img width="873" height="177" alt="Screenshot 2026-07-24 at 9 28 35 AM" src="https://github.com/user-attachments/assets/4c4bae19-298f-4ebe-a269-043415067918" />|
|(API) Add IP to Interface|<img width="865" height="96" alt="Screenshot 2026-07-24 at 9 34 32 AM" src="https://github.com/user-attachments/assets/f4a1fd02-f622-4196-869b-dbd07c4e5082" />|<img width="876" height="180" alt="Screenshot 2026-07-24 at 9 33 12 AM" src="https://github.com/user-attachments/assets/0ad978a5-d949-47e7-86f3-e7ce4f64e3de" />|
|(API) Remove IP from Interface|<img width="865" height="96" alt="Screenshot 2026-07-24 at 9 34 32 AM" src="https://github.com/user-attachments/assets/63be7e64-1819-4e29-a833-788e3675c38c" />|<img width="868" height="175" alt="Screenshot 2026-07-24 at 9 33 39 AM" src="https://github.com/user-attachments/assets/f0e80199-cbd9-498e-a7bf-c01cca9a876a" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [N/A] Example App Updates (when adding/changing features)
- [N/A] Outline Remaining Work, Constraints from Design

NTC-6277
NTC-6316