### PR TITLE
[2.4] Update GitPython to 3.1.61

### DIFF
--- a/changes/9423.security
+++ b/changes/9423.security
@@ -1,0 +1,1 @@
+Updated dependency `GitPython` to `~3.1.61` to mitigate multiple vulnerabilities.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1666,14 +1666,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.59"
+version = "3.1.61"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c"},
-    {file = "gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4"},
+    {file = "gitpython-3.1.61-py3-none-any.whl", hash = "sha256:8ab28c9da863cdd9e7d7694ec46cf3e6c9a12d8a30a1acd3447aec11975d530c"},
+    {file = "gitpython-3.1.61.tar.gz", hash = "sha256:f51c24d8c0f733a195447385f5774a5dfe8767f5acfd7994a33755644c6ecc95"},
 ]
 
 [package.dependencies]
@@ -5915,4 +5915,4 @@ sso = ["social-auth-core"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "d1766be796372f7e2e02cfbe57686c8249f2154bd7419e3c7c28196292085d40"
+content-hash = "685e386d314446841979fdad529b6913877f08ebf58ac0367d3f6724d2b33989"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ drf-spectacular = {version = "~0.28.0", extras = ["sidecar"]}
 # Emoji terminal output for Python.
 emoji = "~2.15.0"
 # Git integrations for Python
-GitPython = "~3.1.59"
+GitPython = "~3.1.61"
 # GraphQL support
 # NOTE: graphene-django 3.x is available but includes breaking changes. Will address in a future release.
 graphene-django = "~2.16.0"


### PR DESCRIPTION
Security update equivalent to #9422.