### PR TITLE
Handle miles in to_meters()

### DIFF
--- a/changes/9465.fixed
+++ b/changes/9465.fixed
@@ -1,0 +1,1 @@
+Fixed `ValueError` when saving a cable with a length unit of miles.

--- a/nautobot/core/utils/data.py
+++ b/nautobot/core/utils/data.py
@@ -155,6 +155,8 @@ def to_meters(length, unit):
         return length
     if unit == choices.CableLengthUnitChoices.UNIT_CENTIMETER:
         return length / 100
+    if unit == choices.CableLengthUnitChoices.UNIT_MILE:
+        return length * Decimal("1609.344")
     if unit == choices.CableLengthUnitChoices.UNIT_FOOT:
         return length * Decimal("0.3048")
     if unit == choices.CableLengthUnitChoices.UNIT_INCH:

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -15,6 +15,7 @@ from nautobot.circuits.models import Circuit, CircuitTermination, CircuitType, P
 from nautobot.core import settings
 from nautobot.core.testing.models import ModelTestCases
 from nautobot.dcim.choices import (
+    CableLengthUnitChoices,
     CableStatusChoices,
     CableTypeChoices,
     ConsolePortTypeChoices,
@@ -750,6 +751,22 @@ class CableLengthTestCase(TestCase):
         cable.length = 2
         cable.save()
         cable.full_clean()
+
+    def test_cable_length_unit_miles(self):
+        """Miles is an offered CableLengthUnitChoices value, so saving a cable in miles must work."""
+        interfacestatus = Status.objects.get_for_model(Interface).first()
+        interface5 = Interface.objects.create(device=self.device1, name="eth2", status=interfacestatus)
+        interface6 = Interface.objects.create(device=self.device2, name="eth2", status=interfacestatus)
+        cable = Cable(
+            termination_a=interface5,
+            termination_b=interface6,
+            length_unit=CableLengthUnitChoices.UNIT_MILE,
+            length=2,
+            status=self.status,
+        )
+        cable.validated_save()
+        cable.refresh_from_db()
+        self.assertEqual(cable._abs_length, Decimal("3218.6880"))
 
 
 class InterfaceTemplateCustomFieldTestCase(TestCase):


### PR DESCRIPTION
`"mi"` is a member of `CableLengthUnitChoices` (`nautobot/dcim/choices.py:1431`), so it passes the `valid_units` check at the top of `to_meters()` — but there is no branch for it, and it falls through to the terminal `raise ValueError`.

Running `to_meters` over the whole choice set:

```
CableLengthUnitChoices.values() = ['km', 'm', 'cm', 'mi', 'ft', 'in']
  to_meters(1, 'km') = 1000
  to_meters(1, 'm')  = 1
  to_meters(1, 'cm') = 0.01
  to_meters(1, 'mi') -> ValueError: Unknown unit mi. Must be 'km', 'm', 'cm', 'ft', or 'in'.
  to_meters(1, 'ft') = 0.3048
  to_meters(1, 'in') = 3.6576
```

Five of the six are handled. Note that the terminal error message enumerates exactly those five.

`Cable.save()` (`nautobot/dcim/models/cables.py:996`) calls `to_meters()` unconditionally whenever `length` and `length_unit` are both set, and `Cable.clean()` never calls it, so nothing catches this earlier. Both the cable form (`forms.py:4461`) and the REST serializer (`api/serializers.py:907`) offer the full choice set, so picking **Miles** in the UI, or POSTing `length_unit: "mi"` to `/api/dcim/cables/`, raises `ValueError` out of `Model.save()`.

### This branch used to exist

- `413f27d7a` (2023-03-17, "Update DCIM ChoiceSets from netbox", #3413) added it as `length * Decimal("1609.344")`, alongside the kilometer branch.
- `v2.0.0` has neither — the move from `nautobot/utilities/utils.py` to `nautobot/core/utils/data.py` dropped both. (`git show v2.0.0:nautobot/core/utils/data.py` contains no `UNIT_KILOMETER` or `UNIT_MILE`.)
- `cb0db2cf0` (2026-06-30, "Various enhancements and fixes to breakout cable support", #9160) restored the **kilometer** branch and updated the error string from `'m', 'cm', 'ft', 'in'` to `'km', 'm', 'cm', 'ft', 'in'`.

This restores the other one, with the project's own prior constant unchanged.

### Testing

`test_cable_length_unit_miles` added to the existing `CableLengthTestCase`, which currently covers `ft` and `in` only. There is no test for `to_meters` anywhere in the repo, so nothing pinned the current behaviour.

- On `develop` it errors: `ValueError: Unknown unit mi. Must be 'km', 'm', 'cm', 'ft', or 'in'.`, raised from `cable.validated_save()`.
- Mutation-checked both directions, failing at different lines: removing the branch again fails at the `validated_save()` call, and using `Decimal("0.3048") * 1760` (the yards-per-mile slip) fails the assertion with `Decimal('1072.8960') != Decimal('3218.6880')`.
- `CableLengthTestCase` passes: `Ran 3 tests ... OK`.
- `ruff format --check` and `ruff check` are clean on both files.

I ran the tests on Python 3.12 against a local Postgres, not CI's 3.10/3.14 matrix, and I did not run `pylint`, `djlint`, `check-migrations` or `build-and-check-docs` — the diff is two Python lines plus a test, with no migration and no docs change. Separately, `nautobot.core.tests.test_utils` has one pre-existing failure here (`test_get_docs_url`), which reproduces with `data.py` and `test_models.py` both restored to `develop`; it needs `invoke build-and-check-docs` to have run first.

No issue was opened beforehand, so the changelog fragment uses this PR's number, per `nautobot/docs/development/core/index.md:330`.

---

AI assistance disclosure: this patch was found and written with Claude Code. Every value above is verbatim from running it against `develop` and against this branch.
