### PR TITLE
Fix HTTP 500 on out-of-range REST API depth parameter

### DIFF
--- a/changes/8449.fixed
+++ b/changes/8449.fixed
@@ -1,0 +1,1 @@
+Fixed REST API returning an HTTP 500 error instead of an HTTP 400 when an invalid `depth` query parameter (outside the range 0-10) was provided.

--- a/nautobot/core/api/views.py
+++ b/nautobot/core/api/views.py
@@ -233,6 +233,9 @@ class ModelViewSetMixin:
             except ValueError:
                 self.logger.warning("The depth parameter must be an integer between 0 and 10")
 
+            if depth < 0 or depth > 10:
+                raise ParseError("The depth parameter must be an integer between 0 and 10")
+
             context["depth"] = depth
         else:
             # Use depth=0 in all write type requests.

--- a/nautobot/core/tests/test_api.py
+++ b/nautobot/core/tests/test_api.py
@@ -998,6 +998,27 @@ class DepthPermissionEnforcementTest(testing.APITestCase):
         self.assertEqual(hidden["display"], self.hidden_location.display)
 
 
+class InvalidDepthParameterTest(testing.APITestCase):
+    """Test that an out-of-range `?depth=` query parameter results in an HTTP 400, not an HTTP 500."""
+
+    def setUp(self):
+        super().setUp()
+        self.add_permissions("ipam.view_vlangroup")
+        self.vlan_group_list_url = reverse(get_route_for_model(ipam_models.VLANGroup, "list", api=True))
+
+    def test_depth_greater_than_max_returns_400(self):
+        response = self.client.get(f"{self.vlan_group_list_url}?depth=11", **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_negative_depth_returns_400(self):
+        response = self.client.get(f"{self.vlan_group_list_url}?depth=-1", **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_depth_within_range_returns_200(self):
+        response = self.client.get(f"{self.vlan_group_list_url}?depth=10", **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+
 @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
 class WriteRelatedObjectPermissionTest(testing.APITestCase):
     """


### PR DESCRIPTION
# Closes #8449

# What's Changed
Requests to the REST API with an out-of-range `?depth=` query parameter (e.g. `depth=11` or a negative value) returned an unhandled HTTP 500 instead of a proper HTTP 400.

Root cause: `get_serializer_context()` in `nautobot/core/api/views.py` passed the raw `depth` value straight through to context, which DRF's `ModelSerializer` later validates internally with a bare `assert depth >= 0` / `assert depth <= 10` in `rest_framework/serializers.py`. Since `AssertionError` isn't caught by DRF's exception handler, it bubbled up as a 500.

The fix validates the depth range in `get_serializer_context()` itself and raises a DRF `ParseError`, which is correctly converted to an HTTP 400 response.

Verified the root cause and fix logic against the actual DRF assertion (`rest_framework/serializers.py`) in an isolated repro before writing the fix.

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example
- [x] Unit Tests
- [ ] Documentation Updates (not applicable, bugfix only)
- [ ] Example App Updates (not applicable)
- [x] Outline Remaining Work, Constraints from Design (none)