### PR TITLE
Fixed AttributeError on interface edit form

### DIFF
--- a/changes/9282.fixed
+++ b/changes/9282.fixed
@@ -1,0 +1,1 @@
+Fixed an `AttributeError` raised when editing an Interface belonging to a Module that has no parent Device while its 802.1Q mode was set to "Tagged".

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -252,7 +252,7 @@ class InterfaceCommonForm(forms.Form):
         # layers scope tagged VLANs by the parent device only.
         module = self.cleaned_data.get("module")
         if module is None:
-            return None
+            raise forms.ValidationError("Either device or module must be set")
         return getattr(module, "device", None)
 
     def clean(self):

--- a/nautobot/dcim/forms.py
+++ b/nautobot/dcim/forms.py
@@ -239,12 +239,27 @@ class ModularDeviceComponentTemplateFilterForm(DeviceComponentTemplateFilterForm
 
 
 class InterfaceCommonForm(forms.Form):
+    def _get_tagged_vlan_scope(self):
+        """Return the object whose Location constrains this interface's tagged VLANs, or None if there is none."""
+        if "device" not in self.cleaned_data:
+            # VMInterface forms scope tagged VLANs by the parent virtual machine instead of a device
+            return self.cleaned_data.get("virtual_machine")
+        if self.cleaned_data["device"] is not None:
+            return self.cleaned_data["device"]
+        # A Module interface has no device of its own in cleaned_data.
+        # A Module installed directly at a Location also has no parent device.
+        # Its own Location is deliberately not used here, because the model and REST API
+        # layers scope tagged VLANs by the parent device only.
+        module = self.cleaned_data.get("module")
+        if module is None:
+            return None
+        return getattr(module, "device", None)
+
     def clean(self):
         super().clean()
 
-        parent_field = "device" if "device" in self.cleaned_data else "virtual_machine"
-        tagged_vlans = self.cleaned_data["tagged_vlans"]
-        mode = self.cleaned_data["mode"]
+        tagged_vlans = self.cleaned_data.get("tagged_vlans") or []
+        mode = self.cleaned_data.get("mode")
 
         # Untagged interfaces cannot be assigned tagged VLANs
         if mode == InterfaceModeChoices.MODE_ACCESS and tagged_vlans:
@@ -257,26 +272,28 @@ class InterfaceCommonForm(forms.Form):
         # Validate tagged VLANs; must be a global VLAN or in the same location as the
         # parent device/VM or any of that location's parent locations
         elif mode == InterfaceModeChoices.MODE_TAGGED:
-            location = self.cleaned_data[parent_field].location
-            if location:
-                location_ids = location.ancestors(include_self=True).values_list("id", flat=True)
-            else:
-                location_ids = []
-            invalid_vlans = [
-                str(v)
-                for v in tagged_vlans
-                if v.locations.without_tree_fields().exists()
-                and not VLANLocationAssignment.objects.filter(location__in=location_ids, vlan=v).exists()
-            ]
+            scope = self._get_tagged_vlan_scope()
+            if scope is not None:
+                location = scope.location
+                if location:
+                    location_ids = location.ancestors(include_self=True).values_list("id", flat=True)
+                else:
+                    location_ids = []
+                invalid_vlans = [
+                    str(v)
+                    for v in tagged_vlans
+                    if v.locations.without_tree_fields().exists()
+                    and not VLANLocationAssignment.objects.filter(location__in=location_ids, vlan=v).exists()
+                ]
 
-            if invalid_vlans:
-                raise forms.ValidationError(
-                    {
-                        "tagged_vlans": f"The tagged VLANs ({', '.join(invalid_vlans)}) must have the same location as the "
-                        "interface's parent device, or is in one of the parents of the interface's parent device's location, "
-                        "or it must be global."
-                    }
-                )
+                if invalid_vlans:
+                    raise forms.ValidationError(
+                        {
+                            "tagged_vlans": f"The tagged VLANs ({', '.join(invalid_vlans)}) must have the same location as the "
+                            "interface's parent device, or is in one of the parents of the interface's parent device's location, "
+                            "or it must be global."
+                        }
+                    )
 
 
 class ComponentForm(BootstrapMixin, EmbeddedActionsFormMixin, forms.Form):
@@ -3812,14 +3829,15 @@ class InterfaceBulkEditForm(
     def clean(self):
         super().clean()
 
-        tagged_vlans = bool(self.cleaned_data["add_tagged_vlans"] or self.cleaned_data["remove_tagged_vlans"])
+        mode = self.cleaned_data.get("mode")
+        tagged_vlans = bool(self.cleaned_data.get("add_tagged_vlans") or self.cleaned_data.get("remove_tagged_vlans"))
         # Untagged interfaces cannot be assigned tagged VLANs
-        if self.cleaned_data["mode"] == InterfaceModeChoices.MODE_ACCESS and tagged_vlans:
+        if mode == InterfaceModeChoices.MODE_ACCESS and tagged_vlans:
             raise forms.ValidationError({"mode": "An access interface cannot have tagged VLANs assigned."})
 
         # In theory UI blocks this from happening, but to ensure on backend we enforce.
         # An interface must be in tagged mode to have an untagged VLAN assigned
-        elif tagged_vlans and self.cleaned_data["mode"] != InterfaceModeChoices.MODE_TAGGED:
+        elif tagged_vlans and mode != InterfaceModeChoices.MODE_TAGGED:
             non_tagged = (
                 Interface.objects.filter(pk__in=self.cleaned_data["pk"])
                 .exclude(mode=InterfaceModeChoices.MODE_TAGGED)[:5]
@@ -3834,7 +3852,7 @@ class InterfaceBulkEditForm(
                 )
 
         # Remove all tagged VLAN assignments from "tagged all" interfaces
-        elif self.cleaned_data["mode"] == InterfaceModeChoices.MODE_TAGGED_ALL:
+        elif mode == InterfaceModeChoices.MODE_TAGGED_ALL:
             self.cleaned_data["tagged_vlans"] = []
 
 

--- a/nautobot/dcim/tests/test_forms.py
+++ b/nautobot/dcim/tests/test_forms.py
@@ -45,8 +45,10 @@ from nautobot.dcim.models import (
     Location,
     LocationType,
     Manufacturer,
+    Module,
     ModuleBay,
     ModuleFamily,
+    ModuleType,
     Platform,
     PowerFeed,
     PowerPanel,
@@ -523,6 +525,35 @@ class InterfaceTestCase(NautobotTestCaseMixin, TestCase):
             "tagged_vlans": [cls.vlan.pk],
         }
 
+        cls.module_type = ModuleType.objects.create(
+            manufacturer=Manufacturer.objects.first(), model="Test Interface Form Module Type"
+        )
+        module_status = Status.objects.get_for_model(Module).first()
+        # A Module installed directly at a Location has no parent Device, and neither do its components
+        cls.module_location = Location.objects.get_for_model(Module).first()
+        cls.location_module = Module.objects.create(
+            module_type=cls.module_type,
+            location=cls.module_location,
+            status=module_status,
+            serial="interface-form-location",
+        )
+        cls.location_module_interface = Interface.objects.create(
+            module=cls.location_module,
+            name="test module interface 0.0",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            status=cls.status,
+        )
+        # A Module installed in a ModuleBay does have a parent Device, whose Location scopes its VLANs
+        cls.module_bay = ModuleBay.objects.create(
+            parent_device=cls.device, name="test interface form bay", position="1"
+        )
+        cls.bay_module = Module.objects.create(
+            module_type=cls.module_type,
+            parent_module_bay=cls.module_bay,
+            status=module_status,
+            serial="interface-form-bay",
+        )
+
     def test_interface_form_clean_vlan_location_success(self):
         """Assert that form validation succeeds when matching locations/parent locations are associated to tagged VLAN"""
         location = self.device.location
@@ -562,6 +593,99 @@ class InterfaceTestCase(NautobotTestCaseMixin, TestCase):
         self.vlan.locations.clear()
         form = InterfaceForm(data=self.data, instance=self.interface)
         self.assertTrue(form.is_valid())
+
+    def test_interface_form_invalid_tagged_vlan_reports_field_error(self):
+        """Assert that a tagged VLAN that fails field validation is reported instead of raising an exception."""
+        self.data["tagged_vlans"] = [uuid.uuid4()]
+        form = InterfaceForm(data=self.data, instance=self.interface)
+        self.assertFalse(form.is_valid())
+        self.assertIn("tagged_vlans", form.errors)
+
+    def test_interface_form_invalid_mode_reports_field_error(self):
+        """Assert that a mode that fails field validation is reported instead of raising an exception."""
+        self.data["mode"] = "not-a-mode"
+        form = InterfaceForm(data=self.data, instance=self.interface)
+        self.assertFalse(form.is_valid())
+        self.assertIn("mode", form.errors)
+
+    def test_bulk_interface_form_invalid_tagged_vlan_reports_field_error(self):
+        """Assert that a tagged VLAN that fails field validation is reported instead of raising an exception."""
+        form = InterfaceBulkEditForm(
+            model=Interface,
+            data={
+                "pk": [self.interface.pk],
+                "add_tagged_vlans": [uuid.uuid4()],
+                "mode": InterfaceModeChoices.MODE_TAGGED,
+            },
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("add_tagged_vlans", form.errors)
+
+    def test_interface_form_module_interface_tagged_mode_saves_without_parent_device(self):
+        """Assert that an Interface on a Module with no parent Device can be saved in tagged mode (issue #9282)."""
+        self.assertIsNone(self.location_module_interface.device)
+        # Assign the VLAN while it is still global and locate it afterwards, which is how such data comes to exist
+        self.vlan.locations.clear()
+        self.location_module_interface.mode = InterfaceModeChoices.MODE_TAGGED
+        self.location_module_interface.validated_save()
+        self.location_module_interface.tagged_vlans.set([self.vlan])
+        self.vlan.locations.set([self.module_location])
+
+        data = {
+            "name": self.location_module_interface.name,
+            "type": self.location_module_interface.type,
+            "status": self.status.pk,
+            "mode": InterfaceModeChoices.MODE_TAGGED,
+            "tagged_vlans": [self.vlan.pk],
+        }
+        form = InterfaceForm(data=data, instance=self.location_module_interface)
+        self.assertTrue(form.is_valid(), form.errors)
+        interface = form.save()
+        self.assertEqual(list(interface.tagged_vlans.all()), [self.vlan])
+
+    def test_interface_form_module_interface_access_mode_rejects_tagged_vlans(self):
+        """Assert that access mode still rejects tagged VLANs on an Interface with no parent Device."""
+        data = {
+            "name": self.location_module_interface.name,
+            "type": self.location_module_interface.type,
+            "status": self.status.pk,
+            "mode": InterfaceModeChoices.MODE_ACCESS,
+            "tagged_vlans": [self.vlan.pk],
+        }
+        form = InterfaceForm(data=data, instance=self.location_module_interface)
+        self.assertFalse(form.is_valid())
+        self.assertIn("mode", form.errors)
+        self.assertNotIn("tagged_vlans", form.errors)
+
+    def test_interface_create_form_module_in_bay_uses_parent_device_location(self):
+        """Assert that a Module's parent Device location is used to validate tagged VLANs when device is blank."""
+        self.vlan.locations.set([self.device.location])
+        data = {
+            "module": self.bay_module.pk,
+            "name_pattern": "test module interface 1.0",
+            "status": self.status.pk,
+            "type": InterfaceTypeChoices.TYPE_1GE_FIXED,
+            "mode": InterfaceModeChoices.MODE_TAGGED,
+            "tagged_vlans": [self.vlan.pk],
+        }
+        form = InterfaceCreateForm(data)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_interface_create_form_module_in_bay_rejects_vlan_in_other_location(self):
+        """Assert that a tagged VLAN outside the Module's parent Device location is rejected when device is blank."""
+        location_ids = self.device.location.ancestors(include_self=True).values_list("id", flat=True)
+        self.vlan.locations.set(list(Location.objects.exclude(pk__in=location_ids))[:1])
+        data = {
+            "module": self.bay_module.pk,
+            "name_pattern": "test module interface 1.0",
+            "status": self.status.pk,
+            "type": InterfaceTypeChoices.TYPE_1GE_FIXED,
+            "mode": InterfaceModeChoices.MODE_TAGGED,
+            "tagged_vlans": [self.vlan.pk],
+        }
+        form = InterfaceCreateForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("tagged_vlans", form.errors)
 
     def test_untagged_vlans_dropdown_options_align_in_interface_edit_form_and_bulk_edit_form(self):
         """

--- a/nautobot/dcim/tests/test_forms.py
+++ b/nautobot/dcim/tests/test_forms.py
@@ -671,6 +671,19 @@ class InterfaceTestCase(NautobotTestCaseMixin, TestCase):
         form = InterfaceCreateForm(data)
         self.assertTrue(form.is_valid(), form.errors)
 
+    def test_interface_create_form_without_device_or_module_reports_error(self):
+        """Assert that an interface belonging to neither a device nor a module is rejected."""
+        data = {
+            "name_pattern": "test module interface 1.0",
+            "status": self.status.pk,
+            "type": InterfaceTypeChoices.TYPE_1GE_FIXED,
+            "mode": InterfaceModeChoices.MODE_TAGGED,
+            "tagged_vlans": [self.vlan.pk],
+        }
+        form = InterfaceCreateForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors["__all__"], ["Either device or module must be set"])
+
     def test_interface_create_form_module_in_bay_rejects_vlan_in_other_location(self):
         """Assert that a tagged VLAN outside the Module's parent Device location is rejected when device is blank."""
         location_ids = self.device.location.ancestors(include_self=True).values_list("id", flat=True)

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -3916,6 +3916,54 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
         self.assertEqual(instance.type, InterfaceTypeChoices.TYPE_VIRTUAL)
         self.assertEqual(instance.parent_interface, self.lag_interface)
 
+    def test_edit_interface_on_module_without_parent_device(self):
+        """https://github.com/nautobot/nautobot/issues/9282."""
+        self.add_permissions("dcim.change_interface", "dcim.view_module", "extras.view_status", "ipam.view_vlan")
+        module_location = Location.objects.get_for_model(Module).first()
+        module = Module.objects.create(
+            module_type=ModuleType.objects.create(
+                manufacturer=Manufacturer.objects.first(), model="Issue 9282 Module Type"
+            ),
+            location=module_location,
+            status=Status.objects.get_for_model(Module).first(),
+        )
+        interface = Interface.objects.create(
+            module=module,
+            name="Module Interface 1",
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            mode=InterfaceModeChoices.MODE_TAGGED,
+            status=Status.objects.get_for_model(Interface).first(),
+        )
+        # A Module installed at a Location has no parent Device, so neither does its interface
+        self.assertIsNone(interface.device)
+        vlan = VLAN.objects.create(
+            vid=920,
+            name="Issue 9282 VLAN",
+            status=Status.objects.get_for_model(VLAN).first(),
+            vlan_group=VLANGroup.objects.first(),
+        )
+        # Assign the VLAN while it is still global and locate it afterwards, which is how such data comes to exist
+        interface.tagged_vlans.set([vlan])
+        vlan.locations.set([module_location])
+
+        request = {
+            "path": self._get_url("edit", interface),
+            "data": post_data(
+                {
+                    "name": interface.name,
+                    "status": interface.status.pk,
+                    "type": interface.type,
+                    "mode": InterfaceModeChoices.MODE_TAGGED,
+                    "tagged_vlans": [vlan.pk],
+                    "description": "Edited via the UI",
+                }
+            ),
+        }
+        self.assertHttpStatus(self.client.post(**request), 302)
+        interface.refresh_from_db()
+        self.assertEqual(interface.description, "Edited via the UI")
+        self.assertEqual(list(interface.tagged_vlans.all()), [vlan])
+
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_valid_ipaddress_link_of_ipaddress_table_in_interface_detail(self):
         """Assert bug https://github.com/nautobot/nautobot/issues/4685 Invalid link in IPAddress Table in an

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -3916,17 +3916,27 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
         self.assertEqual(instance.type, InterfaceTypeChoices.TYPE_VIRTUAL)
         self.assertEqual(instance.parent_interface, self.lag_interface)
 
+    def _create_location_module(self, module_type_model):
+        """Create a Module installed directly at a Location, which therefore has no parent Device."""
+        return Module.objects.create(
+            module_type=ModuleType.objects.create(manufacturer=Manufacturer.objects.first(), model=module_type_model),
+            location=Location.objects.get_for_model(Module).first(),
+            status=Status.objects.get_for_model(Module).first(),
+        )
+
+    def _create_vlan(self, vid, name):
+        return VLAN.objects.create(
+            vid=vid,
+            name=name,
+            status=Status.objects.get_for_model(VLAN).first(),
+            vlan_group=VLANGroup.objects.first(),
+        )
+
     def test_edit_interface_on_module_without_parent_device(self):
         """https://github.com/nautobot/nautobot/issues/9282."""
         self.add_permissions("dcim.change_interface", "dcim.view_module", "extras.view_status", "ipam.view_vlan")
-        module_location = Location.objects.get_for_model(Module).first()
-        module = Module.objects.create(
-            module_type=ModuleType.objects.create(
-                manufacturer=Manufacturer.objects.first(), model="Issue 9282 Module Type"
-            ),
-            location=module_location,
-            status=Status.objects.get_for_model(Module).first(),
-        )
+        module = self._create_location_module("Issue 9282 Module Type")
+        module_location = module.location
         interface = Interface.objects.create(
             module=module,
             name="Module Interface 1",
@@ -3936,12 +3946,7 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
         )
         # A Module installed at a Location has no parent Device, so neither does its interface
         self.assertIsNone(interface.device)
-        vlan = VLAN.objects.create(
-            vid=920,
-            name="Issue 9282 VLAN",
-            status=Status.objects.get_for_model(VLAN).first(),
-            vlan_group=VLANGroup.objects.first(),
-        )
+        vlan = self._create_vlan(920, "Issue 9282 VLAN")
         # Assign the VLAN while it is still global and locate it afterwards, which is how such data comes to exist
         interface.tagged_vlans.set([vlan])
         vlan.locations.set([module_location])
@@ -3963,6 +3968,87 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
         interface.refresh_from_db()
         self.assertEqual(interface.description, "Edited via the UI")
         self.assertEqual(list(interface.tagged_vlans.all()), [vlan])
+
+    def test_create_interface_on_module_without_parent_device(self):
+        """A tagged interface can be created on a Module that has no parent Device."""
+        self.add_permissions("dcim.add_interface", "dcim.view_module", "extras.view_status", "ipam.view_vlan")
+        module = self._create_location_module("Module Interface Create Module Type")
+        # Only global VLANs can be tagged when there is no parent device to scope them by
+        vlan = self._create_vlan(921, "Module Interface Create VLAN")
+
+        request = {
+            "path": self._get_url("add"),
+            "data": post_data(
+                {
+                    "module": module.pk,
+                    "name_pattern": "Module Interface Create 1",
+                    "status": Status.objects.get_for_model(Interface).first().pk,
+                    "type": InterfaceTypeChoices.TYPE_1GE_FIXED,
+                    "mode": InterfaceModeChoices.MODE_TAGGED,
+                    "tagged_vlans": [vlan.pk],
+                }
+            ),
+        }
+        self.assertHttpStatus(self.client.post(**request), 302)
+        interface = Interface.objects.get(module=module, name="Module Interface Create 1")
+        self.assertIsNone(interface.device)
+        self.assertEqual(list(interface.tagged_vlans.all()), [vlan])
+
+    def test_create_interface_on_module_in_module_bay(self):
+        """A tagged interface created on a Module in a ModuleBay is scoped by that bay's parent Device."""
+        self.add_permissions("dcim.add_interface", "dcim.view_module", "extras.view_status", "ipam.view_vlan")
+        device = Device.objects.first()
+        module_bay = ModuleBay.objects.create(parent_device=device, name="Module Interface Create Bay", position="1")
+        module = Module.objects.create(
+            module_type=ModuleType.objects.create(
+                manufacturer=Manufacturer.objects.first(), model="Module Interface Create Bay Module Type"
+            ),
+            parent_module_bay=module_bay,
+            status=Status.objects.get_for_model(Module).first(),
+        )
+        vlan = self._create_vlan(922, "Module Bay Interface Create VLAN")
+        vlan.locations.set([device.location])
+
+        request = {
+            "path": self._get_url("add"),
+            "data": post_data(
+                {
+                    "module": module.pk,
+                    "name_pattern": "Module Bay Interface Create 1",
+                    "status": Status.objects.get_for_model(Interface).first().pk,
+                    "type": InterfaceTypeChoices.TYPE_1GE_FIXED,
+                    "mode": InterfaceModeChoices.MODE_TAGGED,
+                    "tagged_vlans": [vlan.pk],
+                }
+            ),
+        }
+        self.assertHttpStatus(self.client.post(**request), 302)
+        interface = Interface.objects.get(module=module, name="Module Bay Interface Create 1")
+        # `ModularComponentModel.save()` backfills the device from the module's parent module bay
+        self.assertEqual(interface.device, device)
+        self.assertEqual(list(interface.tagged_vlans.all()), [vlan])
+
+    def test_create_interface_without_device_or_module_reports_error(self):
+        """An interface belonging to neither a device nor a module is rejected rather than raising an exception."""
+        self.add_permissions("dcim.add_interface", "dcim.view_module", "extras.view_status", "ipam.view_vlan")
+        vlan = self._create_vlan(923, "Ownerless Interface Create VLAN")
+
+        request = {
+            "path": self._get_url("add"),
+            "data": post_data(
+                {
+                    "name_pattern": "Ownerless Interface Create 1",
+                    "status": Status.objects.get_for_model(Interface).first().pk,
+                    "type": InterfaceTypeChoices.TYPE_1GE_FIXED,
+                    "mode": InterfaceModeChoices.MODE_TAGGED,
+                    "tagged_vlans": [vlan.pk],
+                }
+            ),
+        }
+        response = self.client.post(**request)
+        self.assertHttpStatus(response, 200)
+        self.assertBodyContains(response, "Either device or module must be set")
+        self.assertFalse(Interface.objects.filter(name="Ownerless Interface Create 1").exists())
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_valid_ipaddress_link_of_ipaddress_table_in_interface_detail(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
# Closes #9282
# What's Changed

When a module's interface is edited and the 802.1Q mode set to `Tagged`, we expect there to be a parent device or VM to scope the VLANs that can be applied to the `tagged_vlans`. When a module does not have a parent device, the form fails and raises an AttributeError.

This PR simply adds some safe `.get()` operations and verification that we have a parent device to the form clean so that we can drop through if that situation occurs.

# Screenshots

|Before|After|
|-|-|
|<img width="499" height="96" alt="Screenshot 2026-08-07 at 9 45 08 AM" src="https://github.com/user-attachments/assets/d9156949-3193-4961-b587-061bea9a3a65" />|<img width="395" height="87" alt="Screenshot 2026-08-06 at 2 14 58 PM" src="https://github.com/user-attachments/assets/d0fde7c6-5c52-4b99-b060-e4783096c4fa" />|

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [N/A] Documentation Updates (when adding/changing features)
- [N/A] Example App Updates (when adding/changing features)
- [N/A] Outline Remaining Work, Constraints from Design

NTC-6352