### PR TITLE
chore: move log_in out of fixture and into a helper and add section to docs for using with a one off script

### DIFF
--- a/changes/9479.housekeeping
+++ b/changes/9479.housekeeping
@@ -1,0 +1,1 @@
+Moved Playwright login out of the auth fixture and into a helper with documentation for using it in a script.

--- a/nautobot/docs/development/core/playwright-testing.md
+++ b/nautobot/docs/development/core/playwright-testing.md
@@ -70,6 +70,49 @@ are registered in pyproject.toml, and a misspelled mark on a test fails
 collection with `--strict-markers` in the repo's pytest config. App scoping
 is by directory (`--app dcim`), not by mark.
 
+## Writing a script instead of a test
+
+A one-off script that checks a selector or watches a page does not need pytest. The
+page objects take a Playwright `Page` and a base URL, and `log_in` in
+`nautobot.playwright.helpers` performs the same UI login the session fixture uses. It
+fills the login form and waits for the logout link, which only renders once a session
+exists. On a failed login it raises Playwright's `TimeoutError` after 15 seconds, with
+`a[href='/logout/']` in the call log.
+
+`log_in` navigates to the relative path `/login/`, so the browser context must be
+created with `base_url`. A page from `browser.new_page()` has no base URL and the
+first `goto` fails.
+
+```python
+import os
+
+from playwright.sync_api import sync_playwright
+
+from nautobot.dcim.tests.integration.pages.locations_page import LocationsPage
+from nautobot.playwright.helpers import log_in
+
+base_url = os.getenv("NAUTOBOT_PLAYWRIGHT_URL", "http://localhost:8080").rstrip("/")
+username = os.getenv("NAUTOBOT_PLAYWRIGHT_USERNAME", "admin")
+password = os.getenv("NAUTOBOT_PLAYWRIGHT_PASSWORD", "admin")
+
+with sync_playwright() as playwright:
+    browser = playwright.chromium.launch()
+    context = browser.new_context(base_url=base_url)
+    page = context.new_page()
+
+    log_in(page, username, password)
+
+    locations = LocationsPage(page, base_url)
+    locations.navigate()
+    print(f"{locations.get_data_row_count()} rows on the first page")
+
+    browser.close()
+```
+
+Run it with `poetry run python <script>` from this repository so `nautobot.playwright`
+imports. The pytest flags `--headed` and `--slowmo` do not apply outside pytest. Use
+`launch(headless=False, slow_mo=500)` instead.
+
 ## CI
 
 The CI job (`playwright-test`) starts an isolated instance, seeds it with

--- a/nautobot/playwright/fixtures.py
+++ b/nautobot/playwright/fixtures.py
@@ -22,8 +22,9 @@ development API token.
 
 import os
 
-from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 import pytest
+
+from nautobot.playwright.helpers import log_in
 
 PLAYWRIGHT_DEFAULT_URL = "http://localhost:8080"
 # The defaults below match the documented development-instance bootstrap
@@ -59,17 +60,11 @@ def auth_state_path(browser, base_url, tmp_path_factory):
     state_file = tmp_path_factory.mktemp("auth") / "session.json"
     context = browser.new_context(base_url=base_url)
     page = context.new_page()
-    page.goto(f"{base_url}/login/")
-    page.fill("input[name='username']", username)
-    page.fill("input[name='password']", password)
-    page.click("button[type='submit']")
     try:
-        # The logout link only exists once a session does. It sits in a collapsed
-        # dropdown, so wait for "attached" rather than visible.
-        page.wait_for_selector("a[href='/logout/']", state="attached", timeout=15_000)
-    except PlaywrightTimeoutError:
+        log_in(page, username, password)
+    except RuntimeError as exc:
         pytest.fail(
-            f"Playwright login failed as {username!r} against {base_url} (still on {page.url}). "
+            f"Playwright login failed against {base_url}: {exc} "
             "Check NAUTOBOT_PLAYWRIGHT_USERNAME/NAUTOBOT_PLAYWRIGHT_PASSWORD and that the instance is up."
         )
     context.storage_state(path=str(state_file))

--- a/nautobot/playwright/helpers.py
+++ b/nautobot/playwright/helpers.py
@@ -6,6 +6,8 @@ per test, with dependencies or teardown) live in `fixtures.py`.
 
 from uuid import uuid4
 
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
 
 def unique_name(prefix="ZZZ-test"):
     """Return a unique, sortable name for a test-owned record.
@@ -14,3 +16,21 @@ def unique_name(prefix="ZZZ-test"):
     repeated runs against a shared instance from colliding.
     """
     return f"{prefix}-{uuid4().hex[:8]}"
+
+
+def log_in(page, username, password):
+    """Log in through the UI and wait for the logged-in state.
+
+    A plain function so scripts outside pytest can call it. Navigates to the relative
+    path `/login/`, so the page's context must be created with `base_url`.
+    """
+    page.goto("/login/")
+    page.fill("input[name='username']", username)
+    page.fill("input[name='password']", password)
+    page.click("button[type='submit']")
+    try:
+        # The logout link only exists once a session does. It sits in a collapsed
+        # dropdown, so wait for "attached" rather than visible.
+        page.wait_for_selector("a[href='/logout/']", state="attached", timeout=15_000)
+    except PlaywrightTimeoutError as exc:
+        raise RuntimeError(f"Login as {username!r} did not reach a logged-in session (still on {page.url}).") from exc


### PR DESCRIPTION
# Closes # NBOTQA-135
# What's Changed

Move playwright login out of auth fixture body and into a helper by itself so one-off scripts can use it as well. Also added a section to the documentation describing using the helper in a one-off script.

# Screenshots

N/A

# TODO
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Example App Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
