### PR TITLE
Add per-phase rack power utilization

### DIFF
--- a/changes/9476.added
+++ b/changes/9476.added
@@ -1,0 +1,1 @@
+Added per-phase power utilization reporting for three-phase rack power feeds.

--- a/nautobot/dcim/models/racks.py
+++ b/nautobot/dcim/models/racks.py
@@ -13,7 +13,14 @@ from nautobot.core.models.tree_queries import TreeModel
 from nautobot.core.models.utils import array_to_string
 from nautobot.core.utils.config import get_settings_or_config
 from nautobot.core.utils.data import UtilizationData
-from nautobot.dcim.choices import DeviceFaceChoices, RackDimensionUnitChoices, RackTypeChoices, RackWidthChoices
+from nautobot.dcim.choices import (
+    DeviceFaceChoices,
+    PowerFeedPhaseChoices,
+    PowerOutletFeedLegChoices,
+    RackDimensionUnitChoices,
+    RackTypeChoices,
+    RackWidthChoices,
+)
 from nautobot.dcim.constants import RACK_ELEVATION_LEGEND_WIDTH_DEFAULT, RACK_U_HEIGHT_DEFAULT, RACK_U_HEIGHT_MAXIMUM
 from nautobot.dcim.svg.rack_elevation import RackElevationSVG
 from nautobot.dcim.utils import power_ports_connected_to
@@ -261,6 +268,10 @@ class Rack(PrimaryModel):
     def power_utilization(self):
         return self.get_power_utilization()
 
+    @property
+    def power_utilization_by_phase(self):
+        return self.get_power_utilization_by_phase()
+
     def get_rack_units(
         self,
         user=None,
@@ -442,19 +453,88 @@ class Rack(PrimaryModel):
             return UtilizationData(numerator=0, denominator=0)
 
         pf_powerports = power_ports_connected_to(powerfeeds)
+        powerports_with_manual_draw = pf_powerports.exclude(allocated_draw__isnull=True, maximum_draw__isnull=True)
         direct_allocated_draw = int(
-            pf_powerports.aggregate(total=Sum(F("allocated_draw") / F("power_factor")))["total"] or 0
+            powerports_with_manual_draw.aggregate(total=Sum(F("allocated_draw") / F("power_factor")))["total"]
+            or 0
         )
-        poweroutlets = PowerOutlet.objects.filter(power_port_id__in=pf_powerports)
-        allocated_draw_total = int(
+        poweroutlets = PowerOutlet.objects.filter(
+            power_port_id__in=pf_powerports.filter(allocated_draw__isnull=True, maximum_draw__isnull=True)
+        )
+        downstream_allocated_draw = int(
             power_ports_connected_to(poweroutlets).aggregate(total=Sum(F("allocated_draw") / F("power_factor")))[
                 "total"
             ]
             or 0
         )
-        allocated_draw_total += direct_allocated_draw
+
+        # Manual inlet draw takes precedence over downstream outlet draw, matching
+        # PowerPort.get_power_draw(), so the two sources must not be added for one inlet.
+        allocated_draw_total = direct_allocated_draw + downstream_allocated_draw
 
         return UtilizationData(numerator=allocated_draw_total, denominator=available_power_total)
+
+    def get_power_utilization_by_phase(self):
+        """Determine rack power utilization independently for each three-phase feed leg.
+
+        Only three-phase PowerFeeds participate in this calculation. The available
+        power of each feed is divided evenly across its three legs. Loads are
+        assigned to a leg exclusively through PowerOutlet.feed_leg. The returned
+        dictionary has the same leg keys as before and also exposes an
+        ``attribution_complete`` attribute. It is true only when every load was
+        attributable to a leg; it is false when an inlet has manual draw or
+        a downstream outlet has no assigned feed leg. No phase is guessed for those
+        loads, so they are omitted from the per-leg numerators.
+        """
+        utilization_by_phase = {leg: {"allocated": 0, "available": 0} for leg, _leg_name in PowerOutletFeedLegChoices}
+
+        powerfeeds = PowerFeed.objects.filter(rack=self, phase=PowerFeedPhaseChoices.PHASE_3PHASE)
+        attribution_complete = True
+
+        for available_power in powerfeeds.values_list("available_power", flat=True):
+            available_power_per_leg = available_power / 3
+            for leg, _leg_name in PowerOutletFeedLegChoices:
+                utilization_by_phase[leg]["available"] += available_power_per_leg
+
+        feed_powerports = power_ports_connected_to(powerfeeds)
+        powerports_with_manual_draw = feed_powerports.exclude(allocated_draw__isnull=True, maximum_draw__isnull=True)
+        if powerports_with_manual_draw.exists():
+            attribution_complete = False
+        poweroutlets = PowerOutlet.objects.filter(
+            power_port_id__in=feed_powerports.filter(allocated_draw__isnull=True, maximum_draw__isnull=True)
+        )
+
+        # Group all downstream draw by outlet leg in one query instead of issuing an
+        # aggregate query for every feed/leg pair. Keep the aggregate untruncated
+        # until all inlets on a leg have been combined.
+        downstream_draws = (
+            power_ports_connected_to(poweroutlets)
+            .filter(cable_termination__cable__terminations__power_outlet__in=poweroutlets)
+            .values("cable_termination__cable__terminations__power_outlet__feed_leg")
+            .annotate(total=Sum(F("allocated_draw") / F("power_factor")))
+        )
+
+        for row in downstream_draws:
+            leg = row["cable_termination__cable__terminations__power_outlet__feed_leg"]
+            if leg not in utilization_by_phase:
+                attribution_complete = False
+            else:
+                utilization_by_phase[leg]["allocated"] += row["total"] or 0
+
+        class PhaseUtilizationData(dict):
+            """Backwards-compatible leg mapping with load-attribution status."""
+
+            def __init__(self, *args, attribution_complete, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.attribution_complete = attribution_complete
+
+        return PhaseUtilizationData(
+            {
+                leg: UtilizationData(numerator=int(values["allocated"]), denominator=values["available"])
+                for leg, values in utilization_by_phase.items()
+            },
+            attribution_complete=attribution_complete,
+        )
 
 
 @extras_features(

--- a/nautobot/dcim/tests/test_models.py
+++ b/nautobot/dcim/tests/test_models.py
@@ -373,6 +373,170 @@ class PowerPortTestCase(ModularDeviceComponentTestCaseMixin, ModelTestCases.Base
         self.assertEqual(result["allocated"], 400)
         self.assertEqual(result["maximum"], 600)
 
+    def test_rack_get_power_utilization_by_phase(self):
+        """Rack utilization groups three-phase downstream load by PowerOutlet.feed_leg."""
+        rack = Rack.objects.create(
+            name="rack-power-utilization-3ph",
+            location=self.device.location,
+            status=Status.objects.get_for_model(Rack).first(),
+        )
+        feed = PowerFeed.objects.create(
+            name="rack-feed-3ph",
+            power_panel=self.power_panel,
+            rack=rack,
+            status=self.feed_status,
+            voltage=120,
+            amperage=20,
+            max_utilization=100,
+            phase=PowerFeedPhaseChoices.PHASE_3PHASE,
+        )
+        pdu_port = PowerPort.objects.create(device=self.device, name="rack-pdu-inlet")
+        Cable.objects.create(termination_a=pdu_port, termination_b=feed, status=self.cable_status)
+
+        self._build_outlets_with_remote_ports(
+            pdu_port,
+            [(95, 190)],
+            feed_leg=PowerOutletFeedLegChoices.FEED_LEG_A,
+        )
+        self._build_outlets_with_remote_ports(
+            pdu_port,
+            [(190, 285)],
+            feed_leg=PowerOutletFeedLegChoices.FEED_LEG_B,
+        )
+        self._build_outlets_with_remote_ports(
+            pdu_port,
+            [(285, 380)],
+            feed_leg=PowerOutletFeedLegChoices.FEED_LEG_C,
+        )
+
+        result = rack.get_power_utilization_by_phase()
+
+        self.assertEqual(set(result), {"A", "B", "C"})
+        self.assertTrue(result.attribution_complete)
+        # Default PowerPort power_factor is 0.95, hence 95/190/285 W -> 100/200/300 VA.
+        self.assertEqual(result["A"].numerator, 100)
+        self.assertEqual(result["B"].numerator, 200)
+        self.assertEqual(result["C"].numerator, 300)
+
+        expected_available_per_leg = feed.available_power / 3
+        self.assertEqual(result["A"].denominator, expected_available_per_leg)
+        self.assertEqual(result["B"].denominator, expected_available_per_leg)
+        self.assertEqual(result["C"].denominator, expected_available_per_leg)
+
+    def test_rack_get_power_utilization_by_phase_without_three_phase_feeds(self):
+        """A rack without three-phase feeds reports zero utilization for all legs."""
+        rack = Rack.objects.create(
+            name="rack-power-utilization-single",
+            location=self.device.location,
+            status=Status.objects.get_for_model(Rack).first(),
+        )
+        PowerFeed.objects.create(
+            name="rack-feed-single",
+            power_panel=self.power_panel,
+            rack=rack,
+            status=self.feed_status,
+            voltage=120,
+            amperage=20,
+            max_utilization=100,
+            phase=PowerFeedPhaseChoices.PHASE_SINGLE,
+        )
+
+        result = rack.get_power_utilization_by_phase()
+
+        self.assertEqual(set(result), {"A", "B", "C"})
+        for utilization in result.values():
+            self.assertEqual(utilization.numerator, 0)
+            self.assertEqual(utilization.denominator, 0)
+
+        self.assertTrue(result.attribution_complete)
+
+    def test_rack_get_power_utilization_does_not_double_count_inlet_draw(self):
+        """A manual inlet draw replaces, rather than adds to, downstream outlet draw."""
+        rack = Rack.objects.create(
+            name="rack-power-utilization-overall",
+            location=self.device.location,
+            status=Status.objects.get_for_model(Rack).first(),
+        )
+        feed = self._make_powerfeed("rack-feed-overall")
+        feed.rack = rack
+        feed.save()
+        pdu_port = PowerPort.objects.create(device=self.device, name="rack-pdu-overall", allocated_draw=190)
+        Cable.objects.create(termination_a=pdu_port, termination_b=feed, status=self.cable_status)
+        self._build_outlets_with_remote_ports(pdu_port, [(95, 190), (190, 285)])
+
+        result = rack.get_power_utilization()
+
+        # The inlet's 190 W manual draw is 200 VA. The two downstream
+        # loads must not be added because manual draw takes precedence.
+        self.assertEqual(result.numerator, 200)
+        self.assertEqual(result.denominator, feed.available_power)
+
+    def test_rack_get_power_utilization_by_phase_incomplete_for_unassigned_load(self):
+        """Unassigned downstream load is omitted and marks phase attribution incomplete."""
+        rack = Rack.objects.create(
+            name="rack-power-utilization-unassigned",
+            location=self.device.location,
+            status=Status.objects.get_for_model(Rack).first(),
+        )
+        feed = self._make_powerfeed("rack-feed-unassigned", phase=PowerFeedPhaseChoices.PHASE_3PHASE)
+        feed.rack = rack
+        feed.save()
+        pdu_port = PowerPort.objects.create(device=self.device, name="rack-pdu-unassigned")
+        Cable.objects.create(termination_a=pdu_port, termination_b=feed, status=self.cable_status)
+        self._build_outlets_with_remote_ports(pdu_port, [(95, 190)])
+
+        result = rack.get_power_utilization_by_phase()
+
+        self.assertFalse(result.attribution_complete)
+        for utilization in result.values():
+            self.assertEqual(utilization.numerator, 0)
+
+    def test_rack_get_power_utilization_by_phase_aggregates_before_truncating(self):
+        """Multiple inlets on one phase retain fractional VA until phase aggregation."""
+        rack = Rack.objects.create(
+            name="rack-power-utilization-fractions",
+            location=self.device.location,
+            status=Status.objects.get_for_model(Rack).first(),
+        )
+        for index, allocated_draw in enumerate((18, 1)):
+            feed = self._make_powerfeed(
+                f"rack-feed-fractions-{index}", phase=PowerFeedPhaseChoices.PHASE_3PHASE
+            )
+            feed.rack = rack
+            feed.save()
+            pdu_port = PowerPort.objects.create(device=self.device, name=f"rack-pdu-fractions-{index}")
+            Cable.objects.create(termination_a=pdu_port, termination_b=feed, status=self.cable_status)
+            self._build_outlets_with_remote_ports(
+                pdu_port,
+                [(allocated_draw, allocated_draw)],
+                feed_leg=PowerOutletFeedLegChoices.FEED_LEG_A,
+            )
+
+        result = rack.get_power_utilization_by_phase()
+
+        # 18 / .95 + 1 / .95 = 20 VA after the phase-level truncation;
+        # truncating each inlet first would incorrectly produce 18 VA.
+        self.assertEqual(result[PowerOutletFeedLegChoices.FEED_LEG_A].numerator, 20)
+
+    def test_rack_get_power_utilization_by_phase_incomplete_for_manual_draw(self):
+        """Manual inlet draw is omitted and marks phase attribution incomplete."""
+        rack = Rack.objects.create(
+            name="rack-power-utilization-admin",
+            location=self.device.location,
+            status=Status.objects.get_for_model(Rack).first(),
+        )
+        feed = self._make_powerfeed("rack-feed-admin", phase=PowerFeedPhaseChoices.PHASE_3PHASE)
+        feed.rack = rack
+        feed.save()
+        pdu_port = PowerPort.objects.create(device=self.device, name="rack-pdu-admin", allocated_draw=190)
+        Cable.objects.create(termination_a=pdu_port, termination_b=feed, status=self.cable_status)
+
+        result = rack.get_power_utilization_by_phase()
+
+        self.assertFalse(result.attribution_complete)
+        for utilization in result.values():
+            self.assertEqual(utilization.numerator, 0)
+
 
 class PowerOutletTestCase(ModularDeviceComponentTestCaseMixin, ModelTestCases.BaseModelTestCase):
     model = PowerOutlet

--- a/nautobot/dcim/tests/test_views.py
+++ b/nautobot/dcim/tests/test_views.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 import json
 import signal
 import unittest
+from unittest import mock
 import zoneinfo
 
 from constance.test import override_config
@@ -29,6 +30,7 @@ from nautobot.core.testing import (
 from nautobot.core.testing.utils import (
     generate_random_device_asset_tag_of_specified_size,
 )
+from nautobot.core.utils.data import UtilizationData
 from nautobot.dcim.choices import (
     CableLengthUnitChoices,
     CableTypeChoices,
@@ -896,6 +898,29 @@ class RackTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         </div>
         """
         self.assertContains(response, total_utilization_html, html=True)
+
+    def test_rack_power_phase_graphs_require_complete_attribution(self):
+        phase_utilization = self.racks[0].get_power_utilization_by_phase()
+        phase_utilization.update({leg: UtilizationData(numerator=1, denominator=100) for leg in phase_utilization})
+        phase_utilization.attribution_complete = False
+
+        with mock.patch.object(Rack, "get_power_utilization_by_phase", return_value=phase_utilization):
+            response = self.client.get(reverse("dcim:rack", args=[self.racks[0].pk]))
+
+        self.assertHttpStatus(response, 200)
+        self.assertNotContains(response, "<strong>Phase A</strong>", html=True)
+
+    def test_rack_power_phase_graphs_show_with_complete_attribution(self):
+        phase_utilization = self.racks[0].get_power_utilization_by_phase()
+        phase_utilization.update({leg: UtilizationData(numerator=1, denominator=100) for leg in phase_utilization})
+        phase_utilization.attribution_complete = True
+
+        with mock.patch.object(Rack, "get_power_utilization_by_phase", return_value=phase_utilization):
+            response = self.client.get(reverse("dcim:rack", args=[self.racks[0].pk]))
+
+        self.assertHttpStatus(response, 200)
+        for leg in ("A", "B", "C"):
+            self.assertContains(response, f"<strong>Phase {leg}</strong>", html=True)
 
 
 class DeviceFamilyTestCase(ViewTestCases.PrimaryObjectViewTestCase):

--- a/nautobot/dcim/views.py
+++ b/nautobot/dcim/views.py
@@ -908,8 +908,11 @@ class RackUIViewSet(NautobotUIViewSet):
 
     class RackObjectFieldsPanel(object_detail.ObjectFieldsPanel):
         def render_value(self, key, value, context):
-            if key == "space_utilization" or key == "power_utilization":
+            if key == "space_utilization":
                 return self.get_utilization_graph(value)
+
+            if key == "power_utilization":
+                return self.get_power_utilization_graph(value, context)
 
             if key == "devices":
                 request = context["request"]
@@ -926,6 +929,24 @@ class RackUIViewSet(NautobotUIViewSet):
         def get_utilization_graph(self, value):
             data = helpers.utilization_graph(value)
             return render_to_string("utilities/templatetags/utilization_graph.html", data)
+
+        def get_power_utilization_graph(self, value, context):
+            """Render overall rack utilization and, when applicable, utilization by phase."""
+            overall_graph = self.get_utilization_graph(value)
+            obj = get_obj_from_context(context, self.context_object_key)
+            utilization_by_phase = obj.get_power_utilization_by_phase()
+
+            if not utilization_by_phase.attribution_complete or not any(
+                utilization.denominator for utilization in utilization_by_phase.values()
+            ):
+                return overall_graph
+
+            phase_graphs = format_html_join(
+                "",
+                '<div class="mt-2"><strong>Phase {}</strong>{}</div>',
+                ((leg, self.get_utilization_graph(utilization)) for leg, utilization in utilization_by_phase.items()),
+            )
+            return format_html("<div><strong>Overall</strong>{}{}</div>", overall_graph, phase_graphs)
 
     class DimensionsObjectFieldsPanel(object_detail.ObjectFieldsPanel):
         def render_value(self, key, value, context):


### PR DESCRIPTION
# Closes #9476

# What's Changed

## Per-phase rack power utilization

- Added per-phase power utilization reporting for racks with three-phase power feeds.
- Added Phase A, Phase B, and Phase C utilization graphs to the Rack detail view when all downstream PDU loads can be attributed through `PowerOutlet.feed_leg`.
- Preserved the existing overall rack power-utilization graph.

## Correctness safeguards

- Aligned rack power-utilization calculation with `PowerPort.get_power_draw()`: an administrative `allocated_draw` on the PDU inlet takes precedence over downstream outlet aggregation and is not double-counted.
- Suppressed per-phase graphs when phase attribution is incomplete, for example when:
  - a downstream outlet has no assigned `feed_leg`; or
  - the PDU inlet has an administrative `allocated_draw`.

In these cases, the overall utilization graph remains available because it is still accurate.

## Tests

Added model and view coverage for:

- A/B/C utilization aggregation for three-phase feeds;
- racks without three-phase feeds;
- prevention of double counting between inlet administrative draw and downstream loads;
- incomplete attribution caused by unassigned outlet feed legs;
- incomplete attribution caused by administrative inlet draw;
- visibility of phase graphs only when attribution is complete.

# Screenshots
High Rack usage
<img width="1531" height="837" alt="image" src="https://github.com/user-attachments/assets/5c7cd71e-1304-4f7e-a256-0e767a90786d" />

Low Rack usage
<img width="1579" height="886" alt="image" src="https://github.com/user-attachments/assets/e5bda64e-2ebe-4873-aab7-63519bde80be" />

Rack without Three-phase PDU but single phase PDU
<img width="1600" height="709" alt="image" src="https://github.com/user-attachments/assets/910be5c3-1cd6-486a-86ef-35ab2ae10643" />

# TODO

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
  - Not required: this change exposes calculated utilization using existing power-feed and outlet attributes.
- [ ] Example App Updates (when adding/changing features)
  - Not applicable.
- [x] Outline Remaining Work, Constraints from Design
  - Per-phase graphs are intentionally hidden whenever load cannot be attributed accurately to a specific phase.
