### PR TITLE
Prevent redundant custom field choices lookups during filterset construction

### DIFF
--- a/changes/9328.fixed
+++ b/changes/9328.fixed
@@ -1,0 +1,1 @@
+Reduced redundant Redis cache lookups for `CustomField.choices` when constructing FilterSets, by building the choice widget once per CustomField instead of once per generated filter (base filter plus lookup-expression variants).

--- a/nautobot/extras/filter_mixins.py
+++ b/nautobot/extras/filter_mixins.py
@@ -85,14 +85,19 @@ class CustomFieldModelFilterSetMixin(django_filters.FilterSet):
             # Determine filter class for this CustomField type, default to CustomFieldCharFilter
             new_filter_name = cf.add_prefix_to_cf_key()
             filter_class = custom_field_filter_classes.get(cf.type, CustomFieldCharFilter)
-            new_filter = filter_class(field_name=cf.key, custom_field=cf)
+            # Build the widget once and reuse it below instead of each filter independently calling
+            # `cf.to_form_field()`, which redundantly re-reads the cached `cf.choices` each time.
+            widget = cf.to_form_field(set_initial=False, enforce_required=False).widget
+            new_filter = filter_class(field_name=cf.key, custom_field=cf, widget=widget)
             new_filter.label = f"{cf.label}"
             # Create base filter (cf_customfieldname)
             self.filters[new_filter_name] = new_filter
 
             # Create extra lookup expression filters (cf_customfieldname__lookup_expr)
             self.filters.update(
-                self._generate_custom_field_lookup_expression_filters(filter_name=new_filter_name, custom_field=cf)
+                self._generate_custom_field_lookup_expression_filters(
+                    filter_name=new_filter_name, custom_field=cf, widget=widget
+                )
             )
 
     @staticmethod
@@ -117,11 +122,13 @@ class CustomFieldModelFilterSetMixin(django_filters.FilterSet):
     # TODO 2.0: Transition CustomField filters to nautobot.core.filters.MultiValue* filters and
     # leverage BaseFilterSet to add dynamic lookup expression filters. Remove CustomField.filter_logic field
     @classmethod
-    def _generate_custom_field_lookup_expression_filters(cls, filter_name, custom_field):
+    def _generate_custom_field_lookup_expression_filters(cls, filter_name, custom_field, widget=None):
         """
         For specific filter types, new filters are created based on defined lookup expressions in
         the form `<field_name>__<lookup_expr>`. Copied from nautobot.core.filters.BaseFilterSet
         and updated to work with custom fields.
+
+        `widget`, if provided, is reused across all generated filters instead of each one rebuilding it.
         """
         magic_filters = {}
         custom_field_type_to_filter_map = {
@@ -161,6 +168,7 @@ class CustomFieldModelFilterSetMixin(django_filters.FilterSet):
                 custom_field=custom_field,
                 label=label,
                 exclude=lookup_name.startswith("n"),
+                widget=widget,
             )
 
             magic_filters[new_filter_name] = new_filter

--- a/nautobot/extras/filter_mixins_customfields.py
+++ b/nautobot/extras/filter_mixins_customfields.py
@@ -37,7 +37,10 @@ class CustomFieldFilterMixin:
         if custom_field.type not in EXACT_FILTER_TYPES:
             if custom_field.filter_logic == CustomFieldFilterLogicChoices.FILTER_LOOSE:
                 kwargs.setdefault("lookup_expr", "icontains")
-        kwargs["widget"] = custom_field.to_form_field(set_initial=False, enforce_required=False).widget
+        # A pre-built widget may be passed in (e.g. shared across a base filter and its lookup-expression
+        # variants) to avoid rebuilding it, which would redundantly re-read `custom_field.choices`.
+        if kwargs.get("widget") is None:
+            kwargs["widget"] = custom_field.to_form_field(set_initial=False, enforce_required=False).widget
         super().__init__(*args, **kwargs)
         self.field_name = f"_custom_field_data__{self.field_name}"
 

--- a/nautobot/extras/tests/test_customfields.py
+++ b/nautobot/extras/tests/test_customfields.py
@@ -8,6 +8,7 @@ import uuid
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError, QuerySet
 from django.db.models.signals import m2m_changed
@@ -24,6 +25,7 @@ from nautobot.core.tables import CustomFieldColumn
 from nautobot.core.testing import APITestCase, TestCase, TransactionTestCase
 from nautobot.core.testing.models import ModelTestCases
 from nautobot.core.testing.utils import extract_page_body, post_data
+from nautobot.core.utils.cache import construct_cache_key
 from nautobot.core.utils.lookup import get_changes_for_model
 from nautobot.dcim.filters import LocationFilterSet
 from nautobot.dcim.forms import RackFilterForm
@@ -1984,6 +1986,19 @@ class CustomFieldFilterTest(TestCase):
             location_type=cls.location_type,
             status=location_status,
             _custom_field_data={},
+        )
+
+    def test_filterset_construction_does_not_repeatedly_look_up_choices_per_custom_field(self):
+        """FilterSet construction should read a CustomField's cached `choices` at most once, not once per filter."""
+        cf8 = CustomField.objects.get(label="CF8")  # TYPE_SELECT, has choices
+        with mock.patch.object(cache, "get", wraps=cache.get) as mock_cache_get:
+            self.filterset({}, self.queryset)
+        choices_cache_key = construct_cache_key(cf8, method_name="choices", branch_aware=True)
+        choices_lookups = [call for call in mock_cache_get.call_args_list if call.args[0] == choices_cache_key]
+        self.assertLessEqual(
+            len(choices_lookups),
+            1,
+            f"Expected at most 1 Redis lookup for {choices_cache_key}, got {len(choices_lookups)}",
         )
 
     def test_filter_integer(self):


### PR DESCRIPTION
# Closes DNE

Disclaimer: I used an LLM to analyze tracing data and help figure out solutions to our performance problem for the /api/dcim/interfaces endpoint. I also used it to perform the actual changes, but I did manually verify everything worked and the logic is sound (at least to me).

# What's Changed

Constructing a `FilterSet` for a model with select/multiselect Custom Fields builds one base filter plus 13 lookup-expression filters per CustomField. Each of these filters independently called `CustomField.to_form_field()` , which reads the Redis-cached `CustomField.choices`, resulting in 14 identical Redis round-trips per CustomField and request, regardless of the number of objects.

# Screenshots

Not applicable, but I do have some tracing data from our Dev and Prod instances:

- Dev trace: 112 of 136 Redis GETs were caused by this, 8 custom fields with 14 lookups each
- Prod trace (representative average, 4.8s): ~5% of the latency is caused by this

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
