### PR TITLE
Fixed homepage performing a database write on every GET request

### DIFF
--- a/changes/9413.fixed
+++ b/changes/9413.fixed
@@ -1,0 +1,2 @@
+Fixed the homepage returning an HTTP 500 error against a read-only database, such as when `MAINTENANCE_MODE` is enabled.
+Fixed the homepage writing the panel layout to the user's configuration on every page view, which could discard a panel's saved position when an App was uninstalled or a permission was revoked.

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -344,22 +344,45 @@ class HomeViewTestCase(TestCase):
 
     def test_homepage_layout_panels_ignores_unknown_stored_panel_ids(self):
         """
-        Validate that panel IDs in the stored config which no longer resolve to a registered panel are ignored.
+        Validate that the homepage still renders when the stored layout contains an ID matching no available panel.
 
-        The homepage no longer prunes stale IDs from the stored config, so they must remain inert when rendering.
+        The layout lives in `User.config_data["homepage_layout"]["panels"]` as a list of `{"id", "collapsed"}`
+        entries, one list per column. An ID stops matching when the panel is removed (e.g. an App is uninstalled)
+        or the user loses the permission that made it visible. `HomeView.get()` skips such entries.
+
+        This asserts that every panel available to the user is still present, and in the same document order as
+        the render with nothing stored -- the column distribution does differ, see the comment below. The case
+        previously had no coverage;stale IDs also persist longer now that the layout is not overwritten on each
+        render.
         """
-        self.add_permissions("dcim.view_device", "dcim.view_location")
+        self.add_permissions("dcim.view_location", "circuits.view_circuit", "ipam.view_prefix", "dcim.view_device")
+        url = reverse("home")
+        panel_ids = r'class="card nb-draggable" id="([^"]+)"'
+
+        # Baseline: capture the panels rendered with nothing stored, to compare against.
+        self.user.config_data = {}
+        self.user.save()
+        response = self.client.get(url)
+        expected = re.findall(panel_ids, extract_page_body(response.content.decode(response.charset)))
+        self.assertNotEqual(
+            expected,
+            [],
+            "No panels rendered for the baseline; the panel markup or the test's permissions may have changed",
+        )
+
+        # A stored layout naming only an unavailable panel must not change which panels render.
         panels = [[{"id": "no-such-panel", "collapsed": False}]]
         panels += [[] for _ in range(HOMEPAGE_PANELS_LAYOUT_COLUMNS - 1)]
         self.user.config_data = {"homepage_layout": {"panels": panels}}
         self.user.save()
 
-        response = self.client.get(reverse("home"))
+        # With no resolvable IDs every panel is appended to the last column, so the column distribution differs
+        # from the default even spread. Document order is unaffected, which is what this compares.
+        response = self.client.get(url)
         self.assertHttpStatus(response, 200)
-        self.assertNotIn(
-            "no-such-panel",
-            extract_page_body(response.content.decode(response.charset)),
-            "A stale panel ID from the stored config was rendered instead of being ignored",
+        rendered = re.findall(panel_ids, extract_page_body(response.content.decode(response.charset)))
+        self.assertEqual(
+            rendered, expected, "An unresolvable stored panel ID changed which panels rendered, or their order"
         )
 
     def test_homepage_layout_panels_render_from_stored_layout(self):

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -21,7 +21,7 @@ from prometheus_client.parser import text_string_to_metric_families
 from nautobot.circuits.models import Circuit, CircuitType, Provider
 from nautobot.circuits.tables import ProviderTable
 from nautobot.circuits.views import ProviderUIViewSet
-from nautobot.core.constants import GLOBAL_SEARCH_EXCLUDE_LIST, SEARCH_MAX_RESULTS
+from nautobot.core.constants import GLOBAL_SEARCH_EXCLUDE_LIST, HOMEPAGE_PANELS_LAYOUT_COLUMNS, SEARCH_MAX_RESULTS
 from nautobot.core.forms.forms import TableConfigForm
 from nautobot.core.testing import TestCase
 from nautobot.core.testing.api import APITestCase
@@ -292,6 +292,136 @@ class HomeViewTestCase(TestCase):
         assertBodyContains("""<h2 class="d-inline fs-4 fw-bold nb-text-none text-body">IPAM</h2>""")
         assertBodyContains("""<h3 class="fw-normal fs-4 lh-base"><a href="/ipam/prefixes/">Prefixes</a></h3>""")
         assertBodyContains("""<h3 class="fw-normal fs-4 lh-base"><a href="/ipam/ip-addresses/">IP Addresses</a></h3>""")
+
+    def test_homepage_layout_panels_no_stored_layout_does_not_write(self):
+        """
+        Validate that rendering the homepage without a stored panel layout performs no write.
+
+        Regression test: when no valid layout was stored, `HomeView.get()` called `clear_config(..., commit=True)`,
+        saving the user record even though nothing had changed, which raised a database error when the database
+        was read-only (e.g. under MAINTENANCE_MODE). The unrelated top-level key additionally guards against
+        `clear_config()` removing the leaf key from the wrong nesting level.
+        """
+        self.add_permissions("dcim.view_device", "dcim.view_location")
+        unrelated = {"timezone": "Europe/Rome", "panels": "unrelated-top-level-key"}
+        self.user.config_data = unrelated
+        self.user.save()
+
+        with mock.patch.object(get_user_model(), "save", autospec=True) as mock_save:
+            self.assertHttpStatus(self.client.get(reverse("home")), 200)
+        self.assertFalse(mock_save.called, "Rendering the homepage saved the user record")
+
+        self.user.refresh_from_db()
+        self.assertEqual(
+            self.user.config_data,
+            unrelated,
+            "Rendering the homepage modified the user's stored config; a write bypassed User.save()",
+        )
+
+    def test_homepage_layout_panels_stored_layout_does_not_write(self):
+        """
+        Validate that rendering the homepage with a stored panel layout performs no write.
+
+        Regression test: when a valid layout was stored, `HomeView.get()` called `set_config(..., commit=True)`,
+        writing the computed layout back to the user's config on every GET.
+        """
+        self.add_permissions("dcim.view_device", "dcim.view_location")
+        panels = [[{"id": "organization", "collapsed": True}]]
+        panels += [[] for _ in range(HOMEPAGE_PANELS_LAYOUT_COLUMNS - 1)]
+        self.user.config_data = {"homepage_layout": {"panels": panels}}
+        self.user.save()
+
+        with mock.patch.object(get_user_model(), "save", autospec=True) as mock_save:
+            self.assertHttpStatus(self.client.get(reverse("home")), 200)
+        self.assertFalse(mock_save.called, "Rendering the homepage saved the user record")
+
+        self.user.refresh_from_db()
+        self.assertEqual(
+            self.user.config_data["homepage_layout"]["panels"],
+            panels,
+            "Rendering the homepage modified the user's stored config; a write bypassed User.save()",
+        )
+
+    def test_homepage_layout_panels_ignores_unknown_stored_panel_ids(self):
+        """
+        Validate that panel IDs in the stored config which no longer resolve to a registered panel are ignored.
+
+        The homepage no longer prunes stale IDs from the stored config, so they must remain inert when rendering.
+        """
+        self.add_permissions("dcim.view_device", "dcim.view_location")
+        panels = [[{"id": "no-such-panel", "collapsed": False}]]
+        panels += [[] for _ in range(HOMEPAGE_PANELS_LAYOUT_COLUMNS - 1)]
+        self.user.config_data = {"homepage_layout": {"panels": panels}}
+        self.user.save()
+
+        response = self.client.get(reverse("home"))
+        self.assertHttpStatus(response, 200)
+        self.assertNotIn(
+            "no-such-panel",
+            extract_page_body(response.content.decode(response.charset)),
+            "A stale panel ID from the stored config was rendered instead of being ignored",
+        )
+
+    def test_homepage_layout_panels_render_from_stored_layout(self):
+        """
+        Validate that a stored panel layout still drives the rendered panel order and collapsed state.
+
+        The layout is persisted solely by the drag/collapse `PATCH` to `/api/users/config/`; the homepage no
+        longer writes its own computed copy back on GET. This guards that the homepage still *reads* and honors
+        what that `PATCH` stored, including overriding the default registry ordering. The fixture below stands
+        in for a layout the user had previously saved that way.
+        """
+        self.add_permissions("dcim.view_location", "circuits.view_circuit")
+        url = reverse("home")
+        panel_ids = r'class="card nb-draggable" id="([^"]+)"'
+
+        def rendered_panels(body):
+            return re.findall(panel_ids, body)
+
+        def panel_html(body):
+            return {chunk.split('"', 1)[0]: chunk for chunk in body.split('class="card nb-draggable" id="')[1:]}
+
+        # Baseline: with no stored layout, the default registry ordering places "organization" before "circuits".
+        self.user.config_data = {}
+        self.user.save()
+        response = self.client.get(url)
+        default_body = extract_page_body(response.content.decode(response.charset))
+        default_order = rendered_panels(default_body)
+        self.assertLess(
+            default_order.index("organization"),
+            default_order.index("circuits"),
+            "Default panel order is no longer organization-before-circuits, invalidating this test's baseline",
+        )
+
+        # A stored layout inverts that ordering and collapses "circuits" only.
+        panels = [
+            [{"id": "circuits", "collapsed": True}],
+            [{"id": "organization", "collapsed": False}],
+        ]
+        panels += [[] for _ in range(HOMEPAGE_PANELS_LAYOUT_COLUMNS - len(panels))]
+        self.user.config_data = {"homepage_layout": {"panels": panels}}
+        self.user.save()
+
+        response = self.client.get(url)
+        body = extract_page_body(response.content.decode(response.charset))
+        stored_order = rendered_panels(body)
+        self.assertLess(
+            stored_order.index("circuits"),
+            stored_order.index("organization"),
+            "The stored panel layout did not override the default panel ordering",
+        )
+
+        by_id = panel_html(body)
+        self.assertIn(
+            'aria-expanded="false"',
+            by_id["circuits"],
+            "The stored collapsed state was not applied to the circuits panel",
+        )
+        self.assertIn(
+            'aria-expanded="true"',
+            by_id["organization"],
+            "The organization panel rendered collapsed despite collapsed=False in the stored config",
+        )
 
 
 class AppDocsViewTestCase(TestCase):

--- a/nautobot/core/tests/test_views.py
+++ b/nautobot/core/tests/test_views.py
@@ -309,7 +309,8 @@ class HomeViewTestCase(TestCase):
 
         with mock.patch.object(get_user_model(), "save", autospec=True) as mock_save:
             self.assertHttpStatus(self.client.get(reverse("home")), 200)
-        self.assertFalse(mock_save.called, "Rendering the homepage saved the user record")
+        # Rendering the homepage must not save the user record.
+        mock_save.assert_not_called()
 
         self.user.refresh_from_db()
         self.assertEqual(
@@ -333,7 +334,8 @@ class HomeViewTestCase(TestCase):
 
         with mock.patch.object(get_user_model(), "save", autospec=True) as mock_save:
             self.assertHttpStatus(self.client.get(reverse("home")), 200)
-        self.assertFalse(mock_save.called, "Rendering the homepage saved the user record")
+        # Rendering the homepage must not save the user record.
+        mock_save.assert_not_called()
 
         self.user.refresh_from_db()
         self.assertEqual(

--- a/nautobot/core/views/__init__.py
+++ b/nautobot/core/views/__init__.py
@@ -202,21 +202,8 @@ class HomeView(AccessMixin, TemplateView):
             panel_layout[-1] += missing_panels
             # Convert panel key-value pairs to `dict`.
             panel_layout = [dict(panel_group) for panel_group in panel_layout]
-            # Update user config to always keep it up to date with the latest homepage panel layout structure.
-            request.user.set_config(
-                "homepage_layout.panels",
-                [
-                    [
-                        {"id": slugify(kv_pair[0]), "collapsed": kv_pair[1].get("collapsed", False)}
-                        for kv_pair in panel_group.items()
-                    ]
-                    for panel_group in panel_layout
-                ],
-                commit=True,
-            )
         else:
             # If `user_config` is not found or is invalid, create a default panel layout.
-            request.user.clear_config("homepage_layout.panels", commit=True)
             # Using an upside-down floor division here. Source: from https://stackoverflow.com/a/17511341.
             panel_layout_rows = -(len(user_panels) // -HOMEPAGE_PANELS_LAYOUT_COLUMNS)
             # Lambda key function is responsible by grouping the panels into equal chunks representing rows per column.


### PR DESCRIPTION
# Closes #9413

# What's Changed

HTTP GETting the nautobot home page is again a read-only operation. The writes to user record have been removed.

# Why

From nautobot `3.2.x` `HomeView.get()` wrote to the user record on every render, whichever path it took: `set_config(..., commit=True)` when a valid layout was stored and `clear_config(..., commit=True)` when one was not. No path through the view avoided a write.

This made the homepage return HTTP error 500 against a read-only database, which is the state `MAINTENANCE_MODE` is meant to support. On a writable database it issued a redundant full-row `UPDATE` on users for every page view (even if nothing changed in the user configuration) and it might have discarded a panel's saved position whenever that panel became temporarily unavailable because an App was uninstalled or a permission revoked.

The layout has always been computed at render time from two inputs: the user's stored panel order and collapsed state, and the set of panels currently available to them (the App registry filtered by their permissions). Stored entries with no matching available panel were skipped and available panels missing from the stored config were appended. Rendering has always used that computed value directly. The removed code took the same value and wrote a copy back into the user's stored config, which rendering never read anyway. This PR removes only this write-back because it is effectively useless. 

The persistence logic of user customized layout by drag-and-drop is unchanged. It still goes through the existing drag/collapse PATCH to /api/users/config/. 

Added 4 tests in `nautobot/core/tests/test_views.py::HomeViewTestCase`to check everything still renders fine after removing the code:

| Test | What it asserts | Fails without fix |
| --- | --- | --- |
| `test_homepage_layout_panels_no_stored_layout_does_not_write` | With no stored layout — the path that previously called `clear_config(..., commit=True)` — `User.save()` is never called during the GET and the stored config is byte-identical afterwards. An unrelated top-level key in the fixture also catches a write that bypasses `save()`. | ✅ |
| `test_homepage_layout_panels_stored_layout_does_not_write` | With a valid stored layout — the path that previously called `set_config(..., commit=True)` — same assertions as previous test. Covered separately because fixing only one path would leave users who had customized their homepage still erroring. | ✅ |
| `test_homepage_layout_panels_ignores_unknown_stored_panel_ids` | An unresolvable stored panel ID is skipped rather than rendered. This behavior is pre-existing and unchanged (`views/__init__.py:189-192`); it matters more now, because the stored list is no longer overwritten on each render, so a stale ID can sit there until the user's next rearrangement. Previously untested. | ❌ |
| `test_homepage_layout_panels_render_from_stored_layout` | A stored layout still drives rendered panel order and collapsed state, inverting the default registry ordering. Passes with and without the fix by design and **this is the evidence that rendering behavior is unchanged**. | ❌ |

The last three are the first unit coverage of the stored-layout path in `HomeView.get()`, previously reachable only indirectly via the Selenium integration test.

Regression introduced in 3.2.0 by #8963.

<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
