### PR TITLE
Add per-user 12/24-hour time display preference

### DIFF
--- a/changes/7356.added
+++ b/changes/7356.added
@@ -1,0 +1,1 @@
+Added a per-user preference to select 12-hour or 24-hour time display.

--- a/nautobot/core/formats/__init__.py
+++ b/nautobot/core/formats/__init__.py
@@ -1,0 +1,116 @@
+"""Helpers for request-local display-format preferences."""
+
+from contextvars import ContextVar
+
+TIME_FORMAT_12_HOUR = "12-hour"
+TIME_FORMAT_24_HOUR = "24-hour"
+TIME_FORMAT_PREFERENCES = frozenset({TIME_FORMAT_12_HOUR, TIME_FORMAT_24_HOUR})
+
+_time_format_preference = ContextVar("nautobot_time_format_preference", default=None)
+
+
+def get_time_format_preference():
+    """Return the active request's preferred hour cycle, if any."""
+    return _time_format_preference.get()
+
+
+def set_time_format_preference(preference):
+    """Set the active request's preferred hour cycle and return its ContextVar token."""
+    if preference not in TIME_FORMAT_PREFERENCES:
+        preference = None
+    return _time_format_preference.set(preference)
+
+
+def reset_time_format_preference(token):
+    """Restore the hour-cycle preference that preceded ``token``."""
+    _time_format_preference.reset(token)
+
+
+def apply_time_format_preference(format_string, preference=None):
+    """
+    Rewrite a Django date/time format string for a 12-hour or 24-hour display.
+
+    This intentionally changes only hour-cycle tokens. Date fields, separators,
+    seconds, microseconds, and timezone tokens are otherwise preserved.
+    Backslash-escaped format characters are left untouched.
+    """
+    if isinstance(format_string, PreferredTimeFormat):
+        format_string = str.__str__(format_string)
+    else:
+        format_string = str(format_string)
+
+    if preference is None:
+        preference = get_time_format_preference()
+    if preference not in TIME_FORMAT_PREFERENCES:
+        return format_string
+
+    output = []
+    has_hour = False
+    has_meridiem = False
+    last_clock_output_index = None
+    removed_meridiem = False
+    index = 0
+
+    while index < len(format_string):
+        format_char = format_string[index]
+
+        # Preserve escaped Django format characters as-is.
+        if format_char == "\\" and index + 1 < len(format_string):
+            output.append(format_string[index : index + 2])
+            index += 2
+            continue
+
+        if preference == TIME_FORMAT_12_HOUR:
+            if format_char in "gGhH":
+                output.append("g")
+                has_hour = True
+                last_clock_output_index = len(output)
+            elif format_char == "f":
+                output.append(format_char)
+                has_hour = True
+                last_clock_output_index = len(output)
+            elif format_char == "P":
+                output.append(format_char)
+                has_hour = True
+                has_meridiem = True
+                last_clock_output_index = len(output)
+            else:
+                output.append(format_char)
+                if has_hour and format_char in {"i", "s", "u"}:
+                    last_clock_output_index = len(output)
+                if format_char in {"a", "A"}:
+                    has_meridiem = True
+        else:
+            if format_char in "gGhH":
+                output.append("H")
+                has_hour = True
+            elif format_char in {"f", "P"}:
+                output.append("H:i")
+                has_hour = True
+            elif format_char in {"a", "A"}:
+                removed_meridiem = True
+                if output and output[-1].isspace():
+                    output.pop()
+            else:
+                output.append(format_char)
+
+        index += 1
+
+    if preference == TIME_FORMAT_12_HOUR and has_hour and not has_meridiem and last_clock_output_index is not None:
+        output.insert(last_clock_output_index, " a")
+
+    result = "".join(output)
+    return result.strip() if removed_meridiem else result
+
+
+class PreferredTimeFormat(str):
+    """
+    A Django format string that resolves its hour cycle at render time.
+
+    Django caches localized format objects. Keeping the cached value as this
+    immutable ``str`` subclass while resolving ``__str__`` from a ContextVar
+    lets concurrent requests use different user preferences safely.
+    """
+
+    def __str__(self):
+        return apply_time_format_preference(str.__str__(self))

--- a/nautobot/core/formats/en/formats.py
+++ b/nautobot/core/formats/en/formats.py
@@ -4,6 +4,17 @@ Stub "localization" formats module to re-enable support for settings like DATE_F
 
 from django.conf import settings
 
+from nautobot.core.formats import PreferredTimeFormat
+
+_TIME_FORMAT_SETTINGS = frozenset({"DATETIME_FORMAT", "SHORT_DATETIME_FORMAT", "TIME_FORMAT"})
+_PREFERRED_LITERAL_FORMATS = frozenset({"Y-m-d H:i:s.u"})
+
 
 def __getattr__(name):
-    return getattr(settings, name)
+    if name in _PREFERRED_LITERAL_FORMATS:
+        return PreferredTimeFormat(name)
+
+    value = getattr(settings, name)
+    if name in _TIME_FORMAT_SETTINGS:
+        return PreferredTimeFormat(value)
+    return value

--- a/nautobot/core/middleware.py
+++ b/nautobot/core/middleware.py
@@ -22,6 +22,10 @@ from nautobot.core.authentication import (
     assign_groups_to_user,
     assign_permissions_to_user,
 )
+from nautobot.core.formats import (
+    reset_time_format_preference,
+    set_time_format_preference,
+)
 from nautobot.core.settings_funcs import (
     ldap_auth_enabled,
     remote_auth_enabled,
@@ -223,12 +227,17 @@ class UserDefinedTimeZoneMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if request.user.is_authenticated:
-            if tzname := request.user.get_config("timezone"):
-                timezone.activate(ZoneInfo(tzname))
-            else:
-                timezone.deactivate()
-        return self.get_response(request)
+        preference = request.user.get_config("time_format") if request.user.is_authenticated else None
+        token = set_time_format_preference(preference)
+        try:
+            if request.user.is_authenticated:
+                if tzname := request.user.get_config("timezone"):
+                    timezone.activate(ZoneInfo(tzname))
+                else:
+                    timezone.deactivate()
+            return self.get_response(request)
+        finally:
+            reset_time_format_preference(token)
 
 
 class GraphQLOpenTelemetryMiddleware:

--- a/nautobot/core/templatetags/time_formats.py
+++ b/nautobot/core/templatetags/time_formats.py
@@ -1,0 +1,17 @@
+import re
+
+from django import template
+from django.template.defaultfilters import time as format_time
+
+from nautobot.core.formats import PreferredTimeFormat
+
+register = template.Library()
+
+
+@register.filter()
+def preferred_time_milliseconds(value):
+    """Render a time using the user's hour-cycle preference and millisecond precision."""
+    rendered = format_time(value, PreferredTimeFormat("H:i:s.u"))
+    if not rendered:
+        return rendered
+    return re.sub(r"(\.\d{3})\d{3}", r"\1", rendered)

--- a/nautobot/core/tests/test_formats.py
+++ b/nautobot/core/tests/test_formats.py
@@ -3,6 +3,12 @@ import datetime
 from django.template.defaultfilters import date, time
 from django.test import override_settings
 
+from nautobot.core.formats import (
+    reset_time_format_preference,
+    set_time_format_preference,
+    TIME_FORMAT_12_HOUR,
+    TIME_FORMAT_24_HOUR,
+)
 from nautobot.core.testing import TestCase
 
 
@@ -29,3 +35,63 @@ class FormatsTestCase(TestCase):
 
         with self.subTest("TIME_FORMAT"), override_settings(TIME_FORMAT="H/i.s"):
             self.assertEqual(time(datetime.datetime.fromisoformat("2026-02-23 16:54:03"), "TIME_FORMAT"), "16/54.03")
+
+    @override_settings(
+        DATETIME_FORMAT="Y/m/d H:i:s",
+        SHORT_DATETIME_FORMAT="Y-m-d H:i",
+        TIME_FORMAT="H:i:s",
+    )
+    def test_12_hour_time_preference(self):
+        value = datetime.datetime.fromisoformat("2026-02-23 16:54:03")
+        token = set_time_format_preference(TIME_FORMAT_12_HOUR)
+        try:
+            self.assertEqual(date(value, "DATETIME_FORMAT"), "2026/02/23 4:54:03 p.m.")
+            self.assertEqual(date(value, "SHORT_DATETIME_FORMAT"), "2026-02-23 4:54 p.m.")
+            self.assertEqual(time(value, "TIME_FORMAT"), "4:54:03 p.m.")
+        finally:
+            reset_time_format_preference(token)
+
+    @override_settings(
+        DATETIME_FORMAT="Y/m/d g:i:s a",
+        SHORT_DATETIME_FORMAT="Y-m-d g:i a",
+        TIME_FORMAT="g:i:s a",
+    )
+    def test_24_hour_time_preference(self):
+        value = datetime.datetime.fromisoformat("2026-02-23 16:54:03")
+        token = set_time_format_preference(TIME_FORMAT_24_HOUR)
+        try:
+            self.assertEqual(date(value, "DATETIME_FORMAT"), "2026/02/23 16:54:03")
+            self.assertEqual(date(value, "SHORT_DATETIME_FORMAT"), "2026-02-23 16:54")
+            self.assertEqual(time(value, "TIME_FORMAT"), "16:54:03")
+        finally:
+            reset_time_format_preference(token)
+
+    @override_settings(TIME_FORMAT="H:i")
+    def test_time_preference_is_request_local_with_cached_format(self):
+        value = datetime.datetime.fromisoformat("2026-02-23 16:54:03")
+        token = set_time_format_preference(TIME_FORMAT_12_HOUR)
+        try:
+            self.assertEqual(time(value, "TIME_FORMAT"), "4:54 p.m.")
+        finally:
+            reset_time_format_preference(token)
+
+        token = set_time_format_preference(TIME_FORMAT_24_HOUR)
+        try:
+            self.assertEqual(time(value, "TIME_FORMAT"), "16:54")
+        finally:
+            reset_time_format_preference(token)
+
+    def test_literal_datetime_format_honors_time_preference(self):
+        value = datetime.datetime.fromisoformat("2026-02-23 16:54:03")
+
+        token = set_time_format_preference(TIME_FORMAT_12_HOUR)
+        try:
+            self.assertEqual(date(value, "Y-m-d H:i:s.u"), "2026-02-23 4:54:03.000000 p.m.")
+        finally:
+            reset_time_format_preference(token)
+
+        token = set_time_format_preference(TIME_FORMAT_24_HOUR)
+        try:
+            self.assertEqual(date(value, "Y-m-d H:i:s.u"), "2026-02-23 16:54:03.000000")
+        finally:
+            reset_time_format_preference(token)

--- a/nautobot/core/tests/test_templatetags_time_formats.py
+++ b/nautobot/core/tests/test_templatetags_time_formats.py
@@ -1,0 +1,27 @@
+import datetime
+
+from nautobot.core.formats import (
+    reset_time_format_preference,
+    set_time_format_preference,
+    TIME_FORMAT_12_HOUR,
+    TIME_FORMAT_24_HOUR,
+)
+from nautobot.core.templatetags import time_formats
+from nautobot.core.testing import TestCase
+
+
+class TimeFormatTemplatetagsTest(TestCase):
+    def test_preferred_time_milliseconds(self):
+        value = datetime.datetime.fromisoformat("2026-02-23 16:54:03.123456")
+
+        token = set_time_format_preference(TIME_FORMAT_12_HOUR)
+        try:
+            self.assertEqual(time_formats.preferred_time_milliseconds(value), "4:54:03.123 p.m.")
+        finally:
+            reset_time_format_preference(token)
+
+        token = set_time_format_preference(TIME_FORMAT_24_HOUR)
+        try:
+            self.assertEqual(time_formats.preferred_time_milliseconds(value), "16:54:03.123")
+        finally:
+            reset_time_format_preference(token)

--- a/nautobot/docs/development/core/user-preferences.md
+++ b/nautobot/docs/development/core/user-preferences.md
@@ -10,4 +10,5 @@ The `users.User` model holds individual preferences for each user in the form of
 | `navbar_favorites` | Navbar items marked as "favorites" (starred) |
 | `pagination.per_page` | The number of items to display per page of a paginated table |
 | `tables.TABLE_NAME.columns` | The ordered list of columns to display when viewing the table |
+| `time_format` | Preferred hour-cycle for rendering time information (`12-hour` or `24-hour`) |
 | `timezone` | Time zone to use when rendering datetime information |

--- a/nautobot/extras/tables.py
+++ b/nautobot/extras/tables.py
@@ -9,6 +9,7 @@ from django_tables2.utils import Accessor
 from jsonschema import Draft7Validator
 from jsonschema.exceptions import ValidationError as JSONSchemaValidationError
 
+from nautobot.core.formats import PreferredTimeFormat
 from nautobot.core.tables import (
     ApprovalButtonsColumn,
     BaseTable,
@@ -1257,7 +1258,7 @@ class JobHookTable(BaseTable):
 
 
 class JobLogEntryTable(BaseTable):
-    created = tables.DateTimeColumn(verbose_name="Time", format="Y-m-d H:i:s.u")
+    created = tables.DateTimeColumn(verbose_name="Time", format=PreferredTimeFormat("Y-m-d H:i:s.u"))
     grouping = tables.Column()
     log_level = tables.Column(
         verbose_name="Level",

--- a/nautobot/extras/templates/extras/inc/jobresult_console_log_lines.html
+++ b/nautobot/extras/templates/extras/inc/jobresult_console_log_lines.html
@@ -1,10 +1,11 @@
+{% load time_formats %}
 {% spaceless %}
     {% for entry in entries %}
         <span
             class="console-line console-{{ entry.output_type }} d-block"
             data-timestamp="{{ entry.timestamp.isoformat }}"
         >
-            <span>[{{ entry.timestamp|time:"H:i:s.u"|slice:":12" }}]</span>
+            <span>[{{ entry.timestamp|preferred_time_milliseconds }}]</span>
             <span> {{ entry.text }}</span>
         </span>
     {% endfor %}

--- a/nautobot/users/forms.py
+++ b/nautobot/users/forms.py
@@ -7,6 +7,7 @@ from django.contrib.auth.forms import (
 from timezone_field import TimeZoneFormField
 
 from nautobot.core.events import publish_event
+from nautobot.core.formats import TIME_FORMAT_12_HOUR, TIME_FORMAT_24_HOUR
 from nautobot.core.forms import BootstrapMixin, DateTimePicker
 from nautobot.core.forms.widgets import StaticSelect2
 from nautobot.core.utils.config import get_settings_or_config
@@ -73,6 +74,16 @@ class AdvancedProfileSettingsForm(BootstrapMixin, forms.Form):
 
 class PreferenceProfileSettingsForm(BootstrapMixin, forms.Form):
     timezone = TimeZoneFormField(required=False, help_text="Set your preferred timezone.", widget=StaticSelect2)
+    time_format = forms.ChoiceField(
+        required=False,
+        label="Time format",
+        choices=(
+            ("", "Site default"),
+            (TIME_FORMAT_12_HOUR, "12-hour (e.g. 7:30 p.m.)"),
+            (TIME_FORMAT_24_HOUR, "24-hour (e.g. 19:30)"),
+        ),
+        help_text="Choose how times are displayed in the Nautobot UI.",
+    )
 
 
 class NavbarFavoritesAddForm(forms.Form):

--- a/nautobot/users/templates/users/preferences.html
+++ b/nautobot/users/templates/users/preferences.html
@@ -62,6 +62,7 @@
                     <div class="card-header"><strong>Preference Settings</strong></div>
                     <div class="card-body">
                         {% render_field form.timezone %}
+                        {% render_field form.time_format %}
                     </div>
                 </div>
             </div>

--- a/nautobot/users/tests/test_views.py
+++ b/nautobot/users/tests/test_views.py
@@ -191,3 +191,25 @@ class PreferenceTestCase(TestCase):
         self.assertEqual(timezone.get_current_timezone_name(), new_timezone_name)
         self.assertNotEqual(timezone_name, new_timezone_name)
         self.assertHttpStatus(response, 200)
+
+    def test_time_format_change_and_reset(self):
+        self.user.is_superuser = True
+        self.user.save()
+        self.client.force_login(self.user)
+
+        url = reverse("user:preferences")
+        form_data = {
+            "timezone": timezone.get_current_timezone_name(),
+            "time_format": "24-hour",
+            "_update_preference_form": [""],
+        }
+        response = self.client.post(path=url, data=post_data(form_data), follow=True)
+        self.assertHttpStatus(response, 200)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.get_config("time_format"), "24-hour")
+
+        form_data["time_format"] = ""
+        response = self.client.post(path=url, data=post_data(form_data), follow=True)
+        self.assertHttpStatus(response, 200)
+        self.user.refresh_from_db()
+        self.assertIsNone(self.user.get_config("time_format"))

--- a/nautobot/users/views.py
+++ b/nautobot/users/views.py
@@ -193,6 +193,7 @@ class UserConfigView(GenericView):
     def get(self, request):
         initial = {}
         initial["timezone"] = request.user.get_config("timezone", get_default_timezone_name())
+        initial["time_format"] = request.user.get_config("time_format", "")
         form = PreferenceProfileSettingsForm(initial=initial)
         preferences = request.user.all_config()
 
@@ -217,6 +218,10 @@ class UserConfigView(GenericView):
                 response = redirect("user:preferences")
                 if timezone := form.cleaned_data["timezone"]:
                     request.user.set_config("timezone", str(timezone), commit=True)
+                if time_format := form.cleaned_data["time_format"]:
+                    request.user.set_config("time_format", time_format, commit=True)
+                else:
+                    request.user.clear_config("time_format", commit=True)
                 return response
 
             return render(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

Closes #7356

## What's Changed

- Added a per-user preference to choose Site default, 12-hour, or 24-hour time display.
- Applied the preference request-locally without mutating global Django settings.
- Preserved Nautobot's existing DATE/TIME format settings as the site-level fallback.
- Applied the preference to standard date/time rendering, the Job Log table, and live job-console timestamps.
- Added unit tests and updated user preference documentation.

## Implementation note

Django caches localized format values globally. This implementation stores the active user's hour-cycle preference in a request-local `ContextVar`, while a small `str` subclass resolves the effective format when Django renders it. This avoids process-global setting mutation and allows concurrent users to have different display preferences.

The Job Log's explicit `Y-m-d H:i:s.u` format is also exposed through Nautobot's custom format module so django-tables2 can resolve the user preference at render time even though it materializes its template when the table class is imported.

## Testing

The full Nautobot pull-request CI workflow was run against this change in the fork and passed, including Ruff, Pylint, docs/schema checks, PostgreSQL and MySQL migration tests, PostgreSQL and MySQL unit-test suites, integration tests, and amd64/arm64 container builds.