### PR TITLE
Check JobSchedule permissions while scheduling job

### DIFF
--- a/changes/9363.changed
+++ b/changes/9363.changed
@@ -1,0 +1,1 @@
+Scheduling a Job to run in the future or on a recurring interval now requires the `extras.add_scheduledjob` permission in addition to `extras.run_job`; running a Job immediately is unaffected.

--- a/nautobot/core/ui/object_detail.py
+++ b/nautobot/core/ui/object_detail.py
@@ -2852,8 +2852,9 @@ class _JobModalButton(Button):
                 allowing the job to be scheduled for future or recurring execution in addition to immediate
                 execution. Requires button_id to be set, since the view resolves this setting from the
                 registered component (never from request data). Jobs with `has_sensitive_variables = True`
-                cannot be scheduled regardless of this flag. Defaults to `False` (immediate-only, backward
-                compatible).
+                cannot be scheduled regardless of this flag, nor can users lacking the
+                `extras.add_scheduledjob` permission — in both cases the modal falls back to immediate-only
+                execution. Defaults to `False` (immediate-only, backward compatible).
             redirect_button_callback (callable, optional): A callback that returns a redirect button dict for the
                 modal footer after the job completes. Requires button_id to be set.
                 Signature: `callback(job_result, request) -> dict`.

--- a/nautobot/docs/development/jobs/job-structure.md
+++ b/nautobot/docs/development/jobs/job-structure.md
@@ -289,6 +289,9 @@ A template can provide additional JavaScript, CSS, or even display HTML. A good 
 +++ 3.0.0 "Added job_form_wrapper"
     Added the `job_form_wrapper` sub-block to `extras/job.html`, for use by Jobs that additionally want to override the card titles, headers, footers, etc. without replacing all of `{% block content %}`,
 
+!!! note
+    The `schedule_form` sub-block is only rendered for users holding the `extras.add_scheduledjob` permission; see [Job Scheduling](../../user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md#job-scheduling). For users without it, `extras/job.html` omits the scheduling card entirely and submits an immediate run, so anything you place in that block is not rendered for those users. A Job template that replaces all of `{% block content %}` is responsible for its own equivalent handling.
+
 For another example checkout [the template used in the Example App](https://github.com/nautobot/nautobot/blob/main/examples/example_app/example_app/templates/example_app/example_with_custom_template.html) in the GitHub repo.
 
 ### `time_limit`

--- a/nautobot/docs/user-guide/administration/guides/permissions.md
+++ b/nautobot/docs/user-guide/administration/guides/permissions.md
@@ -206,10 +206,11 @@ Note that the per-object "Change Log" tab additionally requires `view` permissio
 [Jobs](../../platform-functionality/jobs/index.md) deserve special attention because they execute code:
 
 - **Running**: requires the `run` action on the Job model (`extras.run_job`). Constraints can limit which specific jobs a user may run (see the [Export Job recipe](#export-job) below).
+- **Scheduling**: creating a schedule that runs a job in the future or on a recurring interval additionally requires `extras.add_scheduledjob`. `extras.run_job` on its own permits only immediate execution, so you can grant run-on-demand access without granting the ability to leave a persistent recurring schedule behind.
 - **Database access**: the permission check (and the `enabled` flag on an individual Job record) gate only whether the job may be *launched*. Once running, job code accesses the database **without any per-user restriction** by default — a job can read and write objects its submitter has no permission on, unless the job's own code enforces otherwise. Enable a job only if you trust what that job does with full database access.
 - **Canceling**: a user can always cancel a job **they submitted**, with no additional permission. Canceling another user's job requires the `cancel` action (`extras.cancel_job`), which is object-level and can be constrained to specific jobs.
 - **Re-running**: re-running a previous job result is gated by the same `run` permission as a fresh run.
-- **Scheduled jobs**: visibility of scheduled jobs follows the standard `extras.view_scheduledjob` permission — it is *not* limited to your own schedules. Taking ownership of another user's schedule requires `extras.change_scheduledjob` plus `run` on the underlying job.
+- **Scheduled jobs**: creating a schedule requires `extras.add_scheduledjob` in addition to `run` on the job (see **Scheduling** above). Visibility of scheduled jobs follows the standard `extras.view_scheduledjob` permission — it is *not* limited to your own schedules. Taking ownership of another user's schedule requires `extras.change_scheduledjob` plus `run` on the underlying job.
 - **Sensitive variables**: jobs flagged as having sensitive input variables cannot be scheduled (only run immediately) and cannot be combined with approval workflows, so that sensitive input is never persisted.
 
 ### Approval Workflows

--- a/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
@@ -12,7 +12,9 @@ Jobs can be scheduled through the UI or the API.
     A Job **must** be [enabled](./managing-jobs.md#enabling-and-disabling-jobs) and cannot have [has_sensitive_variables](../../../development/jobs/job-structure.md#class-metadata-attributes) set to `True` in order to be scheduled. If these requirements are not met, a warning banner will appear on the run Job view with the reason why Job Scheduling is not an option.
 
 !!! important "Scheduling requires the `extras.add_scheduledjob` permission"
-    Running a Job immediately requires only `extras.run_job`, but scheduling one to run in the future or on a recurring interval also requires `extras.add_scheduledjob`. A user with `extras.run_job` alone who submits a scheduled run is rejected — in the UI with an error banner, and via the REST API with an HTTP 403 response. This lets an administrator grant run-on-demand access without also granting the ability to create persistent recurring schedules.
+    Running a Job immediately requires only `extras.run_job`, but scheduling one to run in the future or on a recurring interval also requires `extras.add_scheduledjob`. This lets an administrator grant run-on-demand access without also granting the ability to create persistent recurring schedules.
+
+    For a user with `extras.run_job` alone, the scheduling form is not rendered at all — neither on the run Job view nor in the Job form modal — and their submissions run immediately. Should such a user submit a scheduled run anyway (for example by posting directly to the endpoint), it is rejected: in the UI with an error banner, and via the REST API with an HTTP 403 response.
 
     This requirement does not apply to jobs that are routed through an [approval workflow](#job-approvals), which creates a `ScheduledJob` record for the pending approval as an implementation detail even for an immediate run.
 

--- a/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/job-scheduling-and-approvals.md
@@ -11,6 +11,11 @@ Jobs can be scheduled through the UI or the API.
 !!! warning
     A Job **must** be [enabled](./managing-jobs.md#enabling-and-disabling-jobs) and cannot have [has_sensitive_variables](../../../development/jobs/job-structure.md#class-metadata-attributes) set to `True` in order to be scheduled. If these requirements are not met, a warning banner will appear on the run Job view with the reason why Job Scheduling is not an option.
 
+!!! important "Scheduling requires the `extras.add_scheduledjob` permission"
+    Running a Job immediately requires only `extras.run_job`, but scheduling one to run in the future or on a recurring interval also requires `extras.add_scheduledjob`. A user with `extras.run_job` alone who submits a scheduled run is rejected — in the UI with an error banner, and via the REST API with an HTTP 403 response. This lets an administrator grant run-on-demand access without also granting the ability to create persistent recurring schedules.
+
+    This requirement does not apply to jobs that are routed through an [approval workflow](#job-approvals), which creates a `ScheduledJob` record for the pending approval as an implementation detail even for an immediate run.
+
 ### Scheduling via the UI
 
 The Job Scheduling views can be accessed via the navigation at `Jobs > Jobs`, selecting a Job as appropriate.
@@ -42,7 +47,7 @@ The most common reason to use this action is to recover a scheduled job whose or
 
 ### Scheduling via the API
 
-Jobs can also be scheduled via the REST API. The endpoint used for this is the regular job endpoint; specifying the optional `schedule` parameter will act just as scheduling in the UI.
+Jobs can also be scheduled via the REST API. The endpoint used for this is the regular job endpoint; specifying the optional `schedule` parameter will act just as scheduling in the UI. A `schedule` whose `interval` is anything other than `immediately` requires the `extras.add_scheduledjob` permission; without it the request is rejected with HTTP 403.
 
 ```no-highlight
 curl -X POST \

--- a/nautobot/docs/user-guide/platform-functionality/jobs/managing-jobs.md
+++ b/nautobot/docs/user-guide/platform-functionality/jobs/managing-jobs.md
@@ -136,6 +136,7 @@ When a Job is submitted for execution or scheduling, Nautobot checks for any rel
 | Assign Job Queues          | `extras.change_job` + permissions on specific Job Queues |
 | Delete Job                 | `extras.delete_job`                                      |
 | Run Job                    | `extras.run_job`                                         |
+| Schedule Job               | `extras.run_job` + `extras.add_scheduledjob`             |
 | Cancel Job                 | `extras.cancel_job` (not required when canceling your own job) + `extras.view_jobresult` |
 | Approve scheduled Job      | `extras.change_approvalworkflowstage` + `extras.view_approvalworkflowstage` + `extras.change_scheduledjob`|
 | View Job Log Entries       | `extras.view_joblogentry`                                |

--- a/nautobot/extras/api/views.py
+++ b/nautobot/extras/api/views.py
@@ -940,6 +940,13 @@ class JobViewSetBase(
                 )
             schedule_data = input_serializer.validated_data.get("schedule", None)
 
+        # Creating a persistent (future or recurring) schedule is a distinct privilege from running a Job
+        # on demand; `extras.run_job` alone is not sufficient. Note that this does not apply to the
+        # approval-workflow path, which creates an "immediately" ScheduledJob as an implementation detail.
+        if schedule_data is not None and schedule_data.get("interval") in JobExecutionType.SCHEDULE_CHOICES:
+            if not request.user.has_perm("extras.add_scheduledjob"):
+                raise PermissionDenied("This user does not have permission to create scheduled jobs.")
+
         if task_queue not in valid_queues:
             raise ValidationError({"task_queue": [f'"{task_queue}" is not a valid choice.']})
 

--- a/nautobot/extras/templates/extras/job.html
+++ b/nautobot/extras/templates/extras/job.html
@@ -79,23 +79,28 @@
                             </div>
                         </div>
                     {% endblock job_execution_form_wrapper %}
-                    <div class="card {% if job_model.has_sensitive_variables %}border-warning{% endif %}">
-                        <div class="card-header {% if job_model.has_sensitive_variables %}bg-warning-subtle border-warning{% endif %}">
-                            <strong>Job Schedule Type</strong>
+                    {% if can_schedule %}
+                        <div class="card {% if job_model.has_sensitive_variables %}border-warning{% endif %}">
+                            <div class="card-header {% if job_model.has_sensitive_variables %}bg-warning-subtle border-warning{% endif %}">
+                                <strong>Job Schedule Type</strong>
+                            </div>
+                            <div class="card-body job_execution">
+                                {% block schedule_form %}
+                                    {% render_form schedule_form %}
+                                {% endblock %}
+                            </div>
+                            {% if job_model.has_sensitive_variables %}
+                                <div class="card-footer">
+                                    <span class="form-text">
+                                        This job may have sensitive input variables and therefore can only be executed immediately — it cannot be scheduled for later execution or submitted for approval before execution as those processes may expose sensitive information. <p>If this categorization is inaccurate, it may be appropriate to update the job to set <code>has_sensitive_variables</code> to <code>False</code> if appropriate.
+                                        </span>
+                                    </div>
+                            {% endif %}
                         </div>
-                        <div class="card-body job_execution">
-                            {% block schedule_form %}
-                                {% render_form schedule_form %}
-                            {% endblock %}
-                        </div>
-                        {% if job_model.has_sensitive_variables %}
-                            <div class="card-footer">
-                                <span class="form-text">
-                                    This job may have sensitive input variables and therefore can only be executed immediately — it cannot be scheduled for later execution or submitted for approval before execution as those processes may expose sensitive information. <p>If this categorization is inaccurate, it may be appropriate to update the job to set <code>has_sensitive_variables</code> to <code>False</code> if appropriate.
-                                    </span>
-                                </div>
-                        {% endif %}
-                    </div>
+                    {% else %}
+                        {# No permission to create a ScheduledJob: hide the scheduling form and submit as an immediate run. #}
+                        <input type="hidden" name="_schedule_type" value="{{ immediate_schedule_type }}">
+                    {% endif %}
                 </div>
             </div>
             <div class="nb-form-sticky-footer">
@@ -137,7 +142,10 @@
                         return false;
                     })();
 
-                    const schedule_type = document.querySelector('#id__schedule_type').selectedOptions[0]?.value;
+                    // The scheduling form is absent for users without permission to create a ScheduledJob,
+                    // in which case the run is always immediate.
+                    const scheduleTypeSelect = document.querySelector('#id__schedule_type');
+                    const schedule_type = scheduleTypeSelect?.selectedOptions?.[0]?.value ?? 'immediately';
                     const custom = schedule_type === 'custom';
                     const immediately = schedule_type === 'immediately';
 
@@ -155,6 +163,10 @@
                     // Toggle `'btn-primary'` and `'btn-warning'` classes.
                     run.classList.toggle('btn-primary', immediately);
                     run.classList.toggle('btn-warning', !immediately);
+
+                    // The remaining toggles act on the scheduling fields, which are only rendered
+                    // alongside the schedule type select.
+                    if (!scheduleTypeSelect) return;
 
                     // Toggle schedule name and schedule time field rows.
                     ['#id__schedule_name', '#id__schedule_start_time'].forEach((selector) => {
@@ -187,8 +199,11 @@
                 };
 
                 {% if job_model.has_sensitive_variables %}
-                    document.querySelector('#id__schedule_type').value = 'immediately';
-                    document.querySelector('.job_execution').classList.toggle('d-none', true);
+                    const sensitiveScheduleType = document.querySelector('#id__schedule_type');
+                    if (sensitiveScheduleType) {
+                        sensitiveScheduleType.value = 'immediately';
+                        document.querySelector('.job_execution')?.classList.toggle('d-none', true);
+                    }
                 {% endif %}
 
                 document.addEventListener('change', (event) => {

--- a/nautobot/extras/tests/test_api.py
+++ b/nautobot/extras/tests/test_api.py
@@ -2824,6 +2824,7 @@ class JobTest(
         """Job run requests can reference objects by their primary keys."""
         mock_get_worker_count.return_value = 1
         self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
         device_role = Role.objects.get_for_model(Device).first()
         job_data = {
             "var1": "FooBar",
@@ -3125,6 +3126,7 @@ class JobTest(
 
         mock_get_worker_count.return_value = 1
         self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
 
         job_data = {
             "var2": "Ground control to Major Tom",
@@ -3145,6 +3147,7 @@ class JobTest(
         """In addition to the base test case provided by JobAPIRunTestMixin, also verify the JSON response data."""
         mock_get_worker_count.return_value = 1
         self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
         d = Role.objects.get_for_model(Device).first()
         data = {
             "data": {"var1": "x", "var2": 1, "var3": False, "var4": d.pk},
@@ -3176,9 +3179,44 @@ class JobTest(
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     @mock.patch("nautobot.extras.api.views.get_worker_count")
+    def test_run_job_scheduled_without_add_scheduledjob_permission(self, mock_get_worker_count):
+        """Scheduling a Job via the API requires extras.add_scheduledjob, not just extras.run_job."""
+        mock_get_worker_count.return_value = 1
+        self.add_permissions("extras.run_job")
+
+        d = Role.objects.get_for_model(Device).first()
+        url = self.get_run_url()
+        for interval in ("future", "hourly", "daily", "weekly"):
+            data = {
+                "data": {"var1": "x", "var2": 1, "var3": False, "var4": d.pk},
+                "schedule": {
+                    "start_time": str(now() + timedelta(minutes=1)),
+                    "interval": interval,
+                    "name": f"unauthorized {interval}",
+                },
+            }
+            response = self.client.post(url, data, format="json", **self.header)
+            self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN, msg=interval)
+            self.assertFalse(ScheduledJob.objects.filter(name=data["schedule"]["name"]).exists(), msg=interval)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    @mock.patch("nautobot.extras.api.views.get_worker_count")
+    def test_run_job_immediately_without_add_scheduledjob_permission(self, mock_get_worker_count):
+        """An immediate run via the API is unaffected by the extras.add_scheduledjob requirement."""
+        mock_get_worker_count.return_value = 1
+        self.add_permissions("extras.run_job")
+
+        d = Role.objects.get_for_model(Device).first()
+        data = {"data": {"var1": "x", "var2": 1, "var3": False, "var4": d.pk}}
+        response = self.client.post(self.get_run_url(), data, format="json", **self.header)
+        self.assertHttpStatus(response, self.run_success_response_status)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    @mock.patch("nautobot.extras.api.views.get_worker_count")
     def test_run_a_job_with_sensitive_variables_for_future(self, mock_get_worker_count):
         mock_get_worker_count.return_value = 1
         self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
 
         job_model = Job.objects.get(job_class_name="TestHasSensitiveVariables")
         job_model.enabled = True
@@ -3285,6 +3323,7 @@ class JobTest(
     def test_run_job_interval(self, mock_get_worker_count):
         mock_get_worker_count.return_value = 1
         self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
         d = Role.objects.get_for_model(Device).first()
         data = {
             "data": {"var1": "x", "var2": 1, "var3": False, "var4": d.pk},
@@ -3430,6 +3469,7 @@ class JobTest(
         mock_get_worker_count.return_value = 1
         self.add_permissions("extras.run_job")
         self.add_permissions("extras.view_scheduledjob")
+        self.add_permissions("extras.add_scheduledjob")
 
         url = self.get_run_url()
 
@@ -3520,6 +3560,7 @@ class JobTest(
         mock_get_worker_count.return_value = 1
         self.add_permissions("extras.run_job")
         self.add_permissions("extras.view_scheduledjob")
+        self.add_permissions("extras.add_scheduledjob")
 
         ApprovalWorkflowDefinition.objects.create(
             name="Approval Definition",
@@ -3558,6 +3599,7 @@ class JobTest(
         mock_get_worker_count.return_value = 1
         self.add_permissions("extras.run_job")
         self.add_permissions("extras.view_scheduledjob")
+        self.add_permissions("extras.add_scheduledjob")
 
         start_time = now() + timedelta(minutes=1)
         data = {

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -5971,6 +5971,7 @@ class JobTestCase(
         """Submitting a future-scheduled job via the HTMX modal closes the modal and queues a success message."""
         self.add_permissions("extras.run_job")
         self.add_permissions("extras.view_scheduledjob")
+        self.add_permissions("extras.add_scheduledjob")
 
         start_time = timezone.now() + timedelta(minutes=5)
         data = {
@@ -6268,10 +6269,70 @@ class JobTestCase(
             )
 
     @mock.patch("nautobot.extras.views.get_worker_count", return_value=1)
+    def test_run_later_without_add_scheduledjob_permission(self, _):
+        """Creating a future or recurring schedule requires extras.add_scheduledjob, not just extras.run_job."""
+        self.add_permissions("extras.run_job")
+
+        start_time = timezone.now() + timedelta(minutes=5)
+        for interval in ("future", "hourly", "daily", "weekly"):
+            data = {
+                "_schedule_type": interval,
+                "_schedule_name": f"unauthorized {interval}",
+                "_schedule_start_time": str(start_time),
+            }
+            for run_url in self.run_urls:
+                response = self.client.post(run_url, data)
+                self.assertBodyContains(
+                    response, "Unable to schedule job: You do not have permission to create scheduled jobs."
+                )
+                self.assertFalse(
+                    ScheduledJob.objects.filter(name=data["_schedule_name"]).exists(),
+                    msg=f"{run_url} ({interval})",
+                )
+
+    @mock.patch("nautobot.extras.views.get_worker_count", return_value=1)
+    def test_run_immediately_does_not_require_add_scheduledjob_permission(self, _):
+        """An immediate run is unaffected by the extras.add_scheduledjob requirement."""
+        self.add_permissions("extras.run_job")
+        self.add_permissions("extras.view_jobresult")
+
+        for run_url in self.run_urls:
+            response = self.client.post(run_url, self.data_run_immediately)
+            self.assertNotIn(
+                "You do not have permission to create scheduled jobs",
+                response.content.decode(response.charset),
+                msg=run_url,
+            )
+
+    @mock.patch("nautobot.extras.views.get_worker_count", return_value=1)
+    @mock.patch("nautobot.extras.models.mixins.ApprovableModelMixin.begin_approval_workflow")
+    def test_approval_workflow_does_not_require_add_scheduledjob_permission(self, mock_begin_approval_workflow, _):
+        """The approval-workflow path creates an "immediately" ScheduledJob and must not require add_scheduledjob."""
+        self.add_permissions("extras.run_job")
+        self.add_permissions("extras.view_scheduledjob")
+
+        ApprovalWorkflowDefinition.objects.create(
+            name="Approval Definition No Add Permission",
+            model_content_type=ContentType.objects.get_for_model(ScheduledJob),
+            weight=0,
+            model_constraints={"job_model__name": self.test_pass.name},
+        )
+
+        for run_url in self.run_urls:
+            response = self.client.post(run_url, self.data_run_immediately)
+            self.assertNotIn(
+                "You do not have permission to create scheduled jobs",
+                response.content.decode(response.charset),
+                msg=run_url,
+            )
+        mock_begin_approval_workflow.assert_called()
+
+    @mock.patch("nautobot.extras.views.get_worker_count", return_value=1)
     @mock.patch("nautobot.extras.models.mixins.ApprovableModelMixin.begin_approval_workflow")
     def test_run_later_triggers_approval_workflow(self, mock_begin_approval_workflow, _):
         self.add_permissions("extras.run_job")
         self.add_permissions("extras.view_scheduledjob")
+        self.add_permissions("extras.add_scheduledjob")
 
         start_time = timezone.now() + timedelta(minutes=1)
         data = {
@@ -6411,6 +6472,7 @@ class JobTestCase(
     def test_scheduled_job_triggers_approval_workflow_if_defined(self, _):
         self.add_permissions("extras.run_job")
         self.add_permissions("extras.view_scheduledjob")
+        self.add_permissions("extras.add_scheduledjob")
 
         workflow = ApprovalWorkflowDefinition(
             name="Approval Definition",
@@ -6440,6 +6502,7 @@ class JobTestCase(
     def test_run_scheduled_job_with_no_approval_workflow_defined(self, _):
         self.add_permissions("extras.run_job")
         self.add_permissions("extras.view_scheduledjob")
+        self.add_permissions("extras.add_scheduledjob")
 
         data = {
             "_schedule_type": "future",
@@ -6526,6 +6589,7 @@ class JobTestCase(
     def test_run_dryrun_schedule_job_with_approval_workflow_definded(self, _):
         self.add_permissions("extras.run_job")
         self.add_permissions("extras.view_scheduledjob")
+        self.add_permissions("extras.add_scheduledjob")
 
         ApprovalWorkflowDefinition.objects.create(
             name="Approval Definition",
@@ -6553,6 +6617,7 @@ class JobTestCase(
     def test_run_dryrun_schedule_job_with_no_approval_workflow_definded(self, _):
         self.add_permissions("extras.run_job")
         self.add_permissions("extras.view_scheduledjob")
+        self.add_permissions("extras.add_scheduledjob")
 
         data = {
             "_schedule_type": "future",

--- a/nautobot/extras/tests/test_views.py
+++ b/nautobot/extras/tests/test_views.py
@@ -5884,6 +5884,7 @@ class JobTestCase(
 
     def test_run_missing_schedule(self):
         self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
 
         for run_url in self.run_urls:
             response = self.client.post(run_url)
@@ -5934,6 +5935,7 @@ class JobTestCase(
     def test_render_job_form_modal_scheduling_resolved_from_registered_button(self):
         """The schedule form is rendered based on the registered _JobModalButton, never the POST payload."""
         self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
 
         button = _JobModalButton(
             weight=100,
@@ -5965,6 +5967,64 @@ class JobTestCase(
             self.assertHttpStatus(response, 200, msg=run_url)
             content = response.content.decode(response.charset)
             self.assertNotIn("id__schedule_type", content, msg=run_url)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
+    def test_render_job_form_modal_scheduling_hidden_without_add_scheduledjob_permission(self):
+        """A registered scheduling button must not render the schedule form without extras.add_scheduledjob."""
+        self.add_permissions("extras.run_job")
+
+        button = _JobModalButton(
+            weight=100,
+            label="Schedule Job",
+            class_path=self.test_pass.class_path,
+            button_id="test_render_modal_scheduling_unauthorized_button",
+            enable_scheduling=True,
+        )
+        self.addCleanup(lambda: registry["job_modal_buttons"].pop(button.button_id, None))
+
+        for run_url in self.run_urls:
+            response = self.client.post(
+                run_url,
+                data={"render_job_form": True, "job_modal_button": button.button_id},
+                HTTP_HX_REQUEST="true",
+            )
+            self.assertHttpStatus(response, 200, msg=run_url)
+            content = response.content.decode(response.charset)
+            self.assertNotIn("id__schedule_type", content, msg=run_url)
+            self.assertNotIn("Schedule name", content, msg=run_url)
+            # hx-vals must force an immediate run so the hidden form cannot be worked around.
+            self.assertIn(JobExecutionType.TYPE_IMMEDIATELY, content, msg=run_url)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
+    def test_job_run_view_hides_schedule_form_without_add_scheduledjob_permission(self):
+        """The full job run view hides the scheduling card and submits as an immediate run."""
+        self.add_permissions("extras.run_job")
+
+        for run_url in self.run_urls:
+            response = self.client.get(run_url)
+            self.assertHttpStatus(response, 200, msg=run_url)
+            content = response.content.decode(response.charset)
+            self.assertNotIn("Job Schedule Type", content, msg=run_url)
+            # Match the rendered widget rather than the bare id, which also appears in the page's JS selectors.
+            self.assertNotIn('id="id__schedule_type"', content, msg=run_url)
+            self.assertInHTML(
+                f'<input type="hidden" name="_schedule_type" value="{JobExecutionType.TYPE_IMMEDIATELY}">',
+                content,
+                msg_prefix=run_url,
+            )
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=[])
+    def test_job_run_view_shows_schedule_form_with_add_scheduledjob_permission(self):
+        """The full job run view renders the scheduling card for a user that may create schedules."""
+        self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
+
+        for run_url in self.run_urls:
+            response = self.client.get(run_url)
+            self.assertHttpStatus(response, 200, msg=run_url)
+            content = response.content.decode(response.charset)
+            self.assertIn("Job Schedule Type", content, msg=run_url)
+            self.assertIn('id="id__schedule_type"', content, msg=run_url)
 
     @mock.patch("nautobot.extras.views.get_worker_count", return_value=1)
     def test_schedule_job_via_modal_closes_modal_and_queues_message(self, _):
@@ -6211,6 +6271,7 @@ class JobTestCase(
     @mock.patch("nautobot.extras.views.get_worker_count", return_value=1)
     def test_run_later_missing_name(self, _):
         self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
 
         data = {
             "_schedule_type": "future",
@@ -6226,6 +6287,7 @@ class JobTestCase(
     @mock.patch("nautobot.extras.views.get_worker_count", return_value=1)
     def test_run_later_missing_date(self, _):
         self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
 
         data = {
             "_schedule_type": "future",
@@ -6248,6 +6310,7 @@ class JobTestCase(
     @mock.patch("nautobot.extras.views.get_worker_count", return_value=1)
     def test_run_later_date_passed(self, _):
         self.add_permissions("extras.run_job")
+        self.add_permissions("extras.add_scheduledjob")
 
         data = {
             "_schedule_type": "future",

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2676,15 +2676,27 @@ class JobUIViewSet(NautobotUIViewSet):
                 )
         return template_name
 
+    @staticmethod
+    def _user_can_create_schedule(request):
+        """Whether this user may create a future or recurring ScheduledJob.
+
+        This is the same permission enforced when a scheduled run is submitted; it is resolved here so that
+        the scheduling form can be hidden from users who would only be rejected on submission.
+        """
+        return request.user.has_perm("extras.add_scheduledjob")
+
     def _resolve_enable_scheduling(self, request, job_model):
         """Determine whether the job modal should render the scheduling form.
 
         The setting is sourced exclusively from the server-side `_JobModalButton` component, looked up from
         the registry using the `button_id` carried in the request. The request payload's `enable_scheduling`
         value is never trusted: an unregistered (or missing) `button_id` resolves to `False`. Scheduling is
-        always disabled for jobs flagged with sensitive variables, regardless of the component setting.
+        always disabled for jobs flagged with sensitive variables, regardless of the component setting, and
+        for users lacking permission to create a ScheduledJob.
         """
         if job_model.has_sensitive_variables:
+            return False
+        if not self._user_can_create_schedule(request):
             return False
         button_id = request.POST.get("job_modal_button", "")
         job_modal_button = registry["job_modal_buttons"].get(button_id) if button_id else None
@@ -2747,6 +2759,8 @@ class JobUIViewSet(NautobotUIViewSet):
                     "job_form": job_form,
                     "job_execution_form": job_execution_form,
                     "schedule_form": schedule_form,
+                    "can_schedule": self._user_can_create_schedule(request),
+                    "immediate_schedule_type": JobExecutionType.TYPE_IMMEDIATELY,
                 },
             )
         patch_vary_headers(response, ["HX-Request"])

--- a/nautobot/extras/views.py
+++ b/nautobot/extras/views.py
@@ -2852,6 +2852,15 @@ class JobUIViewSet(NautobotUIViewSet):
             and request.POST.get("_schedule_type") != JobExecutionType.TYPE_IMMEDIATELY
         ):
             messages.error(request, "Unable to schedule job: Job may have sensitive input variables.")
+        elif (
+            schedule_form_is_valid
+            and schedule_form.cleaned_data["_schedule_type"] in JobExecutionType.SCHEDULE_CHOICES
+            and not request.user.has_perm("extras.add_scheduledjob")
+        ):
+            # Creating a persistent (future or recurring) schedule is a distinct privilege from running a Job
+            # on demand; `extras.run_job` alone is not sufficient. Note that this does not apply to the
+            # approval-workflow path, which creates an "immediately" ScheduledJob as an implementation detail.
+            messages.error(request, "Unable to schedule job: You do not have permission to create scheduled jobs.")
         elif job_form_is_valid and job_execution_form_is_valid and schedule_form_is_valid:
             if job_queue.queue_type == JobQueueTypeChoices.TYPE_CELERY and not get_worker_count(queue=job_queue):
                 messages.warning(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #9363
# What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
-->

When launching a job, users are able to schedule the job to be run later or recurringly.
Nautobot provides permissions for "ScheduledJob" but they weren't being checked, so users without that permission were able to schedule jobs.
This PR adds a check whether the user has that permission or not.

# Screenshots
<!--
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
