### PR TITLE
docker: fail the build when the hadolint download fails

### DIFF
--- a/changes/9384.housekeeping
+++ b/changes/9384.housekeeping
@@ -1,0 +1,1 @@
+Fixed the `hadolint` download in the development Docker image to use `curl --fail`, so that an HTTP error during the download fails the build instead of installing the error response as the `hadolint` binary.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,13 +89,13 @@ RUN apt-get update && \
 FROM system-dev-dependencies AS system-dev-dependencies-amd64
 
 # Install hadolint for linting Dockerfiles
-RUN curl -Lo /usr/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.10.0/hadolint-Linux-x86_64 && \
+RUN curl -fLo /usr/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.10.0/hadolint-Linux-x86_64 && \
     chmod +x /usr/bin/hadolint
 
 FROM system-dev-dependencies AS system-dev-dependencies-arm64
 
 # Install hadolint for linting Dockerfiles
-RUN curl -Lo /usr/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.10.0/hadolint-Linux-arm64 && \
+RUN curl -fLo /usr/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.10.0/hadolint-Linux-arm64 && \
     chmod +x /usr/bin/hadolint
 
 ################################ Stage: poetry (stub for poetry only)


### PR DESCRIPTION
# Closes #

No issue was opened beforehand, and I would rather explain that than file on the wrong
template. The 🏡 Housekeeping template says it is for maintainers only and asks people
not to use it unless invited; the 🐛 Bug Report template asks for a Nautobot version,
Python version and database platform, which a build-time bug does not have. Happy to
open one under whichever you would prefer, and equally happy for this to be closed
without ceremony if a two-character change is not worth a review slot.

Per the contributing guide — *"use your GitHub issue number (or the number of the pull
request, if no issue was opened beforehand)"* — the changelog fragment is named after
this PR and pushed as a second commit once the number exists.

# What's Changed

`docker/Dockerfile` installs `hadolint` in both `system-dev-dependencies-$ARCH` stages
with:

```dockerfile
RUN curl -Lo /usr/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.10.0/hadolint-Linux-x86_64 && \
    chmod +x /usr/bin/hadolint
```

`curl` without `--fail` treats an HTTP error as a successful transfer: it writes the
error *body* to the output file and exits `0`. If that asset is ever renamed or retired,
or the host answers with a 5xx or a rate-limit page, the build does not stop — it writes
the error page to `/usr/bin/hadolint`, `chmod +x` succeeds, and the layer is committed.
The failure then surfaces somewhere else entirely, as `cannot execute binary file` or as
a lint step that looks like it passed.

This adds `-f`. On the happy path it changes nothing at all; `curl` only behaves
differently when the server returns >= 400, and then it exits 22 and writes no file, so
`&& chmod` never runs and the build stops at the instruction that actually broke.

**To be clear about what is and is not wrong today:** the v2.10.0 assets are live — I
checked both, they return 200. This is a latent failure mode, not an outage. I am not
reporting that your builds are broken.

Measured against the real release host on 2026-08-13, rather than recalled:

```console
$ curl -sL https://github.com/hadolint/hadolint/releases/download/v2.10.0/hadolint-Linux-x86_64-typo -o probe.bin
$ echo $?
0
$ ls -l probe.bin
-rw-rw-r-- 1 ... 9 ... probe.bin
$ cat probe.bin
Not Found
```

Nine bytes, exit `0`, and `chmod +x` would have been perfectly happy with it.

Two things that I think make this cheap to accept:

- **It is your own convention already.** The `fnm` install one stage below uses
  `curl -fsSL`. These two lines are the inconsistent ones; I am not proposing a new
  policy.
- **It is on the critical path for every target, not just `dev`.** `final` is
  `FROM system-dependencies`, but it `COPY --from=python-dependencies`, and
  `python-dependencies` is `FROM system-dev-dependencies-${ARCH}`. So the production
  image builds through the hadolint download too.

# Screenshots

N/A — build-time change, no user-visible surface.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example — N/A
- [ ] Unit, Integration Tests — see the note below
- [ ] Documentation Updates — N/A, no user-facing change
- [ ] Example App Updates — N/A

**On testing, plainly: there is no Docker daemon on the machine this was written on and
I did not build the image.** I would rather say that than imply otherwise. What I did
measure is the `curl` behaviour above, directly against the same host and release path
the Dockerfile uses. What I would ask a reviewer to run:

```console
docker buildx build . --platform linux/amd64 --target dev --load \
    -f ./docker/Dockerfile --build-arg PYTHON_VER=3.12
```

and, to see the old behaviour, the same build with the URL deliberately mistyped: on
`develop` it succeeds and produces a 9-byte `/usr/bin/hadolint`; on this branch it fails
at that instruction.

No unit test is added. There is no runtime behaviour to assert — the change is in how a
build step reports failure, and I did not want to add a test I could not run against a
real build.

**One thing I noticed and deliberately did not put in this diff.** The
`system-dependencies` stage mounts `--mount=type=cache,target="/var/cache/apt"`, and I
believe that mount never retains anything. Debian-derived images — `python:*-slim`
included — ship `/etc/apt/apt.conf.d/docker-clean`, which sets:

```
DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };
APT::Update::Post-Invoke { ... same ... };
Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";
```

so every `.deb` is deleted the moment `dpkg` finishes and nothing survives in the mount
to be reused. (That file is written by
[debuerreotype](https://github.com/debuerreotype/debuerreotype/blob/master/scripts/debuerreotype-minimizing-config),
which is what builds the Debian base images.) The `/var/lib/apt/lists` mount beside it
*does* work — `docker-clean` does not touch lists. The documented fix is the two-line
`rm -f /etc/apt/apt.conf.d/docker-clean` + `Binary::apt::APT::Keep-Downloaded-Packages
"true"` prelude. I have left it out because one PR should do one thing, and because
`sharing=locked` on that mount tells me it was written deliberately and you may know
something I do not. Say the word and I will send it separately.

Provenance, since it bears on how much you should trust the above: the file was surfaced
by a Dockerfile linter I maintain across a scan of 500 repositories, and then read by
hand — most of what the linter flagged here was wrong, because it cannot see cache
mounts or your `hadolint ignore` annotations, and none of that is in this diff. The
patch was prepared by an automated agent. Close it without ceremony if it is not useful.
