### PR TITLE
Add Devices and Racks count columns to the Locations list view

### DIFF
--- a/changes/7145.added
+++ b/changes/7145.added
@@ -1,0 +1,1 @@
+Added optional "Devices" and "Racks" count columns to the Locations list view.

--- a/nautobot/dcim/tables/locations.py
+++ b/nautobot/dcim/tables/locations.py
@@ -5,6 +5,7 @@ from nautobot.core.tables import (
     BooleanColumn,
     ButtonsColumn,
     ContentTypesColumn,
+    LinkedCountColumn,
     TagColumn,
     ToggleColumn,
 )
@@ -57,6 +58,16 @@ class LocationTable(StatusTableMixin, BaseTable):
     location_type = tables.Column(linkify=True)
     parent = tables.Column(linkify=True)
     tenant = TenantColumn()
+    device_count = LinkedCountColumn(
+        viewname="dcim:device_list",
+        url_params={"location": "pk"},
+        verbose_name="Devices",
+    )
+    rack_count = LinkedCountColumn(
+        viewname="dcim:rack_list",
+        url_params={"location": "pk"},
+        verbose_name="Racks",
+    )
     tags = TagColumn(url_name="dcim:location_list")
     actions = ButtonsColumn(Location)
 
@@ -80,6 +91,8 @@ class LocationTable(StatusTableMixin, BaseTable):
             "contact_name",
             "contact_phone",
             "contact_email",
+            "device_count",
+            "rack_count",
             "tags",
             "actions",
         )

--- a/nautobot/dcim/tests/test_tables.py
+++ b/nautobot/dcim/tests/test_tables.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.test import TestCase
@@ -26,9 +27,15 @@ from nautobot.dcim.models import (
     PowerOutlet,
     PowerPanel,
     PowerPort,
+    Rack,
     RearPort,
 )
-from nautobot.dcim.tables import ConsoleConnectionTable, InterfaceConnectionTable, PowerConnectionTable
+from nautobot.dcim.tables import (
+    ConsoleConnectionTable,
+    InterfaceConnectionTable,
+    LocationTable,
+    PowerConnectionTable,
+)
 from nautobot.dcim.tables.devices import DeviceModuleInterfaceTable, InterfaceTable
 from nautobot.dcim.tables.devicetypes import InterfaceTemplateTable
 from nautobot.dcim.views import (
@@ -608,3 +615,99 @@ class ConnectionTableTestCase(TestCase):
             Cable.objects.create(termination_a=near, termination_b=far, status=self.connected)
 
         self._assert_render_has_no_n_plus_one(InterfaceConnectionTable, InterfaceConnectionsListView.base_queryset())
+
+
+class LocationCountColumnTestCase(TestCase):
+    """Render tests for the Devices / Racks count columns on `LocationTable`.
+
+    These columns are not in `default_columns`, and `BaseTable` only annotates the count onto the
+    queryset for columns that are *visible*. The table is therefore instantiated with a user whose
+    table config enables them, which is what the list view does, so these tests fail if either the
+    column definitions or that annotation regress.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = get_user_model().objects.create_user(username="location-count-columns")
+        cls.user.set_config(
+            "tables.LocationTable.columns",
+            ["name", "device_count", "rack_count"],
+            commit=True,
+        )
+
+        location_status = Status.objects.get_for_model(Location).first()
+        cls.location_type = LocationType.objects.create(name="Count Column Location Type")
+        cls.location_type.content_types.set(
+            [
+                ContentType.objects.get_for_model(Device),
+                ContentType.objects.get_for_model(Rack),
+            ]
+        )
+
+        cls.location_many = Location.objects.create(
+            name="Count Column Many", location_type=cls.location_type, status=location_status
+        )
+        cls.location_one = Location.objects.create(
+            name="Count Column One", location_type=cls.location_type, status=location_status
+        )
+        cls.location_none = Location.objects.create(
+            name="Count Column None", location_type=cls.location_type, status=location_status
+        )
+
+        manufacturer = Manufacturer.objects.create(name="Count Column Manufacturer")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="Count Column Device Type")
+        device_role = Role.objects.get_for_model(Device).first()
+        device_status = Status.objects.get_for_model(Device).first()
+        rack_status = Status.objects.get_for_model(Rack).first()
+
+        for index in range(2):
+            Device.objects.create(
+                name=f"count-column-device-{index}",
+                device_type=device_type,
+                role=device_role,
+                status=device_status,
+                location=cls.location_many,
+            )
+            Rack.objects.create(
+                name=f"count-column-rack-{index}",
+                status=rack_status,
+                location=cls.location_many,
+            )
+
+        cls.only_device = Device.objects.create(
+            name="count-column-lonely-device",
+            device_type=device_type,
+            role=device_role,
+            status=device_status,
+            location=cls.location_one,
+        )
+
+    def _row_for(self, location) -> BoundRow:
+        """Bound row for `location`, with the count columns made visible via the user's table config."""
+        table = LocationTable(Location.objects.filter(pk=location.pk), user=self.user)
+        return table.rows[0]
+
+    def test_counts_are_rendered_and_linked(self):
+        row = self._row_for(self.location_many)
+
+        device_cell = row.get_cell("device_count")
+        self.assertIn(">2<", device_cell)
+        self.assertIn(f"{reverse('dcim:device_list')}?location={self.location_many.pk}", device_cell)
+
+        rack_cell = row.get_cell("rack_count")
+        self.assertIn(">2<", rack_cell)
+        self.assertIn(f"{reverse('dcim:rack_list')}?location={self.location_many.pk}", rack_cell)
+
+    def test_single_related_object_is_rendered_instead_of_a_count(self):
+        """`LinkedCountColumn` renders the object itself when exactly one related object exists."""
+        row = self._row_for(self.location_one)
+
+        device_cell = row.get_cell("device_count")
+        self.assertIn(self.only_device.name, device_cell)
+        self.assertIn(self.only_device.get_absolute_url(), device_cell)
+
+    def test_locations_without_related_objects_render_the_column_default(self):
+        row = self._row_for(self.location_none)
+
+        self.assertNotIn(reverse("dcim:device_list"), row.get_cell("device_count"))
+        self.assertNotIn(reverse("dcim:rack_list"), row.get_cell("rack_count"))


### PR DESCRIPTION
# Closes #7145

# What's Changed

Adds optional **Devices** and **Racks** count columns to the Locations list view, following @glennmatthews' suggestion on the issue to use `LinkedCountColumn` on `LocationTable`.

Each column renders the number of objects assigned to that location and links through to the corresponding filtered list view, matching the pattern already used by `TenantGroupTable.tenant_count` and `RackDetailTable.device_count`.

## Scope

The issue asks for device counts, and the comment mentions "or several such columns". I have limited this to **Device** and **Rack**, because they are the only location-related models with a direct foreign key to `Location`:

| Model | Relationship to Location | In this PR |
| --- | --- | --- |
| Device | direct FK | yes |
| Rack | direct FK | yes |
| Prefix, VLAN | M2M via `location_assignments` | no |
| Circuit | indirect, `circuit_terminations__location` | no |
| VirtualMachine | indirect, `cluster__location` | no |

The other four make up the rest of the set used by the `location-stats` REST endpoint, and they are all addable — they just need `distinct=True` and an explicit `lookup` rather than the default behaviour. Happy to extend this PR to all six if that is what you had in mind; I would rather confirm the semantics than guess at them.

## Not added to `default_columns`

The columns are in `Meta.fields` but deliberately **not** in `default_columns`, so the out-of-the-box Locations list view is unchanged and users opt in via the column selector. Say the word if you would rather they be shown by default.

## Note on tree semantics

`count_related()` counts direct assignments only, whereas the `location` filter these columns link to is a `TreeNodeMultipleChoiceFilter`, so the linked list view also includes child locations. A location with children can therefore show a smaller count than the page it links to.

This is pre-existing behaviour rather than something introduced here — `RackGroupTable.rack_count` links to the equally tree-aware `rack_group` filter — so I kept it consistent rather than inventing different semantics for this one table. Flagging it in case you would prefer descendant-inclusive counts, which would need something other than a plain `LinkedCountColumn`.

# Screenshots

Locations list with both columns enabled, sorted by **Devices** descending:

![Locations list showing Devices and Racks count columns](https://raw.githubusercontent.com/somaliz/nautobot/screenshots/nautobot-7145-locations.png)

Note the rows showing an object name (`Router-10`, `WLAN Controller-24`) rather than a number — that is `LinkedCountColumn`'s existing behaviour of rendering the object itself when exactly one related object exists, not something specific to this change.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) — `changes/7145.added`
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests — see below
- [ ] Documentation Updates (when adding/changing features) — no docs change; the columns are self-describing in the column selector and the Locations list is not documented column-by-column. Happy to add something if you disagree.
- [ ] Example App Updates (when adding/changing features) — n/a
- [x] Outline Remaining Work, Constraints from Design — see Scope and Note on tree semantics above

## Testing

No new test was added, because the existing generic `test_model_properties_as_table_columns_are_not_orderable` already covers exactly the risk here: it enables **every** column on the table and sorts by each one, asserting HTTP 200. Sorting is what breaks for a `LinkedCountColumn` if the count is not annotated onto the queryset, and `BaseTable` applies `.annotate(<column>=count_related(...))` for these columns automatically. I confirmed that test executes for `LocationTestCase` and passes with the new columns present:

```
$ invoke tests --label nautobot.dcim --pattern test_model_properties_as_table_columns_are_not_orderable --verbose
test_model_properties_as_table_columns_are_not_orderable
  (nautobot.dcim.tests.test_views.LocationTestCase.test_model_properties_as_table_columns_are_not_orderable) ... ok
Ran 38 tests in 77.409s
OK
```

Full Location suite is also green:

```
$ invoke tests --label nautobot.dcim --pattern Location
Ran 236 tests in 98.303s
OK (skipped=3)
```

If you would still like a dedicated test asserting the two columns are present and render linked counts, I am glad to add one.
