### PR TITLE
Fix interface-connection count performance with correlated peer lookups

### DIFF
--- a/changes/9467.fixed
+++ b/changes/9467.fixed
@@ -1,0 +1,1 @@
+Replaced the full-table visibility subquery in the interface-connections API with a correlated lookup to improve pagination count performance.

--- a/nautobot/dcim/api/views.py
+++ b/nautobot/dcim/api/views.py
@@ -3,7 +3,7 @@ import socket
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import F
+from django.db.models import Exists, F, OuterRef
 from django.http import HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404
 from django.views.decorators.clickjacking import xframe_options_sameorigin
@@ -697,7 +697,8 @@ class InterfaceConnectionViewSet(ListModelMixin, GenericViewSet):
                 # lower-PK end so it is listed once. Deduplicate only when the far end is visible as well:
                 # when it isn't, the near end is the sole candidate row for that connection and dropping it
                 # would make the connection's visibility depend on the two random UUIDs' relative ordering.
-                _path__destination_id__in=visible_interfaces.values("pk"),
+                # Look up the far end by PK instead of materializing all visible Interface IDs (#9467).
+                Exists(visible_interfaces.filter(pk=OuterRef("_path__destination_id"))),
                 pk__gt=F("_path__destination_id"),
             )
         )

--- a/nautobot/dcim/tests/test_api.py
+++ b/nautobot/dcim/tests/test_api.py
@@ -6,7 +6,9 @@ import uuid
 from constance.test import override_config
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from rest_framework import status
 
@@ -3423,6 +3425,37 @@ class InterfaceConnectionTest(ConnectionTestMixin, APITestCase):
                 str(self.cross_pair_granted_end_high[1].pk),
             },
         )
+
+    def test_pagination_count_uses_correlated_peer_lookup(self):
+        """Do not materialize all visible Interface IDs to deduplicate the count (#9467)."""
+        self.add_permissions(self.view_permission)
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.get(f"{self.url}?limit=1", **self.header)
+
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 4)
+        self.assertEqual(len(response.data["results"]), 1)
+        count_queries = [
+            query["sql"]
+            for query in queries
+            if "COUNT(*)" in query["sql"] and connection.ops.quote_name("dcim_interface") in query["sql"]
+        ]
+        self.assertEqual(len(count_queries), 1)
+        self.assertIn("EXISTS", count_queries[0])
+        self.assertNotIn(" IN (SELECT", count_queries[0])
+
+    def test_superuser_lists_each_connection_once(self):
+        self.user.is_superuser = True
+        self.user.save()
+        response = self.client.get(f"{self.url}?limit=0", **self.header)
+        self.assertEqual(len(self._get_near_end_ids(response)), 4)
+        self.assertEqual(response.data["count"], 4)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["dcim.interface"])
+    def test_exempt_view_lists_each_connection_once(self):
+        response = self.client.get(f"{self.url}?limit=0", **self.header)
+        self.assertEqual(len(self._get_near_end_ids(response)), 4)
+        self.assertEqual(response.data["count"], 4)
 
     def test_non_interface_far_end_excluded(self):
         """A connection to a non-Interface endpoint is skipped rather than crashing the serializer."""


### PR DESCRIPTION

[fix-validation-pr-2.4.zip](https://github.com/user-attachments/files/32135171/fix-validation-pr-2.4.zip)
# Closes #9467

# What's Changed

Replace the full-set visibility subquery in `InterfaceConnectionViewSet.get_queryset()` with a correlated `EXISTS` lookup for the far Interface.
This addresses the pagination-count regression introduced in Nautobot 2.4.40 for `/api/dcim/interface-connections/`.
The relevant view file is identical in the `v2.4.40` and `v2.4.41` tags.

The original duplicate-removal condition can repeatedly scan materialized Interface IDs at larger table sizes and low `work_mem`.
The replacement lets PostgreSQL check each far Interface by its primary key.

The existing behavior remains unchanged:

- Restrict the near Interface through the existing permission checks.
- Remove the higher-UUID duplicate only when the far Interface is also visible.
- Retain the visible end when its peer is inaccessible, regardless of UUID order.
- Exclude non-Interface destinations and retain the existing serializer behavior.

The change adds no migration, index, dependency, database-memory setting, or API response field.
It includes three API tests and the changelog fragment `changes/9467.fixed`.
This PR targets `ltm-2.4` only. The 3.2 comparison below explains why no corresponding performance patch is proposed for 3.2.
Reverting the patch requires no data migration, but restores the original query and its potential performance cost.

For example, `GET /api/dcim/interface-connections/?limit=1` still needs a total count before it returns the page.
The page limit does not bound the count to one connection.

## Performance validation

The primary synthetic fixture preserves the proportions of the reported production counts, with integer rounding:

- 250,000 Interfaces, including 24,801 with paths.
- 49,222 CablePaths, with the production endpoint-type mix.
- 12,389 expected connections.

The source counts came from a read-only production reader snapshot on September 10, 2026, at 01:59:44 UTC.
They describe a later snapshot, not verified incident-time counts.
The fixture builder creates synthetic tables from these proportions. It does not copy production objects.

Both queries ran on the same regular PostgreSQL tables.
Each query had one excluded warm-up and six measured executions at each memory setting.
Execution order alternated. Analyzed plans ran separately from the count measurements.
The measured code baseline was `v2.4.41` (`ed71958edf78d64223f0bd616c83e6f664501fd9`).
The runtime used PostgreSQL 15.15, Python 3.11.15, Django 4.2.30, psycopg2-binary 2.9.13, and `hash_mem_multiplier=2`.
The primary repeated run completed on September 11, 2026, from 21:42:09 through 21:49:42 UTC.

| `work_mem` | Original median | Patched median |
| --- | ---: | ---: |
| 4 MB | 53.70 seconds | 41.57 milliseconds |
| 256 MB, diagnostic | 52.37 milliseconds | 40.49 milliseconds |

All 24 measured counts completed without timeouts and returned 12,389 connections.
At 4 MB, the ratio of medians is approximately 1,292 to 1 for this count query.
The completed original plan reports approximately 3.10 billion row visits through `Materialize`.
The patched plan instead performs 24,778 indexed peer lookups.

Increasing `work_mem` to 256 MB also avoids the slow plan in this fixture.
That result is a diagnostic control, not a recommendation to raise production memory limits globally.
The patch addresses the query structure without requiring that larger per-operation memory budget.

The benefit depends on the query plan, not a fixed percentage improvement.
In the separate 3,176,329-Interface test at 256 MB, the original median was 1.135 seconds and the patched median was 1.225 seconds.
That case slightly favors the original query and remains in the attached evidence.
The full-scale 4 MB original hit an earlier 30-second test cutoff, so its completed duration and exact speedup are unknown.

A separate 2.4 control after the 3.2 retest reproduced the slowdown on the same PostgreSQL server.
It took 54.87 seconds original versus 41.71 ms patched.
These single executions are not included in the medians above.

The current benchmark uses a 600-second SQL safety cap.
This is a test setting, not a verified production database timeout or a measurement of the HTTP timeout stack.

## Query structure: the 2.4 regression and the 3.2 difference

This section includes the explanation from `fix-validation/interface-connection-query-comparison.md` so it can be reviewed without downloading the attachment.
It compares the original 2.4.41 query, this patch, and the existing 3.2.4 implementation.

The key difference is not simply `IN` versus `EXISTS`.
It is how permission checks interact with duplicate removal.
The 2.4 patch preserves that release's behavior and makes one expensive check efficient.
The existing 3.2 implementation uses a different query structure.

### 1. Why 2.4 combines permissions with duplicate removal

The 2.4 endpoint starts with Interface rows.
A connection between A and B can appear twice: once from A and once from B.

When both endpoints are visible, Nautobot keeps the endpoint with the lower UUID.
When only one endpoint is visible, it must keep that endpoint regardless of UUID order.

For valid Interface-to-Interface paths, the rule simplifies to:

```text
Keep the visible near endpoint,
unless the far endpoint is also visible AND near_uuid > far_uuid.
```

The original code expresses that final condition with:

```python
.exclude(
    _path__destination_id__in=visible_interfaces.values("pk"),
    pk__gt=F("_path__destination_id"),
)
```

Conceptually, its SQL contains:

```sql
AND NOT (
    far_id IN (SELECT id FROM visible_interfaces)
    AND near_id > far_id
)
```

The visibility test is inside a negated compound condition.
It is not an independent filter that requires the far endpoint to be visible.
A normal inner join to visible far Interfaces would incorrectly remove connections whose far endpoint is hidden.

The SQL examples here simplify the relevant logic.
They omit surrounding joins, destination-type checks, and null guards.
`fix-validation/2.4-production-scaled-results.json` contains the complete compiled SQL and patch diff.

### 2. Why that query became expensive

PostgreSQL can often convert a straightforward membership subquery into a join.
That transformation has restrictions on where the subquery appears within the Boolean expression.
Its optimizer handles suitable top-level conditions and their `AND` branches.
See the [PostgreSQL optimizer source](https://doxygen.postgresql.org/prepjointree_8c_source.html).

In the original 2.4 plan, the nested visibility check remained a subplan.
At `work_mem=4MB`, PostgreSQL used a `Materialize` node to retain visible Interface IDs.
The expensive operation was repeatedly scanning those retained IDs to answer:

> Is this particular far endpoint visible?

This does not mean Django issued thousands of separate SQL queries.
Nor does it necessarily mean PostgreSQL rebuilt the entire list each time.
The problem was repeated scans within one SQL statement.

The recorded plan showed approximately:

- 24,787 scans of the materialized result.
- 125,109 Interface rows examined per scan, on average.
- 3.10 billion row visits in total.

At 256 MB, PostgreSQL instead used a hashed visibility subplan, which avoided those repeated linear scans.
Both memory cases used `hash_mem_multiplier=2`.
The completed plans are described in `fix-validation/2.4-production-scaled-benchmark.md` and retained in its companion JSON file.

### 3. What the 2.4 patch changes

The patch replaces only the membership expression:

```python
# Original
_path__destination_id__in=visible_interfaces.values("pk")

# Patched
Exists(
    visible_interfaces.filter(
        pk=OuterRef("_path__destination_id")
    )
)
```

The surrounding `.exclude()` and UUID comparison remain unchanged:

```python
.exclude(
    Exists(visible_interfaces.filter(pk=OuterRef("_path__destination_id"))),
    pk__gt=F("_path__destination_id"),
)
```

`OuterRef` supplies the far endpoint's UUID from the current candidate row.
The subquery now asks:

```sql
EXISTS (
    SELECT 1
    FROM visible_interfaces
    WHERE id = current_path.destination_id
)
```

That explicit equality gives PostgreSQL an indexed lookup for the individual far Interface.
In the measured plan, it performs 24,778 such lookups instead of billions of materialized-row visits.

The lookup still applies `.restrict(user, "view")`.
The patch does not bypass permissions, change the duplicate-removal rule, or require more database memory.
The implementation changes `InterfaceConnectionViewSet.get_queryset()` in `nautobot/dcim/api/views.py`.

### 4. How unmodified 3.2 differs

The 3.2 endpoint starts with CablePath rows, through `CablePath.interface_connections()`.
That method chooses one representative direction per connection independently of user permissions:

- For ordinary point-to-point connections, it keeps `origin_id < destination_id`.
- For breakout connections, it uses the stored fan-out flags to retain each lane once.

The API then applies permissions separately.
The following excerpt simplifies the request and queryset variable names:

```python
visible_ifaces = Interface.objects.restrict(user, "view").values("pk")

return queryset.filter(
    origin_id__in=visible_ifaces,
    destination_id__in=visible_ifaces,
)
```

Conceptually:

```sql
WHERE canonical_path_condition
  AND origin_id IN (SELECT id FROM visible_interfaces)
  AND destination_id IN (SELECT id FROM visible_interfaces)
```

Both membership checks are independent, positive requirements.
A connection is returned only when both endpoints are visible.

PostgreSQL converted these checks into indexed endpoint joins in every recorded 3.2 comparison.
It did not need the repeated materialized visibility scan.

The permission difference explains why the 3.2 implementation is not a direct replacement for the 2.4 implementation:

| Endpoint visibility | 2.4, including this patch | Unmodified 3.2 |
| --- | --- | --- |
| Both visible | Return the connection once. | Return the connection once. |
| Only one visible | Return it from the visible endpoint. | Exclude the connection. |
| Neither visible | Exclude the connection. | Exclude the connection. |

The 3.2 path-selection logic is in `CablePath.interface_connections()` in `nautobot/dcim/models/cables.py`.
The API visibility checks are in `InterfaceConnectionViewSet.get_queryset()` in `nautobot/dcim/api/views.py`.
`fix-validation/3.2-production-scaled-results.json` contains the original and experimental SQL, source diff, and query plans.

### 5. Why the experimental 3.2 patch adds no demonstrated benefit

The experimental port replaced both positive `IN` checks with explicit `EXISTS` checks.
PostgreSQL already turned the original checks into indexed lookups.
The rewrite therefore produced broadly the same execution strategy, with the endpoint lookup order reversed.

At 4 MB on the production-proportional fixture:

| Release | Original median | Patched median |
| --- | ---: | ---: |
| 2.4.41 | 53.70 seconds | 41.57 ms |
| 3.2.4 | 17.91 ms | 18.13 ms |

Each median comes from six direct count measurements.
Warm-ups and analyzed plans are separate from these measurements.
The repeated scale and index-layout controls support the same conclusion.
`fix-validation/3.2-production-scaled-benchmark.md` records those controls and their limitations.

The 2.4 patch makes its existing permission-dependent duplicate check efficient.
Version 3.2 separates those concerns and already gets efficient indexed checks in the recorded tests.
The proposed contribution is therefore a 2.4 PR only.
No separate 3.2 issue or performance patch is proposed for this regression.

This conclusion does not claim that every possible 3.2 workload is immune to performance problems.
The comparisons measure unrestricted count SQL, not concurrent requests, serialization, or constrained-RBAC latency.
They use reduced synthetic tables, not a complete production database.
The separate API tests check permission correctness, including hidden endpoints and, in 3.2, breakout lanes.

## Correctness validation

The API controls ran on PostgreSQL 15.15 with the bundled `example_app` and `example_app_with_view_override` enabled.
They did not load production Apps or custom RBAC.
These correctness tests are separate from the isolated count-SQL measurements above.

- All 22 interface, console, and power connection API tests passed with the patch.
- The original-query control passed 21 tests and failed only the new assertion that the count uses correlated `EXISTS`.
- The pagination test also checks the response count and page size. New tests cover superuser and exempt-view access.
- Existing tests cover constrained permissions, hidden peers, both UUID orientations, and non-Interface destinations.
- All 23 offline fixture and evidence checks passed: six fixture tests, eight 2.4 artifact checks, and nine 3.2 comparison checks.
- Ruff lint, formatting, and `git diff --check` passed for the changed 2.4 source files.
- The target branch's Towncrier changelog check passed against the committed diff.

The baseline failure is a deliberate negative control, not a failure in the patched suite.
The control uses the tagged query method in the same runtime without replacing source files.
It is not an unmodified-release deployment test.

## Evidence and limits

The shared attachment, `fix-validation-pr-2.4.zip`, contains the supporting records for both release lines.
The 3.2 evidence explains the scope decision. No 3.2 code is included in this PR.
Paths below refer to files within the ZIP, not files added to the Nautobot repository.
The archive replaces workstation paths in log copies with `<review-workspace>` and excludes generated files and caches.
It preserves the measurement JSON and scripts. Its README explains the disposable test configuration and reproduction safeguards.
Start with these files:

| File in the ZIP | Contents |
| --- | --- |
| `fix-validation/README.md` | Evidence index, release scope, and reproduction guidance. |
| `fix-validation/interface-connection-query-comparison.md` | Standalone copy of the code-level explanation included above. |
| `fix-validation/2.4-production-scaled-benchmark.md` | Method, dataset, timeout context, and detailed limitations. |
| `fix-validation/2.4-production-scaled-results.json` | SQL, parameters, all samples, effective settings, plans, and source hashes. |
| `fix-validation/2.4-repeated-benchmark.md` | Historical size and memory controls, including the higher-memory tradeoff. |
| `fix-validation/validation-audit.md` | API controls and verification of the retained evidence. |
| `fix-validation/2.4-api-recheck-patched.log` | Passing API test log. |
| `fix-validation/2.4-control-after-3.2.json` | Separate positive control after the 3.2 retest. |
| `fix-validation/3.2-production-scaled-benchmark.md` | Repeated 3.2 comparison, index-layout controls, and scale controls. |

These are isolated count-query measurements, not end-to-end latency or production CPU-savings estimates.
The benchmark uses unrestricted core visibility and does not execute production Apps or custom RBAC logic.
The reduced schema, all-visible pages, caches, and serial execution do not reproduce production load or storage conditions.
Constrained-RBAC performance, MySQL, the full Nautobot suite, and deployment-level load were not tested.
Project CI and maintainer review remain necessary.

# Screenshots

This change has no UI or response-format change, so screenshots are not applicable.
The pagination regression test uses this representative request with an authenticated account that has unrestricted Interface view permission:

```http
GET /api/dcim/interface-connections/?limit=1 HTTP/1.1
Host: nautobot.example.com
Accept: application/json
```

In the four-connection API fixture, both query forms return HTTP 200, `count=4`, and one object in `results`.
The patch changes the count-query structure, not the response contract.
The attachment provides before/after SQL, query plans, timings, and API assertions.

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s): `changes/9467.fixed`.
- [x] Attached Screenshots, Payload Example: request example included. Attach `fix-validation-pr-2.4.zip`. Screenshots are not applicable.
- [ ] Unit, Integration Tests: targeted API tests passed. Full-suite and integration CI remain pending.
- [x] Documentation Updates (when adding/changing features): no user-facing feature changes require documentation updates. Validation documentation is in the attachment.
- [x] Example App Updates (when adding/changing features): not applicable. No App API changes.
- [x] Outline Remaining Work, Constraints from Design: validation limits and remaining CI are stated above.
