### PR TITLE
Fixed Console/Power Connections list view

### DIFF
--- a/changes/9341.fixed
+++ b/changes/9341.fixed
@@ -1,0 +1,1 @@
+Fixed the peer-side columns rendering as empty placeholders on the Console Connections and Power Connections list views.

--- a/changes/9341.housekeeping
+++ b/changes/9341.housekeeping
@@ -1,1 +1,0 @@
-Added a test that detects table column accessors traversing a to-many relation, which silently render as empty placeholders rather than raising.

--- a/changes/9341.housekeeping
+++ b/changes/9341.housekeeping
@@ -1,0 +1,1 @@
+Added a test that detects table column accessors traversing a to-many relation, which silently render as empty placeholders rather than raising.

--- a/changes/9362.fixed
+++ b/changes/9362.fixed
@@ -1,0 +1,1 @@
+Fixed a N+1 issue in the Interface Connections list view and REST API endpoint.

--- a/nautobot/core/tests/test_tables.py
+++ b/nautobot/core/tests/test_tables.py
@@ -4,11 +4,11 @@ import pkgutil
 from types import SimpleNamespace
 import warnings
 
-from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
 from django.db import connection
-from django.db.models import IntegerField, ManyToManyField, ManyToManyRel, ManyToOneRel, Value
+from django.db.models import IntegerField, Value
 from django.test import SimpleTestCase, tag, TestCase
 from django.test.utils import CaptureQueriesContext
 from django_tables2.utils import Accessor
@@ -387,14 +387,11 @@ def _import_all_table_modules():
 
 
 class TableAccessorAuditTestCase(SimpleTestCase):
-    """Static audit of every declared table column accessor.
+    """Static audit of every table column accessor, whether declared or derived from the column name.
 
     Pure introspection, no database access.
     Regression test for nautobot#9341.
     """
-
-    # Relations that resolve to a *manager* when read off a model instance.
-    TO_MANY_FIELDS = (ManyToManyField, ManyToManyRel, ManyToOneRel, GenericRelation)
 
     def test_no_accessor_traverses_a_to_many_relation(self):
         """No column accessor may traverse a to-many relation and then keep going.
@@ -412,9 +409,8 @@ class TableAccessorAuditTestCase(SimpleTestCase):
             if model is None:
                 continue
             for name, column in table.base_columns.items():
-                if column.accessor is None:
-                    continue  # derived from the column name (e.g. TemplateColumn)
-                bits = str(column.accessor).split(Accessor.SEPARATOR)
+                accessor = column.accessor if column.accessor is not None else name
+                bits = str(accessor).split(Accessor.SEPARATOR)
                 current = model
                 for index, bit in enumerate(bits):
                     if current is None:
@@ -423,9 +419,9 @@ class TableAccessorAuditTestCase(SimpleTestCase):
                         field = current._meta.get_field(bit)
                     except (FieldDoesNotExist, AttributeError):
                         break  # a property or method: not statically decidable, so leave it alone
-                    if isinstance(field, self.TO_MANY_FIELDS):
+                    if field.one_to_many or field.many_to_many:
                         if index < len(bits) - 1:
-                            violations.append(f"{table.__module__}.{table.__name__}.{name} -> {column.accessor}")
+                            violations.append(f"{table.__module__}.{table.__name__}.{name} -> {accessor}")
                         break
                     if isinstance(field, GenericForeignKey):
                         break  # resolves to a single object, but its model isn't knowable statically

--- a/nautobot/core/tests/test_tables.py
+++ b/nautobot/core/tests/test_tables.py
@@ -1,15 +1,23 @@
+import contextlib
+import importlib
+import pkgutil
 from types import SimpleNamespace
+import warnings
 
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import FieldDoesNotExist
 from django.db import connection
-from django.db.models import IntegerField, Value
-from django.test import tag, TestCase
+from django.db.models import IntegerField, ManyToManyField, ManyToManyRel, ManyToOneRel, Value
+from django.test import SimpleTestCase, tag, TestCase
 from django.test.utils import CaptureQueriesContext
+from django_tables2.utils import Accessor
 
+import nautobot
 from nautobot.circuits.models import Circuit
 from nautobot.circuits.tables import CircuitTable
 from nautobot.core.models.querysets import count_related
-from nautobot.core.tables import ButtonsColumn, ComputedFieldColumn, LinkedCountColumn
+from nautobot.core.tables import BaseTable, ButtonsColumn, ComputedFieldColumn, LinkedCountColumn
 from nautobot.core.templatetags import helpers
 from nautobot.dcim.models import Device, InventoryItem, Location, LocationType, Rack, RackGroup
 from nautobot.dcim.tables import InventoryItemTable, LocationTable, LocationTypeTable, RackGroupTable
@@ -350,3 +358,81 @@ class ComputedFieldColumnRenderTestCase(TestCase):
         column = ComputedFieldColumn(self.markdown_field)
         record = Location(name="Bold")
         self.assertEqual(column.render(record=record), helpers.render_markdown("**Bold**"))
+
+
+def _all_subclasses(cls):
+    """Every subclass of `cls`, recursively."""
+    subclasses = set()
+    for subclass in cls.__subclasses__():
+        subclasses.add(subclass)
+        subclasses |= _all_subclasses(subclass)
+    return subclasses
+
+
+def _import_all_table_modules():
+    """Import every `tables` module under `nautobot` so all `BaseTable` subclasses are registered.
+
+    A test run only imports the table modules its own imports happen to reach, so the audit below
+    would otherwise silently inspect a subset.
+    """
+    for module_info in pkgutil.walk_packages(nautobot.__path__, f"{nautobot.__name__}."):
+        if ".tables" not in module_info.name and not module_info.name.endswith("tables"):
+            continue
+        with contextlib.suppress(Exception):
+            # Some optional/app modules aren't importable in every configuration; skipping them
+            # only narrows coverage, and the assertion below is about what *is* importable.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                importlib.import_module(module_info.name)
+
+
+class TableAccessorAuditTestCase(SimpleTestCase):
+    """Static audit of every declared table column accessor.
+
+    Pure introspection, no database access.
+    Regression test for nautobot#9341.
+    """
+
+    # Relations that resolve to a *manager* when read off a model instance.
+    TO_MANY_FIELDS = (ManyToManyField, ManyToManyRel, ManyToOneRel, GenericRelation)
+
+    def test_no_accessor_traverses_a_to_many_relation(self):
+        """No column accessor may traverse a to-many relation and then keep going.
+
+        `Accessor.resolve()` walks Python attributes, so a to-many relation yields a related manager,
+        which has none of the target model's attributes. Any further path segment therefore raises,
+        and `BoundRow._get_and_render_with` swallows the exception and renders the column default.
+        The column silently degrades to a placeholder at HTTP 200, which is exactly how nautobot#9341
+        shipped undetected past the list-view test suite.
+        """
+        _import_all_table_modules()
+        violations = []
+        for table in _all_subclasses(BaseTable):
+            model = getattr(table._meta, "model", None)
+            if model is None:
+                continue
+            for name, column in table.base_columns.items():
+                if column.accessor is None:
+                    continue  # derived from the column name (e.g. TemplateColumn)
+                bits = str(column.accessor).split(Accessor.SEPARATOR)
+                current = model
+                for index, bit in enumerate(bits):
+                    if current is None:
+                        break
+                    try:
+                        field = current._meta.get_field(bit)
+                    except (FieldDoesNotExist, AttributeError):
+                        break  # a property or method: not statically decidable, so leave it alone
+                    if isinstance(field, self.TO_MANY_FIELDS):
+                        if index < len(bits) - 1:
+                            violations.append(f"{table.__module__}.{table.__name__}.{name} -> {column.accessor}")
+                        break
+                    if isinstance(field, GenericForeignKey):
+                        break  # resolves to a single object, but its model isn't knowable statically
+                    current = getattr(getattr(field, "remote_field", None), "model", None)
+        self.assertEqual(
+            sorted(violations),
+            [],
+            "These accessors traverse a to-many relation (a manager) and will render as placeholders. "
+            "Route them through a property that returns a single object instead.",
+        )

--- a/nautobot/core/tests/test_tables.py
+++ b/nautobot/core/tests/test_tables.py
@@ -370,11 +370,7 @@ def _all_subclasses(cls):
 
 
 def _import_all_table_modules():
-    """Import every `tables` module under `nautobot` so all `BaseTable` subclasses are registered.
-
-    A test run only imports the table modules its own imports happen to reach, so the audit below
-    would otherwise silently inspect a subset.
-    """
+    """Import every `tables` module under `nautobot` so all `BaseTable` subclasses are registered."""
     for module_info in pkgutil.walk_packages(nautobot.__path__, f"{nautobot.__name__}."):
         if ".tables" not in module_info.name and not module_info.name.endswith("tables"):
             continue

--- a/nautobot/dcim/models/cables.py
+++ b/nautobot/dcim/models/cables.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.contenttypes.prefetch import GenericPrefetch
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
@@ -48,7 +49,7 @@ from nautobot.extras.utils import extras_features
 # would be the much more invasive but much more "correct" fix.
 from nautobot.core.models.generics import BaseModel, PrimaryModel  # isort: skip
 
-from .device_components import CableTermination, FrontPort, RearPort
+from .device_components import CableTermination, FrontPort, Interface, RearPort
 
 __all__ = (
     "Cable",
@@ -1520,7 +1521,10 @@ class CablePath(BaseModel):
                 | (models.Q(destination_fans_out=False) & models.Q(origin_id__lt=models.F("destination_id")))
             )
             .order_by("origin_type", "origin_id", "peer_connector")
-            .prefetch_related("origin", "destination")
+            .prefetch_related(
+                GenericPrefetch("origin", [Interface.objects.select_related("device")]),
+                GenericPrefetch("destination", [Interface.objects.select_related("device")]),
+            )
         )
 
     @classmethod

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -759,6 +759,33 @@ class PathEndpoint(models.Model):
         """
         return [path.destination for path in self.cable_paths.all() if path.destination is not None]
 
+    @classmethod
+    def connection_destination_querysets(cls):
+        """Per-destination-model querysets for `connection_destination_prefetch()`.
+
+        Empty on the base class, which still batches one query per content type but without joining
+        each destination's `parent`. Overridden by the endpoint types whose connections list view
+        renders the peer's parent.
+        """
+        return []
+
+    @classmethod
+    def connection_destination_prefetch(cls):
+        """A `GenericPrefetch` of this endpoint's CablePath destinations, joining each possible
+        destination model's own `parent` relation.
+
+        `CablePath.destination` is a `GenericForeignKey`, so `select_related` cannot reach it, while
+        the peer-side columns of `ConsoleConnectionTable` / `PowerConnectionTable` render both the
+        destination and its `parent`. Prefetching `cable_paths__destination` also populates the
+        `cable_paths` manager, which is what makes the `path` property query-free: `CablePath.Meta`
+        sets `ordering`, so `first()` slices the populated result cache instead of re-querying.
+
+        Distinct from `_connected_endpoint_destination_prefetch()`, which is tuned for the
+        `connection` column's Interface / CircuitTermination destinations and their breakout
+        annotations; those types never appear as console/power path destinations.
+        """
+        return GenericPrefetch("cable_paths__destination", cls.connection_destination_querysets())
+
 
 #
 # Console ports
@@ -786,6 +813,10 @@ class ConsolePort(ModularComponentModel, CableTermination, PathEndpoint):
     )
 
     objects = CableTerminationManager()
+
+    @classmethod
+    def connection_destination_querysets(cls):
+        return [ConsoleServerPort.objects.select_related("device")]
 
 
 #
@@ -854,6 +885,15 @@ class PowerPort(ModularComponentModel, CableTermination, PathEndpoint):
     )
 
     objects = CableTerminationManager()
+
+    @classmethod
+    def connection_destination_querysets(cls):
+        from nautobot.dcim.models.power import PowerFeed
+
+        return [
+            PowerOutlet.objects.select_related("device"),  # parent -> device
+            PowerFeed.objects.select_related("power_panel"),  # parent -> power_panel
+        ]
 
     def clean(self):
         super().clean()

--- a/nautobot/dcim/models/device_components.py
+++ b/nautobot/dcim/models/device_components.py
@@ -761,11 +761,16 @@ class PathEndpoint(models.Model):
 
     @classmethod
     def connection_destination_querysets(cls):
-        """Per-destination-model querysets for `connection_destination_prefetch()`.
+        """Returns a list of querysets, one for each model that can serve as a CablePath destination.
 
-        Empty on the base class, which still batches one query per content type but without joining
-        each destination's `parent`. Overridden by the endpoint types whose connections list view
-        renders the peer's parent.
+        These querysets are passed by `connection_destination_prefetch()` to `GenericPrefetch`, enabling each
+        destination model to prefetch its related `parent` object—such as a `Device` for a `ConsoleServerPort` or
+        a `PowerPanel` for a `PowerFeed`.
+
+        By default, this method returns an empty list, which works but is less efficient. Each destination would be
+        fetched individually using the model's default manager, resulting in an additional query per row to access
+        the `parent`. Subclasses should override this method for endpoint types whose connection list views display
+        the parent, to optimize query performance.
         """
         return []
 

--- a/nautobot/dcim/tables/__init__.py
+++ b/nautobot/dcim/tables/__init__.py
@@ -140,17 +140,8 @@ __all__ = (
 
 
 class ConsoleConnectionTable(BaseTable):
-    """Table over `ConsolePort` rows representing console-port-to-console-server-port connections.
-
-    The peer (B) side is reached through `PathEndpoint.path`, a property returning
-    `cable_paths.first()`. It must NOT be written as `cable_paths__...`: `Accessor.resolve()` walks
-    Python attributes, so `cable_paths` yields a related *manager* with no `destination`/`is_active`
-    attribute, and the failed lookup is swallowed into a placeholder (see nautobot#9341). A
-    ConsolePort has at most one `CablePath` -- `BREAKOUT_COMPATIBLE_TERMINATION_TYPES` excludes
-    console terminations -- so `first()` is the whole path, not an arbitrary one of several.
-    """
-
     console_server = tables.Column(
+        # We cannot use `cable_paths__...` here because it would traverse a related manager, which is not a single object.
         accessor=Accessor("path__destination__parent"),
         orderable=False,
         linkify=True,
@@ -182,15 +173,8 @@ class ConsoleConnectionTable(BaseTable):
 
 
 class PowerConnectionTable(BaseTable):
-    """Table over `PowerPort` rows representing power-port-to-power-outlet/feed connections.
-
-    As with `ConsoleConnectionTable`, the peer (B) side goes through the `PathEndpoint.path` property
-    rather than `cable_paths__...`, which cannot resolve through a related manager (nautobot#9341).
-    The `pdu` column is the peer's `parent`: a `Device` for a `PowerOutlet`, a `PowerPanel` for a
-    `PowerFeed`.
-    """
-
     pdu = tables.Column(
+        # We cannot use `cable_paths__...` here because it would traverse a related manager, which is not a single object.
         accessor=Accessor("path__destination__parent"),
         orderable=False,
         linkify=True,

--- a/nautobot/dcim/tables/__init__.py
+++ b/nautobot/dcim/tables/__init__.py
@@ -140,21 +140,35 @@ __all__ = (
 
 
 class ConsoleConnectionTable(BaseTable):
+    """Table over `ConsolePort` rows representing console-port-to-console-server-port connections.
+
+    The peer (B) side is reached through `PathEndpoint.path`, a property returning
+    `cable_paths.first()`. It must NOT be written as `cable_paths__...`: `Accessor.resolve()` walks
+    Python attributes, so `cable_paths` yields a related *manager* with no `destination`/`is_active`
+    attribute, and the failed lookup is swallowed into a placeholder (see nautobot#9341). A
+    ConsolePort has at most one `CablePath` -- `BREAKOUT_COMPATIBLE_TERMINATION_TYPES` excludes
+    console terminations -- so `first()` is the whole path, not an arbitrary one of several.
+    """
+
     console_server = tables.Column(
-        accessor=Accessor("cable_paths__destination__parent"),
+        accessor=Accessor("path__destination__parent"),
         orderable=False,
         linkify=True,
         verbose_name="Console Server",
     )
     console_server_port = tables.Column(
-        accessor=Accessor("cable_paths__destination"),
+        accessor=Accessor("path__destination"),
         orderable=False,
         linkify=True,
         verbose_name="Port",
     )
     device = tables.Column(linkify=True, accessor="parent", orderable=False)
     name = tables.Column(linkify=True, verbose_name="Console Port")
-    reachable = BooleanColumn(accessor=Accessor("cable_paths__is_active"), verbose_name="Reachable")
+    # `order_by` is the ORM equivalent of the `path__is_active` accessor: `path` is a Python property
+    # and cannot be sorted on, but the underlying relation can, so this column stays sortable.
+    reachable = BooleanColumn(
+        accessor=Accessor("path__is_active"), order_by="cable_paths__is_active", verbose_name="Reachable"
+    )
 
     class Meta(BaseTable.Meta):
         model = ConsolePort
@@ -168,21 +182,33 @@ class ConsoleConnectionTable(BaseTable):
 
 
 class PowerConnectionTable(BaseTable):
+    """Table over `PowerPort` rows representing power-port-to-power-outlet/feed connections.
+
+    As with `ConsoleConnectionTable`, the peer (B) side goes through the `PathEndpoint.path` property
+    rather than `cable_paths__...`, which cannot resolve through a related manager (nautobot#9341).
+    The `pdu` column is the peer's `parent`: a `Device` for a `PowerOutlet`, a `PowerPanel` for a
+    `PowerFeed`.
+    """
+
     pdu = tables.Column(
-        accessor=Accessor("cable_paths__destination__parent"),
+        accessor=Accessor("path__destination__parent"),
         orderable=False,
         linkify=True,
         verbose_name="PDU",
     )
     outlet = tables.Column(
-        accessor=Accessor("cable_paths__destination"),
+        accessor=Accessor("path__destination"),
         orderable=False,
         linkify=True,
         verbose_name="Outlet",
     )
     device = tables.Column(linkify=True, accessor="parent", orderable=False)
     name = tables.Column(linkify=True, verbose_name="Power Port")
-    reachable = BooleanColumn(accessor=Accessor("cable_paths__is_active"), verbose_name="Reachable")
+    # `order_by` is the ORM equivalent of the `path__is_active` accessor: `path` is a Python property
+    # and cannot be sorted on, but the underlying relation can, so this column stays sortable.
+    reachable = BooleanColumn(
+        accessor=Accessor("path__is_active"), order_by="cable_paths__is_active", verbose_name="Reachable"
+    )
 
     class Meta(BaseTable.Meta):
         model = PowerPort
@@ -204,7 +230,7 @@ class InterfaceConnectionTable(BaseTable):
         template_code=INTERFACE_CONNECTION_INTERFACE_A, orderable=False, verbose_name="Interface A"
     )
     device_b = tables.Column(
-        accessor=Accessor("destination.parent"), orderable=False, linkify=True, verbose_name="Device B"
+        accessor=Accessor("destination__parent"), orderable=False, linkify=True, verbose_name="Device B"
     )
     interface_b = tables.Column(
         accessor=Accessor("destination"), orderable=False, linkify=True, verbose_name="Interface B"

--- a/nautobot/dcim/tests/test_tables.py
+++ b/nautobot/dcim/tests/test_tables.py
@@ -483,13 +483,7 @@ class ConnectionTableTestCase(TestCase):
         self.assertIn(self.power_feed.get_absolute_url(), row.get_cell("outlet"))
 
     def test_connection_table_renders_unreachable_path(self):
-        """A path whose cable is not Connected renders reachable=False, not the placeholder.
-
-        `render_boolean(None)` is byte-identical to `HTML_NONE`, and `_get_and_render_with` returns
-        the column default *without* calling `render()` when the value is in `Column.empty_values`.
-        So asserting the False markup is the only way to distinguish "resolved to False" from
-        "failed to resolve".
-        """
+        """A path whose cable is not Connected renders reachable=False, not the placeholder."""
         row = self._row_for(ConsoleConnectionsListView, ConsoleConnectionTable, self.console_port_planned)
         self.assertIn(self.console_server_port_planned.get_absolute_url(), row.get_cell("console_server_port"))
         self.assertEqual(row.get_cell("reachable"), helpers.render_boolean(False))

--- a/nautobot/dcim/tests/test_tables.py
+++ b/nautobot/dcim/tests/test_tables.py
@@ -515,13 +515,20 @@ class ConnectionTableTestCase(TestCase):
         self.assertIn(path.destination.get_absolute_url(), row.get_cell("interface_b"))  # pylint: disable=no-member
         self.assertEqual(row.get_cell("reachable"), helpers.render_boolean(True))  # pylint: disable=no-member
 
-    def test_connection_table_render_has_no_n_plus_one(self):
-        """Rendering the peer-side columns must not issue a query per row.
+    def _assert_render_has_no_n_plus_one(self, table_class, queryset):
+        """Rendering every cell of `queryset` must not issue a query per row.
 
-        Twelve rows against `AssertNoRepeatedQueries`' default threshold of 10 means *any* single
-        per-row query trips the assertion (12 repeats > 10), so this doesn't depend on estimating how
-        many queries per row the accessors happen to cost.
+        Callers supply at least 12 rows: against `AssertNoRepeatedQueries`' default threshold of 10,
+        *any* single per-row query then trips the assertion (12 repeats > 10), so this doesn't depend
+        on estimating how many queries per row the accessors happen to cost.
         """
+        table = table_class(queryset)
+        with AssertNoRepeatedQueries(self):
+            for row in table.rows:
+                for column in table.columns:
+                    row.get_cell(column.name)
+
+    def test_console_connection_table_render_has_no_n_plus_one(self):
         pks = []
         for i in range(12):
             console_port = ConsolePort.objects.create(device=self.device_a, name=f"cp-bulk-{i}")
@@ -529,8 +536,38 @@ class ConnectionTableTestCase(TestCase):
             Cable.objects.create(termination_a=console_port, termination_b=peer, status=self.connected)
             pks.append(console_port.pk)
 
-        table = ConsoleConnectionTable(ConsoleConnectionsListView.queryset.filter(pk__in=pks))
-        with AssertNoRepeatedQueries(self):
-            for row in table.rows:
-                for column in table.columns:
-                    row.get_cell(column.name)
+        self._assert_render_has_no_n_plus_one(
+            ConsoleConnectionTable, ConsoleConnectionsListView.queryset.filter(pk__in=pks)
+        )
+
+    def test_power_connection_table_render_has_no_n_plus_one(self):
+        """Power rows alternate PowerOutlet and PowerFeed peers, so both destination content types of
+        the `GenericPrefetch` are exercised in one render."""
+        pks = []
+        for i in range(12):
+            power_port = PowerPort.objects.create(device=self.device_a, name=f"pp-bulk-{i}")
+            if i % 2:
+                peer = PowerOutlet.objects.create(device=self.device_b, name=f"po-bulk-{i}")
+            else:
+                peer = PowerFeed.objects.create(
+                    power_panel=self.power_panel,
+                    name=f"pf-bulk-{i}",
+                    status=Status.objects.get_for_model(PowerFeed).first(),
+                )
+            Cable.objects.create(termination_a=power_port, termination_b=peer, status=self.connected)
+            pks.append(power_port.pk)
+
+        self._assert_render_has_no_n_plus_one(
+            PowerConnectionTable, PowerConnectionsListView.queryset.filter(pk__in=pks)
+        )
+
+    def test_interface_connection_table_render_has_no_n_plus_one(self):
+        """The A and B device columns resolve `origin.parent` / `destination.parent`, i.e.
+        `Interface.device`, which `interface_connections()` joins via `GenericPrefetch`."""
+        interface_status = Status.objects.get_for_model(Interface).first()
+        for i in range(12):
+            near = Interface.objects.create(device=self.device_a, name=f"if-bulk-a-{i}", status=interface_status)
+            far = Interface.objects.create(device=self.device_b, name=f"if-bulk-b-{i}", status=interface_status)
+            Cable.objects.create(termination_a=near, termination_b=far, status=self.connected)
+
+        self._assert_render_has_no_n_plus_one(InterfaceConnectionTable, InterfaceConnectionsListView.base_queryset())

--- a/nautobot/dcim/tests/test_tables.py
+++ b/nautobot/dcim/tests/test_tables.py
@@ -2,12 +2,16 @@ from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
+from django_tables2.rows import BoundRow
 
 from nautobot.core.templatetags import helpers
-from nautobot.dcim.choices import InterfaceDuplexChoices, InterfaceSpeedChoices, InterfaceTypeChoices
+from nautobot.core.testing import AssertNoRepeatedQueries
+from nautobot.dcim.choices import InterfaceDuplexChoices, InterfaceSpeedChoices, InterfaceTypeChoices, PortTypeChoices
 from nautobot.dcim.models import (
     Cable,
     CableType,
+    ConsolePort,
+    ConsoleServerPort,
     Device,
     DeviceType,
     Interface,
@@ -15,9 +19,20 @@ from nautobot.dcim.models import (
     Location,
     LocationType,
     Manufacturer,
+    PowerFeed,
+    PowerOutlet,
+    PowerPanel,
+    PowerPort,
+    RearPort,
 )
+from nautobot.dcim.tables import ConsoleConnectionTable, InterfaceConnectionTable, PowerConnectionTable
 from nautobot.dcim.tables.devices import DeviceModuleInterfaceTable, InterfaceTable
 from nautobot.dcim.tables.devicetypes import InterfaceTemplateTable
+from nautobot.dcim.views import (
+    ConsoleConnectionsListView,
+    InterfaceConnectionsListView,
+    PowerConnectionsListView,
+)
 from nautobot.extras.models import Role, Status
 
 
@@ -350,3 +365,178 @@ class InterfaceTemplateTableTestCase(TestCase):
         rendered_duplex = bound_row.get_cell("duplex")  # pylint: disable=no-member
         self.assertEqual(rendered_speed, helpers.HTML_NONE)
         self.assertEqual(rendered_duplex, helpers.HTML_NONE)
+
+
+class ConnectionTableTestCase(TestCase):
+    """Render tests for the Console / Power / Interface Connections tables.
+
+    These tables render the far (B) side of each connection through accessors that walk Python
+    attributes rather than ORM fields, and `BoundRow._get_and_render_with` swallows any resolution
+    error and renders the column default instead. A broken accessor is therefore invisible at the
+    HTTP level, which is how nautobot#9341 shipped. Assert on the rendered cells directly.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        manufacturer = Manufacturer.objects.create(name="Test Manuf Conn")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="DT-Conn")
+        device_role = Role.objects.get_for_model(Device).first()
+        location_type = LocationType.objects.get(name="Campus")
+        location = Location.objects.filter(location_type=location_type).first()
+        device_status = Status.objects.get_for_model(Device).first()
+        interface_status = Status.objects.get_for_model(Interface).first()
+        cls.connected = Status.objects.get_for_model(Cable).get(name="Connected")
+        planned = Status.objects.get_for_model(Cable).get(name="Planned")
+
+        cls.device_a = Device.objects.create(
+            name="Conn Device A",
+            device_type=device_type,
+            role=device_role,
+            location=location,
+            status=device_status,
+        )
+        cls.device_b = Device.objects.create(
+            name="Conn Device B",
+            device_type=device_type,
+            role=device_role,
+            location=location,
+            status=device_status,
+        )
+
+        # Console: a reachable connection, an unreachable one, and one dead-ending on a RearPort.
+        cls.console_port = ConsolePort.objects.create(device=cls.device_a, name="cp-active")
+        cls.console_server_port = ConsoleServerPort.objects.create(device=cls.device_b, name="csp-active")
+        Cable.objects.create(
+            termination_a=cls.console_port, termination_b=cls.console_server_port, status=cls.connected
+        )
+
+        cls.console_port_planned = ConsolePort.objects.create(device=cls.device_a, name="cp-planned")
+        cls.console_server_port_planned = ConsoleServerPort.objects.create(device=cls.device_b, name="csp-planned")
+        Cable.objects.create(
+            termination_a=cls.console_port_planned, termination_b=cls.console_server_port_planned, status=planned
+        )
+
+        # A RearPort is a CableTermination but not a PathEndpoint, so the path has no destination.
+        cls.console_port_unresolved = ConsolePort.objects.create(device=cls.device_a, name="cp-deadend")
+        rear_port = RearPort.objects.create(device=cls.device_b, name="rp-deadend", type=PortTypeChoices.TYPE_8P8C)
+        Cable.objects.create(termination_a=cls.console_port_unresolved, termination_b=rear_port, status=cls.connected)
+
+        # Power: one path terminating on a PowerOutlet (parent -> device) and one on a PowerFeed
+        # (parent -> power_panel), so both `pdu` column shapes are covered.
+        cls.power_port_outlet = PowerPort.objects.create(device=cls.device_a, name="pp-outlet")
+        cls.power_outlet = PowerOutlet.objects.create(device=cls.device_b, name="po-1")
+        Cable.objects.create(termination_a=cls.power_port_outlet, termination_b=cls.power_outlet, status=cls.connected)
+
+        cls.power_panel = PowerPanel.objects.create(location=location, name="Conn Power Panel")
+        cls.power_feed = PowerFeed.objects.create(
+            power_panel=cls.power_panel,
+            name="Conn Power Feed",
+            status=Status.objects.get_for_model(PowerFeed).first(),
+        )
+        cls.power_port_feed = PowerPort.objects.create(device=cls.device_a, name="pp-feed")
+        Cable.objects.create(termination_a=cls.power_port_feed, termination_b=cls.power_feed, status=cls.connected)
+
+        # Interface Connections is backed by CablePath and is NOT affected by nautobot#9341.
+        cls.interface_a = Interface.objects.create(device=cls.device_a, name="conn-eth0", status=interface_status)
+        cls.interface_b = Interface.objects.create(device=cls.device_b, name="conn-eth1", status=interface_status)
+        Cable.objects.create(termination_a=cls.interface_a, termination_b=cls.interface_b, status=cls.connected)
+
+    def _first_row(self, table_class, queryset) -> BoundRow:
+        """First bound row of `table_class` rendered over `queryset`."""
+        return table_class(queryset).rows[0]
+
+    def _row_for(self, view_class, table_class, instance) -> BoundRow:
+        """Bound row for `instance`, built from the list view's real (prefetch-carrying) queryset.
+
+        Building from the view's own queryset rather than a bare `objects.filter()` keeps the table
+        and the view in lockstep: these tests fail if either the accessors or the prefetching regress.
+        """
+        return self._first_row(table_class, view_class.queryset.filter(pk=instance.pk))
+
+    def test_console_connection_table_renders_peer_columns(self):
+        row = self._row_for(ConsoleConnectionsListView, ConsoleConnectionTable, self.console_port)
+
+        console_server = row.get_cell("console_server")
+        self.assertIn(self.device_b.get_absolute_url(), console_server)
+        self.assertIn(self.device_b.name, console_server)
+
+        port = row.get_cell("console_server_port")
+        self.assertIn(self.console_server_port.get_absolute_url(), port)
+        self.assertIn(self.console_server_port.name, port)
+
+        self.assertEqual(row.get_cell("reachable"), helpers.render_boolean(True))
+
+        # The near (A) side must keep working too.
+        self.assertIn(self.device_a.get_absolute_url(), row.get_cell("device"))
+        self.assertIn(self.console_port.get_absolute_url(), row.get_cell("name"))
+
+    def test_power_connection_table_renders_power_outlet_peer(self):
+        row = self._row_for(PowerConnectionsListView, PowerConnectionTable, self.power_port_outlet)
+        self.assertIn(self.device_b.get_absolute_url(), row.get_cell("pdu"))
+        self.assertIn(self.power_outlet.get_absolute_url(), row.get_cell("outlet"))
+        self.assertEqual(row.get_cell("reachable"), helpers.render_boolean(True))
+
+    def test_power_connection_table_renders_power_feed_peer(self):
+        """A PowerPort cabled to a PowerFeed shows the PowerPanel as its PDU (`PowerFeed.parent`)."""
+        row = self._row_for(PowerConnectionsListView, PowerConnectionTable, self.power_port_feed)
+        self.assertIn(self.power_panel.get_absolute_url(), row.get_cell("pdu"))
+        self.assertIn(self.power_feed.get_absolute_url(), row.get_cell("outlet"))
+
+    def test_connection_table_renders_unreachable_path(self):
+        """A path whose cable is not Connected renders reachable=False, not the placeholder.
+
+        `render_boolean(None)` is byte-identical to `HTML_NONE`, and `_get_and_render_with` returns
+        the column default *without* calling `render()` when the value is in `Column.empty_values`.
+        So asserting the False markup is the only way to distinguish "resolved to False" from
+        "failed to resolve".
+        """
+        row = self._row_for(ConsoleConnectionsListView, ConsoleConnectionTable, self.console_port_planned)
+        self.assertIn(self.console_server_port_planned.get_absolute_url(), row.get_cell("console_server_port"))
+        self.assertEqual(row.get_cell("reachable"), helpers.render_boolean(False))
+
+    def test_connection_table_unresolved_destination_renders_placeholder(self):
+        """A path dead-ending on a RearPort has no destination; the peer columns blank gracefully."""
+        row = self._row_for(ConsoleConnectionsListView, ConsoleConnectionTable, self.console_port_unresolved)
+        self.assertEqual(row.get_cell("console_server"), helpers.HTML_NONE)
+        self.assertEqual(row.get_cell("console_server_port"), helpers.HTML_NONE)
+        self.assertEqual(row.get_cell("reachable"), helpers.render_boolean(False))
+        # The near side still renders, so the row isn't wholly empty.
+        self.assertIn(self.console_port_unresolved.get_absolute_url(), row.get_cell("name"))
+
+    def test_interface_connection_table_renders_peer_columns(self):
+        """Interface Connections was reworked onto CablePath in 3.2 and is not affected by #9341."""
+        # `interface_connections()` canonicalizes a point-to-point pair onto the single direction where
+        # `origin_id < destination_id`, so which of the two interfaces lands on the A side depends on
+        # randomly generated UUIDs. Assert against the row's own endpoints rather than assuming a side.
+        queryset = InterfaceConnectionsListView.base_queryset().filter(
+            origin_id__in=[self.interface_a.pk, self.interface_b.pk]
+        )
+        path = queryset.get()
+        self.assertIn(path.destination, [self.interface_a, self.interface_b])
+
+        # pylint mis-infers `BoundRows[0]` as `BoundRows` when the table class is statically known, so
+        # `get_cell` reads as a missing member here but not where the class arrives as an argument.
+        row = self._first_row(InterfaceConnectionTable, queryset)
+        self.assertIn(path.destination.parent.get_absolute_url(), row.get_cell("device_b"))  # pylint: disable=no-member
+        self.assertIn(path.destination.get_absolute_url(), row.get_cell("interface_b"))  # pylint: disable=no-member
+        self.assertEqual(row.get_cell("reachable"), helpers.render_boolean(True))  # pylint: disable=no-member
+
+    def test_connection_table_render_has_no_n_plus_one(self):
+        """Rendering the peer-side columns must not issue a query per row.
+
+        Twelve rows against `AssertNoRepeatedQueries`' default threshold of 10 means *any* single
+        per-row query trips the assertion (12 repeats > 10), so this doesn't depend on estimating how
+        many queries per row the accessors happen to cost.
+        """
+        pks = []
+        for i in range(12):
+            console_port = ConsolePort.objects.create(device=self.device_a, name=f"cp-bulk-{i}")
+            peer = ConsoleServerPort.objects.create(device=self.device_b, name=f"csp-bulk-{i}")
+            Cable.objects.create(termination_a=console_port, termination_b=peer, status=self.connected)
+            pks.append(console_port.pk)
+
+        table = ConsoleConnectionTable(ConsoleConnectionsListView.queryset.filter(pk__in=pks))
+        with AssertNoRepeatedQueries(self):
+            for row in table.rows:
+                for column in table.columns:
+                    row.get_cell(column.name)

--- a/nautobot/dcim/tests/test_tables.py
+++ b/nautobot/dcim/tests/test_tables.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
@@ -19,6 +20,8 @@ from nautobot.dcim.models import (
     Location,
     LocationType,
     Manufacturer,
+    Module,
+    ModuleType,
     PowerFeed,
     PowerOutlet,
     PowerPanel,
@@ -514,6 +517,40 @@ class ConnectionTableTestCase(TestCase):
         self.assertIn(path.destination.parent.get_absolute_url(), row.get_cell("device_b"))  # pylint: disable=no-member
         self.assertIn(path.destination.get_absolute_url(), row.get_cell("interface_b"))  # pylint: disable=no-member
         self.assertEqual(row.get_cell("reachable"), helpers.render_boolean(True))  # pylint: disable=no-member
+
+    def test_interface_connection_table_renders_peer_without_device(self):
+        """An interface on a Module sitting in storage has no device, so its `parent` is None."""
+        location = self.device_a.location
+        location.location_type.content_types.add(ContentType.objects.get_for_model(Module))
+        module = Module.objects.create(
+            module_type=ModuleType.objects.create(
+                manufacturer=self.device_a.device_type.manufacturer, model="MT-Storage"
+            ),
+            location=location,
+            status=Status.objects.get_for_model(Module).first(),
+        )
+        interface_status = Status.objects.get_for_model(Interface).first()
+        stored = Interface.objects.create(module=module, name="stored-eth0", status=interface_status)
+        self.assertIsNone(stored.device)  # the premise of this test
+
+        peer = Interface.objects.create(device=self.device_a, name="peer-of-stored", status=interface_status)
+        Cable.objects.create(termination_a=stored, termination_b=peer, status=self.connected)
+
+        queryset = InterfaceConnectionsListView.base_queryset().filter(origin_id__in=[stored.pk, peer.pk])
+        path = queryset.get()
+        row = self._first_row(InterfaceConnectionTable, queryset)
+
+        # Canonicalization picks the A side by UUID order, so derive which column holds which side.
+        if path.origin_id == stored.pk:
+            deviceless, with_device = "device_a", "device_b"
+        else:
+            deviceless, with_device = "device_b", "device_a"
+        self.assertEqual(row.get_cell(deviceless).strip(), helpers.HTML_NONE)
+        self.assertIn(self.device_a.get_absolute_url(), row.get_cell(with_device))
+        # Both interfaces still render regardless of device assignment.
+        both_interface_cells = row.get_cell("interface_a") + row.get_cell("interface_b")
+        self.assertIn(stored.get_absolute_url(), both_interface_cells)
+        self.assertIn(peer.get_absolute_url(), both_interface_cells)
 
     def _assert_render_has_no_n_plus_one(self, table_class, queryset):
         """Rendering every cell of `queryset` must not issue a query per row.

--- a/nautobot/dcim/tests/test_tables.py
+++ b/nautobot/dcim/tests/test_tables.py
@@ -545,10 +545,10 @@ class ConnectionTableTestCase(TestCase):
             deviceless, with_device = "device_a", "device_b"
         else:
             deviceless, with_device = "device_b", "device_a"
-        self.assertEqual(row.get_cell(deviceless).strip(), helpers.HTML_NONE)
-        self.assertIn(self.device_a.get_absolute_url(), row.get_cell(with_device))
+        self.assertEqual(row.get_cell(deviceless).strip(), helpers.HTML_NONE)  # pylint: disable=no-member
+        self.assertIn(self.device_a.get_absolute_url(), row.get_cell(with_device))  # pylint: disable=no-member
         # Both interfaces still render regardless of device assignment.
-        both_interface_cells = row.get_cell("interface_a") + row.get_cell("interface_b")
+        both_interface_cells = row.get_cell("interface_a") + row.get_cell("interface_b")  # pylint: disable=no-member
         self.assertIn(stored.get_absolute_url(), both_interface_cells)
         self.assertIn(peer.get_absolute_url(), both_interface_cells)
 

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -5794,7 +5794,17 @@ class ConsoleConnectionsTestCase(ViewTestCases.ListObjectsViewTestCase):
         return "dcim:console_connections_{}"
 
     def _get_queryset(self):
-        return ConsolePort.objects.filter(cable__isnull=False)
+        # Reuse the view's own definition so the base tests operate on exactly what the table renders.
+        return ConsoleConnectionsListView.queryset
+
+    def get_instance_display_strings(self, instance):
+        # Assert the peer-side (B) columns actually render, not just that the view returns 200.
+        # Guards nautobot#9341, where they silently degraded to the em-dash placeholder.
+        strings = super().get_instance_display_strings(instance)
+        peer = instance.connected_endpoint
+        if peer is not None:  # a path dead-ending on a rear port has no destination
+            strings.append(peer.get_absolute_url())
+        return strings
 
     def get_list_url(self):
         return "/dcim/console-connections/"
@@ -5852,7 +5862,17 @@ class PowerConnectionsTestCase(ViewTestCases.ListObjectsViewTestCase):
         return "dcim:power_connections_{}"
 
     def _get_queryset(self):
-        return PowerPort.objects.filter(cable__isnull=False)
+        # Reuse the view's own definition so the base tests operate on exactly what the table renders.
+        return PowerConnectionsListView.queryset
+
+    def get_instance_display_strings(self, instance):
+        # Assert the peer-side (B) columns actually render, not just that the view returns 200.
+        # Guards nautobot#9341, where they silently degraded to the em-dash placeholder.
+        strings = super().get_instance_display_strings(instance)
+        peer = instance.connected_endpoint
+        if peer is not None:  # a path dead-ending on a rear port has no destination
+            strings.append(peer.get_absolute_url())
+        return strings
 
     def get_list_url(self):
         return "/dcim/power-connections/"

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -5871,7 +5871,17 @@ class ConnectionsListView(generic.ObjectListView):
 
 
 class ConsoleConnectionsListView(ConnectionsListView):
-    queryset = ConsolePort.objects.filter(cable_paths__isnull=False).distinct()
+    # `select_related("device")` feeds the `device` column (`ConsolePort.parent` -> `self.device`) and
+    # the GenericPrefetch feeds `path`, `path.destination`, and the destination's `parent`. Both are
+    # applied here rather than via `BaseTable.add_conditional_prefetch` because every column of this
+    # table is default-visible, and because two columns share the `cable_paths__destination` lookup
+    # (calling `prefetch_related` twice for one `prefetch_to` raises in Django).
+    queryset = (
+        ConsolePort.objects.filter(cable_paths__isnull=False)
+        .select_related("device")
+        .prefetch_related(ConsolePort.connection_destination_prefetch())
+        .distinct()
+    )
     filterset = filters.ConsoleConnectionFilterSet
     filterset_form = forms.ConsoleConnectionFilterForm
     table = tables.ConsoleConnectionTable
@@ -5881,7 +5891,13 @@ class ConsoleConnectionsListView(ConnectionsListView):
 
 
 class PowerConnectionsListView(ConnectionsListView):
-    queryset = PowerPort.objects.filter(cable_paths__isnull=False).distinct()
+    # See ConsoleConnectionsListView for why these are applied on the queryset.
+    queryset = (
+        PowerPort.objects.filter(cable_paths__isnull=False)
+        .select_related("device")
+        .prefetch_related(PowerPort.connection_destination_prefetch())
+        .distinct()
+    )
     filterset = filters.PowerConnectionFilterSet
     filterset_form = forms.PowerConnectionFilterForm
     table = tables.PowerConnectionTable


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #9341 
# What's Changed

Nautobot v3.2.0 (#8974) replaced the `_path` ForeignKey on PathEndpoint with a `cable_paths` GenericRelation (e.g., `_path__destination__parent` became `cable_paths__destination__parent`). django-tables2 resolves accessors by walking Python attributes, not ORM lookups, so `cable_paths` yielded a related manager, which has no `destination` or `is_active` attribute. This caused the column render to fail silently and fall back to a placeholder.

This PR changes the columns to use the `PathEndpoint.path` property (`cable_paths.first()`), which should be exact rather than lossy since breakout cables cannot terminate on console or power ports, so they have at most one `CablePath`.

Because the failure was silent, the existing view tests never flagged it. This PR also adds a regression test that flags any accessor attempting to traverse a to-many relation.

# Screenshots

|Before|After|
|-|-|
|<img width="996" height="426" alt="Screenshot 2026-08-04 at 1 48 25 PM" src="https://github.com/user-attachments/assets/95b0d93f-eaa6-4957-9822-0bd1366e17ac" />|<img width="992" height="427" alt="Screenshot 2026-08-04 at 1 45 47 PM" src="https://github.com/user-attachments/assets/8480e015-a1ad-4c28-94f3-ed6cadf420e4" />|
|<img width="1000" height="538" alt="Screenshot 2026-08-04 at 1 48 53 PM" src="https://github.com/user-attachments/assets/2efa81a3-5f79-48a4-a5c6-dac431ff4594" />|<img width="998" height="549" alt="Screenshot 2026-08-04 at 1 45 53 PM" src="https://github.com/user-attachments/assets/104aa1b1-ae0b-4680-9d71-2836638d1226" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [N/A] Documentation Updates (when adding/changing features)
- [N/A] Example App Updates (when adding/changing features)
- [N/A] Outline Remaining Work, Constraints from Design
