### PR TITLE
Allow putting a breakout subinterface into a LAG, Issue #9346

### DIFF
--- a/changes/9346.changed
+++ b/changes/9346.changed
@@ -1,0 +1,1 @@
+Changed validation of interfaces to allow putting a breakout sub-interface into a LAG.

--- a/changes/9346.documentation
+++ b/changes/9346.documentation
@@ -1,0 +1,1 @@
+Changed documentation of interfaces to say that a breakout sub-interface can be member of a LAG.

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -1282,7 +1282,13 @@ class Interface(ModularComponentModel, CableTermination, PathEndpoint, BaseInter
 
             # A virtual interface cannot have a parent LAG
             if self.type == InterfaceTypeChoices.TYPE_VIRTUAL:
-                raise ValidationError({"lag": "Virtual interfaces cannot have a parent LAG interface."})
+                # Unless interface is a Breakout Sub-Interface
+                if self.parent_interface is None or self.breakout_position is None:
+                    raise ValidationError(
+                        {
+                            "lag": "Virtual interfaces other than breakout child interfaces cannot have a parent LAG interface."
+                        }
+                    )
 
         # Virtual interfaces cannot be connected
         if self.type in NONCONNECTABLE_IFACE_TYPES and (self.cable or getattr(self, "circuit_termination", False)):

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -4697,6 +4697,7 @@ class InterfaceTestCase(ModularDeviceComponentTestCaseMixin, ModelTestCases.Base
         )
         status = Status.objects.get_for_model(Device).first()
         cls.intf_status = Status.objects.get_for_model(Interface).first()
+        cls.intf_role = Role.objects.get_for_model(Interface).first()
         cls.device = Device.objects.create(
             name="Device 1",
             device_type=devicetype,
@@ -4714,6 +4715,20 @@ class InterfaceTestCase(ModularDeviceComponentTestCaseMixin, ModelTestCases.Base
             vid=100,
             location=location_2,
             status=vlan_status,
+        )
+        cls.parent_interface = Interface.objects.create(
+            name="test_parent_if",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            device=cls.device,
+            status=cls.intf_status,
+            role=cls.intf_role,
+        )
+        cls.lag_interface = Interface.objects.create(
+            name="test_lag_if",
+            type=InterfaceTypeChoices.TYPE_LAG,
+            device=cls.device,
+            status=cls.intf_status,
+            role=cls.intf_role,
         )
 
         cls.namespace = Namespace.objects.create(name="dcim_test_interface_ip_addresses")
@@ -5108,6 +5123,40 @@ class InterfaceTestCase(ModularDeviceComponentTestCaseMixin, ModelTestCases.Base
         self.assertEqual(
             err.exception.message_dict["port_type"][0], "Virtual and wireless interfaces cannot have a port type."
         )
+
+    def test_error_raised_when_adding_lag_to_virtual_interface(self):
+        """Test that an error is raised when adding a lag to a virtual interface that is not a breakout subinterface"""
+        interface = Interface.objects.create(
+            name="Int1",
+            type=InterfaceTypeChoices.TYPE_VIRTUAL,
+            device=self.device,
+            status=self.intf_status,
+            role=self.intf_role,
+        )
+        interface.lag = self.lag_interface
+        for parent_if, br_pos in [(None, None), (self.parent_interface, None), (None, 1)]:
+            interface.parent_interface = parent_if
+            interface.breakout_position = br_pos
+            with self.assertRaises(ValidationError) as err:
+                interface.validated_save()
+            self.assertEqual(
+                err.exception.message_dict["lag"][0],
+                "Virtual interfaces other than breakout child interfaces cannot have a parent LAG interface.",
+            )
+
+    def test_adding_lag_for_virtual_breakout_interface(self):
+        "Test that adding a lag to a virtual breakout subinterface is possible"
+        interface = Interface.objects.create(
+            name="Int1",
+            type=InterfaceTypeChoices.TYPE_VIRTUAL,
+            device=self.device,
+            status=self.intf_status,
+            role=self.intf_role,
+            lag=self.lag_interface,
+            parent_interface=self.parent_interface,
+            breakout_position=1,
+        )
+        interface.full_clean()
 
 
 class SoftwareImageFileTestCase(ModelTestCases.BaseModelTestCase):

--- a/nautobot/docs/user-guide/core-data-model/dcim/interface.md
+++ b/nautobot/docs/user-guide/core-data-model/dcim/interface.md
@@ -44,7 +44,7 @@ Sub-interfaces (virtual interfaces associated to a `parent_interface`) may now o
 
 ## LAGs
 
-Physical interfaces may be arranged into a link aggregation group (LAG) and associated with a parent LAG (virtual) interface. LAG interfaces can be recursively nested to model bonding of trunk groups. Like all virtual interfaces, LAG interfaces cannot be connected physically. Interfaces can be assigned to an [Interface Redundancy Group](./interfaceredundancygroup.md) to represent redundancy protocols such as HSRP or VRRP.
+Physical interfaces and breakout sub-interfaces may be arranged into a link aggregation group (LAG) and associated with a parent LAG (virtual) interface. LAG interfaces can be recursively nested to model bonding of trunk groups. Like all virtual interfaces, LAG interfaces cannot be connected physically. Interfaces can be assigned to an [Interface Redundancy Group](./interfaceredundancygroup.md) to represent redundancy protocols such as HSRP or VRRP.
 
 +/- 2.0.0
     The relationship to IP addresses has been changed to a many-to-many relationship. This allows an IP address to be assigned to multiple interfaces, and an interface to have multiple IP addresses assigned to it.


### PR DESCRIPTION
# Closes #9346
# What's Changed
Change to validation of Interface to allow putting a breakout subinterface into a LAG.
