### PR TITLE
Add Logic To Change Cable Interface Colors And Icons When Cable Status Changed

### DIFF
--- a/changes/9325.fixed
+++ b/changes/9325.fixed
@@ -1,0 +1,1 @@
+Fixed breakout cable interfaces to change colors and icons correctly when a cable status is changed.

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -37,7 +37,7 @@ from nautobot.dcim.models import (
     VirtualChassis,
     VirtualDeviceContext,
 )
-from nautobot.dcim.utils import cable_status_color_css
+from nautobot.dcim.utils import cable_status_color_css, get_cable_pk
 from nautobot.extras.tables import RoleTableMixin, StatusTableMixin
 from nautobot.tenancy.tables import TenantColumn
 
@@ -739,7 +739,10 @@ class InterfaceTable(ModularDeviceComponentTable, BaseInterfaceTable, PathEndpoi
 
     class Meta(ModularDeviceComponentTable.Meta):
         model = Interface
-        row_attrs = {"class": cable_status_color_css}
+        row_attrs = {
+            "cable_pk": get_cable_pk,
+            "class": cable_status_color_css,
+        }
         fields = (
             "pk",
             "device",
@@ -870,6 +873,7 @@ class DeviceModuleInterfaceTable(InterfaceTable):
             "actions",
         ]
         row_attrs = {
+            "cable_pk": get_cable_pk,
             "class": cable_status_color_css,
             "data-name": lambda record: record.name,
         }

--- a/nautobot/dcim/tables/devices.py
+++ b/nautobot/dcim/tables/devices.py
@@ -740,7 +740,7 @@ class InterfaceTable(ModularDeviceComponentTable, BaseInterfaceTable, PathEndpoi
     class Meta(ModularDeviceComponentTable.Meta):
         model = Interface
         row_attrs = {
-            "cable_pk": get_cable_pk,
+            "data-cable-pk": get_cable_pk,
             "class": cable_status_color_css,
         }
         fields = (
@@ -873,7 +873,7 @@ class DeviceModuleInterfaceTable(InterfaceTable):
             "actions",
         ]
         row_attrs = {
-            "cable_pk": get_cable_pk,
+            "data-cable-pk": get_cable_pk,
             "class": cable_status_color_css,
             "data-name": lambda record: record.name,
         }

--- a/nautobot/dcim/tests/integration/test_breakout_cables.py
+++ b/nautobot/dcim/tests/integration/test_breakout_cables.py
@@ -1,0 +1,260 @@
+from django.urls import reverse
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.ui import WebDriverWait
+
+from nautobot.core.testing.integration import SeleniumTestCase
+from nautobot.dcim.choices import InterfaceTypeChoices
+from nautobot.dcim.models import Cable, CableType, Interface
+from nautobot.extras.models import Status
+from nautobot.extras.tests.integration import create_test_device
+
+
+class BreakoutCablesTestCase(SeleniumTestCase):
+    """Breakout cable integration tests."""
+
+    def setUp(self):
+        super().setUp()
+        self.user.is_superuser = True
+        self.user.save()
+        self.login(self.user.username, self.password)
+
+    def tearDown(self):
+        self.logout()
+        super().tearDown()
+
+    def create1x2BreakoutCable(self):
+        spine_device = create_test_device("Breakout Cable Local Device")
+        leaf_device = create_test_device("Breakout Cable Remote Device")
+
+        spine_interface_status = Status.objects.get_for_model(Interface).first()
+        cable_connected_status = Status.objects.get_for_model(Cable).get(name="Connected")
+
+        spine_interface = Interface.objects.create(
+            device=spine_device,
+            name="Spine Interface 1",
+            type=InterfaceTypeChoices.TYPE_10GE_FIXED,
+            status=spine_interface_status,
+        )
+
+        leaf_interfaces = [
+            Interface.objects.create(device=leaf_device, name="Leaf Interface 1", status=spine_interface_status),
+            Interface.objects.create(device=leaf_device, name="Leaf Interface 2", status=spine_interface_status),
+        ]
+
+        breakout_type = CableType.objects.create(
+            name="1x2 Breakout Cable", a_connectors=1, b_connectors=2, total_lanes=2
+        )
+
+        cable = Cable(
+            termination_a=spine_interface,
+            termination_b=leaf_interfaces[0],
+            cable_type=breakout_type,
+            status=cable_connected_status,
+        )
+        cable.save()
+        cable.add_termination(leaf_interfaces[1], "B", connector=2)
+
+        spine_interface_children = [
+            Interface.objects.create(
+                device=spine_device,
+                name="Spine Interface 1/1",
+                type=InterfaceTypeChoices.TYPE_VIRTUAL,
+                status=spine_interface_status,
+                parent_interface=spine_interface,
+                breakout_position=1,
+            ),
+            Interface.objects.create(
+                device=spine_device,
+                name="Spine Interface 1/2",
+                type=InterfaceTypeChoices.TYPE_VIRTUAL,
+                status=spine_interface_status,
+                parent_interface=spine_interface,
+                breakout_position=2,
+            ),
+        ]
+
+        return cable, spine_device, spine_interface, spine_interface_children, leaf_device, leaf_interfaces
+
+    def test_device_detail_view_interface_tab_colors_change_after_cable_toggled_from_connected_to_planned(self):
+        _, spine_device, spine_interface, spine_interface_children, _, _ = self.create1x2BreakoutCable()
+
+        self.browser.visit(self.live_server_url + reverse("dcim:device_interfaces", kwargs={"pk": spine_device.pk}))
+
+        self.assertTrue(
+            self.browser.is_element_present_by_css(
+                f'tr[data-name="{spine_interface.name}"].table-success', wait_time=10
+            ),
+            "Parent interface row did not start green",
+        )
+        for child in spine_interface_children:
+            self.assertTrue(
+                self.browser.is_element_present_by_css(f'tr[data-name="{child.name}"].table-success', wait_time=10),
+                f"{child.name} row did not start green",
+            )
+
+        toggle = WebDriverWait(self.browser.driver, 10).until(
+            expected_conditions.presence_of_element_located(
+                (By.CSS_SELECTOR, f'tr[data-name="{spine_interface.name}"] a.cable-toggle')
+            )
+        )
+        self.browser.driver.execute_script("arguments[0].click();", toggle)
+
+        self.assertTrue(
+            self.browser.is_element_present_by_css(f'tr[data-name="{spine_interface.name}"].table-info', wait_time=10),
+            "Parent interface row did not turn blue after toggling its cable to Planned",
+        )
+        for child in spine_interface_children:
+            self.assertTrue(
+                self.browser.is_element_present_by_css(f'tr[data-name="{child.name}"].table-info', wait_time=10),
+                f"{child.name} row did not turn blue after toggling the parent cable",
+            )
+            self.assertFalse(
+                self.browser.is_element_present_by_css(f'tr[data-name="{child.name}"].table-success', wait_time=1),
+                f"{child.name} row is still green after toggling the parent cable",
+            )
+
+    def test_device_detail_view_interface_tab_icons_change_after_cable_toggled_from_connected_to_planned(self):
+        _, _, _, _, leaf_device, leaf_interfaces = self.create1x2BreakoutCable()
+
+        self.browser.visit(self.live_server_url + reverse("dcim:device_interfaces", kwargs={"pk": leaf_device.pk}))
+
+        for interface in leaf_interfaces:
+            self.assertTrue(
+                self.browser.is_element_present_by_css(
+                    f'tr[data-name="{interface.name}"] a.cable-toggle span.mdi-lan-pending', wait_time=10
+                ),
+                f"{interface.name} did not start with the 'mark planned' icon",
+            )
+
+        toggle = WebDriverWait(self.browser.driver, 10).until(
+            expected_conditions.presence_of_element_located(
+                (By.CSS_SELECTOR, f'tr[data-name="{leaf_interfaces[0].name}"] a.cable-toggle')
+            )
+        )
+        self.browser.driver.execute_script("arguments[0].click();", toggle)
+
+        # After toggling to Planned, EVERY termination's icon should flip to `mdi-lan-connect`.
+        for interface in leaf_interfaces:
+            self.assertTrue(
+                self.browser.is_element_present_by_css(
+                    f'tr[data-name="{interface.name}"] a.cable-toggle span.mdi-lan-connect', wait_time=10
+                ),
+                f"{interface.name} icon did not change to the 'mark connected' icon after toggling the cable",
+            )
+
+    def test_list_interfaces_view_colors_change_after_cable_toggled_from_connected_to_planned(self):
+        _, _, spine_interface, spine_interface_children, _, leaf_interfaces = self.create1x2BreakoutCable()
+
+        self.browser.visit(self.live_server_url + reverse("dcim:interface_list"))
+
+        cable_colored_interfaces = [spine_interface, *spine_interface_children, *leaf_interfaces]
+        for interface in cable_colored_interfaces:
+            self.assertTrue(
+                self.browser.is_element_present_by_css(
+                    f'tr:has(input[name="pk"][value="{interface.pk}"]).table-success', wait_time=10
+                ),
+                f"{interface.name} row did not start green",
+            )
+
+        toggle = WebDriverWait(self.browser.driver, 10).until(
+            expected_conditions.presence_of_element_located(
+                (By.CSS_SELECTOR, f'tr:has(input[name="pk"][value="{spine_interface.pk}"]) a.cable-toggle')
+            )
+        )
+        self.browser.driver.execute_script("arguments[0].click();", toggle)
+
+        for interface in cable_colored_interfaces:
+            self.assertTrue(
+                self.browser.is_element_present_by_css(
+                    f'tr:has(input[name="pk"][value="{interface.pk}"]).table-info', wait_time=10
+                ),
+                f"{interface.name} row did not turn blue after toggling the cable",
+            )
+            self.assertFalse(
+                self.browser.is_element_present_by_css(
+                    f'tr:has(input[name="pk"][value="{interface.pk}"]).table-success', wait_time=1
+                ),
+                f"{interface.name} row is still green after toggling the cable",
+            )
+
+    def test_list_interfaces_view_unrelated_interface_color_unchanged_when_cable_toggled(self):
+        _, spine_device, spine_interface, _, _, _ = self.create1x2BreakoutCable()
+
+        interface_status = Status.objects.get_for_model(Interface).first()
+        unrelated_interface = Interface.objects.create(
+            device=spine_device,
+            name="Unrelated Interface",
+            type=InterfaceTypeChoices.TYPE_10GE_FIXED,
+            status=interface_status,
+        )
+
+        self.browser.visit(self.live_server_url + reverse("dcim:interface_list"))
+
+        unrelated_row = f'tr:has(input[name="pk"][value="{unrelated_interface.pk}"])'
+
+        self.assertTrue(
+            self.browser.is_element_present_by_css(unrelated_row, wait_time=10),
+            "Unrelated interface row was not rendered",
+        )
+        self.assertFalse(
+            self.browser.is_element_present_by_css(f"{unrelated_row}.table-success", wait_time=1),
+            "Unrelated interface row should not start green",
+        )
+        self.assertFalse(
+            self.browser.is_element_present_by_css(f"{unrelated_row}.table-info", wait_time=1),
+            "Unrelated interface row should not start blue",
+        )
+
+        toggle = WebDriverWait(self.browser.driver, 10).until(
+            expected_conditions.presence_of_element_located(
+                (By.CSS_SELECTOR, f'tr:has(input[name="pk"][value="{spine_interface.pk}"]) a.cable-toggle')
+            )
+        )
+        self.browser.driver.execute_script("arguments[0].click();", toggle)
+
+        self.assertTrue(
+            self.browser.is_element_present_by_css(
+                f'tr:has(input[name="pk"][value="{spine_interface.pk}"]).table-info', wait_time=10
+            ),
+            "Cable row did not turn blue after toggling (the JS update did not run)",
+        )
+        self.assertFalse(
+            self.browser.is_element_present_by_css(f"{unrelated_row}.table-info", wait_time=1),
+            "Unrelated interface row incorrectly turned blue after toggling the cable",
+        )
+        self.assertFalse(
+            self.browser.is_element_present_by_css(f"{unrelated_row}.table-success", wait_time=1),
+            "Unrelated interface row incorrectly turned green after toggling the cable",
+        )
+
+    def test_list_interfaces_view_icons_change_after_cable_toggled_from_connected_to_planned(self):
+        _, _, spine_interface, _, _, leaf_interfaces = self.create1x2BreakoutCable()
+
+        self.browser.visit(self.live_server_url + reverse("dcim:interface_list"))
+
+        cable_terminations = [spine_interface, *leaf_interfaces]
+        for interface in cable_terminations:
+            self.assertTrue(
+                self.browser.is_element_present_by_css(
+                    f'tr:has(input[name="pk"][value="{interface.pk}"]) a.cable-toggle span.mdi-lan-pending',
+                    wait_time=10,
+                ),
+                f"{interface.name} did not start with the 'mark planned' icon",
+            )
+
+        toggle = WebDriverWait(self.browser.driver, 10).until(
+            expected_conditions.presence_of_element_located(
+                (By.CSS_SELECTOR, f'tr:has(input[name="pk"][value="{spine_interface.pk}"]) a.cable-toggle')
+            )
+        )
+        self.browser.driver.execute_script("arguments[0].click();", toggle)
+
+        for interface in cable_terminations:
+            self.assertTrue(
+                self.browser.is_element_present_by_css(
+                    f'tr:has(input[name="pk"][value="{interface.pk}"]) a.cable-toggle span.mdi-lan-connect',
+                    wait_time=10,
+                ),
+                f"{interface.name} icon did not change to the 'mark connected' icon after toggling the cable",
+            )

--- a/nautobot/dcim/tests/integration/test_breakout_cables.py
+++ b/nautobot/dcim/tests/integration/test_breakout_cables.py
@@ -23,23 +23,23 @@ class BreakoutCablesTestCase(SeleniumTestCase):
         self.logout()
         super().tearDown()
 
-    def create1x2BreakoutCable(self):
-        spine_device = create_test_device("Breakout Cable Local Device")
-        leaf_device = create_test_device("Breakout Cable Remote Device")
+    def create_1x2_breakout_cable(self):
+        spine_device = create_test_device("Breakout Cable Spine Device")
+        leaf_device = create_test_device("Breakout Cable Leaf Device")
 
-        spine_interface_status = Status.objects.get_for_model(Interface).first()
-        cable_connected_status = Status.objects.get_for_model(Cable).get(name="Connected")
+        status_active = Status.objects.get_for_model(Interface).get(name="Active")
+        status_connected = Status.objects.get_for_model(Cable).get(name="Connected")
 
         spine_interface = Interface.objects.create(
             device=spine_device,
             name="Spine Interface 1",
             type=InterfaceTypeChoices.TYPE_10GE_FIXED,
-            status=spine_interface_status,
+            status=status_active,
         )
 
         leaf_interfaces = [
-            Interface.objects.create(device=leaf_device, name="Leaf Interface 1", status=spine_interface_status),
-            Interface.objects.create(device=leaf_device, name="Leaf Interface 2", status=spine_interface_status),
+            Interface.objects.create(device=leaf_device, name="Leaf Interface 1", status=status_active),
+            Interface.objects.create(device=leaf_device, name="Leaf Interface 2", status=status_active),
         ]
 
         breakout_type = CableType.objects.create(
@@ -50,7 +50,7 @@ class BreakoutCablesTestCase(SeleniumTestCase):
             termination_a=spine_interface,
             termination_b=leaf_interfaces[0],
             cable_type=breakout_type,
-            status=cable_connected_status,
+            status=status_connected,
         )
         cable.save()
         cable.add_termination(leaf_interfaces[1], "B", connector=2)
@@ -60,7 +60,7 @@ class BreakoutCablesTestCase(SeleniumTestCase):
                 device=spine_device,
                 name="Spine Interface 1/1",
                 type=InterfaceTypeChoices.TYPE_VIRTUAL,
-                status=spine_interface_status,
+                status=status_active,
                 parent_interface=spine_interface,
                 breakout_position=1,
             ),
@@ -68,7 +68,7 @@ class BreakoutCablesTestCase(SeleniumTestCase):
                 device=spine_device,
                 name="Spine Interface 1/2",
                 type=InterfaceTypeChoices.TYPE_VIRTUAL,
-                status=spine_interface_status,
+                status=status_active,
                 parent_interface=spine_interface,
                 breakout_position=2,
             ),
@@ -77,7 +77,7 @@ class BreakoutCablesTestCase(SeleniumTestCase):
         return cable, spine_device, spine_interface, spine_interface_children, leaf_device, leaf_interfaces
 
     def test_device_detail_view_interface_tab_colors_change_after_cable_toggled_from_connected_to_planned(self):
-        _, spine_device, spine_interface, spine_interface_children, _, _ = self.create1x2BreakoutCable()
+        _, spine_device, spine_interface, spine_interface_children, _, _ = self.create_1x2_breakout_cable()
 
         self.browser.visit(self.live_server_url + reverse("dcim:device_interfaces", kwargs={"pk": spine_device.pk}))
 
@@ -115,7 +115,7 @@ class BreakoutCablesTestCase(SeleniumTestCase):
             )
 
     def test_device_detail_view_interface_tab_icons_change_after_cable_toggled_from_connected_to_planned(self):
-        _, _, _, _, leaf_device, leaf_interfaces = self.create1x2BreakoutCable()
+        _, _, _, _, leaf_device, leaf_interfaces = self.create_1x2_breakout_cable()
 
         self.browser.visit(self.live_server_url + reverse("dcim:device_interfaces", kwargs={"pk": leaf_device.pk}))
 
@@ -143,7 +143,7 @@ class BreakoutCablesTestCase(SeleniumTestCase):
             )
 
     def test_list_interfaces_view_colors_change_after_cable_toggled_from_connected_to_planned(self):
-        _, _, spine_interface, spine_interface_children, _, leaf_interfaces = self.create1x2BreakoutCable()
+        _, _, spine_interface, spine_interface_children, _, leaf_interfaces = self.create_1x2_breakout_cable()
 
         self.browser.visit(self.live_server_url + reverse("dcim:interface_list"))
 
@@ -178,14 +178,14 @@ class BreakoutCablesTestCase(SeleniumTestCase):
             )
 
     def test_list_interfaces_view_unrelated_interface_color_unchanged_when_cable_toggled(self):
-        _, spine_device, spine_interface, _, _, _ = self.create1x2BreakoutCable()
+        _, spine_device, spine_interface, _, _, _ = self.create_1x2_breakout_cable()
 
-        interface_status = Status.objects.get_for_model(Interface).first()
+        status_active = Status.objects.get_for_model(Interface).get(name="Active")
         unrelated_interface = Interface.objects.create(
             device=spine_device,
             name="Unrelated Interface",
             type=InterfaceTypeChoices.TYPE_10GE_FIXED,
-            status=interface_status,
+            status=status_active,
         )
 
         self.browser.visit(self.live_server_url + reverse("dcim:interface_list"))
@@ -228,7 +228,7 @@ class BreakoutCablesTestCase(SeleniumTestCase):
         )
 
     def test_list_interfaces_view_icons_change_after_cable_toggled_from_connected_to_planned(self):
-        _, _, spine_interface, _, _, leaf_interfaces = self.create1x2BreakoutCable()
+        _, _, spine_interface, _, _, leaf_interfaces = self.create_1x2_breakout_cable()
 
         self.browser.visit(self.live_server_url + reverse("dcim:interface_list"))
 

--- a/nautobot/dcim/tests/integration/test_breakout_cables.py
+++ b/nautobot/dcim/tests/integration/test_breakout_cables.py
@@ -134,7 +134,6 @@ class BreakoutCablesTestCase(SeleniumTestCase):
         )
         self.browser.driver.execute_script("arguments[0].click();", toggle)
 
-        # After toggling to Planned, EVERY termination's icon should flip to `mdi-lan-connect`.
         for interface in leaf_interfaces:
             self.assertTrue(
                 self.browser.is_element_present_by_css(

--- a/nautobot/dcim/tests/test_utils.py
+++ b/nautobot/dcim/tests/test_utils.py
@@ -2,13 +2,23 @@ from django.core.exceptions import ValidationError
 
 from nautobot.core.testing import TestCase
 from nautobot.dcim.choices import InterfaceTypeChoices
-from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer
+from nautobot.dcim.models import (
+    Cable,
+    CableType,
+    Device,
+    DeviceType,
+    Interface,
+    Location,
+    LocationType,
+    Manufacturer,
+)
 from nautobot.dcim.tests.test_views import create_test_device
 from nautobot.dcim.utils import (
     build_connector_row_layout,
     cable_status_color_css,
     disconnect_termination,
     generate_cable_breakout_mapping,
+    get_cable_pk,
     validate_cable_breakout_mapping,
 )
 from nautobot.extras.models import Role, Status
@@ -252,3 +262,65 @@ class CableStatusColorCssTestCase(TestCase):
         self.assertIsNone(subiface.get_breakout_lane())
 
         self.assertEqual(cable_status_color_css(subiface), "")
+
+
+class GetCablePkTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        status_active = Status.objects.get_for_model(Interface).get(name="Active")
+        status_connected = Status.objects.get_for_model(Cable).get(name="Connected")
+
+        spine_device = create_test_device("Breakout Cable Spine Device")
+        leaf_device = create_test_device("Breakout Cable Leaf Device")
+
+        cls.spine_interface = Interface.objects.create(
+            device=spine_device,
+            name="Spine Interface 1",
+            type=InterfaceTypeChoices.TYPE_40GE_QSFP_PLUS,
+            status=status_active,
+        )
+
+        cls.spine_interface_child = Interface.objects.create(
+            device=spine_device,
+            name="Spine Interface 1/1",
+            type=InterfaceTypeChoices.TYPE_VIRTUAL,
+            status=status_active,
+            parent_interface=cls.spine_interface,
+            breakout_position=1,
+        )
+
+        cls.uncabled_interface = Interface.objects.create(
+            device=spine_device, name="eth-uncabled", status=status_active
+        )
+
+        leaf_interfaces = [
+            Interface.objects.create(device=leaf_device, name="Leaf 1", status=status_active),
+            Interface.objects.create(device=leaf_device, name="Leaf 2", status=status_active),
+        ]
+        breakout_type = CableType.objects.create(
+            name="1x2 Breakout Cable", a_connectors=1, b_connectors=2, total_lanes=2
+        )
+
+        cls.breakout_cable = Cable(
+            termination_a=cls.spine_interface,
+            termination_b=leaf_interfaces[0],
+            cable_type=breakout_type,
+            status=status_connected,
+        )
+        cls.breakout_cable.save()
+        cls.breakout_cable.add_termination(leaf_interfaces[1], "B", connector=2)
+
+    def test_get_cable_pk_breakout_child_returns_parent_cable_pk(self):
+        self.assertIsNone(self.spine_interface_child.cable)
+        self.assertIsNotNone(self.spine_interface_child.parent_interface_id)
+        self.assertIsNotNone(self.spine_interface_child.breakout_position)
+        self.assertIsNotNone(self.spine_interface.cable)
+
+        self.assertEqual(get_cable_pk(self.spine_interface_child), self.spine_interface.cable.pk)
+
+    def test_get_cable_pk_directly_cabled_interface_returns_own_cable_pk(self):
+        self.assertEqual(get_cable_pk(self.spine_interface), self.breakout_cable.pk)
+
+    def test_get_cable_pk_uncabled_interface_returns_empty_string(self):
+        self.assertIsNone(self.uncabled_interface.cable)
+        self.assertEqual(get_cable_pk(self.uncabled_interface), "")

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -76,7 +76,7 @@ def get_cable_pk(record):
     if record.cable:
         return record.cable.pk
     if record.parent_interface_id and record.parent_interface.cable and record.breakout_position is not None:
-        return parent_interface_cable.pk
+        return record.parent_interface.cable.pk
     return ""
 
 

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -75,7 +75,7 @@ def get_cable_pk(record):
     """Given an interface, try to return its cable's primary key."""
     if record.cable:
         return record.cable.pk
-    if record.parent_interface_id and record.parent_interface.cable and record.breakout_position is not None:
+    if record.parent_interface_id and record.breakout_position is not None and record.parent_interface.cable is not None:
         return record.parent_interface.cable.pk
     return ""
 

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -73,14 +73,11 @@ def cable_status_color_css(record):
 
 def get_cable_pk(record):
     """Given an interface, try to return its cable's primary key."""
-    if not record.cable:
-        breakout_lane = record.get_breakout_lane() if getattr(record, "parent_interface_id", None) else None
-        if breakout_lane and breakout_lane.far_termination:
-            parent_interface_cable = record.parent_interface.cable
-            return parent_interface_cable.pk if parent_interface_cable else ""
-        return ""
-
-    return record.cable.pk
+    if record.cable:
+        return record.cable.pk
+    if record.parent_interface_id and record.parent_interface.cable and record.breakout_position is not None:
+        return parent_interface_cable.pk
+    return ""
 
 
 def get_network_driver_mapping_tool_names():

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -75,7 +75,11 @@ def get_cable_pk(record):
     """Given an interface, try to return its cable's primary key."""
     if record.cable:
         return record.cable.pk
-    if record.parent_interface_id and record.breakout_position is not None and record.parent_interface.cable is not None:
+    if (
+        record.parent_interface_id
+        and record.breakout_position is not None
+        and record.parent_interface.cable is not None
+    ):
         return record.parent_interface.cable.pk
     return ""
 

--- a/nautobot/dcim/utils.py
+++ b/nautobot/dcim/utils.py
@@ -71,6 +71,18 @@ def cable_status_color_css(record):
     return CABLE_STATUS_TO_CSS_CLASS.get(status_color, "")
 
 
+def get_cable_pk(record):
+    """Given an interface, try to return its cable's primary key."""
+    if not record.cable:
+        breakout_lane = record.get_breakout_lane() if getattr(record, "parent_interface_id", None) else None
+        if breakout_lane and breakout_lane.far_termination:
+            parent_interface_cable = record.parent_interface.cable
+            return parent_interface_cable.pk if parent_interface_cable else ""
+        return ""
+
+    return record.cable.pk
+
+
 def get_network_driver_mapping_tool_names():
     """
     Return a list of all available network driver tool names derived from the netutils library and the optional NETWORK_DRIVERS setting.

--- a/nautobot/project-static/js/connection_toggles.js
+++ b/nautobot/project-static/js/connection_toggles.js
@@ -6,10 +6,42 @@ function setLabel(elem, icon, text) {
     elem.append(text);
 }
 
+function changeCableTerminationColors(cablePk, newStatus) {
+    if (!cablePk) {
+        return;
+    }
+
+    const cableRows = document.querySelectorAll(`tr[cable_pk="${cablePk}"]`);
+    cableRows.forEach(function(cableRow) {
+        cableRow.classList.remove('table-success', 'table-info', 'table-warning');
+        cableRow.classList.add(newStatus === 'Connected' ? 'table-success' : 'table-info');
+    });
+}
+
+function changeCableTerminationToggleButtons(cablePk, newStatus) {
+    if (!cablePk) {
+        return;
+    }
+
+    const nextAction = newStatus === 'Connected' ? 'Planned' : 'Connected';
+    const toggles = document.querySelectorAll(`a.cable-toggle[data="${cablePk}"]`);
+    toggles.forEach(function(toggle) {
+        const icon = toggle.querySelector(':scope > span');
+        toggle.classList.toggle('connected', newStatus === 'Connected');
+        toggle.classList.toggle('text-warning', newStatus === 'Connected');
+        toggle.classList.toggle('text-success', newStatus === 'Planned');
+        if (icon) {
+            icon.classList.toggle('mdi-lan-connect', newStatus === 'Planned');
+            icon.classList.toggle('mdi-lan-pending', newStatus === 'Connected');
+        }
+        setLabel(toggle, icon, `Mark cable as ${nextAction}`);
+    });
+}
+
 function toggleConnection(elem) {
-    const url = nautobot_api_path + "dcim/cables/" + elem.getAttribute('data') + "/";
+    const cablePk = elem.getAttribute('data');
+    const url = nautobot_api_path + "dcim/cables/" + cablePk + "/";
     const wasConnected = elem.classList.contains('connected');
-    const oldStatus = wasConnected ? 'Connected' : 'Planned';
     const newStatus = wasConnected ? 'Planned' : 'Connected';
 
     fetch(url, {
@@ -24,20 +56,15 @@ function toggleConnection(elem) {
         if (!response.ok) {
             return;
         }
+
         const row = elem.closest('tr');
-        const icon = elem.querySelector(':scope > span');
         if (row) {
             row.classList.toggle('table-success', newStatus === 'Connected');
             row.classList.toggle('table-info', newStatus === 'Planned');
         }
-        elem.classList.toggle('connected', newStatus === 'Connected');
-        elem.classList.toggle('text-warning', newStatus === 'Connected');
-        elem.classList.toggle('text-success', newStatus === 'Planned');
-        if (icon) {
-            icon.classList.toggle('mdi-lan-connect', newStatus === 'Planned');
-            icon.classList.toggle('mdi-lan-pending', newStatus === 'Connected');
-        }
-        setLabel(elem, icon, `Mark cable as ${oldStatus}`);
+
+        changeCableTerminationColors(cablePk, newStatus);
+        changeCableTerminationToggleButtons(cablePk, newStatus);
     });
     return false;
 }

--- a/nautobot/project-static/js/connection_toggles.js
+++ b/nautobot/project-static/js/connection_toggles.js
@@ -57,12 +57,6 @@ function toggleConnection(elem) {
             return;
         }
 
-        const row = elem.closest('tr');
-        if (row) {
-            row.classList.toggle('table-success', newStatus === 'Connected');
-            row.classList.toggle('table-info', newStatus === 'Planned');
-        }
-
         changeCableTerminationColors(cablePk, newStatus);
         changeCableTerminationToggleButtons(cablePk, newStatus);
     });

--- a/nautobot/project-static/js/connection_toggles.js
+++ b/nautobot/project-static/js/connection_toggles.js
@@ -11,7 +11,7 @@ function changeCableTerminationColors(cablePk, newStatus) {
         return;
     }
 
-    const cableRows = document.querySelectorAll(`tr[cable_pk="${cablePk}"]`);
+    const cableRows = document.querySelectorAll(`tr[data-cable-pk="${cablePk}"]`);
     cableRows.forEach(function(cableRow) {
         cableRow.classList.remove('table-success', 'table-info', 'table-warning');
         cableRow.classList.add(newStatus === 'Connected' ? 'table-success' : 'table-info');


### PR DESCRIPTION
# Closes #9244

# What's Changed
- Added `changeCableTerminationColors` method to `connection_toggle.js` in order to change cable interface colors on status change
- Added `changeCableTerminationToggleButtons` method to `connection_toggle.js` in order to change cable interface icons on status change
- Added `cable_pk` to `InterfaceTable` in order to have access to cable primary key
- Added `get_cable_pk` to `nautobot/dcim/utils.py` in order to have access to cable pk

# Screenshots
https://github.com/user-attachments/assets/0f01d6b3-a5fa-4868-bb24-9d671cdcd3ac


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design

NAUTOBOT-1469