### PR TITLE
[3.3] Fix parallel unittest support under Python 3.14 and change dev environment default to 3.14

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -91,11 +91,7 @@ jobs:
             exit 1
           fi
   tests-postgres:
-    # Sticking with Python 3.13 rather than 3.14 here for now, because Django 5.2's test runner doesn't
-    # support parallel execution under 3.14's default multiprocessing start method. Relevant references:
-    # https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods
-    # https://code.djangoproject.com/ticket/36531
-    name: "Unit tests (PostgreSQL and Python 3.13)"
+    name: "Unit tests (PostgreSQL and Python 3.14)"
     runs-on: "ubuntu-24.04"
     env:
       INVOKE_NAUTOBOT_LOCAL: "True"
@@ -123,11 +119,7 @@ jobs:
         with:
           poetry-install-options: "--extras=remote_storage"
           poetry-version: "2.1.4"
-          # Sticking with Python 3.13 rather than 3.14 here for now, because Django 5.2's test runner doesn't
-          # support parallel execution under 3.14's default multiprocessing start method. Relevant references:
-          # https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods
-          # https://code.djangoproject.com/ticket/36531
-          python-version: "3.13"
+          python-version: "3.14"
       - name: "Run unittest"
         run: "poetry run invoke tests --failfast --no-keepdb --no-cache-test-fixtures --parallel"
   tests-mysql:
@@ -264,11 +256,7 @@ jobs:
         with:
           poetry-install-options: ""  # override default "--only dev"
           poetry-version: "2.1.4"
-          # Sticking with Python 3.13 rather than 3.14 here for now, because Django 5.2's test runner doesn't
-          # support parallel execution under 3.14's default multiprocessing start method. Relevant references:
-          # https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods
-          # https://code.djangoproject.com/ticket/36531
-          python-version: "3.13"
+          python-version: "3.14"
       - name: "Run Integration Tests"
         # If NAUTOBOT_SELENIUM_HOST is set to 'localhost' or '127.0.0.1' the connection does not work
         run: "NAUTOBOT_SELENIUM_HOST=`hostname -f` poetry run invoke tests --tag integration --no-keepdb"

--- a/.github/workflows/ci_pullrequest.yml
+++ b/.github/workflows/ci_pullrequest.yml
@@ -358,11 +358,7 @@ jobs:
       - "djhtml"
       - "djlint"
   tests-mysql-plus-coverage:
-    # Sticking with Python 3.13 rather than 3.14 here for now, because Django 5.2's test runner doesn't
-    # support parallel execution under 3.14's default multiprocessing start method. Relevant references:
-    # https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods
-    # https://code.djangoproject.com/ticket/36531
-    name: "Unit tests (MySQL and Python 3.13) plus test coverage reporting"
+    name: "Unit tests (MySQL and Python 3.14) plus test coverage reporting"
     runs-on: "ubuntu-24.04"
     env:
       INVOKE_NAUTOBOT_LOCAL: "True"
@@ -397,11 +393,7 @@ jobs:
         with:
           poetry-install-options: "--extras=mysql --extras=remote_storage"
           poetry-version: "2.1.4"
-          # Sticking with Python 3.13 rather than 3.14 here for now, because Django 5.2's test runner doesn't
-          # support parallel execution under 3.14's default multiprocessing start method. Relevant references:
-          # https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods
-          # https://code.djangoproject.com/ticket/36531
-          python-version: "3.13"
+          python-version: "3.14"
       - name: "Run unittest"
         run: "poetry run invoke tests --failfast --no-keepdb --no-cache-test-fixtures --parallel --coverage"
       - name: "Generate coverage comment"
@@ -437,11 +429,7 @@ jobs:
       - "djhtml"
       - "djlint"
   # tests-doltsql:
-  #   # Sticking with Python 3.13 rather than 3.14 here for now, because Django 5.2's test runner doesn't
-  #   # support parallel execution under 3.14's default multiprocessing start method. Relevant references:
-  #   # https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods
-  #   # https://code.djangoproject.com/ticket/36531
-  #   name: "Unit tests (DoltSQL and Python 3.13)"
+  #   name: "Unit tests (DoltSQL and Python 3.14)"
   #   runs-on: "ubuntu-24.04"
   #   env:
   #     INVOKE_NAUTOBOT_LOCAL: "True"
@@ -473,11 +461,7 @@ jobs:
   #       with:
   #         poetry-install-options: "--extras mysql"
   #         poetry-version: "2.1.4"
-  #         # Sticking with Python 3.13 rather than 3.14 here for now, because Django 5.2's test runner doesn't
-  #         # support parallel execution under 3.14's default multiprocessing start method. Relevant references:
-  #         # https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods
-  #         # https://code.djangoproject.com/ticket/36531
-  #         python-version: "3.13"
+  #         python-version: "3.14"
   #     - name: "Run unittest"
   #       run: "poetry run invoke tests --no-keepdb --no-cache-test-fixtures --no-parallel"
   #   needs:
@@ -612,11 +596,7 @@ jobs:
         with:
           poetry-install-options: ""  # override default "--only dev"
           poetry-version: "2.1.4"
-          # Sticking with Python 3.13 rather than 3.14 here for now, because Django 5.2's test runner doesn't
-          # support parallel execution under 3.14's default multiprocessing start method. Relevant references:
-          # https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods
-          # https://code.djangoproject.com/ticket/36531
-          python-version: "3.13"
+          python-version: "3.14"
       - name: "Run Integration Tests"
         # If NAUTOBOT_SELENIUM_HOST is set to 'localhost' or '127.0.0.1' the connection does not work
         run: "NAUTOBOT_SELENIUM_HOST=`hostname -f` poetry run invoke tests --tag integration --no-keepdb"
@@ -663,7 +643,7 @@ jobs:
         with:
           poetry-install-options: "--with playwright"  # all dependency groups plus the optional playwright group (action default is "--only dev")
           poetry-version: "2.1.4"
-          python-version: "3.13"
+          python-version: "3.14"
       - name: "Install Playwright browser"
         run: "poetry run playwright install --with-deps chromium"
       - name: "Initialize Nautobot config"

--- a/changes/9457.housekeeping
+++ b/changes/9457.housekeeping
@@ -1,0 +1,3 @@
+Fixed support for running parallel tests under Python 3.14.
+Changed the default development environment Python version from 3.13 to 3.14.
+Updated CI to use Python 3.14 for tests where applicable.

--- a/nautobot/core/cli/__init__.py
+++ b/nautobot/core/cli/__init__.py
@@ -18,7 +18,7 @@ from nautobot.core.events import load_event_brokers
 from nautobot.core.settings_funcs import is_truthy
 from nautobot.extras.plugins.utils import load_plugins
 
-CONFIG_TEMPLATE = os.path.join(os.path.dirname(__file__), "../templates/nautobot_config.py.j2")
+CONFIG_TEMPLATE = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates/nautobot_config.py.j2")
 
 DESCRIPTION = """
 Nautobot server management utility.
@@ -236,6 +236,14 @@ def get_config_path():
 
 def main():
     """Run administrative tasks."""
+    # 4.0 TODO: Remove this workaround when moving to Django 6.0, which supports Python 3.14's "forkserver" method.
+    # https://github.com/django/django/pull/19681
+    if "test" in sys.argv:
+        import multiprocessing
+
+        if multiprocessing.get_start_method() == "forkserver":
+            multiprocessing.set_start_method("fork", force=True)
+
     # Point Django to our 'nautobot_config' pseudo-module that we'll load from the provided config path
     os.environ["DJANGO_SETTINGS_MODULE"] = "nautobot_config"
 

--- a/tasks.py
+++ b/tasks.py
@@ -86,11 +86,7 @@ namespace.configure(
     {
         "nautobot": {
             "project_name": "nautobot",  # extended automatically with Nautobot major/minor ver, see docker_compose()
-            # Sticking with 3.13 rather than 3.14 as our default for now, because Django 5.2's test runner doesn't
-            # support parallel execution under 3.14's default multiprocessing start method. Relevant references:
-            # https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods
-            # https://code.djangoproject.com/ticket/36531
-            "python_ver": "3.13",
+            "python_ver": "3.14",
             "local": False,
             "ephemeral_ports": False,
             "compose_dir": os.path.join(BASE_DIR, "development/"),


### PR DESCRIPTION
# What's Changed

- Add a workaround for the fact that Django test runner doesn't support Python 3.14's default `forkserver` multiprocessing mode in versions before Django 6.0.
- Update CI to run with Python 3.14 instead of 3.13 where appropriate
- Change default invoke python version to 3.14.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- n/a Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
