### PR TITLE
docs: correct celery queues flag

### DIFF
--- a/changes/9359.documentation
+++ b/changes/9359.documentation
@@ -1,0 +1,1 @@
+Corrected the documented Celery worker queue flag from `--queue` to `--queues` in the Celery Queues administration guide.

--- a/nautobot/docs/user-guide/administration/guides/celery-queues.md
+++ b/nautobot/docs/user-guide/administration/guides/celery-queues.md
@@ -6,7 +6,7 @@ If you're planning to run multiple jobs, leverage job hooks or are finding that 
 
 The default Celery behavior is:
 
-- [`--queue celery`](https://docs.celeryq.dev/en/stable/reference/cli.html#cmdoption-celery-worker-Q)
+- [`--queues celery`](https://docs.celeryq.dev/en/stable/reference/cli.html#cmdoption-celery-worker-Q)
 - [`--concurrency`](https://docs.celeryq.dev/en/stable/reference/cli.html#cmdoption-celery-worker-c) set to the number of CPUs detected on the system
 - [`worker_prefetch_multiplier=4`](https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-worker_prefetch_multiplier)
 


### PR DESCRIPTION
## Summary

Correct the Celery worker example to use the supported `--queues celery` flag.

## Testing

- verified the stale `--queue celery` form is absent from the guide
- `git diff --check`

The repository Markdown tooling (`invoke`/`pymarkdown`) was not installed locally, so the draft relies on hosted CI for that lint gate.

Fixes #8251.
