### PR TITLE
Fix several UI form regressions from #9343

### DIFF
--- a/changes/9459.fixed
+++ b/changes/9459.fixed
@@ -1,0 +1,3 @@
+Fixed missing "Power Path" field when creating/editing a Power Feed.
+Fixed missing "Virtual Device Contexts" field when creating/edting a VRF.
+Fixed missing "Devices" field when creating/editing a Cluster.

--- a/nautobot/dcim/templates/dcim/powerfeed_create.html
+++ b/nautobot/dcim/templates/dcim/powerfeed_create.html
@@ -27,6 +27,7 @@
             {% render_field form.amperage %}
             {% render_field form.phase %}
             {% render_field form.max_utilization %}
+            {% render_field form.power_path %}
         </div>
     </div>
     <div class="card">

--- a/nautobot/ipam/templates/ipam/vrf_create.html
+++ b/nautobot/ipam/templates/ipam/vrf_create.html
@@ -16,6 +16,7 @@
         <div class="card-header"><strong>Devices</strong></div>
         <div class="card-body">
             {% render_field form.devices %}
+            {% render_field form.virtual_device_contexts %}
         </div>
     </div>
     <div class="card">

--- a/nautobot/virtualization/templates/virtualization/cluster_create.html
+++ b/nautobot/virtualization/templates/virtualization/cluster_create.html
@@ -9,6 +9,7 @@
             {% render_field form.cluster_type %}
             {% render_field form.cluster_group %}
             {% render_field form.location %}
+            {% render_field form.devices %}
         </div>
     </div>
     {% include 'inc/tenancy_form_panel.html' %}


### PR DESCRIPTION
# Closes #9459

NAUTOBOT-1579

# What's Changed

Due to template naming differences between legacy `ObjectEditView` (which used `<model>_create.html` and `<model>_edit.html`) and `NautobotUIViewSet` (which used `<model>_create.html` and `<model>_update.html`), through the process of converting legacy views to UIViewSet views in 2.4 and 3.0, we inadvertently stopped using a number of customized `_edit.html` templates. I addressed this in #9343 by renaming the various `_edit.html` templates to equivalent `_create.html`. However, I missed at the time that several of the Form classes had drifted in the interim (adding new fields to the Form but not updating `_edit.html` to include the new fields). As a result, #9343 actually regressed the behavior of several forms in the UI by silently dropping some important fields, as reported in #9459.

Specifically, I identified by auditing the files touched in #9343 that the following regressions had occurred:

- `PowerFeedForm` added a `power_path` field (and `destination_panel`, `breaker_position`, `breaker_pole_count`), in #7511 but missed adding `power_path` to `powerfeed_edit.html` (the other three new fields were correctly added). This was missed because PowerFeedUIViewSet didn't use `powerfeed_edit.html`.
- `VRFForm` added `virtual_device_contexts` in #6936, but didn't update `vrf_edit.html`, again because VRFUIViewSet wasn't using `vrf_edit.html` at the time.
- `ClusterForm` added `devices` in #7792, but didn't update `cluster_edit.html`, similarly.

I've fixed the above three cases.

Note that `test_views.py` generic tests would not and did not catch any of the above because they send crafted POST data directly to the view, so the form field being present in the server-side Form class is sufficient to drive the view, even though the UI as presented to the user is missing said field. These would need an integration (Selenium/Playwright) test to actually catch the field being absent from the rendered UI.

# Screenshots

<img width="1261" height="981" alt="image" src="https://github.com/user-attachments/assets/a5539029-ecc4-4314-8eff-73e973fac5a5" />


<img width="1253" height="595" alt="image" src="https://github.com/user-attachments/assets/26046b04-eb54-4895-932d-96852988a455" />


<img width="1279" height="618" alt="image" src="https://github.com/user-attachments/assets/9ba90952-daa3-447b-905e-19eeb7a581ec" />


# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- n/a Unit, Integration Tests
- n/a Documentation Updates (when adding/changing features)
- n/a Example App Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
