### PR TITLE
Remove custom verbose_name from ObjectPermission model

### DIFF
--- a/changes/2998.housekeeping
+++ b/changes/2998.housekeeping
@@ -1,0 +1,1 @@
+Removed the custom `verbose_name` from the `ObjectPermission` model so it uses the default "Object permission" naming, consistent with other models.

--- a/nautobot/users/migrations/0012_alter_objectpermission_options.py
+++ b/nautobot/users/migrations/0012_alter_objectpermission_options.py
@@ -1,0 +1,16 @@
+# Generated manually
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0011_alter_user_default_saved_views"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="objectpermission",
+            options={"ordering": ["name"]},
+        ),
+    ]

--- a/nautobot/users/models.py
+++ b/nautobot/users/models.py
@@ -327,7 +327,6 @@ class ObjectPermission(BaseModel, ChangeLoggedModel):
 
     class Meta:
         ordering = ["name"]
-        verbose_name = "permission"
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
# Closes #2998

# What's Changed
`ObjectPermission.Meta` explicitly set `verbose_name = "permission"`, which was inconsistent with the naming convention used by other Nautobot models (which rely on Django's default verbose name derived from the class name).

Removed the custom `verbose_name`, so it now defaults to `"object permission"` (displayed as "Object permission" in the UI/admin), matching the pattern used by other models.

Added a migration (`0012_alter_objectpermission_options.py`) to update the model's Meta options state to reflect the change (verified the resulting default verbose name/plural with an isolated Django model check: `"object permission"` / `"object permissions"`).

# TODO
- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example (not applicable, no UI text change beyond casing)
- [ ] Unit, Integration Tests (no test previously asserted this string; none needed to break/add)
- [ ] Documentation Updates (not applicable)
- [ ] Example App Updates (not applicable)
- [x] Outline Remaining Work, Constraints from Design (none)