### PR TITLE
Fix get_cables() for Devices and Modules

### DIFF
--- a/changes/9320.fixed
+++ b/changes/9320.fixed
@@ -1,0 +1,1 @@
+Fixed `Device.get_cables()` and `Module.get_cables()` raising a `FieldError` after the 3.2 cable data model changes.

--- a/nautobot/dcim/models/devices.py
+++ b/nautobot/dcim/models/devices.py
@@ -1058,8 +1058,8 @@ class Device(PrimaryModel, ConfigContextModel):
             FrontPort,
             RearPort,
         ]:
-            cable_pks += component_model.objects.filter(device=self, cable__isnull=False).values_list(
-                "cable", flat=True
+            cable_pks += component_model.objects.filter(device=self, cable_termination__isnull=False).values_list(
+                "cable_termination__cable", flat=True
             )
         if pk_list:
             return cable_pks
@@ -2239,8 +2239,8 @@ class Module(PrimaryModel):
             FrontPort,
             RearPort,
         ]:
-            cable_pks += component_model.objects.filter(module=self, cable__isnull=False).values_list(
-                "cable", flat=True
+            cable_pks += component_model.objects.filter(module=self, cable_termination__isnull=False).values_list(
+                "cable_termination__cable", flat=True
             )
         if pk_list:
             return cable_pks

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -2714,6 +2714,46 @@ class DeviceTestCase(ModelTestCases.BaseModelTestCase):
         self.assertIn(parent_child_device, nested_devices)
         self.assertIn(child_device, nested_devices)
 
+    def test_device_get_cables(self):
+        """Test Device.get_cables() returns the Cables connected to the device's components."""
+        interface_status = Status.objects.get_for_model(Interface).first()
+        cable_status = Status.objects.get_for_model(Cable).first()
+        peer_device = Device.objects.create(
+            location=self.location_3,
+            device_type=self.device_type,
+            role=self.device_role,
+            status=self.device_status,
+            name="Cable Peer Device",
+        )
+        cables = []
+        for i in range(2):
+            local_interface = Interface.objects.create(
+                device=self.device,
+                name=f"eth{i}",
+                status=interface_status,
+                type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            )
+            peer_interface = Interface.objects.create(
+                device=peer_device,
+                name=f"eth{i}",
+                status=interface_status,
+                type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            )
+            cable = Cable(status=cable_status)
+            cable.validated_save()
+            cable.add_termination(local_interface, "A")
+            cable.add_termination(peer_interface, "B")
+            cables.append(cable)
+        Interface.objects.create(
+            device=self.device,
+            name="eth-uncabled",
+            status=interface_status,
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+
+        self.assertQuerysetEqualAndNotEmpty(self.device.get_cables(), cables, ordered=False)
+        self.assertEqual(set(self.device.get_cables(pk_list=True)), {cable.pk for cable in cables})
+
 
 class DeviceBayTestCase(ModelTestCases.BaseModelTestCase):
     model = DeviceBay
@@ -5983,6 +6023,39 @@ class ModuleTestCase(ModelTestCases.BaseModelTestCase):
 
         module.full_clean()
         module.save()
+
+    def test_module_get_cables(self):
+        """Test Module.get_cables() returns the Cables connected to the module's components."""
+        interface_status = Status.objects.get_for_model(Interface).first()
+        cable_status = Status.objects.get_for_model(Cable).first()
+        cables = []
+        for i in range(2):
+            module_interface = Interface.objects.create(
+                module=self.module,
+                name=f"Module Interface {i}",
+                status=interface_status,
+                type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            )
+            peer_interface = Interface.objects.create(
+                device=self.device,
+                name=f"Module cable peer {i}",
+                status=interface_status,
+                type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            )
+            cable = Cable(status=cable_status)
+            cable.validated_save()
+            cable.add_termination(module_interface, "A")
+            cable.add_termination(peer_interface, "B")
+            cables.append(cable)
+        Interface.objects.create(
+            module=self.module,
+            name="Module Interface uncabled",
+            status=interface_status,
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+        )
+
+        self.assertQuerysetEqualAndNotEmpty(self.module.get_cables(), cables, ordered=False)
+        self.assertEqual(set(self.module.get_cables(pk_list=True)), {cable.pk for cable in cables})
 
 
 class ModuleTypeTestCase(ModelTestCases.BaseModelTestCase):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #9320 
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

Adapted `Device` and `Module` filter for cables attached to their components, to align with the Nautobot 3.2 cable model. Cables are now checked via the `cable_termination` object.
# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
