### PR TITLE
fixes n+1 query problem for device list view with device bays

### DIFF
--- a/changes/9326.fixed
+++ b/changes/9326.fixed
@@ -1,0 +1,1 @@
+Added additional `select_related` for device bays in device API view set.

--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -428,6 +428,7 @@ class DeviceViewSet(ConfigContextQuerySetMixin, NautobotModelViewSet):
     queryset = Device.objects.select_related(
         "device_type__manufacturer",
         "virtual_chassis__master",
+        "parent_bay",
     ).prefetch_related("primary_ip4__nat_outside_list", "primary_ip6__nat_outside_list")
     serializer_class = serializers.DeviceSerializer
     filterset_class = filters.DeviceFilterSet

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -2292,7 +2292,7 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
             device_bay.installed_device = child_device
             device_bay.save()
 
-        with self.assertNumQueries(13):
+        with AssertNoRepeatedQueries(self):
             response = self.client.get(list_url, **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
 

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -2270,6 +2270,32 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
         child_device.refresh_from_db()
         self.assertEqual(child_device.parent_bay.pk, device_bay_1.pk)
 
+    def test_list_query_count_with_device_bays(self):
+        """
+        Listing devices must not run an extra query per device to resolve the reverse one-to-one `parent_bay`.
+        """
+        self.add_permissions("dcim.view_device")
+        list_url = reverse("dcim-api:device-list")
+
+        parent_device, device_bay_1, device_bay_2, device_type_child = self._parent_device_test_data()
+        device_status = Status.objects.get_for_model(Device).first()
+        device_role = Role.objects.get_for_model(Device).first()
+
+        for name, device_bay in (("Child device in bay 1", device_bay_1), ("Child device in bay 2", device_bay_2)):
+            child_device = Device.objects.create(
+                device_type=device_type_child,
+                role=device_role,
+                status=device_status,
+                name=name,
+                location=parent_device.location,
+            )
+            device_bay.installed_device = child_device
+            device_bay.save()
+
+        with self.assertNumQueries(13):
+            response = self.client.get(list_url, **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
 
 class ModuleTestCase(APIViewTestCases.APIViewTestCase):
     model = Module


### PR DESCRIPTION
# Closes DNE

Disclaimer: I used an LLM to find and fix this one; the "Screenshots" section shows proof of it working and the actual change is very minor. 

# What's Changed

Add `select_related` for device_bays to `DeviceViewSet` for API.

# Screenshots

Without then with:

```
❯ inv tests --keepdb -s -l nautobot.dcim.tests.test_api.DeviceTest.test_list_query_count_with_device_bays
[...]
F
======================================================================
FAIL: test_list_query_count_with_device_bays (nautobot.dcim.tests.test_api.DeviceTest.test_list_query_count_with_device_bays)
Listing devices must not run an extra query per device to resolve the reverse one-to-one `parent_bay`.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/source/nautobot/dcim/tests/test_api.py", line 2295, in test_list_query_count_with_device_bays
    with self.assertNumQueries(13):
         ~~~~~~~~~~~~~~~~~~~~~^^^^
AssertionError: 19 != 13 : 19 queries executed, 13 expected
[...]
❯ git stash pop
[...]
❯ inv tests --keepdb -s -l nautobot.dcim.tests.test_api.DeviceTest.test_list_query_count_with_device_bays
[...]
.
----------------------------------------------------------------------
Ran 1 test in 0.498s

OK
[...]
```

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
